### PR TITLE
CsvReporter.createStreamForMetric throws on existing metric files

### DIFF
--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -14,4 +14,10 @@
         <Class name="~com\.yammer\.metrics\.spring\..*"/>
         <Bug code="Se"/>
     </Match>
+
+    <!-- Don't care that a metric report file already exists. -->
+    <Match>
+        <Class name="com.yammer.metrics.reporting.CsvReporter"/>
+        <Bug code="RV"/>
+    </Match>    
 </FindBugsFilter>

--- a/metrics-core/src/main/java/com/yammer/metrics/reporting/CsvReporter.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/reporting/CsvReporter.java
@@ -135,10 +135,8 @@ public class CsvReporter extends AbstractPollingReporter implements
      */
     protected PrintStream createStreamForMetric(MetricName metricName) throws IOException {
         final File newFile = new File(outputDir, metricName.getName() + ".csv");
-        if (newFile.createNewFile()) {
-            return new PrintStream(new FileOutputStream(newFile));
-        }
-        throw new IOException("Unable to create " + newFile);
+        newFile.createNewFile();
+        return new PrintStream(new FileOutputStream(newFile));
     }
 
     @Override


### PR DESCRIPTION
The current CsvReporter.createStreamForMetric implementation throws an IOException if the metric file already exists (when File.createNewFile() returns false). This commit is a quick fix.

Worth noting: FindBugs complains about not checking the return value of newFile.createNewFile(). We can either do a dummy check to make FindBugs happy or add an exclusion, which is the route I took.
