### PR TITLE
Fix failing Guice test case.  Simplify JmxReporter bindings in InstrumentationModule.

### DIFF
--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/InstrumentationModule.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/InstrumentationModule.java
@@ -1,6 +1,7 @@
 package com.yammer.metrics.guice;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.Scopes;
 import com.google.inject.matcher.Matchers;
 import com.yammer.metrics.HealthChecks;
 import com.yammer.metrics.Metrics;
@@ -36,7 +37,7 @@ public class InstrumentationModule extends AbstractModule {
      * Override to provide a custom binding for {@link JmxReporter}
      */
     protected void bindJmxReporter() {
-        bind(JmxReporter.class).toInstance(JmxReporter.getDefault());
+        bind(JmxReporter.class).toProvider(JmxReporterProvider.class).in(Scopes.SINGLETON);
     }
 
     /**

--- a/metrics-guice/src/main/java/com/yammer/metrics/guice/JmxReporterProvider.java
+++ b/metrics-guice/src/main/java/com/yammer/metrics/guice/JmxReporterProvider.java
@@ -2,9 +2,12 @@ package com.yammer.metrics.guice;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import com.google.inject.Singleton;
+import com.yammer.metrics.Metrics;
 import com.yammer.metrics.core.MetricsRegistry;
 import com.yammer.metrics.reporting.JmxReporter;
 
+@Singleton
 public class JmxReporterProvider implements Provider<JmxReporter> {
     private final MetricsRegistry metricsRegistry;
 
@@ -15,6 +18,10 @@ public class JmxReporterProvider implements Provider<JmxReporter> {
 
     @Override
     public JmxReporter get() {
+        if (metricsRegistry == Metrics.defaultRegistry()) {
+            return JmxReporter.getDefault();
+        }
+
         final JmxReporter reporter = new JmxReporter(metricsRegistry);
         reporter.start();
         return reporter;


### PR DESCRIPTION
The module attempts to bind a null JmxReporter if the default Metrics registry is not yet created.

To simplify the handling, move the intelligence into the JmxReporterProvider and bind it unconditionally.
