### PR TITLE
Replace spaces with dashes in graphite metric names

### DIFF
--- a/metrics-graphite/src/main/java/com/yammer/metrics/reporting/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/yammer/metrics/reporting/GraphiteReporter.java
@@ -236,37 +236,43 @@ public class GraphiteReporter implements Runnable {
         }
     }
 
+    private String sanitizeName(String name) {
+      return name.replace(' ', '-');
+    }
+
     private void printGauge(GaugeMetric<?> gauge, String name, long epoch) {
-        sendToGraphite(String.format("%s%s.%s %s %d\n", prefix, name, "value", gauge.value(), epoch));
+        sendToGraphite(String.format("%s%s.%s %s %d\n", prefix, sanitizeName(name), "value", gauge.value(), epoch));
     }
 
     private void printCounter(CounterMetric counter, String name, long epoch) {
-        sendToGraphite(String.format("%s%s.%s %d %d\n", prefix, name, "count", counter.count(), epoch));
+        sendToGraphite(String.format("%s%s.%s %d %d\n", prefix, sanitizeName(name), "count", counter.count(), epoch));
     }
 
     private void printMetered(Metered meter, String name, long epoch) {
+        final String sanitizedName = sanitizeName(name);
         final StringBuilder lines = new StringBuilder();
-        lines.append(String.format("%s%s.%s %d %d\n",    prefix, name, "count",        meter.count(), epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "meanRate",     meter.meanRate(), epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "1MinuteRate",  meter.oneMinuteRate(), epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "5MinuteRate",  meter.fiveMinuteRate(), epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "15MinuteRate", meter.fifteenMinuteRate(), epoch));
+        lines.append(String.format("%s%s.%s %d %d\n",    prefix, sanitizedName, "count",        meter.count(), epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "meanRate",     meter.meanRate(), epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "1MinuteRate",  meter.oneMinuteRate(), epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "5MinuteRate",  meter.fiveMinuteRate(), epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "15MinuteRate", meter.fifteenMinuteRate(), epoch));
         sendToGraphite(lines.toString());
     }
 
     private void printHistogram(HistogramMetric histogram, String name, long epoch) {
+        final String sanitizedName = sanitizeName(name);
         final double[] percentiles = histogram.percentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999);
         final StringBuilder lines = new StringBuilder();
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "min",           histogram.min(), epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "max",           histogram.max(), epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "mean",          histogram.mean(), epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "stddev",        histogram.stdDev(), epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "median",        percentiles[0], epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "75percentile",  percentiles[1], epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "95percentile",  percentiles[2], epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "98percentile",  percentiles[3], epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "99percentile",  percentiles[4], epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "999percentile", percentiles[5], epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "min",           histogram.min(), epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "max",           histogram.max(), epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "mean",          histogram.mean(), epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "stddev",        histogram.stdDev(), epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "median",        percentiles[0], epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "75percentile",  percentiles[1], epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "95percentile",  percentiles[2], epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "98percentile",  percentiles[3], epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "99percentile",  percentiles[4], epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "999percentile", percentiles[5], epoch));
 
         sendToGraphite(lines.toString());
     }
@@ -274,28 +280,29 @@ public class GraphiteReporter implements Runnable {
     private void printTimer(TimerMetric timer, String name, long epoch) {
         printMetered(timer, name, epoch);
 
+        final String sanitizedName = sanitizeName(name);
         final double[] percentiles = timer.percentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999);
 
         final StringBuilder lines = new StringBuilder();
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "min",           timer.min(), epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "max",           timer.max(), epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "mean",          timer.mean(), epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "stddev",        timer.stdDev(), epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "median",        percentiles[0], epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "75percentile",  percentiles[1], epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "95percentile",  percentiles[2], epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "98percentile",  percentiles[3], epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "99percentile",  percentiles[4], epoch));
-        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, name, "999percentile", percentiles[5], epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "min",           timer.min(), epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "max",           timer.max(), epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "mean",          timer.mean(), epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "stddev",        timer.stdDev(), epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "median",        percentiles[0], epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "75percentile",  percentiles[1], epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "95percentile",  percentiles[2], epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "98percentile",  percentiles[3], epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "99percentile",  percentiles[4], epoch));
+        lines.append(String.format("%s%s.%s %2.2f %d\n", prefix, sanitizedName, "999percentile", percentiles[5], epoch));
         sendToGraphite(lines.toString());
     }
 
     private void printDoubleField(String name, double value, long epoch) {
-        sendToGraphite(String.format("%s%s %2.2f %d\n", prefix, name, value, epoch));
+        sendToGraphite(String.format("%s%s %2.2f %d\n", prefix, sanitizedName(name), value, epoch));
     }
 
     private void printLongField(String name, long value, long epoch) {
-        sendToGraphite(String.format("%s%s %d %d\n", prefix, name, value, epoch));
+        sendToGraphite(String.format("%s%s %d %d\n", prefix, sanitizedName(name), value, epoch));
     }
 
     private void printVmMetrics(long epoch) throws IOException {


### PR DESCRIPTION
Currently it's possible to have invalid metric names sent to graphite. In particular, the default gc metrics ("G1 Young Generation") come out invalid.
