### PR TITLE
Correctly name non_heap_usage in GraphiteReporter

### DIFF
--- a/graphite/src/main/java/com/yammer/metrics/reporting/GraphiteReporter.java
+++ b/graphite/src/main/java/com/yammer/metrics/reporting/GraphiteReporter.java
@@ -218,7 +218,7 @@ public class GraphiteReporter implements Runnable {
 
     private void printVmMetrics(long epoch) throws IOException {
         printDoubleField("jvm.memory.heap_usage", heapUsage(), epoch);
-        printDoubleField("jvm.memory.heap_usage", nonHeapUsage(), epoch);
+        printDoubleField("jvm.memory.non_heap_usage", nonHeapUsage(), epoch);
         for (Entry<String, Double> pool : memoryPoolUsage().entrySet()) {
             printDoubleField("jvm.memory.memory_pool_usages." + pool.getKey(), pool.getValue(), epoch);
         }


### PR DESCRIPTION
Small bug in the GraphiteReporter - mis-reporting the non_heap_usage as heap_usage
