### PR TITLE
Add `tick` to Scala Meter façade.

### DIFF
--- a/metrics-scala_2.9.1/src/main/scala/com/yammer/metrics/scala/Meter.scala
+++ b/metrics-scala_2.9.1/src/main/scala/com/yammer/metrics/scala/Meter.scala
@@ -66,5 +66,10 @@ class Meter(metric: com.yammer.metrics.core.Meter) {
    * average in the top Unix command.
    */
   def oneMinuteRate = metric.oneMinuteRate
+
+  /**
+  * Updates the moving averages.
+  */
+  def tick = metric.tick
 }
 


### PR DESCRIPTION
I ran into a case where I needed to force update of the moving averages (in a unit test), and wans't able to because the meter isn't accessible from the Scala façade.

I think it might be worthwhile to expose the whole meter by making it a val, but I went with the house style for this patch.
