### PR TITLE
Add timerContext() to the Scala facade for Timer

### DIFF
--- a/metrics-scala_2.9.1/src/main/scala/com/yammer/metrics/scala/Timer.scala
+++ b/metrics-scala_2.9.1/src/main/scala/com/yammer/metrics/scala/Timer.scala
@@ -28,6 +28,12 @@ class Timer(metric: com.yammer.metrics.core.Timer) {
   }
 
   /**
+   * Returns a timing [[com.metrics.yammer.core.TimerContext]],
+   * which measures an elapsed time in nanoseconds.
+   */
+  def timerContext() = metric.time()
+
+  /**
    * Returns the number of durations recorded.
    */
   def count = metric.count


### PR DESCRIPTION
We would like to use the Scala facade, but it doesn't expose a way to obtain a TimerContext for us to measure asynchronous operations. This patch adds a timerContext() method that creates a new TimerContext.

Thank you!
