### PR TITLE
Rare bug in ExponentiallyDecayingSample

### DIFF
--- a/src/main/java/com/yammer/metrics/stats/ExponentiallyDecayingSample.java
+++ b/src/main/java/com/yammer/metrics/stats/ExponentiallyDecayingSample.java
@@ -80,11 +80,11 @@ public class ExponentiallyDecayingSample implements Sample {
 			} else {
 				Double first = values.firstKey();
 				if (first < priority) {
-					values.put(priority, value);
-
-					// ensure we always remove an item
-					while (values.remove(first) == null) {
-						first = values.firstKey();
+					if (values.putIfAbsent(priority, value) == null) {
+						// ensure we always remove an item
+						while (values.remove(first) == null) {
+							first = values.firstKey();
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Here's a fix for an issue where the list of values shrinks permanently by one in the highly unlikely case of two calls to update resulting in the same priority.
