### PR TITLE
Fixed the EWMA to work regardless of the TICK_THREAD interval settings in

### DIFF
--- a/src/main/java/com/yammer/metrics/stats/EWMA.java
+++ b/src/main/java/com/yammer/metrics/stats/EWMA.java
@@ -25,31 +25,37 @@ public class EWMA {
     /**
      * Creates a new EWMA which is equivalent to the UNIX one minute load average and which expects to be ticked every
      * 5 seconds.
+     * @param intervalUnit tick interval
+     * @param interval  tick interval unit
      *
      * @return a one-minute EWMA
      */
-    public static EWMA oneMinuteEWMA() {
-        return new EWMA(M1_ALPHA, 5, TimeUnit.SECONDS);
+    public static EWMA oneMinuteEWMA(long interval, TimeUnit intervalUnit) {
+        return new EWMA(M1_ALPHA, interval, intervalUnit);
     }
 
     /**
      * Creates a new EWMA which is equivalent to the UNIX five minute load average and which expects to be ticked every
      * 5 seconds.
+     * @param intervalUnit tick interval
+     * @param interval  tick interval unit
      *
      * @return a five-minute EWMA
      */
-    public static EWMA fiveMinuteEWMA() {
-        return new EWMA(M5_ALPHA, 5, TimeUnit.SECONDS);
+    public static EWMA fiveMinuteEWMA(long interval, TimeUnit intervalUnit) {
+        return new EWMA(M5_ALPHA, interval, intervalUnit);
     }
 
     /**
      * Creates a new EWMA which is equivalent to the UNIX fifteen minute load average and which expects to be ticked
      * every 5 seconds.
+     * @param intervalUnit tick interval
+     * @param interval  tick interval unit
      *
      * @return a fifteen-minute EWMA
      */
-    public static EWMA fifteenMinuteEWMA() {
-        return new EWMA(M15_ALPHA, 5, TimeUnit.SECONDS);
+    public static EWMA fifteenMinuteEWMA(long interval, TimeUnit intervalUnit) {
+        return new EWMA(M15_ALPHA, interval, intervalUnit);
     }
 
     /**
@@ -63,7 +69,6 @@ public class EWMA {
         this.interval = intervalUnit.toNanos(interval);
         this.alpha = alpha;
     }
-
     /**
      * Update the moving average with a new value.
      *


### PR DESCRIPTION
Fixed the EWMA to work regardless of the TICK_THREAD interval settings in e.g. MeterMetric.
Before this fix, an EWMA was always created with a default interval of 5 seconds which gave incorrect
results when createing a MeterMetric with different values (for interval and intervalUnit).

The following simple test now gives (aproximaapproximately) the same output:

MeterMetric meter = MeterMetric.newMeter(1, TimeUnit.SECONDS, "test event", TimeUnit.SECONDS);

for (int i = 0; i < 100; i++)
{
    Thread.sleep(100);
    meter.mark();
}

System.out.println(meter.meanRate());
System.out.println(meter.oneMinuteRate());
