### PR TITLE
Resolving inconsistent use of Timer.time() and Clock

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/core/Timer.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/Timer.java
@@ -100,7 +100,7 @@ public class Timer implements Metered, Stoppable, Sampling, Summarizable {
      * @return a new {@link TimerContext}
      */
     public TimerContext time() {
-        return new TimerContext(this);
+        return new TimerContext(this, clock);
     }
 
     @Override

--- a/metrics-core/src/main/java/com/yammer/metrics/core/TimerContext.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/TimerContext.java
@@ -9,6 +9,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class TimerContext {
     private final Timer timer;
+    private final Clock clock;
     private final long startTime;
 
     /**
@@ -17,15 +18,16 @@ public class TimerContext {
      *
      * @param timer the {@link Timer} to report the elapsed time to
      */
-    TimerContext(Timer timer) {
+    TimerContext(Timer timer, Clock clock) {
         this.timer = timer;
-        this.startTime = System.nanoTime();
+        this.clock = clock;
+        this.startTime = clock.tick();
     }
 
     /**
      * Stops recording the elapsed time and updates the timer.
      */
     public void stop() {
-        timer.update(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+        timer.update(clock.tick() - startTime, TimeUnit.NANOSECONDS);
     }
 }

--- a/metrics-ehcache/src/main/java/com/yammer/metrics/ehcache/InstrumentedEhcache.java
+++ b/metrics-ehcache/src/main/java/com/yammer/metrics/ehcache/InstrumentedEhcache.java
@@ -3,6 +3,7 @@ package com.yammer.metrics.ehcache;
 import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.Gauge;
 import com.yammer.metrics.core.Timer;
+import com.yammer.metrics.core.TimerContext;
 import net.sf.ehcache.CacheException;
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
@@ -244,7 +245,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
 
         return new InstrumentedEhcache(cache);
     }
-    
+
     private final Timer getTimer, putTimer;
 
     private InstrumentedEhcache(Ehcache cache) {
@@ -255,51 +256,51 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
 
     @Override
     public Element get(Object key) throws IllegalStateException, CacheException {
-        final long start = System.nanoTime();
+        final TimerContext ctx = getTimer.time();
         try {
             return underlyingCache.get(key);
         } finally {
-            getTimer.update(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            ctx.stop();
         }
     }
 
     @Override
     public Element get(Serializable key) throws IllegalStateException, CacheException {
-        final long start = System.nanoTime();
+        final TimerContext ctx = getTimer.time();
         try {
             return underlyingCache.get(key);
         } finally {
-            getTimer.update(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            ctx.stop();
         }
     }
 
     @Override
     public void put(Element element) throws IllegalArgumentException, IllegalStateException, CacheException {
-        final long start = System.nanoTime();
+        final TimerContext ctx = putTimer.time();
         try {
             underlyingCache.put(element);
         } finally {
-            putTimer.update(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            ctx.stop();
         }
     }
 
     @Override
     public void put(Element element, boolean doNotNotifyCacheReplicators) throws IllegalArgumentException, IllegalStateException, CacheException {
-        final long start = System.nanoTime();
+        final TimerContext ctx = putTimer.time();
         try {
             underlyingCache.put(element, doNotNotifyCacheReplicators);
         } finally {
-            putTimer.update(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            ctx.stop();
         }
     }
 
     @Override
     public Element putIfAbsent(Element element) throws NullPointerException {
-        final long start = System.nanoTime();
+        final TimerContext ctx = putTimer.time();
         try {
             return underlyingCache.putIfAbsent(element);
         } finally {
-            putTimer.update(System.nanoTime() - start, TimeUnit.NANOSECONDS);
+            ctx.stop();
         }
     }
 }

--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/TimedInterceptor.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/TimedInterceptor.java
@@ -4,6 +4,7 @@ import com.yammer.metrics.annotation.Timed;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
 import com.yammer.metrics.core.Timer;
+import com.yammer.metrics.core.TimerContext;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 
@@ -20,7 +21,7 @@ class TimedInterceptor implements MethodInterceptor {
         if (annotation != null) {
             final String group = MetricName.chooseGroup(annotation.group(), klass);
             final String type = MetricName.chooseType(annotation.type(), klass);
-            final String name = MetricName.chooseName(annotation.name(), method);            
+            final String name = MetricName.chooseName(annotation.name(), method);
             final MetricName metricName = new MetricName(group, type, name);
             final Timer timer = metricsRegistry.newTimer(metricName,
                                                                annotation.durationUnit(),
@@ -39,11 +40,11 @@ class TimedInterceptor implements MethodInterceptor {
 
     @Override
     public Object invoke(MethodInvocation invocation) throws Throwable {
-        final long startTime = System.nanoTime();
+        final TimerContext ctx = timer.time();
         try {
             return invocation.proceed();
         } finally {
-            timer.update(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+            ctx.stop();
         }
     }
 }

--- a/metrics-scala_2.9.1/src/main/scala/com/yammer/metrics/scala/Timer.scala
+++ b/metrics-scala_2.9.1/src/main/scala/com/yammer/metrics/scala/Timer.scala
@@ -12,11 +12,11 @@ class Timer(metric: com.yammer.metrics.core.Timer) {
    * Runs f, recording its duration, and returns the result of f.
    */
   def time[A](f: => A): A = {
-    val startTime = System.nanoTime
+    val ctx = metric.time
     try {
       f
     } finally {
-      metric.update(System.nanoTime - startTime, TimeUnit.NANOSECONDS)
+      ctx.stop
     }
   }
 


### PR DESCRIPTION
I noticed a number of places where, instead of getting a `TimerContext` from `Timer.time()`, the elapsed time was tracked by calling `System.nanoTime()`.  Additionally, while `Timer.time(Callable<?>)` uses `Clock`, `TimerContext` does not.

The Jetty `InstrumentedHandler` still uses `nanoTime()` _and_ `currentTimeMillis()` for timing, which I didn't quite understand, but maybe that should be revisited as well?
