### PR TITLE
Move start() to AbstractReporter

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/reporting/AbstractReporter.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/reporting/AbstractReporter.java
@@ -1,6 +1,7 @@
 package com.yammer.metrics.reporting;
 
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import com.yammer.metrics.core.MetricsRegistry;
 
@@ -15,4 +16,12 @@ public abstract class AbstractReporter implements Runnable {
     
     @Override
     public abstract void run();
+    
+    /**
+     * Starts sending output to ganglia server.
+     *
+     * @param period the period between successive displays
+     * @param unit   the time unit of {@code period}
+     */
+    public abstract void start(long period, TimeUnit unit);
 }

--- a/metrics-core/src/main/java/com/yammer/metrics/reporting/JmxReporter.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/reporting/JmxReporter.java
@@ -304,7 +304,7 @@ public class JmxReporter extends AbstractReporter {
     private static JmxReporter INSTANCE;
     public static final void startDefault(MetricsRegistry defaultMetricsRegistry) {
         INSTANCE = new JmxReporter(defaultMetricsRegistry);
-        INSTANCE.start();
+        INSTANCE.start(1, TimeUnit.MINUTES);
     }
 
     public JmxReporter(MetricsRegistry metricsRegistry) {
@@ -313,8 +313,8 @@ public class JmxReporter extends AbstractReporter {
         this.server = ManagementFactory.getPlatformMBeanServer();
     }
 
-    public void start() {
-        tickThread.scheduleAtFixedRate(this, 0, 1, TimeUnit.MINUTES);
+    public void start(long period, TimeUnit unit) {
+        tickThread.scheduleAtFixedRate(this, 0, period, unit);
         // then schedule the tick thread every 100ms for the next second so
         // as to pick up the initialization of most metrics (in the first 1s of
         // the application lifecycle) w/o incurring a high penalty later on


### PR DESCRIPTION
Moved the start() method to Abstract Reporter and update JmxReporter to match.

This enables injecting a Reporter as a dependency:

```
public Foo(AbstractReporter reporter) {
    this.reporter = reporter;
    reporter.start(60, TimeUnit.SECONDS);
}
```
