### PR TITLE
Add absolute values to JVM Metrics + fix test platform and locale dependency

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/core/VirtualMachineMetrics.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/VirtualMachineMetrics.java
@@ -34,6 +34,34 @@ public class VirtualMachineMetrics {
 
     private VirtualMachineMetrics() { /* unused */ }
 
+	public static double totalInit() {
+		return getMemoryMXBean().getHeapMemoryUsage().getInit() + getMemoryMXBean().getNonHeapMemoryUsage().getInit();
+	}
+	public static double totalUsed() {
+		return getMemoryMXBean().getHeapMemoryUsage().getUsed() + getMemoryMXBean().getNonHeapMemoryUsage().getUsed();
+	}
+	public static double totalMax() {
+		return getMemoryMXBean().getHeapMemoryUsage().getMax() + getMemoryMXBean().getNonHeapMemoryUsage().getMax();
+	}
+	public static double totalCommited() {
+		return getMemoryMXBean().getHeapMemoryUsage().getCommitted() +
+				getMemoryMXBean().getNonHeapMemoryUsage().getCommitted();
+	}
+
+	public static double heapInit() {
+		return getMemoryMXBean().getHeapMemoryUsage().getInit() + getMemoryMXBean().getNonHeapMemoryUsage().getInit();
+	}
+	public static double heapUsed() {
+		return getMemoryMXBean().getHeapMemoryUsage().getUsed() + getMemoryMXBean().getNonHeapMemoryUsage().getUsed();
+	}
+	public static double heapMax() {
+		return getMemoryMXBean().getHeapMemoryUsage().getMax() + getMemoryMXBean().getNonHeapMemoryUsage().getMax();
+	}
+	public static double heapCommited() {
+		return getMemoryMXBean().getHeapMemoryUsage().getCommitted() +
+				getMemoryMXBean().getNonHeapMemoryUsage().getCommitted();
+	}
+
     /**
      * Returns the percentage of the JVM's heap which is being used.
      *

--- a/metrics-core/src/main/java/com/yammer/metrics/reporting/ConsoleReporter.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/reporting/ConsoleReporter.java
@@ -1,216 +1,219 @@
 package com.yammer.metrics.reporting;
 
-import com.yammer.metrics.Metrics;
-import com.yammer.metrics.core.*;
-import com.yammer.metrics.util.MetricPredicate;
-import com.yammer.metrics.util.Utils;
-
 import java.io.PrintStream;
 import java.text.DateFormat;
 import java.util.Date;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Clock;
+import com.yammer.metrics.core.CounterMetric;
+import com.yammer.metrics.core.GaugeMetric;
+import com.yammer.metrics.core.HistogramMetric;
+import com.yammer.metrics.core.Metered;
+import com.yammer.metrics.core.Metric;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricsProcessor;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.TimerMetric;
+import com.yammer.metrics.util.MetricPredicate;
+import com.yammer.metrics.util.Utils;
+
 /**
  * A simple reporters which prints out application metrics to a {@link PrintStream} periodically.
  */
-public class ConsoleReporter extends AbstractPollingReporter implements
-                                                             MetricsProcessor<PrintStream> {
+public class ConsoleReporter extends AbstractPollingReporter implements MetricsProcessor<PrintStream> {
 
-    /**
-     * Enables the console reporter for the default metrics registry, and causes it to print to
-     * STDOUT with the specified period.
-     *
-     * @param period the period between successive outputs
-     * @param unit   the time unit of {@code period}
-     */
-    public static void enable(long period, TimeUnit unit) {
-        enable(Metrics.defaultRegistry(), period, unit);
-    }
+	/**
+	 * Enables the console reporter for the default metrics registry, and causes it to print to STDOUT with the specified
+	 * period.
+	 * 
+	 * @param period
+	 *          the period between successive outputs
+	 * @param unit
+	 *          the time unit of {@code period}
+	 */
+	public static void enable(long period, TimeUnit unit) {
+		enable(Metrics.defaultRegistry(), period, unit);
+	}
 
-    /**
-     * Enables the console reporter for the given metrics registry, and causes it to print to STDOUT
-     * with the specified period and unrestricted output.
-     *
-     * @param metricsRegistry the metrics registry
-     * @param period          the period between successive outputs
-     * @param unit            the time unit of {@code period}
-     */
-    public static void enable(MetricsRegistry metricsRegistry, long period, TimeUnit unit) {
-        final ConsoleReporter reporter = new ConsoleReporter(metricsRegistry,
-                                                             System.out,
-                                                             MetricPredicate.ALL);
-        reporter.start(period, unit);
-    }
+	/**
+	 * Enables the console reporter for the given metrics registry, and causes it to print to STDOUT with the specified
+	 * period and unrestricted output.
+	 * 
+	 * @param metricsRegistry
+	 *          the metrics registry
+	 * @param period
+	 *          the period between successive outputs
+	 * @param unit
+	 *          the time unit of {@code period}
+	 */
+	public static void enable(MetricsRegistry metricsRegistry, long period, TimeUnit unit) {
+		final ConsoleReporter reporter = new ConsoleReporter(metricsRegistry, System.out, MetricPredicate.ALL);
+		reporter.start(period, unit);
+	}
 
-    private final PrintStream out;
-    private final MetricPredicate predicate;
-    private final Clock clock;
-    private final TimeZone timeZone;
+	private final PrintStream			out;
+	private final MetricPredicate	predicate;
+	private final Clock						clock;
+	private final TimeZone				timeZone;
+	private final Locale					locale;
 
-    /**
-     * Creates a new {@link ConsoleReporter} for the default metrics registry, with unrestricted
-     * output.
-     *
-     * @param out the {@link java.io.PrintStream} to which output will be written
-     */
-    public ConsoleReporter(PrintStream out) {
-        this(Metrics.defaultRegistry(), out, MetricPredicate.ALL);
-    }
+	/**
+	 * Creates a new {@link ConsoleReporter} for the default metrics registry, with unrestricted output.
+	 * 
+	 * @param out
+	 *          the {@link java.io.PrintStream} to which output will be written
+	 */
+	public ConsoleReporter(PrintStream out) {
+		this(Metrics.defaultRegistry(), out, MetricPredicate.ALL);
+	}
 
-    /**
-     * Creates a new {@link ConsoleReporter} for a given metrics registry.
-     *
-     * @param metricsRegistry the metrics registry
-     * @param out             the {@link java.io.PrintStream} to which output will be written
-     * @param predicate       the {@link MetricPredicate} used to determine whether a metric will be
-     *                        output
-     */
-    public ConsoleReporter(MetricsRegistry metricsRegistry, PrintStream out, MetricPredicate predicate) {
-        this(metricsRegistry, out, predicate, Clock.DEFAULT, TimeZone.getDefault());
-    }
+	/**
+	 * Creates a new {@link ConsoleReporter} for a given metrics registry.
+	 * 
+	 * @param metricsRegistry
+	 *          the metrics registry
+	 * @param out
+	 *          the {@link java.io.PrintStream} to which output will be written
+	 * @param predicate
+	 *          the {@link MetricPredicate} used to determine whether a metric will be output
+	 */
+	public ConsoleReporter(MetricsRegistry metricsRegistry, PrintStream out, MetricPredicate predicate) {
+		this(metricsRegistry, out, predicate, Clock.DEFAULT, TimeZone.getDefault(), Locale.getDefault());
+	}
 
-    /**
-     * Creates a new {@link ConsoleReporter} for a given metrics registry.
-     *
-     * @param metricsRegistry the metrics registry
-     * @param out             the {@link java.io.PrintStream} to which output will be written
-     * @param predicate       the {@link MetricPredicate} used to determine whether a metric will be
-     *                        output
-     * @param clock           the {@link Clock} used to print time
-     * @param timeZone        the {@link TimeZone} used to print time
-     */
-    public ConsoleReporter(MetricsRegistry metricsRegistry,
-                           PrintStream out,
-                           MetricPredicate predicate,
-                           Clock clock,
-                           TimeZone timeZone) {
-        super(metricsRegistry, "console-reporter");
-        this.out = out;
-        this.predicate = predicate;
-        this.clock = clock;
-        this.timeZone = timeZone;
-    }
+	/**
+	 * Creates a new {@link ConsoleReporter} for a given metrics registry.
+	 * 
+	 * @param metricsRegistry
+	 *          the metrics registry
+	 * @param out
+	 *          the {@link java.io.PrintStream} to which output will be written
+	 * @param predicate
+	 *          the {@link MetricPredicate} used to determine whether a metric will be output
+	 * @param clock
+	 *          the {@link Clock} used to print time
+	 * @param timeZone
+	 *          the {@link TimeZone} used to print time
+	 */
+	public ConsoleReporter(MetricsRegistry metricsRegistry, PrintStream out, MetricPredicate predicate, Clock clock, TimeZone timeZone, Locale locale) {
+		super(metricsRegistry, "console-reporter");
+		this.out = out;
+		this.predicate = predicate;
+		this.clock = clock;
+		this.timeZone = timeZone;
+		this.locale = locale;
+	}
 
-    @Override
-    public void run() {
-        try {
-            final DateFormat format = DateFormat.getDateTimeInstance(DateFormat.SHORT,
-                                                                     DateFormat.MEDIUM);
-            format.setTimeZone(timeZone);
-            final String dateTime = format.format(new Date(clock.time()));
-            out.print(dateTime);
-            out.print(' ');
-            for (int i = 0; i < (80 - dateTime.length() - 1); i++) {
-                out.print('=');
-            }
-            out.println();
-            for (Entry<String, Map<MetricName, Metric>> entry : Utils.sortAndFilterMetrics(
-                    metricsRegistry.allMetrics(),
-                    predicate).entrySet()) {
-                out.print(entry.getKey());
-                out.println(':');
-                for (Entry<MetricName, Metric> subEntry : entry.getValue().entrySet()) {
-                    out.print("  ");
-                    out.print(subEntry.getKey().getName());
-                    out.println(':');
-                    subEntry.getValue().processWith(this, subEntry.getKey(), out);
-                    out.println();
-                }
-                out.println();
-            }
-            out.println();
-            out.flush();
-        } catch (Exception e) {
-            e.printStackTrace(out);
-        }
-    }
+	@Override
+	public void run() {
+		try {
+			final DateFormat format = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFormat.MEDIUM, locale);
 
-    @Override
-    public void processGauge(MetricName name, GaugeMetric<?> gauge, PrintStream stream) {
-        stream.print("    value = ");
-        stream.println(gauge.value());
-    }
+			format.setTimeZone(timeZone);
+			final String dateTime = format.format(new Date(clock.time()));
+			out.print(dateTime);
+			out.print(' ');
+			for (int i = 0; i < (80 - dateTime.length() - 1); i++) {
+				out.print('=');
+			}
+			out.println();
+			for (Entry<String, Map<MetricName, Metric>> entry : Utils.sortAndFilterMetrics(metricsRegistry.allMetrics(), predicate)
+																																.entrySet()) {
+				out.print(entry.getKey());
+				out.println(':');
+				for (Entry<MetricName, Metric> subEntry : entry.getValue().entrySet()) {
+					out.print("  ");
+					out.print(subEntry.getKey().getName());
+					out.println(':');
+					subEntry.getValue().processWith(this, subEntry.getKey(), out);
+					out.println();
+				}
+				out.println();
+			}
+			out.println();
+			out.flush();
+		} catch (Exception e) {
+			e.printStackTrace(out);
+		}
+	}
 
-    @Override
-    public void processCounter(MetricName name, CounterMetric counter, PrintStream stream) {
-        stream.print("    count = ");
-        stream.println(counter.count());
-    }
+	@Override
+	public void processGauge(MetricName name, GaugeMetric<?> gauge, PrintStream stream) {
+		stream.print("    value = ");
+		stream.println(gauge.value());
+	}
 
-    @Override
-    public void processMeter(MetricName name, Metered meter, PrintStream stream) {
-        final String unit = abbrev(meter.rateUnit());
-        stream.printf("             count = %d\n", meter.count());
-        stream.printf("         mean rate = %2.2f %s/%s\n",
-                      meter.meanRate(),
-                      meter.eventType(),
-                      unit);
-        stream.printf("     1-minute rate = %2.2f %s/%s\n",
-                      meter.oneMinuteRate(),
-                      meter.eventType(),
-                      unit);
-        stream.printf("     5-minute rate = %2.2f %s/%s\n",
-                      meter.fiveMinuteRate(),
-                      meter.eventType(),
-                      unit);
-        stream.printf("    15-minute rate = %2.2f %s/%s\n",
-                      meter.fifteenMinuteRate(),
-                      meter.eventType(),
-                      unit);
-    }
+	@Override
+	public void processCounter(MetricName name, CounterMetric counter, PrintStream stream) {
+		stream.print("    count = ");
+		stream.println(counter.count());
+	}
 
-    @Override
-    public void processHistogram(MetricName name, HistogramMetric histogram, PrintStream stream) {
-        final Double[] percentiles = histogram.percentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999);
-        stream.printf("               min = %2.2f\n", histogram.min());
-        stream.printf("               max = %2.2f\n", histogram.max());
-        stream.printf("              mean = %2.2f\n", histogram.mean());
-        stream.printf("            stddev = %2.2f\n", histogram.stdDev());
-        stream.printf("            median = %2.2f\n", percentiles[0]);
-        stream.printf("              75%% <= %2.2f\n", percentiles[1]);
-        stream.printf("              95%% <= %2.2f\n", percentiles[2]);
-        stream.printf("              98%% <= %2.2f\n", percentiles[3]);
-        stream.printf("              99%% <= %2.2f\n", percentiles[4]);
-        stream.printf("            99.9%% <= %2.2f\n", percentiles[5]);
-    }
+	@Override
+	public void processMeter(MetricName name, Metered meter, PrintStream stream) {
+		final String unit = abbrev(meter.rateUnit());
+		stream.printf("             count = %d\n", meter.count());
+		stream.printf("         mean rate = %2.2f %s/%s\n", meter.meanRate(), meter.eventType(), unit);
+		stream.printf("     1-minute rate = %2.2f %s/%s\n", meter.oneMinuteRate(), meter.eventType(), unit);
+		stream.printf("     5-minute rate = %2.2f %s/%s\n", meter.fiveMinuteRate(), meter.eventType(), unit);
+		stream.printf("    15-minute rate = %2.2f %s/%s\n", meter.fifteenMinuteRate(), meter.eventType(), unit);
+	}
 
-    @Override
-    public void processTimer(MetricName name, TimerMetric timer, PrintStream stream) {
-        processMeter(name, timer, stream);
-        final String durationUnit = abbrev(timer.durationUnit());
-        final Double[] percentiles = timer.percentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999);
-        stream.printf("               min = %2.2f%s\n", timer.min(), durationUnit);
-        stream.printf("               max = %2.2f%s\n", timer.max(), durationUnit);
-        stream.printf("              mean = %2.2f%s\n", timer.mean(), durationUnit);
-        stream.printf("            stddev = %2.2f%s\n", timer.stdDev(), durationUnit);
-        stream.printf("            median = %2.2f%s\n", percentiles[0], durationUnit);
-        stream.printf("              75%% <= %2.2f%s\n", percentiles[1], durationUnit);
-        stream.printf("              95%% <= %2.2f%s\n", percentiles[2], durationUnit);
-        stream.printf("              98%% <= %2.2f%s\n", percentiles[3], durationUnit);
-        stream.printf("              99%% <= %2.2f%s\n", percentiles[4], durationUnit);
-        stream.printf("            99.9%% <= %2.2f%s\n", percentiles[5], durationUnit);
-    }
+	@Override
+	public void processHistogram(MetricName name, HistogramMetric histogram, PrintStream stream) {
+		final Double[] percentiles = histogram.percentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999);
+		stream.printf("               min = %2.2f\n", histogram.min());
+		stream.printf("               max = %2.2f\n", histogram.max());
+		stream.printf("              mean = %2.2f\n", histogram.mean());
+		stream.printf("            stddev = %2.2f\n", histogram.stdDev());
+		stream.printf("            median = %2.2f\n", percentiles[0]);
+		stream.printf("              75%% <= %2.2f\n", percentiles[1]);
+		stream.printf("              95%% <= %2.2f\n", percentiles[2]);
+		stream.printf("              98%% <= %2.2f\n", percentiles[3]);
+		stream.printf("              99%% <= %2.2f\n", percentiles[4]);
+		stream.printf("            99.9%% <= %2.2f\n", percentiles[5]);
+	}
 
-    private String abbrev(TimeUnit unit) {
-        switch (unit) {
-            case NANOSECONDS:
-                return "ns";
-            case MICROSECONDS:
-                return "us";
-            case MILLISECONDS:
-                return "ms";
-            case SECONDS:
-                return "s";
-            case MINUTES:
-                return "m";
-            case HOURS:
-                return "h";
-            case DAYS:
-                return "d";
-        }
-        throw new IllegalArgumentException("Unrecognized TimeUnit: " + unit);
-    }
+	@Override
+	public void processTimer(MetricName name, TimerMetric timer, PrintStream stream) {
+		processMeter(name, timer, stream);
+		final String durationUnit = abbrev(timer.durationUnit());
+		final Double[] percentiles = timer.percentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999);
+		stream.printf("               min = %2.2f%s\n", timer.min(), durationUnit);
+		stream.printf("               max = %2.2f%s\n", timer.max(), durationUnit);
+		stream.printf("              mean = %2.2f%s\n", timer.mean(), durationUnit);
+		stream.printf("            stddev = %2.2f%s\n", timer.stdDev(), durationUnit);
+		stream.printf("            median = %2.2f%s\n", percentiles[0], durationUnit);
+		stream.printf("              75%% <= %2.2f%s\n", percentiles[1], durationUnit);
+		stream.printf("              95%% <= %2.2f%s\n", percentiles[2], durationUnit);
+		stream.printf("              98%% <= %2.2f%s\n", percentiles[3], durationUnit);
+		stream.printf("              99%% <= %2.2f%s\n", percentiles[4], durationUnit);
+		stream.printf("            99.9%% <= %2.2f%s\n", percentiles[5], durationUnit);
+	}
+
+	private String abbrev(TimeUnit unit) {
+		switch (unit) {
+			case NANOSECONDS:
+				return "ns";
+			case MICROSECONDS:
+				return "us";
+			case MILLISECONDS:
+				return "ms";
+			case SECONDS:
+				return "s";
+			case MINUTES:
+				return "m";
+			case HOURS:
+				return "h";
+			case DAYS:
+				return "d";
+		}
+		throw new IllegalArgumentException("Unrecognized TimeUnit: " + unit);
+	}
 }

--- a/metrics-core/src/test/java/com/yammer/metrics/reporting/tests/AbstractPollingReporterTest.java
+++ b/metrics-core/src/test/java/com/yammer/metrics/reporting/tests/AbstractPollingReporterTest.java
@@ -1,13 +1,11 @@
 package com.yammer.metrics.reporting.tests;
 
-import com.yammer.metrics.core.*;
-import com.yammer.metrics.reporting.AbstractPollingReporter;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
-import org.mockito.stubbing.Stubber;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyDouble;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -16,247 +14,258 @@ import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyDouble;
-import static org.mockito.Mockito.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.mockito.stubbing.Stubber;
+
+import com.yammer.metrics.core.Clock;
+import com.yammer.metrics.core.CounterMetric;
+import com.yammer.metrics.core.GaugeMetric;
+import com.yammer.metrics.core.HistogramMetric;
+import com.yammer.metrics.core.MeterMetric;
+import com.yammer.metrics.core.Metered;
+import com.yammer.metrics.core.Metric;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricsProcessor;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.Percentiled;
+import com.yammer.metrics.core.Summarized;
+import com.yammer.metrics.core.TimerMetric;
+import com.yammer.metrics.reporting.AbstractPollingReporter;
 
 public abstract class AbstractPollingReporterTest {
 
-    protected final Clock clock = mock(Clock.class);
-    private AbstractPollingReporter reporter;
-    private ByteArrayOutputStream out;
-    private TestMetricsRegistry registry;
+	protected final Clock						clock	= mock(Clock.class);
+	private AbstractPollingReporter	reporter;
+	private ByteArrayOutputStream		out;
+	private TestMetricsRegistry			registry;
 
-    @Before
-    public void init() throws Exception {
-        when(clock.tick()).thenReturn(1234L);
-        when(clock.time()).thenReturn(5678L);
-        registry = new TestMetricsRegistry();
-        out = new ByteArrayOutputStream();
-        reporter = createReporter(registry, out, clock);
-    }
+	@Before
+	public void init() throws Exception {
+		when(clock.tick()).thenReturn(1234L);
+		when(clock.time()).thenReturn(5678L);
+		registry = new TestMetricsRegistry();
+		out = new ByteArrayOutputStream();
+		reporter = createReporter(registry, out, clock);
+	}
 
-    private static class TestMetricsRegistry extends MetricsRegistry {
-        public <T extends Metric> T add(MetricName name, T metric) {
-            return getOrAdd(name, metric);
-        }
-    }
+	private static class TestMetricsRegistry extends MetricsRegistry {
+		public <T extends Metric> T add(MetricName name, T metric) {
+			return getOrAdd(name, metric);
+		}
+	}
 
-    protected final <T extends Metric> void assertReporterOutput(Callable<T> action, String... expected) throws Exception {
-        // Invoke the callable to trigger (ie, mark()/inc()/etc) and return the metric
-        final T metric = action.call();
-        try {
-            // Add the metric to the registry, run the reporter and flush the result
-            registry.add(new MetricName(Object.class, "metric"), metric);
-            reporter.run();
-            out.flush();
-            final String[] lines = out.toString().split("\n");
-            // Assertions: first check that the line count matches then compare line by line ignoring leading and trailing whitespace
-            assertEquals("Line count mismatch, was:\n" + Arrays.toString(lines) + "\nexpected:\n" + Arrays
-                    .toString(expected) + "\n", expected.length,
-                         lines.length);
-            for (int i = 0; i < lines.length; i++) {
-                if (!expected[i].trim().equals(lines[i].trim())) {
-                    System.err.println("Failure comparing line " + (1 + i));
-                    System.err.println("Was:      '" + lines[i] + "'");
-                    System.err.println("Expected: '" + expected[i] + "'\n");
-                }
-                assertEquals(expected[i].trim(), lines[i].trim());
-            }
-        } finally {
-            reporter.shutdown();
-        }
-    }
+	protected final <T extends Metric> void assertReporterOutput(Callable<T> action, String... expected) throws Exception {
+		// Invoke the callable to trigger (ie, mark()/inc()/etc) and return the metric
+		final T metric = action.call();
+		try {
+			// Add the metric to the registry, run the reporter and flush the result
+			registry.add(new MetricName(Object.class, "metric"), metric);
+			reporter.run();
+			out.flush();
+			// Split by lines such that it works regardless of the underlying platform
+			final String[] lines = out.toString().split("\r?\n|\r");
+			// Assertions: first check that the line count matches then compare line by line ignoring leading and trailing
+			// whitespace
+			assertEquals("Line count mismatch, was:\n" +
+					Arrays.toString(lines) +
+					"\nexpected:\n" +
+					Arrays.toString(expected) +
+					"\n", expected.length, lines.length);
+			for (int i = 0; i < lines.length; i++) {
+				if (!expected[i].trim().equals(lines[i].trim())) {
+					System.err.println("Failure comparing line " + (1 + i));
+					System.err.println("Was:      '" + lines[i] + "'");
+					System.err.println("Expected: '" + expected[i] + "'\n");
+				}
+				assertEquals(expected[i].trim(), lines[i].trim());
+			}
+		} finally {
+			reporter.shutdown();
+		}
+	}
 
-    protected abstract AbstractPollingReporter createReporter(MetricsRegistry registry, OutputStream out, Clock clock) throws Exception;
+	protected abstract AbstractPollingReporter createReporter(MetricsRegistry registry, OutputStream out, Clock clock) throws Exception;
 
-    @Test
-    public final void counter() throws Exception {
-        final long count = new Random().nextInt(Integer.MAX_VALUE);
-        assertReporterOutput(
-                new Callable<CounterMetric>() {
-                    @Override
-                    public CounterMetric call() throws Exception {
-                        return createCounter(count);
-                    }
-                },
-                expectedCounterResult(count));
-    }
+	@Test
+	public final void counter() throws Exception {
+		final long count = new Random().nextInt(Integer.MAX_VALUE);
+		assertReporterOutput(new Callable<CounterMetric>() {
+			@Override
+			public CounterMetric call() throws Exception {
+				return createCounter(count);
+			}
+		}, expectedCounterResult(count));
+	}
 
-    @Test
-    public final void histogram() throws Exception {
-        assertReporterOutput(
-                new Callable<HistogramMetric>() {
-                    @Override
-                    public HistogramMetric call() throws Exception {
-                        return createHistogram();
-                    }
-                },
-                expectedHistogramResult());
-    }
+	@Test
+	public final void histogram() throws Exception {
+		assertReporterOutput(new Callable<HistogramMetric>() {
+			@Override
+			public HistogramMetric call() throws Exception {
+				return createHistogram();
+			}
+		}, expectedHistogramResult());
+	}
 
-    @Test
-    public final void meter() throws Exception {
-        assertReporterOutput(
-                new Callable<MeterMetric>() {
-                    @Override
-                    public MeterMetric call() throws Exception {
-                        return createMeter();
-                    }
-                },
-                expectedMeterResult());
-    }
+	@Test
+	public final void meter() throws Exception {
+		assertReporterOutput(new Callable<MeterMetric>() {
+			@Override
+			public MeterMetric call() throws Exception {
+				return createMeter();
+			}
+		}, expectedMeterResult());
+	}
 
-    @Test
-    public final void timer() throws Exception {
-        assertReporterOutput(
-                new Callable<TimerMetric>() {
-                    @Override
-                    public TimerMetric call() throws Exception {
-                        return createTimer();
-                    }
-                },
-                expectedTimerResult());
-    }
+	@Test
+	public final void timer() throws Exception {
+		assertReporterOutput(new Callable<TimerMetric>() {
+			@Override
+			public TimerMetric call() throws Exception {
+				return createTimer();
+			}
+		}, expectedTimerResult());
+	}
 
-    @Test
-    public final void gauge() throws Exception {
-        final String value = "gaugeValue";
-        assertReporterOutput(
-                new Callable<GaugeMetric<String>>() {
-                    @Override
-                    public GaugeMetric<String> call() throws Exception {
-                        return createGauge();
-                    }
-                },
-                expectedGaugeResult(value));
-    }
+	@Test
+	public final void gauge() throws Exception {
+		final String value = "gaugeValue";
+		assertReporterOutput(new Callable<GaugeMetric<String>>() {
+			@Override
+			public GaugeMetric<String> call() throws Exception {
+				return createGauge();
+			}
+		}, expectedGaugeResult(value));
+	}
 
-    @SuppressWarnings("unchecked")
-    static CounterMetric createCounter(long count) throws Exception {
-        final CounterMetric mock = mock(CounterMetric.class);
-        when(mock.count()).thenReturn(count);
-        return configureMatcher(mock, doAnswer(new MetricsProcessorAction() {
-            @Override
-            void delegateToProcessor(MetricsProcessor processor, MetricName name, Object context) throws Exception {
-                processor.processCounter(name, mock, context);
-            }
-        }));
-    }
+	@SuppressWarnings("unchecked")
+	static CounterMetric createCounter(long count) throws Exception {
+		final CounterMetric mock = mock(CounterMetric.class);
+		when(mock.count()).thenReturn(count);
+		return configureMatcher(mock, doAnswer(new MetricsProcessorAction() {
+			@Override
+			void delegateToProcessor(MetricsProcessor processor, MetricName name, Object context) throws Exception {
+				processor.processCounter(name, mock, context);
+			}
+		}));
+	}
 
-    @SuppressWarnings("unchecked")
-    static HistogramMetric createHistogram() throws Exception {
-        final HistogramMetric mock = mock(HistogramMetric.class);
-        setupSummarizedMock(mock);
-        setupPercentiledMock(mock);
-        return configureMatcher(mock, doAnswer(new MetricsProcessorAction() {
-            @Override
-            void delegateToProcessor(MetricsProcessor processor, MetricName name, Object context) throws Exception {
-                processor.processHistogram(name, mock, context);
-            }
-        }));
-    }
+	@SuppressWarnings("unchecked")
+	static HistogramMetric createHistogram() throws Exception {
+		final HistogramMetric mock = mock(HistogramMetric.class);
+		setupSummarizedMock(mock);
+		setupPercentiledMock(mock);
+		return configureMatcher(mock, doAnswer(new MetricsProcessorAction() {
+			@Override
+			void delegateToProcessor(MetricsProcessor processor, MetricName name, Object context) throws Exception {
+				processor.processHistogram(name, mock, context);
+			}
+		}));
+	}
 
-    @SuppressWarnings("unchecked")
-    static GaugeMetric<String> createGauge() throws Exception {
-        final GaugeMetric<String> mock = mock(GaugeMetric.class);
-        when(mock.value()).thenReturn("gaugeValue");
-        return configureMatcher(mock, doAnswer(new MetricsProcessorAction() {
-            @Override
-            void delegateToProcessor(MetricsProcessor processor, MetricName name, Object context) throws Exception {
-                processor.processGauge(name, mock, context);
-            }
-        }));
-    }
+	@SuppressWarnings("unchecked")
+	static GaugeMetric<String> createGauge() throws Exception {
+		final GaugeMetric<String> mock = mock(GaugeMetric.class);
+		when(mock.value()).thenReturn("gaugeValue");
+		return configureMatcher(mock, doAnswer(new MetricsProcessorAction() {
+			@Override
+			void delegateToProcessor(MetricsProcessor processor, MetricName name, Object context) throws Exception {
+				processor.processGauge(name, mock, context);
+			}
+		}));
+	}
 
-    @SuppressWarnings("unchecked")
-    static TimerMetric createTimer() throws Exception {
-        final TimerMetric mock = mock(TimerMetric.class);
-        when(mock.durationUnit()).thenReturn(TimeUnit.MILLISECONDS);
-        setupSummarizedMock(mock);
-        setupMeteredMock(mock);
-        setupPercentiledMock(mock);
-        return configureMatcher(mock, doAnswer(new MetricsProcessorAction() {
-            @Override
-            void delegateToProcessor(MetricsProcessor processor, MetricName name, Object context) throws Exception {
-                processor.processTimer(name, mock, context);
-            }
-        }));
-    }
+	@SuppressWarnings("unchecked")
+	static TimerMetric createTimer() throws Exception {
+		final TimerMetric mock = mock(TimerMetric.class);
+		when(mock.durationUnit()).thenReturn(TimeUnit.MILLISECONDS);
+		setupSummarizedMock(mock);
+		setupMeteredMock(mock);
+		setupPercentiledMock(mock);
+		return configureMatcher(mock, doAnswer(new MetricsProcessorAction() {
+			@Override
+			void delegateToProcessor(MetricsProcessor processor, MetricName name, Object context) throws Exception {
+				processor.processTimer(name, mock, context);
+			}
+		}));
+	}
 
-    @SuppressWarnings("unchecked")
-    static MeterMetric createMeter() throws Exception {
-        final MeterMetric mock = mock(MeterMetric.class);
-        setupMeteredMock(mock);
-        return configureMatcher(mock, doAnswer(new MetricsProcessorAction() {
-            @Override
-            void delegateToProcessor(MetricsProcessor processor, MetricName name, Object context) throws Exception {
-                processor.processMeter(name, mock, context);
-            }
-        }));
-    }
+	@SuppressWarnings("unchecked")
+	static MeterMetric createMeter() throws Exception {
+		final MeterMetric mock = mock(MeterMetric.class);
+		setupMeteredMock(mock);
+		return configureMatcher(mock, doAnswer(new MetricsProcessorAction() {
+			@Override
+			void delegateToProcessor(MetricsProcessor processor, MetricName name, Object context) throws Exception {
+				processor.processMeter(name, mock, context);
+			}
+		}));
+	}
 
-    @SuppressWarnings("unchecked")
-    static <T extends Metric> T configureMatcher(T mock, Stubber stub) throws Exception {
-        stub.when(mock).processWith(any(MetricsProcessor.class), any(MetricName.class), any());
-        return mock;
-    }
+	@SuppressWarnings("unchecked")
+	static <T extends Metric> T configureMatcher(T mock, Stubber stub) throws Exception {
+		stub.when(mock).processWith(any(MetricsProcessor.class), any(MetricName.class), any());
+		return mock;
+	}
 
-    static abstract class MetricsProcessorAction implements Answer<Object> {
-        @Override
-        public Object answer(InvocationOnMock invocation) throws Throwable {
-            final MetricsProcessor<?> processor = (MetricsProcessor<?>) invocation.getArguments()[0];
-            final MetricName name = (MetricName) invocation.getArguments()[1];
-            final Object context = invocation.getArguments()[2];
-            delegateToProcessor(processor, name, context);
-            return null;
-        }
+	static abstract class MetricsProcessorAction implements Answer<Object> {
+		@Override
+		public Object answer(InvocationOnMock invocation) throws Throwable {
+			final MetricsProcessor<?> processor = (MetricsProcessor<?>) invocation.getArguments()[0];
+			final MetricName name = (MetricName) invocation.getArguments()[1];
+			final Object context = invocation.getArguments()[2];
+			delegateToProcessor(processor, name, context);
+			return null;
+		}
 
-        abstract void delegateToProcessor(MetricsProcessor<?> processor, MetricName name, Object context) throws Exception;
-    }
+		abstract void delegateToProcessor(MetricsProcessor<?> processor, MetricName name, Object context) throws Exception;
+	}
 
-    static void setupSummarizedMock(Summarized summarized) {
-        when(summarized.min()).thenReturn(1d);
-        when(summarized.max()).thenReturn(3d);
-        when(summarized.mean()).thenReturn(2d);
-        when(summarized.stdDev()).thenReturn(1.5d);
-    }
+	static void setupSummarizedMock(Summarized summarized) {
+		when(summarized.min()).thenReturn(1d);
+		when(summarized.max()).thenReturn(3d);
+		when(summarized.mean()).thenReturn(2d);
+		when(summarized.stdDev()).thenReturn(1.5d);
+	}
 
-    static void setupMeteredMock(Metered metered) {
-        when(metered.count()).thenReturn(1L);
-        when(metered.oneMinuteRate()).thenReturn(1d);
-        when(metered.fiveMinuteRate()).thenReturn(5d);
-        when(metered.fifteenMinuteRate()).thenReturn(15d);
-        when(metered.meanRate()).thenReturn(2d);
-        when(metered.eventType()).thenReturn("eventType");
-        when(metered.rateUnit()).thenReturn(TimeUnit.SECONDS);
-    }
+	static void setupMeteredMock(Metered metered) {
+		when(metered.count()).thenReturn(1L);
+		when(metered.oneMinuteRate()).thenReturn(1d);
+		when(metered.fiveMinuteRate()).thenReturn(5d);
+		when(metered.fifteenMinuteRate()).thenReturn(15d);
+		when(metered.meanRate()).thenReturn(2d);
+		when(metered.eventType()).thenReturn("eventType");
+		when(metered.rateUnit()).thenReturn(TimeUnit.SECONDS);
+	}
 
-    static void setupPercentiledMock(Percentiled percentiled) {
-        when(percentiled.percentile(anyDouble())).thenAnswer(new Answer<Double>() {
-            @Override
-            public Double answer(InvocationOnMock invocation) throws Throwable {
-                return (Double) invocation.getArguments()[0];
-            }
-        });
-        doAnswer(new Answer<Double[]>() {
-            @Override
-            public Double[] answer(InvocationOnMock invocation) throws Throwable {
-                final Object[] arguments = invocation.getArguments();
-                return Arrays.copyOf(arguments, arguments.length, Double[].class);
-            }
-        }).when(percentiled).percentiles(Mockito.<Double>anyVararg());
-    }
+	static void setupPercentiledMock(Percentiled percentiled) {
+		when(percentiled.percentile(anyDouble())).thenAnswer(new Answer<Double>() {
+			@Override
+			public Double answer(InvocationOnMock invocation) throws Throwable {
+				return (Double) invocation.getArguments()[0];
+			}
+		});
+		doAnswer(new Answer<Double[]>() {
+			@Override
+			public Double[] answer(InvocationOnMock invocation) throws Throwable {
+				final Object[] arguments = invocation.getArguments();
+				return Arrays.copyOf(arguments, arguments.length, Double[].class);
+			}
+		}).when(percentiled).percentiles(Mockito.<Double> anyVararg());
+	}
 
-    public abstract String[] expectedGaugeResult(String value);
+	public abstract String[] expectedGaugeResult(String value);
 
-    public abstract String[] expectedTimerResult();
+	public abstract String[] expectedTimerResult();
 
-    public abstract String[] expectedMeterResult();
+	public abstract String[] expectedMeterResult();
 
-    public abstract String[] expectedHistogramResult();
+	public abstract String[] expectedHistogramResult();
 
-    public abstract String[] expectedCounterResult(long count);
+	public abstract String[] expectedCounterResult(long count);
 
 }

--- a/metrics-core/src/test/java/com/yammer/metrics/reporting/tests/ConsoleReporterTest.java
+++ b/metrics-core/src/test/java/com/yammer/metrics/reporting/tests/ConsoleReporterTest.java
@@ -8,6 +8,7 @@ import com.yammer.metrics.util.MetricPredicate;
 
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.util.Locale;
 import java.util.TimeZone;
 
 public class ConsoleReporterTest extends AbstractPollingReporterTest {
@@ -18,7 +19,8 @@ public class ConsoleReporterTest extends AbstractPollingReporterTest {
                                    new PrintStream(out),
                                    MetricPredicate.ALL,
                                    clock,
-                                   TimeZone.getTimeZone("UTC"));
+                                   TimeZone.getTimeZone("UTC"),
+                                   Locale.US);
     }
 
     @Override

--- a/metrics-servlet/src/main/java/com/yammer/metrics/reporting/MetricsServlet.java
+++ b/metrics-servlet/src/main/java/com/yammer/metrics/reporting/MetricsServlet.java
@@ -1,24 +1,26 @@
 package com.yammer.metrics.reporting;
 
-import com.yammer.metrics.HealthChecks;
-import com.yammer.metrics.Metrics;
-import com.yammer.metrics.core.*;
-import com.yammer.metrics.core.HealthCheck.Result;
-import com.yammer.metrics.core.VirtualMachineMetrics.*;
-import com.yammer.metrics.util.Utils;
-import org.codehaus.jackson.JsonEncoding;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static com.yammer.metrics.core.VirtualMachineMetrics.daemonThreadCount;
+import static com.yammer.metrics.core.VirtualMachineMetrics.fileDescriptorUsage;
+import static com.yammer.metrics.core.VirtualMachineMetrics.garbageCollectors;
+import static com.yammer.metrics.core.VirtualMachineMetrics.heapCommited;
+import static com.yammer.metrics.core.VirtualMachineMetrics.heapInit;
+import static com.yammer.metrics.core.VirtualMachineMetrics.heapMax;
+import static com.yammer.metrics.core.VirtualMachineMetrics.heapUsage;
+import static com.yammer.metrics.core.VirtualMachineMetrics.heapUsed;
+import static com.yammer.metrics.core.VirtualMachineMetrics.memoryPoolUsage;
+import static com.yammer.metrics.core.VirtualMachineMetrics.nonHeapUsage;
+import static com.yammer.metrics.core.VirtualMachineMetrics.threadCount;
+import static com.yammer.metrics.core.VirtualMachineMetrics.threadDump;
+import static com.yammer.metrics.core.VirtualMachineMetrics.threadStatePercentages;
+import static com.yammer.metrics.core.VirtualMachineMetrics.totalCommited;
+import static com.yammer.metrics.core.VirtualMachineMetrics.totalInit;
+import static com.yammer.metrics.core.VirtualMachineMetrics.totalMax;
+import static com.yammer.metrics.core.VirtualMachineMetrics.totalUsed;
+import static com.yammer.metrics.core.VirtualMachineMetrics.uptime;
+import static com.yammer.metrics.core.VirtualMachineMetrics.vmName;
+import static com.yammer.metrics.core.VirtualMachineMetrics.vmVersion;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
@@ -28,435 +30,475 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
-import static com.yammer.metrics.core.VirtualMachineMetrics.*;
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.codehaus.jackson.JsonEncoding;
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.yammer.metrics.HealthChecks;
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.CounterMetric;
+import com.yammer.metrics.core.GaugeMetric;
+import com.yammer.metrics.core.HealthCheck.Result;
+import com.yammer.metrics.core.HealthCheckRegistry;
+import com.yammer.metrics.core.HistogramMetric;
+import com.yammer.metrics.core.Metered;
+import com.yammer.metrics.core.Metric;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricsProcessor;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.Percentiled;
+import com.yammer.metrics.core.Summarized;
+import com.yammer.metrics.core.TimerMetric;
+import com.yammer.metrics.core.VirtualMachineMetrics.GarbageCollector;
+import com.yammer.metrics.util.Utils;
 
 public class MetricsServlet extends HttpServlet implements MetricsProcessor<MetricsServlet.Context> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MetricsServlet.class);
-    public static final String ATTR_NAME_METRICS_REGISTRY = MetricsServlet.class.getSimpleName() + ":" + MetricsRegistry.class.getSimpleName();
-    public static final String ATTR_NAME_HEALTHCHECK_REGISTRY = MetricsServlet.class.getSimpleName() + ":" + HealthCheckRegistry.class.getSimpleName();
+	private static final Logger	LOGGER													= LoggerFactory.getLogger(MetricsServlet.class);
+	public static final String	ATTR_NAME_METRICS_REGISTRY			= MetricsServlet.class.getSimpleName() +
+																																	":" +
+																																	MetricsRegistry.class.getSimpleName();
+	public static final String	ATTR_NAME_HEALTHCHECK_REGISTRY	= MetricsServlet.class.getSimpleName() +
+																																	":" +
+																																	HealthCheckRegistry.class.getSimpleName();
 
-    private static final String TEMPLATE = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\n" +
-                                           "        \"http://www.w3.org/TR/html4/loose.dtd\">\n" +
-                                           "<html>\n" +
-                                           "<head>\n" +
-                                           "  <title>Metrics</title>\n" +
-                                           "</head>\n" +
-                                           "<body>\n" +
-                                           "  <h1>Operational Menu</h1>\n" +
-                                           "  <ul>\n" +
-                                           "    <li><a href=\"{0}{1}?pretty=true\">Metrics</a></li>\n" +
-                                           "    <li><a href=\"{2}{3}\">Ping</a></li>\n" +
-                                           "    <li><a href=\"{4}{5}\">Threads</a></li>\n" +
-                                           "    <li><a href=\"{6}{7}\">Healthcheck</a></li>\n" +
-                                           "  </ul>\n" +
-                                           "</body>\n" +
-                                           "</html>";
-    public static final String HEALTHCHECK_URI = "/healthcheck";
-    public static final String METRICS_URI = "/metrics";
-    public static final String PING_URI = "/ping";
-    public static final String THREADS_URI = "/threads";
-    private MetricsRegistry metricsRegistry;
-    private HealthCheckRegistry healthCheckRegistry;
-    private JsonFactory factory;
-    private String metricsUri, pingUri, threadsUri, healthcheckUri, contextPath;
-    private boolean showJvmMetrics;
+	private static final String	TEMPLATE												= "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\n"
+																																	+ "        \"http://www.w3.org/TR/html4/loose.dtd\">\n"
+																																	+ "<html>\n"
+																																	+ "<head>\n"
+																																	+ "  <title>Metrics</title>\n"
+																																	+ "</head>\n"
+																																	+ "<body>\n"
+																																	+ "  <h1>Operational Menu</h1>\n"
+																																	+ "  <ul>\n"
+																																	+ "    <li><a href=\"{0}{1}?pretty=true\">Metrics</a></li>\n"
+																																	+ "    <li><a href=\"{2}{3}\">Ping</a></li>\n"
+																																	+ "    <li><a href=\"{4}{5}\">Threads</a></li>\n"
+																																	+ "    <li><a href=\"{6}{7}\">Healthcheck</a></li>\n"
+																																	+ "  </ul>\n"
+																																	+ "</body>\n"
+																																	+ "</html>";
+	public static final String	HEALTHCHECK_URI									= "/healthcheck";
+	public static final String	METRICS_URI											= "/metrics";
+	public static final String	PING_URI												= "/ping";
+	public static final String	THREADS_URI											= "/threads";
+	private MetricsRegistry			metricsRegistry;
+	private HealthCheckRegistry	healthCheckRegistry;
+	private JsonFactory					factory;
+	private String							metricsUri, pingUri, threadsUri, healthcheckUri, contextPath;
+	private boolean							showJvmMetrics;
 
-    public MetricsServlet() {
-        this(new JsonFactory(new ObjectMapper()), HEALTHCHECK_URI, METRICS_URI, PING_URI, THREADS_URI, true);
-    }
+	public MetricsServlet() {
+		this(new JsonFactory(new ObjectMapper()), HEALTHCHECK_URI, METRICS_URI, PING_URI, THREADS_URI, true);
+	}
 
-    public MetricsServlet(boolean showJvmMetrics) {
-        this(new JsonFactory(new ObjectMapper()), HEALTHCHECK_URI, METRICS_URI, PING_URI, THREADS_URI, showJvmMetrics);
-    }
+	public MetricsServlet(boolean showJvmMetrics) {
+		this(new JsonFactory(new ObjectMapper()), HEALTHCHECK_URI, METRICS_URI, PING_URI, THREADS_URI, showJvmMetrics);
+	}
 
-    public MetricsServlet(JsonFactory factory) {
-        this(factory, HEALTHCHECK_URI, METRICS_URI, PING_URI, THREADS_URI);
-    }
+	public MetricsServlet(JsonFactory factory) {
+		this(factory, HEALTHCHECK_URI, METRICS_URI, PING_URI, THREADS_URI);
+	}
 
-    public MetricsServlet(JsonFactory factory, boolean showJvmMetrics) {
-        this(factory, HEALTHCHECK_URI, METRICS_URI, PING_URI, THREADS_URI, showJvmMetrics);
-    }
+	public MetricsServlet(JsonFactory factory, boolean showJvmMetrics) {
+		this(factory, HEALTHCHECK_URI, METRICS_URI, PING_URI, THREADS_URI, showJvmMetrics);
+	}
 
-    public MetricsServlet(String healthcheckUri, String metricsUri, String pingUri, String threadsUri) {
-        this(new JsonFactory(new ObjectMapper()), healthcheckUri, metricsUri, pingUri, threadsUri);
-    }
+	public MetricsServlet(String healthcheckUri, String metricsUri, String pingUri, String threadsUri) {
+		this(new JsonFactory(new ObjectMapper()), healthcheckUri, metricsUri, pingUri, threadsUri);
+	}
 
-    public MetricsServlet(JsonFactory factory, String healthcheckUri, String metricsUri, String pingUri, String threadsUri) {
-        this(factory, healthcheckUri, metricsUri, pingUri, threadsUri, true);
-    }
+	public MetricsServlet(JsonFactory factory, String healthcheckUri, String metricsUri, String pingUri, String threadsUri) {
+		this(factory, healthcheckUri, metricsUri, pingUri, threadsUri, true);
+	}
 
-    public MetricsServlet(JsonFactory factory, String healthcheckUri, String metricsUri, String pingUri, String threadsUri, boolean showJvmMetrics) {
-        this(Metrics.defaultRegistry(), HealthChecks.defaultRegistry(), factory, healthcheckUri, metricsUri, pingUri, threadsUri, showJvmMetrics);
-    }
+	public MetricsServlet(JsonFactory factory, String healthcheckUri, String metricsUri, String pingUri, String threadsUri, boolean showJvmMetrics) {
+		this(Metrics.defaultRegistry(), HealthChecks.defaultRegistry(), factory, healthcheckUri, metricsUri, pingUri, threadsUri, showJvmMetrics);
+	}
 
-    public MetricsServlet(MetricsRegistry metricsRegistry, HealthCheckRegistry healthCheckRegistry, String healthcheckUri, String metricsUri, String pingUri, String threadsUri, boolean showJvmMetrics) {
-        this(metricsRegistry, healthCheckRegistry, new JsonFactory(new ObjectMapper()), healthcheckUri, metricsUri, pingUri, threadsUri, showJvmMetrics);
-    }
+	public MetricsServlet(MetricsRegistry metricsRegistry, HealthCheckRegistry healthCheckRegistry, String healthcheckUri, String metricsUri, String pingUri, String threadsUri, boolean showJvmMetrics) {
+		this(metricsRegistry, healthCheckRegistry, new JsonFactory(new ObjectMapper()), healthcheckUri, metricsUri, pingUri, threadsUri, showJvmMetrics);
+	}
 
-    public MetricsServlet(MetricsRegistry metricsRegistry, HealthCheckRegistry healthCheckRegistry, JsonFactory factory, String healthcheckUri, String metricsUri, String pingUri, String threadsUri, boolean showJvmMetrics) {
-        this.metricsRegistry = metricsRegistry;
-        this.healthCheckRegistry = healthCheckRegistry;
-        this.factory = factory;
-        this.healthcheckUri = healthcheckUri;
-        this.metricsUri = metricsUri;
-        this.pingUri = pingUri;
-        this.threadsUri = threadsUri;
-        this.showJvmMetrics = showJvmMetrics;
-    }
+	public MetricsServlet(MetricsRegistry metricsRegistry, HealthCheckRegistry healthCheckRegistry, JsonFactory factory, String healthcheckUri, String metricsUri, String pingUri, String threadsUri, boolean showJvmMetrics) {
+		this.metricsRegistry = metricsRegistry;
+		this.healthCheckRegistry = healthCheckRegistry;
+		this.factory = factory;
+		this.healthcheckUri = healthcheckUri;
+		this.metricsUri = metricsUri;
+		this.pingUri = pingUri;
+		this.threadsUri = threadsUri;
+		this.showJvmMetrics = showJvmMetrics;
+	}
 
-    @Override
-    public void init(ServletConfig config) throws ServletException {
-        super.init(config);
+	@Override
+	public void init(ServletConfig config) throws ServletException {
+		super.init(config);
 
-        final ServletContext context = config.getServletContext();
+		final ServletContext context = config.getServletContext();
 
-        this.contextPath = context.getContextPath();
-        this.metricsRegistry = putAttrIfAbsent(context, ATTR_NAME_METRICS_REGISTRY, this.metricsRegistry);
-        this.healthCheckRegistry = putAttrIfAbsent(context, ATTR_NAME_HEALTHCHECK_REGISTRY, this.healthCheckRegistry);
-        this.metricsUri = getParam(config.getInitParameter("metrics-uri"), this.metricsUri);
-        this.pingUri = getParam(config.getInitParameter("ping-uri"), this.pingUri);
-        this.threadsUri = getParam(config.getInitParameter("threads-uri"), this.threadsUri);
-        this.healthcheckUri = getParam(config.getInitParameter("healthcheck-uri"), this.healthcheckUri);
-        final String showJvmMetricsParam = config.getInitParameter("show-jvm-metrics");
-        if (showJvmMetricsParam != null) {
-            this.showJvmMetrics = Boolean.parseBoolean(showJvmMetricsParam);
-        }
+		this.contextPath = context.getContextPath();
+		this.metricsRegistry = putAttrIfAbsent(context, ATTR_NAME_METRICS_REGISTRY, this.metricsRegistry);
+		this.healthCheckRegistry = putAttrIfAbsent(context, ATTR_NAME_HEALTHCHECK_REGISTRY, this.healthCheckRegistry);
+		this.metricsUri = getParam(config.getInitParameter("metrics-uri"), this.metricsUri);
+		this.pingUri = getParam(config.getInitParameter("ping-uri"), this.pingUri);
+		this.threadsUri = getParam(config.getInitParameter("threads-uri"), this.threadsUri);
+		this.healthcheckUri = getParam(config.getInitParameter("healthcheck-uri"), this.healthcheckUri);
+		final String showJvmMetricsParam = config.getInitParameter("show-jvm-metrics");
+		if (showJvmMetricsParam != null) {
+			this.showJvmMetrics = Boolean.parseBoolean(showJvmMetricsParam);
+		}
 
-        final Object factory = config.getServletContext().getAttribute(JsonFactory.class.getCanonicalName());
-        if (factory != null && factory instanceof JsonFactory) {
-            this.factory = (JsonFactory) factory;
-        }
-    }
+		final Object factory = config.getServletContext().getAttribute(JsonFactory.class.getCanonicalName());
+		if (factory != null && factory instanceof JsonFactory) {
+			this.factory = (JsonFactory) factory;
+		}
+	}
 
-    private static String getParam(String initParam, String defaultValue) {
-        return initParam == null ? defaultValue : initParam;
-    }
+	private static String getParam(String initParam, String defaultValue) {
+		return initParam == null ? defaultValue : initParam;
+	}
 
-    private static <T> T putAttrIfAbsent(ServletContext context, String attrName, T defaultValue) {
-        @SuppressWarnings("unchecked")
-        T attrValue = (T)context.getAttribute(attrName);
-        if (attrValue == null) {
-            attrValue = defaultValue;
-            context.setAttribute(attrName, attrValue);
-        }
-        return attrValue;
-    }
-    
-    @Override
-    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        resp.setHeader("Cache-Control", "must-revalidate,no-cache,no-store");
-        final String uri = req.getPathInfo();
-        final String path = this.contextPath + req.getServletPath();
-        if (uri == null || uri.equals("/")) {
-            handleHome(path, resp);
-        } else if (uri.startsWith(metricsUri)) {
-            handleMetrics(req.getParameter("class"), Boolean.parseBoolean(req.getParameter("full-samples")), 
-                          Boolean.parseBoolean(req.getParameter("pretty")), resp);
-        } else if (uri.equals(pingUri)) {
-            handlePing(resp);
-        } else if (uri.equals(threadsUri)) {
-            handleThreadDump(resp);
-        } else if (uri.equals(healthcheckUri)) {
-            handleHealthCheck(resp);
-        } else {
-            resp.sendError(HttpServletResponse.SC_NOT_FOUND);
-        }
-    }
+	private static <T> T putAttrIfAbsent(ServletContext context, String attrName, T defaultValue) {
+		@SuppressWarnings("unchecked") T attrValue = (T) context.getAttribute(attrName);
+		if (attrValue == null) {
+			attrValue = defaultValue;
+			context.setAttribute(attrName, attrValue);
+		}
+		return attrValue;
+	}
 
-    private void handleHome(String path, HttpServletResponse resp) throws IOException {
-        resp.setStatus(HttpServletResponse.SC_OK);
-        resp.setContentType("text/html");
+	@Override
+	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+		resp.setHeader("Cache-Control", "must-revalidate,no-cache,no-store");
+		final String uri = req.getPathInfo();
+		final String path = this.contextPath + req.getServletPath();
+		if (uri == null || uri.equals("/")) {
+			handleHome(path, resp);
+		} else if (uri.startsWith(metricsUri)) {
+			handleMetrics(req.getParameter("class"), Boolean.parseBoolean(req.getParameter("full-samples")), Boolean.parseBoolean(req.getParameter("pretty")), resp);
+		} else if (uri.equals(pingUri)) {
+			handlePing(resp);
+		} else if (uri.equals(threadsUri)) {
+			handleThreadDump(resp);
+		} else if (uri.equals(healthcheckUri)) {
+			handleHealthCheck(resp);
+		} else {
+			resp.sendError(HttpServletResponse.SC_NOT_FOUND);
+		}
+	}
 
-        final PrintWriter writer = resp.getWriter();
-        writer.println(MessageFormat.format(TEMPLATE, path, metricsUri, path, pingUri, path, threadsUri, path, healthcheckUri));
-        writer.close();
-    }
+	private void handleHome(String path, HttpServletResponse resp) throws IOException {
+		resp.setStatus(HttpServletResponse.SC_OK);
+		resp.setContentType("text/html");
 
-    @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
-    private void handleHealthCheck(HttpServletResponse resp) throws IOException {
-        boolean allHealthy = true;
-        final Map<String, Result> results = healthCheckRegistry.runHealthChecks();
-        for (Result result : results.values()) {
-            allHealthy &= result.isHealthy();
-        }
+		final PrintWriter writer = resp.getWriter();
+		writer.println(MessageFormat.format(TEMPLATE, path, metricsUri, path, pingUri, path, threadsUri, path, healthcheckUri));
+		writer.close();
+	}
 
-        resp.setContentType("text/plain");
+	@SuppressWarnings("ThrowableResultOfMethodCallIgnored")
+	private void handleHealthCheck(HttpServletResponse resp) throws IOException {
+		boolean allHealthy = true;
+		final Map<String, Result> results = healthCheckRegistry.runHealthChecks();
+		for (Result result : results.values()) {
+			allHealthy &= result.isHealthy();
+		}
 
-        final PrintWriter writer = resp.getWriter();
-        if (results.isEmpty()) {
-            resp.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
-            writer.println("! No health checks registered.");
-        } else {
-            if (allHealthy) {
-                resp.setStatus(HttpServletResponse.SC_OK);
-            } else {
-                resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            }
-            for (Entry<String, Result> entry : results.entrySet()) {
-                final Result result = entry.getValue();
-                if (result.isHealthy()) {
-                    if (result.getMessage() != null) {
-                        writer.format("* %s: OK: %s\n", entry.getKey(), result.getMessage());
-                    } else {
-                        writer.format("* %s: OK\n", entry.getKey());
-                    }
-                } else {
-                    if (result.getMessage() != null) {
-                        writer.format("! %s: ERROR\n!  %s\n", entry.getKey(), result.getMessage());
-                    }
+		resp.setContentType("text/plain");
 
-                    final Throwable error = result.getError();
-                    if (error != null) {
-                        writer.println();
-                        error.printStackTrace(writer);
-                        writer.println();
-                    }
-                }
-            }
-        }
-        writer.close();
-    }
+		final PrintWriter writer = resp.getWriter();
+		if (results.isEmpty()) {
+			resp.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
+			writer.println("! No health checks registered.");
+		} else {
+			if (allHealthy) {
+				resp.setStatus(HttpServletResponse.SC_OK);
+			} else {
+				resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+			}
+			for (Entry<String, Result> entry : results.entrySet()) {
+				final Result result = entry.getValue();
+				if (result.isHealthy()) {
+					if (result.getMessage() != null) {
+						writer.format("* %s: OK: %s\n", entry.getKey(), result.getMessage());
+					} else {
+						writer.format("* %s: OK\n", entry.getKey());
+					}
+				} else {
+					if (result.getMessage() != null) {
+						writer.format("! %s: ERROR\n!  %s\n", entry.getKey(), result.getMessage());
+					}
 
-    private static void handleThreadDump(HttpServletResponse resp) throws IOException {
-        resp.setStatus(HttpServletResponse.SC_OK);
-        resp.setContentType("text/plain");
-        final OutputStream output = resp.getOutputStream();
-        threadDump(output);
-        output.close();
-    }
+					final Throwable error = result.getError();
+					if (error != null) {
+						writer.println();
+						error.printStackTrace(writer);
+						writer.println();
+					}
+				}
+			}
+		}
+		writer.close();
+	}
 
-    private static void handlePing(HttpServletResponse resp) throws IOException {
-        resp.setStatus(HttpServletResponse.SC_OK);
-        resp.setContentType("text/plain");
-        final PrintWriter writer = resp.getWriter();
-        writer.println("pong");
-        writer.close();
-    }
+	private static void handleThreadDump(HttpServletResponse resp) throws IOException {
+		resp.setStatus(HttpServletResponse.SC_OK);
+		resp.setContentType("text/plain");
+		final OutputStream output = resp.getOutputStream();
+		threadDump(output);
+		output.close();
+	}
 
-    static final class Context {
-        public final boolean showFullSamples;
-        public final JsonGenerator json;
+	private static void handlePing(HttpServletResponse resp) throws IOException {
+		resp.setStatus(HttpServletResponse.SC_OK);
+		resp.setContentType("text/plain");
+		final PrintWriter writer = resp.getWriter();
+		writer.println("pong");
+		writer.close();
+	}
 
-        Context(JsonGenerator json, boolean showFullSamples) {
-            this.json = json;
-            this.showFullSamples = showFullSamples;
-        }
-    }
+	static final class Context {
+		public final boolean				showFullSamples;
+		public final JsonGenerator	json;
 
-    private void handleMetrics(String classPrefix, boolean showFullSamples, boolean pretty, HttpServletResponse resp)
-        throws IOException {
-        resp.setStatus(HttpServletResponse.SC_OK);
-        resp.setContentType("application/json");
-        final OutputStream output = resp.getOutputStream();
-        final JsonGenerator json = factory.createJsonGenerator(output, JsonEncoding.UTF8);
-        if (pretty) {
-            json.useDefaultPrettyPrinter();
-        }
-        json.writeStartObject();
-        {
-            if (showJvmMetrics && ("jvm".equals(classPrefix) || classPrefix == null)) {
-                writeVmMetrics(json);
-            }
+		Context(JsonGenerator json, boolean showFullSamples) {
+			this.json = json;
+			this.showFullSamples = showFullSamples;
+		}
+	}
 
-            writeRegularMetrics(json, classPrefix, showFullSamples);
-        }
-        json.writeEndObject();
-        json.close();
-    }
+	private void handleMetrics(String classPrefix, boolean showFullSamples, boolean pretty, HttpServletResponse resp) throws IOException {
+		resp.setStatus(HttpServletResponse.SC_OK);
+		resp.setContentType("application/json");
+		final OutputStream output = resp.getOutputStream();
+		final JsonGenerator json = factory.createJsonGenerator(output, JsonEncoding.UTF8);
+		if (pretty) {
+			json.useDefaultPrettyPrinter();
+		}
+		json.writeStartObject();
+		{
+			if (showJvmMetrics && ("jvm".equals(classPrefix) || classPrefix == null)) {
+				writeVmMetrics(json);
+			}
 
-    public void writeRegularMetrics(JsonGenerator json, String classPrefix, boolean showFullSamples) throws IOException {
-        for (Entry<String, Map<MetricName, Metric>> entry : Utils.sortMetrics(metricsRegistry.allMetrics()).entrySet()) {
-            if (classPrefix == null || entry.getKey().startsWith(classPrefix)) {
-                json.writeFieldName(entry.getKey());
-                json.writeStartObject();
-                {
-                    for (Entry<MetricName, Metric> subEntry : entry.getValue().entrySet()) {
-                        json.writeFieldName(subEntry.getKey().getName());
-                        try {
-                            subEntry.getValue().processWith(this, subEntry.getKey(), new Context(json, showFullSamples));
-                        }
-                        catch(Exception e) {
-                        }
-                    }
-                }
-                json.writeEndObject();
-            }
-        }
-    }
+			writeRegularMetrics(json, classPrefix, showFullSamples);
+		}
+		json.writeEndObject();
+		json.close();
+	}
 
-    @Override
-    public void processHistogram(MetricName name, HistogramMetric histogram, Context context) throws Exception {
-        JsonGenerator json = context.json;
-        json.writeStartObject();
-        {
-            json.writeStringField("type", "histogram");
-            json.writeNumberField("count", histogram.count());
-            writeSummarized(histogram, json);
-            writePercentiles(histogram, json);
+	public void writeRegularMetrics(JsonGenerator json, String classPrefix, boolean showFullSamples) throws IOException {
+		for (Entry<String, Map<MetricName, Metric>> entry : Utils.sortMetrics(metricsRegistry.allMetrics()).entrySet()) {
+			if (classPrefix == null || entry.getKey().startsWith(classPrefix)) {
+				json.writeFieldName(entry.getKey());
+				json.writeStartObject();
+				{
+					for (Entry<MetricName, Metric> subEntry : entry.getValue().entrySet()) {
+						json.writeFieldName(subEntry.getKey().getName());
+						try {
+							subEntry.getValue().processWith(this, subEntry.getKey(), new Context(json, showFullSamples));
+						} catch (Exception e) {}
+					}
+				}
+				json.writeEndObject();
+			}
+		}
+	}
 
-            if (context.showFullSamples) {
-                json.writeObjectField("values", histogram.values());
-            }
-        }
-        json.writeEndObject();
-    }
+	@Override
+	public void processHistogram(MetricName name, HistogramMetric histogram, Context context) throws Exception {
+		JsonGenerator json = context.json;
+		json.writeStartObject();
+		{
+			json.writeStringField("type", "histogram");
+			json.writeNumberField("count", histogram.count());
+			writeSummarized(histogram, json);
+			writePercentiles(histogram, json);
 
-    @Override
-    public void processCounter(MetricName name, CounterMetric counter, Context context) throws Exception {
-        JsonGenerator json = context.json;
-        json.writeStartObject();
-        {
-            json.writeStringField("type", "counter");
-            json.writeNumberField("count", counter.count());
-        }
-        json.writeEndObject();
-    }
+			if (context.showFullSamples) {
+				json.writeObjectField("values", histogram.values());
+			}
+		}
+		json.writeEndObject();
+	}
 
-    @Override
-    public void processGauge(MetricName name, GaugeMetric<?> gauge, Context context) throws Exception {
-        JsonGenerator json = context.json;
-        json.writeStartObject();
-        {
-            json.writeStringField("type", "gauge");
-            json.writeObjectField("value", evaluateGauge(gauge));
-        }
-        json.writeEndObject();
-    }
+	@Override
+	public void processCounter(MetricName name, CounterMetric counter, Context context) throws Exception {
+		JsonGenerator json = context.json;
+		json.writeStartObject();
+		{
+			json.writeStringField("type", "counter");
+			json.writeNumberField("count", counter.count());
+		}
+		json.writeEndObject();
+	}
 
-    private static Object evaluateGauge(GaugeMetric<?> gauge) {
-        try {
-            return gauge.value();
-        } catch (RuntimeException e) {
-            LOGGER.warn("Error evaluating gauge", e);
-            return "error reading gauge: " + e.getMessage();
-        }
-    }
+	@Override
+	public void processGauge(MetricName name, GaugeMetric<?> gauge, Context context) throws Exception {
+		JsonGenerator json = context.json;
+		json.writeStartObject();
+		{
+			json.writeStringField("type", "gauge");
+			json.writeObjectField("value", evaluateGauge(gauge));
+		}
+		json.writeEndObject();
+	}
 
-    private static void writeVmMetrics(JsonGenerator json) throws IOException {
-        json.writeFieldName("jvm");
-        json.writeStartObject();
-        {
+	private static Object evaluateGauge(GaugeMetric<?> gauge) {
+		try {
+			return gauge.value();
+		} catch (RuntimeException e) {
+			LOGGER.warn("Error evaluating gauge", e);
+			return "error reading gauge: " + e.getMessage();
+		}
+	}
 
-            json.writeFieldName("vm");
-            json.writeStartObject();
-            {
-                json.writeStringField("name", vmName());
-                json.writeStringField("version", vmVersion());
-            }
-            json.writeEndObject();
-            json.writeFieldName("memory");
-            json.writeStartObject();
-            {
-                json.writeNumberField("heap_usage", heapUsage());
-                json.writeNumberField("non_heap_usage", nonHeapUsage());
-                json.writeFieldName("memory_pool_usages");
-                json.writeStartObject();
-                {
-                    for (Entry<String, Double> pool : memoryPoolUsage().entrySet()) {
-                        json.writeNumberField(pool.getKey(), pool.getValue());
-                    }
-                }
-                json.writeEndObject();
-            }
-            json.writeEndObject();
+	private static void writeVmMetrics(JsonGenerator json) throws IOException {
+		json.writeFieldName("jvm");
+		json.writeStartObject();
+		{
 
-            json.writeNumberField("daemon_thread_count", daemonThreadCount());
-            json.writeNumberField("thread_count", threadCount());
-            json.writeNumberField("current_time", System.currentTimeMillis());
-            json.writeNumberField("uptime", uptime());
-            json.writeNumberField("fd_usage", fileDescriptorUsage());
+			json.writeFieldName("vm");
+			json.writeStartObject();
+			{
+				json.writeStringField("name", vmName());
+				json.writeStringField("version", vmVersion());
+			}
+			json.writeEndObject();
+			json.writeFieldName("memory");
+			json.writeStartObject();
+			{
 
-            json.writeFieldName("thread-states");
-            json.writeStartObject();
-            {
-                for (Entry<State, Double> entry : threadStatePercentages().entrySet()) {
-                    json.writeNumberField(entry.getKey().toString().toLowerCase(), entry.getValue());
-                }
-            }
-            json.writeEndObject();
+				json.writeNumberField("totalInit", totalInit());
+				json.writeNumberField("totalUsed", totalUsed());
+				json.writeNumberField("totalMax", totalMax());
+				json.writeNumberField("totalCommited", totalCommited());
 
-            json.writeFieldName("garbage-collectors");
-            json.writeStartObject();
-            {
-                for (Entry<String, GarbageCollector> entry : garbageCollectors().entrySet()) {
-                    json.writeFieldName(entry.getKey());
-                    json.writeStartObject();
-                    {
-                        final GarbageCollector gc = entry.getValue();
-                        json.writeNumberField("runs", gc.getRuns());
-                        json.writeNumberField("time", gc.getTime(TimeUnit.MILLISECONDS));
-                    }
-                    json.writeEndObject();
-                }
-            }
-            json.writeEndObject();
-        }
-        json.writeEndObject();
-    }
+				json.writeNumberField("heapInit", heapInit());
+				json.writeNumberField("heapUsed", heapUsed());
+				json.writeNumberField("heapMax", heapMax());
+				json.writeNumberField("heapCommited", heapCommited());
 
-    @Override
-    public void processMeter(MetricName name, Metered meter, Context context) throws Exception {
-        JsonGenerator json = context.json;
-        json.writeStartObject();
-        {
-            json.writeStringField("type", "meter");
-            json.writeStringField("event_type", meter.eventType());
-            writeMeteredFields(meter, json);
-        }
-        json.writeEndObject();
-    }
+				json.writeNumberField("heap_usage", heapUsage());
+				json.writeNumberField("non_heap_usage", nonHeapUsage());
+				json.writeFieldName("memory_pool_usages");
+				json.writeStartObject();
+				{
+					for (Entry<String, Double> pool : memoryPoolUsage().entrySet()) {
+						json.writeNumberField(pool.getKey(), pool.getValue());
+					}
+				}
+				json.writeEndObject();
+			}
+			json.writeEndObject();
 
-    @Override
-    public void processTimer(MetricName name, TimerMetric timer, Context context) throws Exception {
-        JsonGenerator json = context.json;
-        json.writeStartObject();
-        {
-            json.writeStringField("type", "timer");
-            json.writeFieldName("duration");
-            json.writeStartObject();
-            {
-                json.writeStringField("unit", timer.durationUnit().toString().toLowerCase());
-                writeSummarized(timer,json);
-                writePercentiles(timer, json);
-                if (context.showFullSamples) {
-                    json.writeObjectField("values", timer.values());
-                }
-            }
-            json.writeEndObject();
+			json.writeNumberField("daemon_thread_count", daemonThreadCount());
+			json.writeNumberField("thread_count", threadCount());
+			json.writeNumberField("current_time", System.currentTimeMillis());
+			json.writeNumberField("uptime", uptime());
+			json.writeNumberField("fd_usage", fileDescriptorUsage());
 
-            json.writeFieldName("rate");
-            json.writeStartObject();
-            {
-                writeMeteredFields(timer, json);
-            }
-            json.writeEndObject();
-        }
-        json.writeEndObject();
-    }
+			json.writeFieldName("thread-states");
+			json.writeStartObject();
+			{
+				for (Entry<State, Double> entry : threadStatePercentages().entrySet()) {
+					json.writeNumberField(entry.getKey().toString().toLowerCase(), entry.getValue());
+				}
+			}
+			json.writeEndObject();
 
-    private static void writeSummarized(Summarized metric, JsonGenerator json) throws IOException {
-        json.writeNumberField("min", metric.min());
-        json.writeNumberField("max", metric.max());
-        json.writeNumberField("mean", metric.mean());
-        json.writeNumberField("std_dev", metric.stdDev());
-    }
-    
-    private static void writePercentiles(Percentiled metric, JsonGenerator json) throws IOException {
-        final Double[] percentiles = metric.percentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999);
-        json.writeNumberField("median", percentiles[0]);
-        json.writeNumberField("p75", percentiles[1]);
-        json.writeNumberField("p95", percentiles[2]);
-        json.writeNumberField("p98", percentiles[3]);
-        json.writeNumberField("p99", percentiles[4]);
-        json.writeNumberField("p999", percentiles[5]);
-    }
-    
-    private static void writeMeteredFields(Metered metered, JsonGenerator json) throws IOException {
-        json.writeStringField("unit", metered.rateUnit().toString().toLowerCase());
-        json.writeNumberField("count", metered.count());
-        json.writeNumberField("mean", metered.meanRate());
-        json.writeNumberField("m1", metered.oneMinuteRate());
-        json.writeNumberField("m5", metered.fiveMinuteRate());
-        json.writeNumberField("m15", metered.fifteenMinuteRate());
-    }
+			json.writeFieldName("garbage-collectors");
+			json.writeStartObject();
+			{
+				for (Entry<String, GarbageCollector> entry : garbageCollectors().entrySet()) {
+					json.writeFieldName(entry.getKey());
+					json.writeStartObject();
+					{
+						final GarbageCollector gc = entry.getValue();
+						json.writeNumberField("runs", gc.getRuns());
+						json.writeNumberField("time", gc.getTime(TimeUnit.MILLISECONDS));
+					}
+					json.writeEndObject();
+				}
+			}
+			json.writeEndObject();
+		}
+		json.writeEndObject();
+	}
+
+	@Override
+	public void processMeter(MetricName name, Metered meter, Context context) throws Exception {
+		JsonGenerator json = context.json;
+		json.writeStartObject();
+		{
+			json.writeStringField("type", "meter");
+			json.writeStringField("event_type", meter.eventType());
+			writeMeteredFields(meter, json);
+		}
+		json.writeEndObject();
+	}
+
+	@Override
+	public void processTimer(MetricName name, TimerMetric timer, Context context) throws Exception {
+		JsonGenerator json = context.json;
+		json.writeStartObject();
+		{
+			json.writeStringField("type", "timer");
+			json.writeFieldName("duration");
+			json.writeStartObject();
+			{
+				json.writeStringField("unit", timer.durationUnit().toString().toLowerCase());
+				writeSummarized(timer, json);
+				writePercentiles(timer, json);
+				if (context.showFullSamples) {
+					json.writeObjectField("values", timer.values());
+				}
+			}
+			json.writeEndObject();
+
+			json.writeFieldName("rate");
+			json.writeStartObject();
+			{
+				writeMeteredFields(timer, json);
+			}
+			json.writeEndObject();
+		}
+		json.writeEndObject();
+	}
+
+	private static void writeSummarized(Summarized metric, JsonGenerator json) throws IOException {
+		json.writeNumberField("min", metric.min());
+		json.writeNumberField("max", metric.max());
+		json.writeNumberField("mean", metric.mean());
+		json.writeNumberField("std_dev", metric.stdDev());
+	}
+
+	private static void writePercentiles(Percentiled metric, JsonGenerator json) throws IOException {
+		final Double[] percentiles = metric.percentiles(0.5, 0.75, 0.95, 0.98, 0.99, 0.999);
+		json.writeNumberField("median", percentiles[0]);
+		json.writeNumberField("p75", percentiles[1]);
+		json.writeNumberField("p95", percentiles[2]);
+		json.writeNumberField("p98", percentiles[3]);
+		json.writeNumberField("p99", percentiles[4]);
+		json.writeNumberField("p999", percentiles[5]);
+	}
+
+	private static void writeMeteredFields(Metered metered, JsonGenerator json) throws IOException {
+		json.writeStringField("unit", metered.rateUnit().toString().toLowerCase());
+		json.writeNumberField("count", metered.count());
+		json.writeNumberField("mean", metered.meanRate());
+		json.writeNumberField("m1", metered.oneMinuteRate());
+		json.writeNumberField("m5", metered.fiveMinuteRate());
+		json.writeNumberField("m15", metered.fifteenMinuteRate());
+	}
 }


### PR DESCRIPTION
**Additional metrics for Dynamic memory profiles**
The changes below are usefull for VM that are configured to have
Dynamic memory profile.
- **metrics-core** : Added heap and non heap absoute values to the
  VirtualMachineMetrics.java such that they can be reported through
  the servlet.
- **metrics-servlet**: changed the servlet to report the additionnal
  values so that absolutes can be calculated for all other JVM metrics.

**Test fix for platform and locale independence**
The changes below are to fix platform and locale dependencies of unit tests.
some changes were necessary in the main code though prior behaviour was kept.
All changes are in metrics-core.
- **ConsoleReporter** - Added locale as constructor properties
                Defaults to the system locale (prior behaviour)
- **ConsoleReporterTest** - Creates ConsoleReporter with US locale
                To match formatted dates in the hard coded strings.
- **AbstractPollingReporterTest** - changed the split regex such that
                It supports all major platforms in a way that remains
                compatible with expected values.
