### PR TITLE
correct 1, 5, 15 minute smoothing factors

### DIFF
--- a/src/main/java/com/yammer/metrics/core/MeterMetric.java
+++ b/src/main/java/com/yammer/metrics/core/MeterMetric.java
@@ -19,9 +19,9 @@ public class MeterMetric implements Metered {
 			Executors.newScheduledThreadPool(2, new NamedThreadFactory("metrics-meter-tick"));
 	private static final long INTERVAL = 5; // seconds
 	private static final double INTERVAL_IN_NS = TimeUnit.SECONDS.toNanos(INTERVAL);
-	private static final double ONE_MINUTE_FACTOR = 1 / Math.exp(TimeUnit.SECONDS.toMinutes(INTERVAL));
-	private static final double FIVE_MINUTE_FACTOR = ONE_MINUTE_FACTOR / 5;
-	private static final double FIFTEEN_MINUTE_FACTOR = ONE_MINUTE_FACTOR / 15;
+	private static final double ONE_MINUTE_FACTOR = 1 - Math.exp(-TimeUnit.SECONDS.toMinutes(INTERVAL));
+	private static final double FIVE_MINUTE_FACTOR = 1 - Math.exp(-TimeUnit.SECONDS.toMinutes(INTERVAL) / 5);
+	private static final double FIFTEEN_MINUTE_FACTOR = 1 - Math.exp(-TimeUnit.SECONDS.toMinutes(INTERVAL) / 15);
 
 	/**
 	 * Creates a new {@link MeterMetric}.


### PR DESCRIPTION
MeterMetric's EWMA function is correct, presuming FACTOR means α, the smoothing factor. However the factors themselves are miscalculated.

The one minute factor is actually 1-α, aka the EXP_R. Five minute and 15 minute factors are calculated in the right direction but only incidentally. Had they been formulated the same way as the one minute EXP_R, i.e. exp(-5/60/5) and exp(-5/60/15), they would be damping even less than the one minute factor. Also, though you can approximate the 5 and 15 minute alphas by dividing the 1 minute alpha, the result is off by a couple percent.

Attached patch to fix the factors. You may also want to rename FACTOR to ALPHA. Note that this dramatically changes the damping effect [the curve is approximately 11x slower]; users on the new code will see quite different behavior for the same input.

The kernel load average EWMA code stores 1, 5, 15 minute 'factors' as hard coded fixed point 11 bit EXP_Rs instead of alphas for the sake of speed and size. The load average macro itself is written in terms of EXP_R instead of alpha [and is the basis of my initial suggestion on twitter]. Perhaps this is where the error originated.

Hopefully I'm not way off in left field here, and thanks for the great project.
