### PR TITLE
Getter for metrics to ease unit testing

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/core/MetricsRegistry.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/MetricsRegistry.java
@@ -475,6 +475,28 @@ public class MetricsRegistry {
     }
 
     /**
+     * Gets any existing metric with the given name or, if none exists, returns null.
+     *
+     * @param name   the metric's name
+     * @return either the existing metric or null
+     */
+    public final Metric get(MetricName name) {
+        return metrics.get(name);
+    }
+
+    /**
+     * Gets any existing metric with the given name or, if none exists, returns null.
+     *
+     * @param name   the metric's name
+     * @param clazz    the class of the metric
+     * @throws ClassCastException if the object is not null and is not assignable to the type T
+     * @return either the existing metric or null
+     */
+    public final <T extends Metric> T get(MetricName name, Class<T> clazz) {
+        return clazz.cast(metrics.get(name));
+    }
+
+    /**
      * Gets any existing metric with the given name or, if none exists, adds the given metric.
      *
      * @param name   the metric's name


### PR DESCRIPTION
Getters to ease the pain of unit testing.

So instead of this:

``` java
    @Test
    public void measuresGets() throws Exception {

        cache.get("woo");

        final Timer gets = Metrics.newTimer(Cache.class,
                                            "get",
                                            "test-config",
                                            TimeUnit.MILLISECONDS,
                                            TimeUnit.SECONDS);

        assertThat(gets.count(), is(1L));

    }
```

You could write this:

``` java
    @Test
    public void measuresGets() throws Exception {

        cache.get("woo");

        Timer gets = Metrics.defaultRegistry().get(
            new MetricName(Cache.class, "get", "test-config"), Timer.class
        );

        assertThat(gets.count(), is(1L));

    }

```
