### PR TITLE
Support building for Scala 2.9.0 RC1.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -2,8 +2,8 @@
 #Tue Feb 23 21:08:43 PST 2010
 project.organization=com.yammer
 project.name=metrics
-sbt.version=0.7.5.RC0
+sbt.version=0.7.6.RC0
 project.version=2.0.0-BETA11-SNAPSHOT
 def.scala.version=2.7.7
-build.scala.versions=2.8.1
+build.scala.versions=2.8.1 2.9.0.RC1
 project.initialize=false

--- a/project/build/MetricsProject.scala
+++ b/project/build/MetricsProject.scala
@@ -34,6 +34,6 @@ class MetricsProject(info: ProjectInfo) extends DefaultProject(info)
   /**
    * Test Dependencies
    */
-  val simplespec = "com.codahale" %% "simplespec" % "0.2.0" % "test"
+  val simplespec = "com.codahale" % "simplespec_2.8.1" % "0.2.0" % "test"
   val mockito = "org.mockito" % "mockito-all" % "1.8.4" % "test"
 }


### PR DESCRIPTION
This appears to build, pass tests and work.

I hardcoded it to use the Scala 2.8.1 version of simplespec as you don't have a 2.9.0 RC1 version of that and there also isn't one for specs yet.

The update to 0.7.6RC0 for sbt is necessary for an issue with the new REPL.

I was hoping to have a (published) 2.9.0 RC1 version of the Metrics code so that it can be used in projects like Akka which already migrated to Scala 2.9.0 RC1 in their master branch.
