### PR TITLE
Fix a NullPointerException caused by a thread becoming inactive after fet

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/core/VirtualMachineMetrics.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/VirtualMachineMetrics.java
@@ -201,12 +201,16 @@ public class VirtualMachineMetrics {
 
         final long[] allThreadIds = getThreadMXBean().getAllThreadIds();
         final ThreadInfo[] allThreads = getThreadMXBean().getThreadInfo(allThreadIds);
+        int liveCount = 0;
         for (ThreadInfo info : allThreads) {
-            final State state = info.getThreadState();
-            conditions.put(state, conditions.get(state) + 1);
+            if (info != null) {
+                final State state = info.getThreadState();
+                conditions.put(state, conditions.get(state) + 1);
+                liveCount++;
+            }
         }
         for (State state : new ArrayList<State>(conditions.keySet())) {
-            conditions.put(state, conditions.get(state) / allThreads.length);
+            conditions.put(state, conditions.get(state) / liveCount);
         }
 
         return conditions;


### PR DESCRIPTION
Should address the following exception encountered in a dropwizard application…

WARN  [2011-10-06 22:24:03,782] org.eclipse.jetty.servlet.ServletHandler: /metrics
! java.lang.NullPointerException
!       at com.yammer.metrics.core.VirtualMachineMetrics.threadStatePercentages(VirtualMachineMetrics.java:205)
!       at com.yammer.metrics.reporting.MetricsServlet.writeVmMetrics(MetricsServlet.java:368)
!       at com.yammer.metrics.reporting.MetricsServlet.handleMetrics(MetricsServlet.java:240)
!       at com.yammer.metrics.reporting.MetricsServlet.doGet(MetricsServlet.java:151)
!       at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
!       at javax.servlet.http.HttpServlet.service(HttpServlet.java:820)
!       at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:547)
!       at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:481)
!       at org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:940)
!       at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:409)
!       at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:874)
!       at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:117)
!       at org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:149)
!       at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:110)
!       at org.eclipse.jetty.server.Server.handle(Server.java:349)
!       at org.eclipse.jetty.server.HttpConnection.handleRequest(HttpConnection.java:441)
!       at org.eclipse.jetty.server.HttpConnection$RequestHandler.headerComplete(HttpConnection.java:904)
!       at org.eclipse.jetty.http.HttpParser.parseNext(HttpParser.java:565)
!       at org.eclipse.jetty.http.HttpParser.parseAvailable(HttpParser.java:217)
!       at org.eclipse.jetty.server.BlockingHttpConnection.handle(BlockingHttpConnection.java:50)
!       at org.eclipse.jetty.server.bio.SocketConnector$ConnectorEndPoint.run(SocketConnector.java:245)
!       at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:598)
!       at org.eclipse.jetty.util.thread.QueuedThreadPool$3.run(QueuedThreadPool.java:533)
!       at java.lang.Thread.run(Thread.java:662)
