### PR TITLE
The Spring Bean Post-Processor for @Timed shouldn't have highest precedence

### DIFF
--- a/metrics-spring/src/main/java/com/yammer/metrics/spring/TimedAnnotationBeanPostProcessor.java
+++ b/metrics-spring/src/main/java/com/yammer/metrics/spring/TimedAnnotationBeanPostProcessor.java
@@ -3,13 +3,11 @@ package com.yammer.metrics.spring;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.springframework.aop.Pointcut;
 import org.springframework.aop.support.annotation.AnnotationMatchingPointcut;
-import org.springframework.core.Ordered;
 
 import com.yammer.metrics.annotation.Timed;
 import com.yammer.metrics.core.MetricsRegistry;
 
-public class TimedAnnotationBeanPostProcessor extends AbstractProxyingBeanPostProcessor implements
-                                                                                        Ordered {
+public class TimedAnnotationBeanPostProcessor extends AbstractProxyingBeanPostProcessor {
 
     private static final long serialVersionUID = -1589475386869891203L;
 
@@ -28,11 +26,6 @@ public class TimedAnnotationBeanPostProcessor extends AbstractProxyingBeanPostPr
     @Override
     public MethodInterceptor getMethodInterceptor(Class<?> targetClass) {
         return new TimedMethodInterceptor(metrics, targetClass);
-    }
-
-    @Override
-    public int getOrder() {
-        return HIGHEST_PRECEDENCE;
     }
 
 }


### PR DESCRIPTION
`@Timed` caused problems when added to a method that also annotated with `@RequestMapping`.  The proxy created by the `TimedAnnotationBeanPostProcessor` apparently obscures any other annotations present.  This is fixed by giving this bean processor normal precedence, so that other bean processors can run before the proxy is created.
