### PR TITLE
Added absolute memory values to JVM metrics

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/core/VirtualMachineMetrics.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/VirtualMachineMetrics.java
@@ -35,6 +35,71 @@ public class VirtualMachineMetrics {
     private VirtualMachineMetrics() { /* unused */ }
 
     /**
+     * Returns the total initial memory of the current JVM.
+     *
+     * @return total Heap and non-heap initial JVM memory in bytes.
+     */
+    public static double totalInit() {
+        return getMemoryMXBean().getHeapMemoryUsage().getInit() + getMemoryMXBean().getNonHeapMemoryUsage().getInit();
+    }
+    /**
+     * Returns the total memory currently used by the current JVM.
+     *
+     * @return total Heap and non-heap memory currently used by JVM in bytes.
+     */
+    public static double totalUsed() {
+        return getMemoryMXBean().getHeapMemoryUsage().getUsed() + getMemoryMXBean().getNonHeapMemoryUsage().getUsed();
+  	}
+    /**
+     * Returns the total memory currently used by the current JVM.
+     *
+     * @return total Heap and non-heap memory currently used by JVM in bytes.
+     */
+    public static double totalMax() {
+        return getMemoryMXBean().getHeapMemoryUsage().getMax() + getMemoryMXBean().getNonHeapMemoryUsage().getMax();
+    }
+    /**
+     * Returns the total memory committed to the JVM.
+     *
+     * @return total Heap and non-heap memory currently committed to the JVM in bytes.
+     */
+    public static double totalCommited() {
+        return getMemoryMXBean().getHeapMemoryUsage().getCommitted() + getMemoryMXBean().getNonHeapMemoryUsage().getCommitted();
+    }
+    /**
+     * Returns the heap initial memory of the current JVM.
+     *
+     * @return Heap initial JVM memory in bytes.
+     */
+    public static double heapInit() {
+        return getMemoryMXBean().getHeapMemoryUsage().getInit() + getMemoryMXBean().getNonHeapMemoryUsage().getInit();
+    }
+    /**
+     * Returns the heap memory currently used by the current JVM.
+     *
+     * @return Heap memory currently used by JVM in bytes.
+     */
+    public static double heapUsed() {
+        return getMemoryMXBean().getHeapMemoryUsage().getUsed() + getMemoryMXBean().getNonHeapMemoryUsage().getUsed();
+    }
+    /**
+     * Returns the heap memory currently used by the current JVM.
+     *
+     * @return Heap memory currently used by JVM in bytes.
+     */
+    public static double heapMax() {
+        return getMemoryMXBean().getHeapMemoryUsage().getMax() + getMemoryMXBean().getNonHeapMemoryUsage().getMax();
+    }
+    /**
+     * Returns the heap memory committed to the JVM.
+     *
+     * @return Heap memory currently committed to the JVM in bytes.
+     */
+    public static double heapCommited() {
+        return getMemoryMXBean().getHeapMemoryUsage().getCommitted() + getMemoryMXBean().getNonHeapMemoryUsage().getCommitted();
+    }
+
+    /**
      * Returns the percentage of the JVM's heap which is being used.
      *
      * @return the percentage of the JVM's heap which is being used

--- a/metrics-servlet/src/main/java/com/yammer/metrics/reporting/MetricsServlet.java
+++ b/metrics-servlet/src/main/java/com/yammer/metrics/reporting/MetricsServlet.java
@@ -347,6 +347,16 @@ public class MetricsServlet extends HttpServlet implements MetricsProcessor<Metr
             json.writeFieldName("memory");
             json.writeStartObject();
             {
+                json.writeNumberField("totalInit", totalInit());
+                json.writeNumberField("totalUsed", totalUsed());
+                json.writeNumberField("totalMax", totalMax());
+                json.writeNumberField("totalCommited", totalCommited());
+
+                json.writeNumberField("heapInit", heapInit());
+                json.writeNumberField("heapUsed", heapUsed());
+                json.writeNumberField("heapMax", heapMax());
+                json.writeNumberField("heapCommited", heapCommited());
+
                 json.writeNumberField("heap_usage", heapUsage());
                 json.writeNumberField("non_heap_usage", nonHeapUsage());
                 json.writeFieldName("memory_pool_usages");


### PR DESCRIPTION
Allows easier tracking for application setup to have dynamic memory profiles.  These values are not the complete set but should allow calculating all other from the already provided ratios.

Exposed the additional values in the JSON data structure published with the servlet.

These are available through other means but it makes things easier if we only have to analyse one data set as opposed to pulling values from different sources.
