### PR TITLE
Document formatting fix for AdminServlet links.

### DIFF
--- a/docs/source/manual/servlet.rst
+++ b/docs/source/manual/servlet.rst
@@ -60,6 +60,7 @@ AdminServlet
 ``PingServlet`` into a single, easy-to-use servlet which provides a set of URIs:
 
 * ``/``: an HTML admin menu with links to the following:
+
   * ``/healthcheck``: ``HealthCheckServlet``
   * ``/metrics``: ``MetricsServlet``
   * ``/ping``: ``PingServlet``


### PR DESCRIPTION
Sublists need to be separated from the parent list items by blank lines.
