### PR TITLE
Allow subclasses to add metrics to MetricsRegistry

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/core/MetricsRegistry.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/MetricsRegistry.java
@@ -285,12 +285,7 @@ public class MetricsRegistry {
         final Metric existingMetric = metrics.get(metricName);
         if (existingMetric == null) {
             final MeterMetric metric = MeterMetric.newMeter(newMeterTickThreadPool(), eventType, unit);
-            final Metric justAddedMetric = metrics.putIfAbsent(metricName, metric);
-            if (justAddedMetric == null) {
-                notifyMetricAdded(metricName, metric);
-                return metric;
-            }
-            return (MeterMetric) justAddedMetric;
+            return getOrAdd(metricName, metric);
         }
         return (MeterMetric) existingMetric;
     }
@@ -374,12 +369,7 @@ public class MetricsRegistry {
         final Metric existingMetric = metrics.get(metricName);
         if (existingMetric == null) {
             final TimerMetric metric = new TimerMetric(newMeterTickThreadPool(), durationUnit, rateUnit);
-            final Metric justAddedMetric = metrics.putIfAbsent(metricName, metric);
-            if (justAddedMetric == null) {
-                notifyMetricAdded(metricName, metric);
-                return metric;
-            }
-            return (TimerMetric) justAddedMetric;
+            return getOrAdd(metricName, metric);
         }
         return (TimerMetric) existingMetric;
     }
@@ -466,7 +456,7 @@ public class MetricsRegistry {
     }
 
     @SuppressWarnings("unchecked")
-    private <T extends Metric> T getOrAdd(MetricName name, T metric) {
+    protected final <T extends Metric> T getOrAdd(MetricName name, T metric) {
         final Metric existingMetric = metrics.get(name);
         if (existingMetric == null) {
             final Metric justAddedMetric = metrics.putIfAbsent(name, metric);


### PR DESCRIPTION
This is primarily for testing purposes: being able to subclass MetricsRegistry and use getOrAdd() from the subclass to add manually constructed metrics (and possibly mock objects).

I made getOrAdd() `final` since I feels its logic is an integral part of MetricsRegistry that you shouldn't tamper with it. Might be to conservative?

Also took the opportunity to use getOrAdd in `newMeter` and `newTimer`.
