### PR TITLE
Apply s/ /_/g to the metric name, to not break the line format

### DIFF
--- a/metrics-graphite/src/main/java/com/yammer/metrics/reporting/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/yammer/metrics/reporting/GraphiteReporter.java
@@ -129,7 +129,7 @@ public class GraphiteReporter implements Runnable {
     private void printRegularMetrics(long epoch) {
         for (Entry<String, Map<String, Metric>> entry : Utils.sortMetrics(Metrics.allMetrics()).entrySet()) {
             for (Entry<String, Metric> subEntry : entry.getValue().entrySet()) {
-                final String simpleName = entry.getKey() + "." + subEntry.getKey();
+                final String simpleName = (entry.getKey() + "." + subEntry.getKey()).replaceAll(" ", "_");
                 final Metric metric = subEntry.getValue();
                 if (metric != null) {
                     try {


### PR DESCRIPTION
Small fix that sanitizes the metric name, which otherwise would break graphite's line format.

Cheers
