### PR TITLE
Add group and type to annotations

### DIFF
--- a/metrics-annotation/src/main/java/com/yammer/metrics/annotation/ExceptionMetered.java
+++ b/metrics-annotation/src/main/java/com/yammer/metrics/annotation/ExceptionMetered.java
@@ -48,6 +48,18 @@ public @interface ExceptionMetered {
     String DEFAULT_NAME_SUFFIX = "Exceptions";
 
     /**
+     * The group of the timer. If not specified, the meter will be given a group based on
+     * the package.
+     */
+    String group() default "";
+
+    /**
+     * The type of the timer. If not specified the meter will be given a type based on
+     * the class name.
+     */
+    String type() default "";
+
+    /**
      * The name of the meter. If not specified, the meter will be given a name based on the method
      * it decorates and the suffix "Exceptions".
      */

--- a/metrics-annotation/src/main/java/com/yammer/metrics/annotation/Gauge.java
+++ b/metrics-annotation/src/main/java/com/yammer/metrics/annotation/Gauge.java
@@ -23,6 +23,16 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 public @interface Gauge {
     /**
+     * The gauge's group.
+     */
+    String group() default "";
+
+    /**
+     * The gauge's type.
+     */
+    String type() default "";
+
+    /**
      * The gauge's name.
      */
     String name() default "";

--- a/metrics-annotation/src/main/java/com/yammer/metrics/annotation/Metered.java
+++ b/metrics-annotation/src/main/java/com/yammer/metrics/annotation/Metered.java
@@ -24,6 +24,16 @@ import java.util.concurrent.TimeUnit;
 @Target(ElementType.METHOD)
 public @interface Metered {
     /**
+     * The group of the timer.
+     */
+    String group() default "";
+
+    /**
+     * The type of the timer.
+     */
+    String type() default "";
+
+    /**
      * The name of the meter.
      */
     String name() default "";

--- a/metrics-annotation/src/main/java/com/yammer/metrics/annotation/Timed.java
+++ b/metrics-annotation/src/main/java/com/yammer/metrics/annotation/Timed.java
@@ -25,6 +25,16 @@ import java.util.concurrent.TimeUnit;
 @Target(ElementType.METHOD)
 public @interface Timed {
     /**
+     * The group of the timer.
+     */
+    String group() default "";
+
+    /**
+     * The type of the timer.
+     */
+    String type() default "";
+
+    /**
      * The name of the timer.
      */
     String name() default "";

--- a/metrics-core/src/main/java/com/yammer/metrics/core/MetricName.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/MetricName.java
@@ -1,5 +1,6 @@
 package com.yammer.metrics.core;
 
+import java.lang.reflect.Method;
 
 /**
  * A value class encapsulating a metric's owning class and name.
@@ -175,5 +176,44 @@ public class MetricName implements Comparable<MetricName> {
             nameBuilder.append(name);
         }
         return nameBuilder.toString();
+    }
+
+    /**
+     * If the group is empty, use the package name of the given class. Otherwise use group
+     * @param group The group to use by default
+     * @param klass The class being tracked
+     * @return a group for the metric
+     */
+    public static String chooseGroup(String group, Class<?> klass) {
+        if(group == null || group.isEmpty()) {
+            group = klass.getPackage() == null ? "" : klass.getPackage().getName();
+        }
+        return group;
+    }
+
+    /**
+     * If the type is empty, use the simple name of the given class. Otherwise use type
+     * @param type The type to use by default
+     * @param klass The class being tracked
+     * @return a type for the metric
+     */
+    public static String chooseType(String type, Class<?> klass) {
+        if(type == null || type.isEmpty()) {
+            type = klass.getSimpleName().replaceAll("\\$$", ""); 
+        }
+        return type;
+    }
+
+    /**
+     * If name is empty, use the name of the given method. Otherwise use name
+     * @param name The name to use by default
+     * @param method The method being tracked
+     * @return a name for the metric
+     */
+    public static String chooseName(String name, Method method) {
+        if(name == null || name.isEmpty()) {
+            name = method.getName();
+        }
+        return name;
     }
 }

--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/ExceptionMeteredInterceptor.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/ExceptionMeteredInterceptor.java
@@ -2,6 +2,7 @@ package com.yammer.metrics.guice;
 
 import com.yammer.metrics.annotation.ExceptionMetered;
 import com.yammer.metrics.core.Meter;
+import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -17,9 +18,11 @@ class ExceptionMeteredInterceptor implements MethodInterceptor {
     static MethodInterceptor forMethod(MetricsRegistry metricsRegistry, Class<?> klass, Method method) {
         final ExceptionMetered annotation = method.getAnnotation(ExceptionMetered.class);
         if (annotation != null) {
+            final String group = MetricName.chooseGroup(annotation.group(), klass);
+            final String type = MetricName.chooseType(annotation.type(), klass);
             final String name = determineName(annotation, method);
-            final Meter meter = metricsRegistry.newMeter(klass,
-                                                               name,
+            final MetricName metricName = new MetricName(group, type, name);
+            final Meter meter = metricsRegistry.newMeter(metricName,
                                                                annotation.eventType(),
                                                                annotation.rateUnit());
             return new ExceptionMeteredInterceptor(meter, annotation.cause());

--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/GaugeInjectionListener.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/GaugeInjectionListener.java
@@ -1,11 +1,11 @@
 package com.yammer.metrics.guice;
 
-import com.google.inject.TypeLiteral;
+import java.lang.reflect.Method;
+
 import com.google.inject.spi.InjectionListener;
 import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
-
-import java.lang.reflect.Method;
 
 /**
  * An injection listener which creates a gauge for the declaring class with the given name (or the
@@ -13,20 +13,18 @@ import java.lang.reflect.Method;
  */
 class GaugeInjectionListener<I> implements InjectionListener<I> {
     private final MetricsRegistry metricsRegistry;
-    private final TypeLiteral<I> literal;
-    private final String name;
+    private final MetricName metricName;
     private final Method method;
 
-    GaugeInjectionListener(MetricsRegistry metricsRegistry, TypeLiteral<I> literal, String name, Method method) {
+    GaugeInjectionListener(MetricsRegistry metricsRegistry, MetricName metricName, Method method) {
         this.metricsRegistry = metricsRegistry;
-        this.literal = literal;
-        this.name = name;
+        this.metricName = metricName;
         this.method = method;
     }
 
     @Override
     public void afterInjection(final I i) {
-        metricsRegistry.newGauge(literal.getRawType(), name, new Gauge<Object>() {
+        metricsRegistry.newGauge(metricName, new Gauge<Object>() {
             @Override
             public Object value() {
                 try {

--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/GaugeListener.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/GaugeListener.java
@@ -4,6 +4,7 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.spi.TypeEncounter;
 import com.google.inject.spi.TypeListener;
 import com.yammer.metrics.annotation.Gauge;
+import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
 
 import java.lang.reflect.Method;
@@ -24,11 +25,12 @@ class GaugeListener implements TypeListener {
             final Gauge annotation = method.getAnnotation(Gauge.class);
             if (annotation != null) {
                 if (method.getParameterTypes().length == 0) {
-                    final String name = annotation.name()
-                                                  .isEmpty() ? method.getName() : annotation.name();
+                    final String group = MetricName.chooseGroup(annotation.group(), literal.getRawType());
+                    final String type = MetricName.chooseType(annotation.type(), literal.getRawType());
+                    final String name = MetricName.chooseName(annotation.name(), method);            
+                    final MetricName metricName = new MetricName(group, type, name);
                     encounter.register(new GaugeInjectionListener<I>(metricsRegistry,
-                                                                     literal,
-                                                                     name,
+                                                                     metricName,
                                                                      method));
                 } else {
                     encounter.addError("Method %s is annotated with @Gauge but requires parameters.",

--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/MeteredInterceptor.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/MeteredInterceptor.java
@@ -2,6 +2,7 @@ package com.yammer.metrics.guice;
 
 import com.yammer.metrics.annotation.Metered;
 import com.yammer.metrics.core.Meter;
+import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -17,9 +18,11 @@ class MeteredInterceptor implements MethodInterceptor {
     static MethodInterceptor forMethod(MetricsRegistry metricsRegistry, Class<?> klass, Method method) {
         final Metered annotation = method.getAnnotation(Metered.class);
         if (annotation != null) {
-            final String name = annotation.name().isEmpty() ? method.getName() : annotation.name();
-            final Meter meter = metricsRegistry.newMeter(klass,
-                                                               name,
+            final String group = MetricName.chooseGroup(annotation.group(), klass);
+            final String type = MetricName.chooseType(annotation.type(), klass);
+            final String name = MetricName.chooseName(annotation.name(), method);            
+            final MetricName metricName = new MetricName(group, type, name);
+            final Meter meter = metricsRegistry.newMeter(metricName,
                                                                annotation.eventType(),
                                                                annotation.rateUnit());
             return new MeteredInterceptor(meter);

--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/TimedInterceptor.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/TimedInterceptor.java
@@ -1,6 +1,7 @@
 package com.yammer.metrics.guice;
 
 import com.yammer.metrics.annotation.Timed;
+import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
 import com.yammer.metrics.core.Timer;
 import org.aopalliance.intercept.MethodInterceptor;
@@ -17,9 +18,11 @@ class TimedInterceptor implements MethodInterceptor {
     static MethodInterceptor forMethod(MetricsRegistry metricsRegistry, Class<?> klass, Method method) {
         final Timed annotation = method.getAnnotation(Timed.class);
         if (annotation != null) {
-            final String name = annotation.name().isEmpty() ? method.getName() : annotation.name();
-            final Timer timer = metricsRegistry.newTimer(klass,
-                                                               name,
+            final String group = MetricName.chooseGroup(annotation.group(), klass);
+            final String type = MetricName.chooseType(annotation.type(), klass);
+            final String name = MetricName.chooseName(annotation.name(), method);            
+            final MetricName metricName = new MetricName(group, type, name);
+            final Timer timer = metricsRegistry.newTimer(metricName,
                                                                annotation.durationUnit(),
                                                                annotation.rateUnit());
             return new TimedInterceptor(timer);

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/ExceptionMeteredTest.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/ExceptionMeteredTest.java
@@ -75,6 +75,29 @@ public class ExceptionMeteredTest {
     }
 
     @Test
+    public void anExceptionMeteredAnnotatedMethod_WithGroupTypeAndName() throws Exception {
+
+        final Metric metric = registry.allMetrics()
+                                      .get(new MetricName("g", "t", "n"));
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+                   ((Meter) metric).count(),
+                   is(0L));
+
+        try {
+            instance.explodeForMetricWithGroupTypeAndName();
+            fail("Expected an exception to be thrown");
+        } catch (RuntimeException e) {
+            // Swallow the expected exception
+        }
+
+        assertThat("Metric is marked",
+                   ((Meter) metric).count(),
+                   is(1L));
+    }
+
+    @Test
     public void anExceptionMeteredAnnotatedMethod_WithPublicScopeButNoExceptionThrown() throws Exception {
 
         final Metric metric = registry.allMetrics()

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/GaugeTest.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/GaugeTest.java
@@ -1,5 +1,7 @@
 package com.yammer.metrics.guice.tests;
 
+import java.util.Set;
+
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.yammer.metrics.core.Gauge;
@@ -66,5 +68,30 @@ public class GaugeTest {
         assertThat("Guice creates a gauge with the given value",
                    ((Gauge<String>) metric).value(),
                    is("anotherThing"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void aGaugeAnnotatedMethodWithGroupTypeAndName() throws Exception {
+        final Injector injector = Guice.createInjector(new InstrumentationModule());
+        final InstrumentedWithGauge instance = injector.getInstance(InstrumentedWithGauge.class);
+        final MetricsRegistry registry = injector.getInstance(MetricsRegistry.class);
+
+        instance.doAThingWithGroupTypeAndName();
+
+        Set<MetricName> keySet = registry.allMetrics().keySet();
+        final Metric metric = registry.allMetrics().get(new MetricName("g", "t", "n"));
+
+        assertThat("Guice creates a metric",
+                   metric,
+                   is(notNullValue()));
+
+        assertThat("Guice creates a gauge",
+                   metric,
+                   is(instanceOf(Gauge.class)));
+
+        assertThat("Guice creates a gauge with the given value",
+                   ((Gauge<String>) metric).value(),
+                   is("anotherThingWithGroupTypeAndName"));
     }
 }

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithExceptionMetered.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithExceptionMetered.java
@@ -21,6 +21,11 @@ public class InstrumentedWithExceptionMetered {
     String explodeForUnnamedMetric() {
         throw new RuntimeException("Boom!");
     }
+    
+    @ExceptionMetered(group="g", type="t", name="n")
+    String explodeForMetricWithGroupTypeAndName() {
+        throw new RuntimeException("Boom!");
+    }
 
     @ExceptionMetered
     String explodeWithDefaultScope() {

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithGauge.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithGauge.java
@@ -12,4 +12,9 @@ public class InstrumentedWithGauge {
     public String doAnotherThing() {
         return "anotherThing";
     }
+
+    @Gauge(group="g", type="t", name="n")
+    public String doAThingWithGroupTypeAndName() {
+        return "anotherThingWithGroupTypeAndName";
+    }
 }

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithMetered.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithMetered.java
@@ -1,6 +1,7 @@
 package com.yammer.metrics.guice.tests;
 
 import com.yammer.metrics.annotation.Metered;
+import com.yammer.metrics.annotation.Timed;
 
 import java.util.concurrent.TimeUnit;
 
@@ -18,5 +19,10 @@ public class InstrumentedWithMetered {
     @Metered
     protected String doAThingWithProtectedScope() {
         return "defaultProtected";
+    }
+
+    @Metered(group="g", type="t", name="n")
+    protected String doAThingWithGroupTypeAndName() {
+        return "newGroupTypeAndName";
     }
 }

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithTimed.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/InstrumentedWithTimed.java
@@ -19,4 +19,9 @@ public class InstrumentedWithTimed {
     protected String doAThingWithProtectedScope() {
         return "defaultProtected";
     }
+
+    @Timed(group="g", type="t", name="n")
+    protected String doAThingWithCustomGroupTypeAndName() {
+        return "defaultProtected";
+    }
 }

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/MeteredTest.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/MeteredTest.java
@@ -90,6 +90,24 @@ public class MeteredTest {
                    is(1L));
     }
 
+    @Test
+    public void aMeteredAnnotatedMethodWithGroupTypeAndName() throws Exception {
+
+        final Metric metric = registry.allMetrics().get(new MetricName("g", "t", "n"));
+
+        assertMetricIsSetup(metric);
+
+        assertThat("Metric intialises to zero",
+                   ((Meter) metric).count(),
+                   is(0L));
+
+        instance.doAThingWithGroupTypeAndName();
+
+        assertThat("Metric is marked",
+                   ((Meter) metric).count(),
+                   is(1L));
+    }
+
     private void assertMetricIsSetup(final Metric metric) {
         assertThat("Guice creates a metric",
                    metric,

--- a/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/TimedTest.java
+++ b/metrics-guice/src/test/java/com/yammer/metrics/guice/tests/TimedTest.java
@@ -72,6 +72,16 @@ public class TimedTest {
         assertMetricSetup(metric);
     }
 
+    @Test
+    public void aTimedAnnotatedMethodWithCustomGroupTypeAndName() throws Exception {
+
+        instance.doAThingWithCustomGroupTypeAndName();
+
+        final Metric metric = registry.allMetrics().get(new MetricName("g", "t", "n"));
+
+        assertMetricSetup(metric);
+    }
+
     private void assertMetricSetup(final Metric metric) {
         assertThat("Guice creates a metric",
                    metric,

--- a/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/MetricsJerseyTest.java
+++ b/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/MetricsJerseyTest.java
@@ -57,7 +57,7 @@ public class MetricsJerseyTest extends JerseyTest {
     @Test
     public void exceptionMeteredMethodsAreExceptionMetered() {
         final Meter meter = Metrics.newMeter(InstrumentedResource.class, "exceptionMeteredExceptions", "blah", TimeUnit.SECONDS);
-
+        
         assertThat(resource().path("exception-metered").get(String.class),
                    is("fuh"));
 

--- a/metrics-servlet/src/test/java/com/yammer/metrics/reporting/tests/AdminServletTest.java
+++ b/metrics-servlet/src/test/java/com/yammer/metrics/reporting/tests/AdminServletTest.java
@@ -70,7 +70,7 @@ public class AdminServletTest {
         verify(response).setStatus(200);
         verify(response).setContentType("text/html");
 
-        assertThat(output.toString(),
+        assertThat(output.toString().replaceAll("\r\n", "\n"),
                    is("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\n        " +
                               "\"http://www.w3.org/TR/html4/loose.dtd\">\n<html>\n<head>\n  " +
                               "<title>Metrics</title>\n</head>\n<body>\n  " +
@@ -91,7 +91,7 @@ public class AdminServletTest {
         verify(response).setStatus(200);
         verify(response).setContentType("text/html");
 
-        assertThat(output.toString(),
+        assertThat(output.toString().replaceAll("\r\n", "\n"),
                    is("<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\"\n        " +
                               "\"http://www.w3.org/TR/html4/loose.dtd\">\n<html>\n<head>\n  " +
                               "<title>Metrics</title>\n</head>\n<body>\n  " +

--- a/metrics-servlet/src/test/java/com/yammer/metrics/reporting/tests/HealthCheckServletTest.java
+++ b/metrics-servlet/src/test/java/com/yammer/metrics/reporting/tests/HealthCheckServletTest.java
@@ -47,7 +47,7 @@ public class HealthCheckServletTest {
 
         servlet.service(request, response);
 
-        assertThat(output.toString(),
+        assertThat(output.toString().replaceAll("\r\n", "\n"),
                    is("! No health checks registered.\n"));
 
         verify(response).setStatus(501);
@@ -89,7 +89,7 @@ public class HealthCheckServletTest {
 
         servlet.service(request, response);
 
-        assertThat(output.toString(),
+        assertThat(output.toString().replaceAll("\r\n", "\n"),
                    is(
                            "! one: ERROR\n" +
                                    "!  msg\n" +


### PR DESCRIPTION
This change adds two attributes to the various metric annotations:
- group
- type

Both are optional and the behavior if they are omitted should be the same as before. The main objective was to simplify the names that ultimately make their way into graphite. Sorry for the three commits. I originally had this in a different server and pull it into this one.
