### PR TITLE
Reduce GraphiteReporter's log verbosity.

### DIFF
--- a/metrics-graphite/src/main/java/com/yammer/metrics/reporting/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/yammer/metrics/reporting/GraphiteReporter.java
@@ -184,7 +184,7 @@ public class GraphiteReporter implements Runnable {
             printRegularMetrics(epoch);
             writer.flush();
         } catch (Exception e) {
-            log.error("Error:", e);
+            log.error("Error: {}", e.getMessage());
             if (writer != null) {
                 try {
                     writer.flush();


### PR DESCRIPTION
The GraphiteReporter is currently very verbose if it cannot reach
or find the graphite server. This commit tweaks the log output to
only print the exception message instead of the entire stack trace.
