### PR TITLE
Remove dependency on Metrics static factory methods in metrics-jersey

### DIFF
--- a/metrics-jersey/src/main/java/com/yammer/metrics/jersey/InstrumentedResourceMethodDispatchAdapter.java
+++ b/metrics-jersey/src/main/java/com/yammer/metrics/jersey/InstrumentedResourceMethodDispatchAdapter.java
@@ -2,13 +2,44 @@ package com.yammer.metrics.jersey;
 
 import com.sun.jersey.spi.container.ResourceMethodDispatchAdapter;
 import com.sun.jersey.spi.container.ResourceMethodDispatchProvider;
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.MetricsRegistry;
 
 import javax.ws.rs.ext.Provider;
 
+/**
+ * A provider that wraps a {@link ResourceMethodDispatchProvider} in an
+ * {@link InstrumentedResourceMethodDispatchProvider}
+ */
 @Provider
 public class InstrumentedResourceMethodDispatchAdapter implements ResourceMethodDispatchAdapter {
+    private MetricsRegistry registry;
+
+    /**
+     * Construct a resource method dispatch adapter using the default
+     * metrics registry
+     *
+     */
+    public InstrumentedResourceMethodDispatchAdapter() {
+        this(Metrics.defaultRegistry());
+    }
+
+    /**
+     * Construct a resource method dispatch adapter using the given
+     * metrics registry
+     * <p />
+     * When using this constructor, the {@link InstrumentedResourceMethodDispatchAdapter}
+     * should be added to a Jersey {@code ResourceConfig} as a singleton
+     *
+     * @param registry a {@link MetricsRegistry}
+     */
+    public InstrumentedResourceMethodDispatchAdapter( MetricsRegistry registry ) {
+        this.registry = registry;
+    }
+
+
     @Override
     public ResourceMethodDispatchProvider adapt(ResourceMethodDispatchProvider provider) {
-        return new InstrumentedResourceMethodDispatchProvider(provider);
+        return new InstrumentedResourceMethodDispatchProvider(provider, registry);
     }
 }

--- a/metrics-jersey/src/main/java/com/yammer/metrics/jersey/InstrumentedResourceMethodDispatchProvider.java
+++ b/metrics-jersey/src/main/java/com/yammer/metrics/jersey/InstrumentedResourceMethodDispatchProvider.java
@@ -4,12 +4,12 @@ import com.sun.jersey.api.core.HttpContext;
 import com.sun.jersey.api.model.AbstractResourceMethod;
 import com.sun.jersey.spi.container.ResourceMethodDispatchProvider;
 import com.sun.jersey.spi.dispatch.RequestDispatcher;
-import com.yammer.metrics.Metrics;
 import com.yammer.metrics.annotation.ExceptionMetered;
 import com.yammer.metrics.annotation.Metered;
 import com.yammer.metrics.annotation.Timed;
 import com.yammer.metrics.core.Meter;
 import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricsRegistry;
 import com.yammer.metrics.core.Timer;
 import com.yammer.metrics.core.TimerContext;
 import sun.misc.Unsafe;
@@ -92,9 +92,11 @@ class InstrumentedResourceMethodDispatchProvider implements ResourceMethodDispat
     }
 
     private final ResourceMethodDispatchProvider provider;
+    private MetricsRegistry registry;
 
-    public InstrumentedResourceMethodDispatchProvider(ResourceMethodDispatchProvider provider) {
+    public InstrumentedResourceMethodDispatchProvider(ResourceMethodDispatchProvider provider, MetricsRegistry registry) {
         this.provider = provider;
+        this.registry = registry;
     }
 
     @Override
@@ -106,14 +108,14 @@ class InstrumentedResourceMethodDispatchProvider implements ResourceMethodDispat
 
         if (method.getMethod().isAnnotationPresent(Timed.class)) {
             final Timed annotation = method.getMethod().getAnnotation(Timed.class);
-            
+
             Class<?> klass = method.getDeclaringResource().getResourceClass();
             String group = MetricName.chooseGroup(annotation.group(), klass);
             String type = MetricName.chooseType(annotation.type(), klass);
-            String name = MetricName.chooseName(annotation.name(), method.getMethod());            
+            String name = MetricName.chooseName(annotation.name(), method.getMethod());
             MetricName metricName = new MetricName(group, type, name);
-            
-            final Timer timer = Metrics.newTimer(metricName,
+
+            final Timer timer = registry.newTimer(metricName,
                                                        annotation.durationUnit() == null ?
                                                                TimeUnit.MILLISECONDS : annotation.durationUnit(),
                                                        annotation.rateUnit() == null ?
@@ -123,14 +125,14 @@ class InstrumentedResourceMethodDispatchProvider implements ResourceMethodDispat
 
         if (method.getMethod().isAnnotationPresent(Metered.class)) {
             final Metered annotation = method.getMethod().getAnnotation(Metered.class);
-            
+
             Class<?> klass = method.getDeclaringResource().getResourceClass();
             String group = MetricName.chooseGroup(annotation.group(), klass);
             String type = MetricName.chooseType(annotation.type(), klass);
-            String name = MetricName.chooseName(annotation.name(), method.getMethod());            
+            String name = MetricName.chooseName(annotation.name(), method.getMethod());
             MetricName metricName = new MetricName(group, type, name);
-            
-            final Meter meter = Metrics.newMeter(metricName,
+
+            final Meter meter = registry.newMeter(metricName,
                                                        annotation.eventType() == null ?
                                                                "requests" : annotation.eventType(),
                                                        annotation.rateUnit() == null ?
@@ -145,10 +147,10 @@ class InstrumentedResourceMethodDispatchProvider implements ResourceMethodDispat
             String group = MetricName.chooseGroup(annotation.group(), klass);
             String type = MetricName.chooseType(annotation.type(), klass);
             String name = annotation.name() == null || annotation.name().equals("") ?
-                    method.getMethod().getName() + ExceptionMetered.DEFAULT_NAME_SUFFIX : annotation.name();            
+                    method.getMethod().getName() + ExceptionMetered.DEFAULT_NAME_SUFFIX : annotation.name();
             MetricName metricName = new MetricName(group, type, name);
-            
-            final Meter meter = Metrics.newMeter(metricName,
+
+            final Meter meter = registry.newMeter(metricName,
                                                        annotation.eventType() == null ?
                                                                "requests" : annotation.eventType(),
                                                        annotation.rateUnit() == null ?

--- a/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/SingletonMetricsJerseyTest.java
+++ b/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/SingletonMetricsJerseyTest.java
@@ -1,0 +1,101 @@
+package com.yammer.metrics.jersey.tests;
+
+import com.sun.jersey.api.container.MappableContainerException;
+import com.sun.jersey.api.core.DefaultResourceConfig;
+import com.sun.jersey.test.framework.AppDescriptor;
+import com.sun.jersey.test.framework.JerseyTest;
+import com.sun.jersey.test.framework.LowLevelAppDescriptor;
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Meter;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.Timer;
+import com.yammer.metrics.jersey.InstrumentedResourceMethodDispatchAdapter;
+import com.yammer.metrics.jersey.tests.resources.InstrumentedResource;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests importing {@link InstrumentedResourceMethodDispatchAdapter} as a singleton
+ * in a Jersey {@link com.sun.jersey.api.core.ResourceConfig}
+ */
+public class SingletonMetricsJerseyTest extends JerseyTest {
+    static {
+        Logger.getLogger("com.sun.jersey").setLevel(Level.OFF);
+    }
+
+    private MetricsRegistry registry;
+
+    @Override
+    protected AppDescriptor configure() {
+        this.registry = new MetricsRegistry();
+
+        DefaultResourceConfig config = new DefaultResourceConfig();
+        config.getSingletons().add(new InstrumentedResourceMethodDispatchAdapter(registry));
+        config.getClasses().add(InstrumentedResource.class);
+
+        return new LowLevelAppDescriptor.Builder(config).build();
+    }
+
+    @Test
+    public void registryIsNotDefault() {
+        final Timer timer1 = registry.newTimer(InstrumentedResource.class, "timed");
+        final Timer timer2 = registry.newTimer(InstrumentedResource.class, "timed");
+        final Timer timer3 = Metrics.newTimer(InstrumentedResource.class, "timed");
+
+        assertThat(timer1, sameInstance(timer2));
+        assertThat(timer1, not(sameInstance(timer3)));
+    }
+
+    @Test
+    public void timedMethodsAreTimed() {
+        assertThat(resource().path("timed").get(String.class),
+                   is("yay"));
+
+        final Timer timer = registry.newTimer(InstrumentedResource.class, "timed");
+        assertThat(timer.count(),
+                   is(1L));
+    }
+
+    @Test
+    public void meteredMethodsAreMetered() {
+        assertThat(resource().path("metered").get(String.class),
+                   is("woo"));
+
+        final Meter meter = registry.newMeter(InstrumentedResource.class, "metered", "blah", TimeUnit.SECONDS);
+        assertThat(meter.count(),
+                   is(1L));
+    }
+
+    @Test
+    public void exceptionMeteredMethodsAreExceptionMetered() {
+        final Meter meter = registry.newMeter(InstrumentedResource.class, "exceptionMeteredExceptions", "blah", TimeUnit.SECONDS);
+        
+        assertThat(resource().path("exception-metered").get(String.class),
+                   is("fuh"));
+
+        assertThat(meter.count(),
+                   is(0L));
+        
+        try {
+            resource().path("exception-metered").queryParam("splode", "true").get(String.class);
+            fail("should have thrown a MappableContainerException, but didn't");
+        } catch (MappableContainerException e) {
+            assertThat(e.getCause(),
+                       is(instanceOf(IOException.class)));
+        }
+
+        assertThat(meter.count(),
+                   is(1L));
+    }
+}


### PR DESCRIPTION
Refactored to allow use of a non-default `MetricsRegistry`, and added tests for using this configuration by importing a Singleton into a Jersey `ResourceConfig`. I left the original tests as is to test the case where `InstrumentedResourceDispatchAdapter` is added to the `ResourceConfig` as a class.
