### PR TITLE
Custom registries for the Instrumented trait.

### DIFF
--- a/metrics-scala_2.9.0-1/src/main/scala/com/yammer/metrics/Instrumented.scala
+++ b/metrics-scala_2.9.0-1/src/main/scala/com/yammer/metrics/Instrumented.scala
@@ -4,10 +4,15 @@ package com.yammer.metrics
  * The mixin trait for creating a class which is instrumented with metrics.
  */
 trait Instrumented {
-  private lazy val metricsGroup = new MetricsGroup(getClass)
+  private lazy val metricsGroup = new MetricsGroup(getClass, metricsRegistry)
 
   /**
    * Returns the {@link MetricsGroup} for the class.
    */
   def metrics = metricsGroup
+
+  /**
+   * Returns the {@link MetricsRegistry} for the class.
+   */
+  def metricsRegistry = Metrics.defaultRegistry()
 }

--- a/metrics-scala_2.9.0-1/src/main/scala/com/yammer/metrics/MetricsGroup.scala
+++ b/metrics-scala_2.9.0-1/src/main/scala/com/yammer/metrics/MetricsGroup.scala
@@ -1,21 +1,22 @@
 package com.yammer.metrics
 
-import core.GaugeMetric
+import core.{MetricsRegistry, GaugeMetric}
 import java.util.concurrent.TimeUnit
 
 /**
  * A helper class for creating and registering metrics.
  */
-class MetricsGroup(val klass: Class[_]) {
+class MetricsGroup(val klass: Class[_], val metricsRegistry: MetricsRegistry = Metrics.defaultRegistry()) {
 
   /**
    * Registers a new gauge metric.
    *
    * @param name  the name of the gauge
    * @param scope the scope of the gauge
+   * @param registry the registry for the gauge
    */
-  def gauge[A](name: String, scope: String = null)(f: => A) = {
-    Metrics.newGauge(klass, name, scope, new GaugeMetric[A] {
+  def gauge[A](name: String, scope: String = null, registry: MetricsRegistry = metricsRegistry)(f: => A) = {
+    registry.newGauge(klass, name, scope, new GaugeMetric[A] {
       def value = f
     })
   }
@@ -25,9 +26,10 @@ class MetricsGroup(val klass: Class[_]) {
    *
    * @param name  the name of the counter
    * @param scope the scope of the gauge
+   * @param registry the registry for the gauge
    */
-  def counter(name: String, scope: String = null) =
-    new Counter(Metrics.newCounter(klass, name, scope))
+  def counter(name: String, scope: String = null, registry: MetricsRegistry = metricsRegistry) =
+    new Counter(registry.newCounter(klass, name, scope))
 
   /**
    * Creates a new histogram metrics.
@@ -35,11 +37,13 @@ class MetricsGroup(val klass: Class[_]) {
    * @param name   the name of the histogram
    * @param scope  the scope of the histogram
    * @param biased whether or not to use a biased sample
+   * @param registry the registry for the gauge
    */
   def histogram(name: String,
                 scope: String = null,
-                biased: Boolean = false) =
-    new Histogram(Metrics.newHistogram(klass, name, scope, biased))
+                biased: Boolean = false,
+                registry: MetricsRegistry = metricsRegistry) =
+    new Histogram(registry.newHistogram(klass, name, scope, biased))
 
   /**
    * Creates a new meter metric.
@@ -49,12 +53,14 @@ class MetricsGroup(val klass: Class[_]) {
    *                  measuring (e.g., {@code "requests"})
    * @param scope the scope of the meter
    * @param unit the time unit of the meter
+   * @param registry the registry for the gauge
    */
   def meter(name: String,
             eventType: String,
             scope: String = null,
-            unit: TimeUnit = TimeUnit.SECONDS) =
-    new Meter(Metrics.newMeter(klass, name, scope, eventType, unit))
+            unit: TimeUnit = TimeUnit.SECONDS,
+            registry: MetricsRegistry = metricsRegistry) =
+    new Meter(registry.newMeter(klass, name, scope, eventType, unit))
 
   /**
    * Creates a new timer metric.
@@ -63,10 +69,12 @@ class MetricsGroup(val klass: Class[_]) {
    * @param scope the scope of the timer
    * @param durationUnit the time unit for measuring duration
    * @param rateUnit the time unit for measuring rate
+   * @param registry the registry for the gauge
    */
   def timer(name: String,
             scope: String = null,
             durationUnit: TimeUnit = TimeUnit.MILLISECONDS,
-            rateUnit: TimeUnit = TimeUnit.SECONDS) =
-    new Timer(Metrics.newTimer(klass, name, scope, durationUnit, rateUnit))
+            rateUnit: TimeUnit = TimeUnit.SECONDS,
+            registry: MetricsRegistry = metricsRegistry) =
+    new Timer(registry.newTimer(klass, name, scope, durationUnit, rateUnit))
 }


### PR DESCRIPTION
Hi Coda,

I enhanced `Instrumented` and `MetricsGroup` a bit so it's possible to set a default registry per mixin. I also added a `registry: MetricsRegistry` parameter to the factory methods on `MetricsGroup` to be able to use a different registry for each call, if desired.

I contemplated leaving out `Instrumented#metricsRegistry` and letting the user return a custom `MetricsGroup` with the according `MetricsRegistry` by overriding `metrics`, but kept it in as I think it reads a bit nicer.

The additional parameters to `MetricsGroup` and the factory methods all have a default value set to no break existing code.

I'd appreciate your thoughts and even more so a merge ;).

Cheers,
  Gerolf
