### PR TITLE
Support using a prefix on all metric names sent to Graphite.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ application report directly to the server:
 GraphiteReporter.enable(1, TimeUnit.MINUTES, "graphite.example.com", 8080)
 ```
 
+Optionally, you can provide a prefix to prepend to all metric names sent
+to Graphite:
+
+```scala
+GraphiteReporter.enable(1, TimeUnit.MINUTES, "graphite.example.com", 8080, "my.host.name")
+```
 
 License
 -------


### PR DESCRIPTION
When you have a bunch of processes spewing data into Graphite, you need a way to separate them ... a prefix handles that well.
