### PR TITLE
Ganglia - Metric Name Cleanup

### DIFF
--- a/metrics-ganglia/src/test/java/com/yammer/metrics/reporting/GangliaReporterTest.java
+++ b/metrics-ganglia/src/test/java/com/yammer/metrics/reporting/GangliaReporterTest.java
@@ -1,0 +1,25 @@
+package com.yammer.metrics.reporting;
+
+import org.junit.Test;
+import java.io.IOException;
+import static junit.framework.Assert.assertEquals;
+
+public class GangliaReporterTest {
+
+    @Test
+    public void testSanitizeName_noBadCharacters() throws IOException {
+        String metricName = "thisIsACleanMetricName";
+        GangliaReporter gangliaReporter = new GangliaReporter("localhost", 5555);
+        String cleanMetricName = gangliaReporter.sanitizeName(metricName);
+        assertEquals("clean metric name was changed unexpectedly", metricName, cleanMetricName);
+    }
+
+    @Test
+    public void testSanitizeName_badCharacters() throws IOException {
+        String metricName = "thisIsAC>&!>leanMetric Name";
+        String expectedMetricName = "thisIsAC____leanMetric_Name";
+        GangliaReporter gangliaReporter = new GangliaReporter("localhost", 5555);
+        String cleanMetricName = gangliaReporter.sanitizeName(metricName);
+        assertEquals("clean metric name did not match expected value", expectedMetricName, cleanMetricName);
+    }
+}


### PR DESCRIPTION
minor changes to GangliaReporter to make sure metric names are compatible with the ganglia spec and add an option to use short package names when reporting to ganglia.
