### PR TITLE
Customized binding of JmxReporter

### DIFF
--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/InstrumentationModule.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/InstrumentationModule.java
@@ -23,11 +23,19 @@ public class InstrumentationModule extends AbstractModule {
         MetricsRegistry metricsRegistry = createMetricsRegistry();
         bind(MetricsRegistry.class).toInstance(metricsRegistry);
         bind(HealthCheckRegistry.class).toInstance(createHealthCheckRegistry());
-        bind(JmxReporter.class).toProvider(JmxReporterProvider.class).asEagerSingleton();
+        bindJmxReporter();
         bindListener(Matchers.any(), new MeteredListener(metricsRegistry));
         bindListener(Matchers.any(), new TimedListener(metricsRegistry));
         bindListener(Matchers.any(), new GaugeListener(metricsRegistry));
         bindListener(Matchers.any(), new ExceptionMeteredListener(metricsRegistry));
+    }
+
+    /**
+     * Override to provide a custom binding for {@link JmxReporter}
+     */
+    protected void bindJmxReporter()
+    {
+        bind(JmxReporter.class).toProvider(JmxReporterProvider.class).asEagerSingleton();
     }
 
     /**


### PR DESCRIPTION
When deploying/hot deploying servlets in Tomcat, its important that mbeans of an earlier version of the service gets unregistered when the servlet's context is destroyed. To be able to do this, there needs to be a way of controlling the lifespan of the started JmxReporter (when using Guice).

By allowing a custom binding of the JmxReporter, it will be possible to shut it down when the context is destroyed.
