### PR TITLE
"MINUTES_PER_SECOND = 60.0" => "SECONDS_PER_MINUTE = 60.0"

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/stats/EWMA.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/stats/EWMA.java
@@ -15,13 +15,13 @@ import static java.lang.Math.exp;
  */
 public class EWMA {
     private static final int INTERVAL = 5;
-    private static final double MINUTES_PER_SECOND = 60.0;
+    private static final double SECONDS_PER_MINUTE = 60.0;
     private static final int ONE_MINUTE = 1;
     private static final int FIVE_MINUTES = 5;
     private static final int FIFTEEN_MINUTES = 15;
-    private static final double M1_ALPHA = 1 - exp(-INTERVAL / MINUTES_PER_SECOND / ONE_MINUTE);
-    private static final double M5_ALPHA = 1 - exp(-INTERVAL / MINUTES_PER_SECOND / FIVE_MINUTES);
-    private static final double M15_ALPHA = 1 - exp(-INTERVAL / MINUTES_PER_SECOND / FIFTEEN_MINUTES);
+    private static final double M1_ALPHA = 1 - exp(-INTERVAL / SECONDS_PER_MINUTE / ONE_MINUTE);
+    private static final double M5_ALPHA = 1 - exp(-INTERVAL / SECONDS_PER_MINUTE / FIVE_MINUTES);
+    private static final double M15_ALPHA = 1 - exp(-INTERVAL / SECONDS_PER_MINUTE / FIFTEEN_MINUTES);
 
     private volatile boolean initialized = false;
     private volatile double rate = 0.0;


### PR DESCRIPTION
Noticed some unusual labeling in the EWMA implementation when reading through it. Is this correct?
