### PR TITLE
ExponentiallyDecayingSample does not lock when clear() is invoked, this makes it dangerous to use when the sample is live

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/stats/ExponentiallyDecayingSample.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/stats/ExponentiallyDecayingSample.java
@@ -51,10 +51,15 @@ public class ExponentiallyDecayingSample implements Sample {
 
     @Override
     public void clear() {
-        values.clear();
-        count.set(0);
-        this.startTime = tick();
-        nextScaleTime.set(System.nanoTime() + RESCALE_THRESHOLD);
+	lockForRegularUsage();
+        try {
+           values.clear();
+           count.set(0);
+           this.startTime = tick();
+           nextScaleTime.set(System.nanoTime() + RESCALE_THRESHOLD);
+        } finally {
+            unlockForRegularUsage();
+	}
     }
 
     @Override


### PR DESCRIPTION
We recently switched from Ostrich and to retain "metric compatibility" we clear meters after they are reported to Graphite. The lack of locking can break the meter until it is cleared again. If the value map and counter in the sample come out of sync, any update will fail:

```
at java.util.concurrent.ConcurrentSkipListMap.firstKey(ConcurrentSkipListMap.java:1999) ~[na:1.6.0_20]
at com.yammer.metrics.stats.ExponentiallyDecayingSample.update(ExponentiallyDecayingSample.java:84) ~[metrics-core-2.0.0-BETA17.jar:na]
at com.yammer.metrics.stats.ExponentiallyDecayingSample.update(ExponentiallyDecayingSample.java:67) ~[metrics-core-2.0.0-BETA17.jar:na]
at com.yammer.metrics.core.HistogramMetric.update(HistogramMetric.java:113) ~[metrics-core-2.0.0-BETA17.jar:na]
at com.yammer.metrics.core.TimerMetric.update(TimerMetric.java:217) ~[metrics-core-2.0.0-BETA17.jar:na]
at com.yammer.metrics.core.TimerMetric.update(TimerMetric.java:108) ~[metrics-core-2.0.0-BETA17.jar:na]
at com.yammer.metrics.Timer.time(Timer.scala:22) ~[metrics-scala_2.9.1-2.0.0-BETA17.jar:na]
```

As far as I can tell, this requires the the values map to be empty and the count to be larger than reservoirSize. The only initialization of a sample in the core code uses a reservoirSize of 1028. The only place I can see the code going out of sync is if values are inserted between the values.clear() and count.set(0) statements in the clear method, but I think I'm missing something as getting 1028 values inserted by other threads in between the two statements sound a bit unlikely... Even if there is another bug in here, the clear() method should lock or clearly be marked as not thread-safe.
