### PR TITLE
Add Stoppable interface for metrics that can be stopped

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/core/MeterMetric.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/MeterMetric.java
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * @see <a href="http://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average">EMA</a>
  */
-public class MeterMetric implements Metered {
+public class MeterMetric implements Metered, Stoppable {
     private static final long INTERVAL = 5; // seconds
 
     /**
@@ -139,7 +139,8 @@ public class MeterMetric implements Metered {
         return ratePerNs * (double) rateUnit.toNanos(1);
     }
 
-    void stop() {
+    @Override
+    public void stop() {
         future.cancel(false);
     }
 }

--- a/metrics-core/src/main/java/com/yammer/metrics/core/MetricsRegistry.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/MetricsRegistry.java
@@ -446,10 +446,8 @@ public class MetricsRegistry {
     public void removeMetric(MetricName name) {
         final Metric metric = metrics.remove(name);
         if (metric != null) {
-            if (metric instanceof MeterMetric) {
-                ((MeterMetric) metric).stop();
-            } else if (metric instanceof TimerMetric) {
-                ((TimerMetric) metric).stop();
+            if (metric instanceof Stoppable) {
+                ((Stoppable) metric).stop();
             }
             notifyMetricRemoved(name);
         }

--- a/metrics-core/src/main/java/com/yammer/metrics/core/Stoppable.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/Stoppable.java
@@ -1,0 +1,9 @@
+package com.yammer.metrics.core;
+
+/**
+ * Interface for {@link Metric} instances that can be stopped.
+ */
+public interface Stoppable {
+
+    public void stop();
+}

--- a/metrics-core/src/main/java/com/yammer/metrics/core/TimerMetric.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/TimerMetric.java
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit;
  * A timer metric which aggregates timing durations and provides duration
  * statistics, plus throughput statistics via {@link MeterMetric}.
  */
-public class TimerMetric implements Metered {
+public class TimerMetric implements Metered, Stoppable {
 
     private final TimeUnit durationUnit, rateUnit;
     private final MeterMetric meter;
@@ -243,7 +243,8 @@ public class TimerMetric implements Metered {
         return ns / TimeUnit.NANOSECONDS.convert(1, durationUnit);
     }
 
-    void stop() {
+    @Override
+    public void stop() {
         meter.stop();
     }
 }


### PR DESCRIPTION
In my quest to annihilate instanceof usage I propose using an interface to determine if a metrics instance should be stopped.
