### PR TITLE
make GraphiteReporter more extensible

### DIFF
--- a/metrics-core/src/test/java/com/yammer/metrics/reporting/tests/AbstractPollingReporterTest.java
+++ b/metrics-core/src/test/java/com/yammer/metrics/reporting/tests/AbstractPollingReporterTest.java
@@ -23,9 +23,9 @@ import static org.mockito.Mockito.*;
 public abstract class AbstractPollingReporterTest {
 
     protected final Clock clock = mock(Clock.class);
-    private AbstractPollingReporter reporter;
-    private ByteArrayOutputStream out;
-    private TestMetricsRegistry registry;
+    protected AbstractPollingReporter reporter;
+    protected ByteArrayOutputStream out;
+    protected TestMetricsRegistry registry;
 
     @Before
     public void init() throws Exception {
@@ -36,13 +36,13 @@ public abstract class AbstractPollingReporterTest {
         reporter = createReporter(registry, out, clock);
     }
 
-    private static class TestMetricsRegistry extends MetricsRegistry {
+    protected static class TestMetricsRegistry extends MetricsRegistry {
         public <T extends Metric> T add(MetricName name, T metric) {
             return getOrAdd(name, metric);
         }
     }
 
-    protected final <T extends Metric> void assertReporterOutput(Callable<T> action, String... expected) throws Exception {
+    protected <T extends Metric> void assertReporterOutput(Callable<T> action, String... expected) throws Exception {
         // Invoke the callable to trigger (ie, mark()/inc()/etc) and return the metric
         final T metric = action.call();
         try {


### PR DESCRIPTION
Change private methods to protected and remove one final keyword so
it is possible to create subclasses of GraphiteReporter that reuse most
of the logic. Similar changes to the parent test class to enable subclasses 
to reuse the existing testing framework.
