### PR TITLE
Added support for Guice to create an MeterMetric to monitor exceptions

### DIFF
--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/ExceptionMetered.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/ExceptionMetered.java
@@ -1,0 +1,71 @@
+package com.yammer.metrics.guice;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An annotation for marking a method of a Guice-provided object as metered.
+ *
+ * Given a method like this:
+ * <pre><code>
+ *     ExceptionMetered(name = "fancyName", eventType = "namings", rateUnit = TimeUnit.SECONDS, cause=IllegalArgumentException.class)
+ *     public String fancyName(String name) {
+ *         return "Sir Captain " + name;
+ *     }
+ * </code></pre>
+ *
+ * A meter for the defining class with the name {@code fancyName} will be
+ * created and each time the {@code #fancyName(String)} throws an 
+ * exception of type {@code cause} (or a subclass), the meter will be 
+ * marked.
+ * 
+ * By default, the annotation default to capturing all exceptions 
+ * (subclasses of {@link Exception}) and will use the default 
+ * event-type of "exceptions".
+ * 
+ * A name for the metric can be specified as an annotation parameter,
+ * otherwise, the metric will be named based on the method name.
+ * 
+ * For instance, given a declaration of
+ * <pre><code>
+ *     ExceptionMetered
+ *     public String fancyName(String name) {
+ *         return "Sir Captain " + name;
+ *     }
+ * </code></pre>
+ * 
+ * A meter named {@code fancyNameExceptionMetric} will be created with
+ * event-type named "exceptions". The meter will be marked every time 
+ * an exception is thrown.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ExceptionMetered {
+	
+	String DEFAULT_NAME_SUFFIX = "ExceptionMetric";
+
+	/**
+     * The name of the meter. If not specified, the meter will be given a name
+     * based on the method it decorates and the suffice "_ExceptionMetric" 
+     */
+    String name() default "";
+
+    /**
+     * The name of the type of events the meter is measuring. The event type 
+     * defaults to "exceptions".
+     */
+    String eventType() default "exceptions";
+
+    /**
+     * The time unit of the meter's rate. Defaults to Seconds.
+     */
+    TimeUnit rateUnit() default TimeUnit.SECONDS;
+    
+    /**
+     * The type of exceptions that the meter will catch and count.
+     */
+    Class<? extends Throwable> cause() default Exception.class;
+}

--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/ExceptionMeteredInterceptor.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/ExceptionMeteredInterceptor.java
@@ -1,0 +1,33 @@
+package com.yammer.metrics.guice;
+
+import com.yammer.metrics.core.MeterMetric;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+/**
+ * A method interceptor which creates a meter for the declaring class with the
+ * given name (or the method's name, if none was provided), and which measures
+ * the rate at which the annotated method throws exceptions of a given type.
+ */
+public class ExceptionMeteredInterceptor implements MethodInterceptor {
+    private final MeterMetric meter;
+    private final Class<? extends Throwable> exceptionClazz;
+
+    public ExceptionMeteredInterceptor(MeterMetric meter, Class<? extends Throwable> exceptionClazz) {
+        this.meter = meter;
+        this.exceptionClazz = exceptionClazz;
+    }
+
+    @Override
+    public Object invoke(MethodInvocation invocation) throws Throwable {
+    	try {
+    		return invocation.proceed();
+    	} catch (Throwable t) {
+    		Class<? extends Throwable> caught = t.getClass();
+    		if (exceptionClazz.isAssignableFrom(caught)) {
+    			meter.mark();
+    		}
+    		throw t;
+    	}
+    }
+}

--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/ExceptionMeteredListener.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/ExceptionMeteredListener.java
@@ -1,0 +1,43 @@
+package com.yammer.metrics.guice;
+
+import com.google.inject.TypeLiteral;
+import com.google.inject.matcher.Matchers;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.spi.TypeListener;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.MeterMetric;
+
+import java.lang.reflect.Method;
+
+/**
+ * A listener which adds method interceptors to methods that should be instrumented for exceptions
+ */
+public class ExceptionMeteredListener implements TypeListener {
+    private final MetricsRegistry metricsRegistry;
+
+    public ExceptionMeteredListener(MetricsRegistry metricsRegistry) {
+        this.metricsRegistry = metricsRegistry;
+    }
+
+    @Override
+    public <T> void hear(TypeLiteral<T> literal,
+                         TypeEncounter<T> encounter) {
+        for (Method method : literal.getRawType().getDeclaredMethods()) {
+            final ExceptionMetered annotation = method.getAnnotation(ExceptionMetered.class);
+            if (annotation != null) {
+                final String name = determineName(annotation, method);
+                final MeterMetric meter = metricsRegistry.newMeter(literal.getRawType(), name, annotation.eventType(), annotation.rateUnit());
+                ExceptionMeteredInterceptor interceptor = new ExceptionMeteredInterceptor(meter, annotation.cause());
+				encounter.bindInterceptor(Matchers.only(method), interceptor);
+            }
+        }
+    }
+    
+    private String determineName(final ExceptionMetered annotation, final Method method) {
+    	if (annotation.name().isEmpty()) {
+    		return method.getName() + ExceptionMetered.DEFAULT_NAME_SUFFIX;
+    	} else {
+    		return annotation.name();
+    	}
+    }
+}

--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/InstrumentationModule.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/InstrumentationModule.java
@@ -27,5 +27,6 @@ public class InstrumentationModule extends AbstractModule {
         bindListener(Matchers.any(), new MeteredListener(metricsRegistry));
         bindListener(Matchers.any(), new TimedListener(metricsRegistry));
         bindListener(Matchers.any(), new GaugeListener(metricsRegistry));
+        bindListener(Matchers.any(), new ExceptionMeteredListener(metricsRegistry));
     }
 }

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/ExceptionMeteredTest.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/ExceptionMeteredTest.java
@@ -1,0 +1,373 @@
+package com.yammer.metrics.guice.tests;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.yammer.metrics.core.*;
+import com.yammer.metrics.guice.ExceptionMetered;
+import com.yammer.metrics.guice.InstrumentationModule;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class ExceptionMeteredTest {
+
+	InstrumentedWithExceptionMetered instance;
+    MetricsRegistry registry;
+	
+	@Before
+	public void setup() {
+		Injector injector = Guice.createInjector(new InstrumentationModule());
+        instance = injector.getInstance(InstrumentedWithExceptionMetered.class);	
+        registry = injector.getInstance(MetricsRegistry.class);
+	}
+	
+    @Test
+    public void anExceptionMeteredAnnotatedMethodWithPublicScope() throws Exception {
+
+        final Metric metric = registry.allMetrics().get(new MetricName(InstrumentedWithExceptionMetered.class,
+                                                                       "exceptionCounter"));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+                   ((MeterMetric) metric).count(),
+                   is(0L));
+        
+        try {
+        	instance.explodeWithPublicScope(true);
+        	fail("Expected an exception to be thrown");
+        } catch(RuntimeException e) {      
+        	// Swallow the expected exception
+        }
+        
+        assertThat("Metric is marked",
+                   ((MeterMetric) metric).count(),
+                   is(1L));
+    }
+    
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithNoMetricName() throws Exception {
+
+        final Metric metric = registry.allMetrics().get(new MetricName(InstrumentedWithExceptionMetered.class,
+                                                                       "explodeForUnnamedMetric" + ExceptionMetered.DEFAULT_NAME_SUFFIX));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+                   ((MeterMetric) metric).count(),
+                   is(0L));
+        
+        try {
+        	instance.explodeForUnnamedMetric();
+        	fail("Expected an exception to be thrown");
+        } catch(RuntimeException e) {      
+        	// Swallow the expected exception
+        }
+        
+        assertThat("Metric is marked",
+                   ((MeterMetric) metric).count(),
+                   is(1L));
+    }
+    
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithPublicScopeButNoExceptionThrown() throws Exception {
+
+        final Metric metric = registry.allMetrics().get(new MetricName(InstrumentedWithExceptionMetered.class,
+                                                                       "exceptionCounter"));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+                   ((MeterMetric) metric).count(),
+                   is(0L));
+        
+        instance.explodeWithPublicScope(false);
+        
+        assertThat("Metric should remain at zero if no exception is thrown",
+                   ((MeterMetric) metric).count(),
+                   is(0L));
+    }
+	
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithDefaultScope() throws Exception {
+
+        final Metric metric = registry.allMetrics().get(new MetricName(InstrumentedWithExceptionMetered.class,
+                                                                       "explodeWithDefaultScopeExceptionMetric"));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+                   ((MeterMetric) metric).count(),
+                   is(0L));
+
+        try {
+        	instance.explodeWithDefaultScope();
+        	fail("Expected an exception to be thrown");
+        } catch(RuntimeException e) {        	
+        }       
+
+        assertThat("Metric is marked",
+                   ((MeterMetric) metric).count(),
+                   is(1L));
+    }
+	
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithProtectedScope() throws Exception {
+
+        final Metric metric = registry.allMetrics().get(new MetricName(InstrumentedWithExceptionMetered.class,
+                                                                       "explodeWithProtectedScopeExceptionMetric"));
+
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+                   ((MeterMetric) metric).count(),
+                   is(0L));
+        
+        try {
+        	instance.explodeWithProtectedScope();
+        	fail("Expected an exception to be thrown");
+        } catch(RuntimeException e) {        	
+        }        
+
+        assertThat("Metric is marked",
+                   ((MeterMetric) metric).count(),
+                   is(1L));
+    }
+    
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithPublicScope_AndSpecificTypeOfException() throws Exception {
+
+        final Metric metric = registry.allMetrics().get(new MetricName(InstrumentedWithExceptionMetered.class,
+                                                                       "failures"));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+                   ((MeterMetric) metric).count(),
+                   is(0L));
+        try {
+        	instance.errorProneMethod(new MyException());
+        	fail("Expected an exception to be thrown");
+        } catch(MyException e) {        	
+        } 
+        
+        assertThat("Metric should be marked when the specified exception type is thrown",
+                   ((MeterMetric) metric).count(),
+                   is(1L));
+    }
+    
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithPublicScope_AndSubclassesOfSpecifiedException() throws Exception {
+
+        final Metric metric = registry.allMetrics().get(new MetricName(InstrumentedWithExceptionMetered.class,
+                                                                       "failures"));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+                   ((MeterMetric) metric).count(),
+                   is(0L));
+        try {
+        	instance.errorProneMethod(new MySpecialisedException());
+        	fail("Expected an exception to be thrown");
+        } catch(MyException e) {        	
+        } 
+        
+        assertThat("Metric should be marked when a subclass of the specified exception type is thrown",
+                   ((MeterMetric) metric).count(),
+                   is(1L));
+    }
+    
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithPublicScope_ButDifferentTypeOfException() throws Exception {
+
+        final Metric metric = registry.allMetrics().get(new MetricName(InstrumentedWithExceptionMetered.class,
+                                                                       "failures"));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+                   ((MeterMetric) metric).count(),
+                   is(0L));
+        try {
+        	instance.errorProneMethod(new MyOtherException());
+        	fail("Expected an exception to be thrown");
+        } catch(MyOtherException e) {        	
+        } 
+        
+        assertThat("Metric should not be marked if the exception is a different type",
+                   ((MeterMetric) metric).count(),
+                   is(0L));
+    }
+    
+    @Test
+    public void anExceptionMeteredAnnotatedMethod_WithExtraOptions() throws Exception {
+    	
+    	try {
+    		instance.causeAnOutOfBoundsException();
+    	} catch (ArrayIndexOutOfBoundsException e) {
+    		
+    	}
+
+        final Metric metric = registry.allMetrics().get(new MetricName(InstrumentedWithExceptionMetered.class,
+                                                                       "things"));
+
+        assertMetricIsSetup(metric);
+
+        assertThat("Guice creates a meter which gets marked",
+                   ((MeterMetric) metric).count(),
+                   is(1L));
+
+        assertThat("Guice creates a meter with the given event type",
+                   ((MeterMetric) metric).eventType(),
+                   is("poops"));
+
+        assertThat("Guice creates a meter with the given rate unit",
+                   ((MeterMetric) metric).rateUnit(),
+                   is(TimeUnit.MINUTES));
+    }
+   
+
+    @Test
+    public void aMethodAnnotatedWithBothATimerAndAnExceptionCounter() throws Exception {
+
+        final Metric timedMetric = registry.allMetrics().get(new MetricName(InstrumentedWithExceptionMetered.class,
+                                                                       "timedAndException"));
+        
+        final Metric errorMetric = registry.allMetrics().get(new MetricName(InstrumentedWithExceptionMetered.class,
+        																"timedAndExceptionExceptionMetric"));
+
+		assertThat("Guice creates a metric",
+				timedMetric,
+                   is(notNullValue()));
+
+        assertThat("Guice creates a timer",
+        		timedMetric,
+                   is(instanceOf(TimerMetric.class)));        
+
+		assertThat("Guice creates a metric",
+				errorMetric,
+                   is(notNullValue()));
+
+        assertThat("Guice creates a meter",
+        		errorMetric,
+                   is(instanceOf(MeterMetric.class)));
+        
+        // Counts should start at zero        
+        assertThat("Timer Metric should be zero when initialised",
+                   ((TimerMetric) timedMetric).count(),
+                   is(0L));
+        
+        
+        assertThat("Error Metric should be zero when initialised",
+                   ((MeterMetric) errorMetric).count(),
+                   is(0L));
+        
+        // Invoke, but don't throw an exception
+        instance.timedAndException(null);
+        
+        assertThat("Expected the meter metric to be marked on invocation",
+                   ((TimerMetric) timedMetric).count(),
+                   is(1L));
+                
+        assertThat("Expected the exception metric to be zero since no exceptions thrown",
+                   ((MeterMetric) errorMetric).count(),
+                   is(0L));
+
+        // Invoke and throw an exception
+        try {
+        	instance.timedAndException(new RuntimeException());
+        	fail("Should have thrown an exception");
+        } catch (Exception e) {}
+      
+        assertThat("Expected a count of 2, one for each invocation",
+                   ((TimerMetric) timedMetric).count(),
+                   is(2L));
+                
+        assertThat("Expected exception count to be 1 as one (of two) invocations threw an exception",
+                   ((MeterMetric) errorMetric).count(),
+                   is(1L));
+        
+    }
+    
+    @Test
+    public void aMethodAnnotatedWithBothAMeteredAndAnExceptionCounter() throws Exception {
+
+        final Metric meteredMetric = registry.allMetrics().get(new MetricName(InstrumentedWithExceptionMetered.class,
+                                                                       "meteredAndException"));
+        
+        final Metric errorMetric = registry.allMetrics().get(new MetricName(InstrumentedWithExceptionMetered.class,
+        																"meteredAndExceptionExceptionMetric"));
+
+		assertThat("Guice creates a metric",
+				meteredMetric,
+                   is(notNullValue()));
+
+        assertThat("Guice creates a meter",
+        		meteredMetric,
+                   is(instanceOf(MeterMetric.class)));        
+
+		assertThat("Guice creates a metric",
+				errorMetric,
+                   is(notNullValue()));
+
+        assertThat("Guice creates an exception meter",
+        		errorMetric,
+                   is(instanceOf(MeterMetric.class)));
+        
+        // Counts should start at zero        
+        assertThat("Meter Metric should be zero when initialised",
+                   ((MeterMetric) meteredMetric).count(),
+                   is(0L));
+        
+        
+        assertThat("Error Metric should be zero when initialised",
+                   ((MeterMetric) errorMetric).count(),
+                   is(0L));
+        
+        // Invoke, but don't throw an exception
+        instance.meteredAndException(null);
+        
+        assertThat("Expected the meter metric to be marked on invocation",
+                   ((MeterMetric) meteredMetric).count(),
+                   is(1L));
+                
+        assertThat("Expected the exception metric to be zero since no exceptions thrown",
+                   ((MeterMetric) errorMetric).count(),
+                   is(0L));
+
+        // Invoke and throw an exception
+        try {
+        	instance.meteredAndException(new RuntimeException());
+        	fail("Should have thrown an exception");
+        } catch (Exception e) {}
+      
+        assertThat("Expected a count of 2, one for each invocation",
+                   ((MeterMetric) meteredMetric).count(),
+                   is(2L));
+                
+        assertThat("Expected exception count to be 1 as one (of two) invocations threw an exception",
+                   ((MeterMetric) errorMetric).count(),
+                   is(1L));
+        
+    }
+
+	private void assertMetricIsSetup(final Metric metric) {
+		assertThat("Guice creates a metric",
+                   metric,
+                   is(notNullValue()));
+
+        assertThat("Guice creates a meter",
+                   metric,
+                   is(instanceOf(MeterMetric.class)));
+	}		
+	
+	@SuppressWarnings("serial")
+	private static class MyOtherException extends RuntimeException {
+	}
+	
+	@SuppressWarnings("serial")
+	private static class MySpecialisedException extends MyException {
+	}
+}

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithExceptionMetered.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithExceptionMetered.java
@@ -1,0 +1,64 @@
+package com.yammer.metrics.guice.tests;
+
+import com.yammer.metrics.guice.ExceptionMetered;
+import com.yammer.metrics.guice.Metered;
+import com.yammer.metrics.guice.Timed;
+
+import java.util.concurrent.TimeUnit;
+
+public class InstrumentedWithExceptionMetered {
+	
+	@ExceptionMetered(name = "exceptionCounter")
+	String explodeWithPublicScope(boolean explode) {
+		if (explode) {
+			throw new RuntimeException("Boom!");
+		} else {
+			return "calm";
+		}
+	}
+	
+	@ExceptionMetered
+	String explodeForUnnamedMetric() {
+		throw new RuntimeException("Boom!");
+	}
+
+	@ExceptionMetered
+	String explodeWithDefaultScope() {
+		throw new RuntimeException("Boom!");
+	}
+
+	@ExceptionMetered
+	protected String explodeWithProtectedScope() {
+		throw new RuntimeException("Boom!");
+	}
+
+	@ExceptionMetered(name = "failures", cause = MyException.class)
+	public void errorProneMethod(RuntimeException e) {
+		throw e;
+	}
+	
+	@ExceptionMetered(name = "things", 
+			 eventType = "poops", 
+			 rateUnit =  TimeUnit.MINUTES, 
+			 cause =  ArrayIndexOutOfBoundsException.class)
+	public Object causeAnOutOfBoundsException() {
+		Object[] arr = {};
+		return arr[1];
+	}
+	
+	@Timed
+	@ExceptionMetered
+	public void timedAndException(RuntimeException e) {
+		if (e != null) {
+			throw e;
+		}
+	}
+	
+	@Metered
+	@ExceptionMetered
+	public void meteredAndException(RuntimeException e) {
+		if (e != null) {
+			throw e;
+		}
+	}
+}

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/MyException.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/MyException.java
@@ -1,0 +1,6 @@
+package com.yammer.metrics.guice.tests;
+
+@SuppressWarnings("serial")
+public class MyException extends RuntimeException {
+
+}


### PR DESCRIPTION
Hi,

Thanks for accepting my last patch. Would this addition be of any interest to you? I've found it helps solve a frequently occurring pattern and removes lots of boiler-plate.

Thanks,

Charles
# 

When instrumenting classes with the annotations in metrics-guice, it is
sometimes desirable to count the number of times a method has failed.
Previously, this resulted in lots of occurrences of the following pattern:

@Metered
public void doBlah() throws MyException {
  try {
    ...
  } catch (MyException e) {
    failureMetric.mark();
    throw e;
  }
}

This commit introduces a new annotation @ExceptionMetered to the
metrics-guice module. This new annotation has similar semantics to the
existing @Metered annotation, but instead of counting invocations of the
decorated method, it counts the number of invocations that resulted in
an exception being thrown. It can be used in conjunction with the
existing @Metered and @Timed annotation. For example, the above example
can be written as:

@Metered
@ExceptionMetered(cause=MyException.class)
public void doBlah() throws MyException {
    ...
}

As usual, the new annotation takes arguments to modify the name and
units of the metric. Using the "cause" field, it is possible to
specify the type of Throwable (defaults to java.lang.Exception) that
the instrumentation will capture.
