### PR TITLE
Robustify MetricsServlet in the face of exceptions thrown by gauges

### DIFF
--- a/metrics-servlet/src/main/java/com/yammer/metrics/reporting/MetricsServlet.java
+++ b/metrics-servlet/src/main/java/com/yammer/metrics/reporting/MetricsServlet.java
@@ -268,11 +268,11 @@ public class MetricsServlet extends HttpServlet {
         {
             json.writeStringField("type", "gauge");
             json.writeFieldName("value");
-            final Object value = gauge.value();
             try {
+                final Object value = gauge.value();
                 json.writeObject(value);
-            } catch (JsonMappingException e) {
-                json.writeString("unknown value type: " + value.getClass());
+            } catch (Exception e) {
+                json.writeString("error reading gauge: " + e.getMessage());
             }
         }
         json.writeEndObject();

--- a/metrics-servlet/src/test/scala/com/yammer/metrics/servlet/experiments/TestServer.scala
+++ b/metrics-servlet/src/test/scala/com/yammer/metrics/servlet/experiments/TestServer.scala
@@ -8,6 +8,9 @@ import com.yammer.metrics.reporting.MetricsServlet
 object TestServer extends Instrumented {
   val counter1 = metrics.counter("wah", "doody")
   val counter2 = metrics.counter("woo")
+  val asplodingGauge = metrics.gauge[Int]("boo") {
+    throw new RuntimeException("asplode!")
+  }
 
   def main(args: Array[String]) {
     val server = new Server(8080)


### PR DESCRIPTION
Slight modification of MetricsServlet to catch Exception instead of just JsonMappingException in gauge evaluations. If a gauge throws an exception in a relatively small response, Jetty catches it before any buffers are flushed and returns an HTTP 500 with a suitable error page. If a gauge throws an exception in a larger response, after some of the buffer has been flushed to the client, Jetty cuts off the response stream, resulting in an HTTP 200 with a partial JSON response.

This modification to MetricsServiet allows a gauge to throw an exception and not trigger a cut off JSON response.
