### PR TITLE
Modified the Guice Listeners to support non-public methods.

### DIFF
--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/MeteredListener.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/MeteredListener.java
@@ -22,7 +22,7 @@ public class MeteredListener implements TypeListener {
     @Override
     public <T> void hear(TypeLiteral<T> literal,
                          TypeEncounter<T> encounter) {
-        for (Method method : literal.getRawType().getMethods()) {
+        for (Method method : literal.getRawType().getDeclaredMethods()) {
             final Metered annotation = method.getAnnotation(Metered.class);
             if (annotation != null) {
                 final String name = annotation.name().isEmpty() ? method.getName() : annotation.name();

--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/TimedListener.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/TimedListener.java
@@ -22,7 +22,7 @@ public class TimedListener implements TypeListener {
     @Override
     public <T> void hear(TypeLiteral<T> literal,
                          TypeEncounter<T> encounter) {
-        for (Method method : literal.getRawType().getMethods()) {
+        for (Method method : literal.getRawType().getDeclaredMethods()) {
             final Timed annotation = method.getAnnotation(Timed.class);
             if (annotation != null) {
                 final String name = annotation.name().isEmpty() ? method.getName() : annotation.name();

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/GaugeTest.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/GaugeTest.java
@@ -7,6 +7,7 @@ import com.yammer.metrics.core.Metric;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
 import com.yammer.metrics.guice.InstrumentationModule;
+
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.instanceOf;
@@ -15,6 +16,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 public class GaugeTest {
+	
     @Test
     @SuppressWarnings("unchecked")
     public void aGaugeAnnotatedMethod() throws Exception {
@@ -38,5 +40,31 @@ public class GaugeTest {
         assertThat("Guice creates a gauge with the given value",
                    ((GaugeMetric<String>) metric).value(),
                    is("poop"));
+    }
+    
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void aGaugeAnnotatedMethodWithDefaultName() throws Exception {
+        final Injector injector = Guice.createInjector(new InstrumentationModule());
+        final InstrumentedWithGauge instance = injector.getInstance(InstrumentedWithGauge.class);
+        final MetricsRegistry registry = injector.getInstance(MetricsRegistry.class);
+        
+        instance.doAnotherThing();
+
+        final Metric metric = registry.allMetrics().get(new MetricName(InstrumentedWithGauge.class,
+                                                                       "doAnotherThing"));
+
+        assertThat("Guice creates a metric",
+                   metric,
+                   is(notNullValue()));
+
+        assertThat("Guice creates a gauge",
+                   metric,
+                   is(instanceOf(GaugeMetric.class)));
+
+        assertThat("Guice creates a gauge with the given value",
+                   ((GaugeMetric<String>) metric).value(),
+                   is("anotherThing"));
     }
 }

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithGauge.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithGauge.java
@@ -6,5 +6,9 @@ public class InstrumentedWithGauge {
     @Gauge(name = "things")
     public String doAThing() {
         return "poop";
-    }
+    }    
+    @Gauge
+    public String doAnotherThing() {
+        return "anotherThing";    	
+    }    
 }

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithMetered.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithMetered.java
@@ -9,4 +9,12 @@ public class InstrumentedWithMetered {
     public String doAThing() {
         return "poop";
     }
+    @Metered
+    String doAThingWithDefaultScope() {
+        return "defaultResult";
+    }
+    @Metered
+    protected String doAThingWithProtectedScope() {
+        return "defaultProtected";
+    }
 }

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithTimed.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithTimed.java
@@ -9,4 +9,12 @@ public class InstrumentedWithTimed {
     public String doAThing() {
         return "poop";
     }
+    @Timed
+    String doAThingWithDefaultScope() {
+        return "defaultResult";
+    }
+    @Timed
+    protected String doAThingWithProtectedScope() {
+        return "defaultProtected";
+    }
 }

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/MeteredTest.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/MeteredTest.java
@@ -4,6 +4,8 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.yammer.metrics.core.*;
 import com.yammer.metrics.guice.InstrumentationModule;
+
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -14,24 +16,26 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 public class MeteredTest {
+
+    InstrumentedWithMetered instance;
+    MetricsRegistry registry;
+	
+	@Before
+	public void setup() {
+		Injector injector = Guice.createInjector(new InstrumentationModule());
+        instance = injector.getInstance(InstrumentedWithMetered.class);	
+        registry = injector.getInstance(MetricsRegistry.class);
+	}
+	
     @Test
     public void aMeteredAnnotatedMethod() throws Exception {
-        final Injector injector = Guice.createInjector(new InstrumentationModule());
-        final InstrumentedWithMetered instance = injector.getInstance(InstrumentedWithMetered.class);
-        final MetricsRegistry registry = injector.getInstance(MetricsRegistry.class);
 
         instance.doAThing();
 
         final Metric metric = registry.allMetrics().get(new MetricName(InstrumentedWithMetered.class,
                                                                        "things"));
 
-        assertThat("Guice creates a metric",
-                   metric,
-                   is(notNullValue()));
-
-        assertThat("Guice creates a meter",
-                   metric,
-                   is(instanceOf(MeterMetric.class)));
+        assertMetricIsSetup(metric);
 
         assertThat("Guice creates a meter which gets marked",
                    ((MeterMetric) metric).count(),
@@ -44,6 +48,52 @@ public class MeteredTest {
         assertThat("Guice creates a meter with the given rate unit",
                    ((MeterMetric) metric).rateUnit(),
                    is(TimeUnit.MINUTES));
-
     }
+	
+    @Test
+    public void aMeteredAnnotatedMethodWithDefaultScope() throws Exception {
+
+        final Metric metric = registry.allMetrics().get(new MetricName(InstrumentedWithMetered.class,
+                                                                       "doAThingWithDefaultScope"));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+                   ((MeterMetric) metric).count(),
+                   is(0L));
+        
+        instance.doAThingWithDefaultScope();        
+
+        assertThat("Metric is marked",
+                   ((MeterMetric) metric).count(),
+                   is(1L));
+    }
+	
+    @Test
+    public void aMeteredAnnotatedMethodWithProtectedScope() throws Exception {
+
+        final Metric metric = registry.allMetrics().get(new MetricName(InstrumentedWithMetered.class,
+                                                                       "doAThingWithProtectedScope"));
+
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+                   ((MeterMetric) metric).count(),
+                   is(0L));
+        
+        instance.doAThingWithProtectedScope();        
+
+        assertThat("Metric is marked",
+                   ((MeterMetric) metric).count(),
+                   is(1L));
+    }
+
+	private void assertMetricIsSetup(final Metric metric) {
+		assertThat("Guice creates a metric",
+                   metric,
+                   is(notNullValue()));
+
+        assertThat("Guice creates a meter",
+                   metric,
+                   is(instanceOf(MeterMetric.class)));
+	}
 }


### PR DESCRIPTION
Hi,

Thanks for maintaining this fantastic library, it's great.

Yesterday, I wanted to instrument non-public methods. Guice can intercept methods for public, protected, and default scopes, so it was a really simple change to make metrics-guice support these additional scopes.  Would you have any objections including this in the main project?

Thanks,

Charles
