### PR TITLE
Slightly better random generation for reservoir sampling

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/stats/UniformSample.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/stats/UniformSample.java
@@ -55,12 +55,27 @@ public class UniformSample implements Sample {
         if (c <= values.length()) {
             values.set((int) c - 1, value);
         } else {
-            final long r = Math.abs(RANDOM.nextLong()) % c;
+            final long r = nextLong(c);
             if (r < values.length()) {
                 values.set((int) r, value);
             }
         }
     }
+
+    /**
+     * Get a pseurandom long uniformally between 0 and n-1.
+     * Stolen from {@code Random.nextInt(int n)}
+     * @param n the bound
+     */
+    private static long nextLong(long n) {
+        long bits,val;
+        do {
+            bits = RANDOM.nextLong() & (~(1L<<63));
+            val = bits % n;
+        } while(bits - val + (n-1) < 0L);
+        return val;
+    }
+
 
     @Override
     public List<Long> values() {


### PR DESCRIPTION
`nextLong() % n` Is ever so slightly not uniform since `2^63` is generally not a multiple of `n`. Truthfully you would need 10+ million calls to even get a tiny change of seeing `nextLong()` return a number in "unfair range" (i.e. above `Long.MAX_VALUE-Long.MAX_VALUE%n`), but even if it doesn't happen the only cost is the extra function call
