### PR TITLE
Add OSGi bundle manifest headers

### DIFF
--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>metrics-annotation</artifactId>
     <name>Metrics Annotations</name>
+    <packaging>bundle</packaging>
     <description>
         A dependency-less package of just the annotations used by other Metrics modules.
     </description>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>metrics-core</artifactId>
     <name>Metrics Core Library</name>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
@@ -18,7 +19,7 @@
             <version>${slf4j.version}</version>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>metrics-ehcache</artifactId>
     <name>Metrics Ehcache Support</name>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>metrics-ganglia</artifactId>
     <name>Metrics Ganglia Support</name>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
@@ -42,4 +43,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Fragment-Host>${project.groupId}.core</Fragment-Host>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>metrics-graphite</artifactId>
     <name>Metrics Graphite Support</name>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
@@ -38,4 +39,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Fragment-Host>${project.groupId}.core</Fragment-Host>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/metrics-guice/pom.xml
+++ b/metrics-guice/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>metrics-guice</artifactId>
     <name>Metrics Guice Support</name>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>metrics-httpclient</artifactId>
     <name>Metrics HttpClient Support</name>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -10,7 +10,8 @@
 
     <artifactId>metrics-jdbi</artifactId>
     <name>Metrics JDBI Support</name>
-    
+    <packaging>bundle</packaging>
+
     <dependencies>
         <dependency>
             <groupId>com.yammer.metrics</groupId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>metrics-jersey</artifactId>
     <name>Metrics Jersey Support</name>
+    <packaging>bundle</packaging>
     <description>
         A set of class providing Metrics integration for Jersey, the reference JAX-RS
         implementation.

--- a/metrics-jetty/pom.xml
+++ b/metrics-jetty/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>metrics-jetty</artifactId>
     <name>Metrics Jetty Support</name>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>metrics-log4j</artifactId>
     <name>Metrics Log4j Support</name>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>metrics-logback</artifactId>
     <name>Metrics Logback Support</name>
+    <packaging>bundle</packaging>
 
     <properties>
         <logback.version>1.0.0</logback.version>

--- a/metrics-scala_2.9.1/pom.xml
+++ b/metrics-scala_2.9.1/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>metrics-scala_2.9.1</artifactId>
     <name>Metrics for Scala ${scala.version}</name>
+    <packaging>bundle</packaging>
 
     <properties>
         <scala.version>2.9.1</scala.version>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>metrics-servlet</artifactId>
     <name>Metrics Servlet</name>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
@@ -41,4 +42,18 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Fragment-Host>${project.groupId}.core</Fragment-Host>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/metrics-spring/pom.xml
+++ b/metrics-spring/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>metrics-spring</artifactId>
     <name>Metrics Spring Support</name>
+    <packaging>bundle</packaging>
 
     <properties>
         <spring.version>3.1.1.RELEASE</spring.version>

--- a/metrics-web/pom.xml
+++ b/metrics-web/pom.xml
@@ -10,6 +10,7 @@
 
     <artifactId>metrics-web</artifactId>
     <name>Metrics Web Application Support</name>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,12 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.8.1</version>


### PR DESCRIPTION
Add maven-bundle-plugin (with all defaults) to parent pom.xml
Change packaging type to bundle.
Set Fragment-Host on metrics-ganglia, metrics-graphite, & metrics-servlet as they expose the same package (com.yammer.metrics.reporting) as metrics-core does.

If it is undesirable to change the packaging to bundle, I can provide a more involved change to the poms. (Using maven-bundle-plugin to generate the MANIFEST.MF & using maven-jar-plugin to include it in the product.)
