### PR TITLE
Use name + scope when creating CSV files.

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/reporting/CsvReporter.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/reporting/CsvReporter.java
@@ -134,7 +134,7 @@ public class CsvReporter extends AbstractPollingReporter implements
      * @throws IOException if there is an error opening the stream
      */
     protected PrintStream createStreamForMetric(MetricName metricName) throws IOException {
-        final File newFile = new File(outputDir, metricName.getName() + ".csv");
+        final File newFile = new File(outputDir, metricName.toString() + ".csv");
         if (newFile.createNewFile()) {
             return new PrintStream(new FileOutputStream(newFile));
         }


### PR DESCRIPTION
This reduces naming conflicts in the presence of "related" metrics.
Specifically, we add instrumentation to Guava's caches and end up with
metrics with names like <cacheName>.<hitRate|missRate> etc. Using either
just the name or just the scope results in errors while creating the CSV
files, if multiple instrumented caches are present.
