### PR TITLE
Allow JMX reporting to custom MBeanServers. 

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/reporting/JmxReporter.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/reporting/JmxReporter.java
@@ -374,9 +374,22 @@ public class JmxReporter extends AbstractReporter implements MetricsRegistryList
      * @param registry    a {@link MetricsRegistry}
      */
     public JmxReporter(MetricsRegistry registry) {
+        this(registry, ManagementFactory.getPlatformMBeanServer());
+    }
+
+    /**
+     * Creates a new {@link JmxReporter} for the given registry and MBeanServer.
+     *
+     * @param registry    a {@link MetricsRegistry}
+     * @param server      a {@link MBeanServer}
+     */
+    public JmxReporter(MetricsRegistry registry, MBeanServer server) {
         super(registry);
+        if (server == null) {
+            throw new IllegalArgumentException("server must not be null");
+        }
         this.registeredBeans = new ConcurrentHashMap<MetricName, ObjectName>(100);
-        this.server = ManagementFactory.getPlatformMBeanServer();
+        this.server = server;
     }
 
     @Override


### PR DESCRIPTION
Hi Coda,

Via the mailing list I requested the ability to report to custom MBeanServers.

In response you wrote:

> This will be fixed in 3.0.0, but that may be a while. 

Just to be sure that we're on the page, this pull request shows that my request can be executed in just a few lines of additional code. Please let me know when you're open to the change but I did something wrong.

If there are other reasons for not including this change, don't worry, I can work around it. Just not nicely ;)

Kind regards,
     Erik.
