### PR TITLE
fix compilation issue in GangliaReporterTest

### DIFF
--- a/metrics-ganglia/src/test/java/com/yammer/metrics/reporting/GangliaReporterTest.java
+++ b/metrics-ganglia/src/test/java/com/yammer/metrics/reporting/GangliaReporterTest.java
@@ -103,15 +103,14 @@ public class GangliaReporterTest extends AbstractPollingReporterTest {
 
     @Test
     public void testCompressPackageName() throws IOException {
-        String metricName = "some.long.package.name.thisIsAC>&!>leanMetric Name";
-        String expectedMetricName = "s.l.p.name.thisIsAC____leanMetric_Name";
+        MetricName metricName = new MetricName("some.long.package.name.thisIs", "AC>&!>lean", "Metric Name");
+        String expectedMetricName = "s.l.p.n.t.AC____lean.Metric_Name";
         GangliaReporter gangliaReporter = new GangliaReporter("localhost", 5555, true);
         String cleanMetricName = gangliaReporter.sanitizeName(metricName);
         assertEquals("clean metric name did not match expected value",
                      expectedMetricName,
                      cleanMetricName);
     }
-
 
     protected String getFromFile(String fileName) {
         try {


### PR DESCRIPTION
GangliaReporter now uses MetricName.  Fixed GangliaReporterTest so that it compiles and all tests pass.

[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] metrics-parent .................................... SUCCESS [0.024s]
[INFO] metrics-core ...................................... SUCCESS [1.483s]
[INFO] metrics-ehcache ................................... SUCCESS [0.283s]
[INFO] metrics-ganglia ................................... SUCCESS [1.063s]
[INFO] metrics-graphite .................................. SUCCESS [0.595s]
[INFO] metrics-guice ..................................... SUCCESS [0.827s]
[INFO] metrics-httpclient ................................ SUCCESS [0.285s]
[INFO] metrics-jetty ..................................... SUCCESS [0.630s]
[INFO] metrics-log4j ..................................... SUCCESS [0.272s]
[INFO] metrics-logback ................................... SUCCESS [0.406s]
[INFO] metrics-scala_2.9.1 ............................... SUCCESS [1.591s]
[INFO] metrics-servlet ................................... SUCCESS [0.656s]
[INFO] metrics-web ....................................... SUCCESS [0.241s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 8.691s
[INFO] Finished at: Sun Dec 04 16:54:35 EST 2011
[INFO] Final Memory: 13M/81M
[INFO] ------------------------------------------------------------------------
