### PR TITLE
DefaultWebappMetricsFilter will get metrics factory from servlet context

### DIFF
--- a/contribs/metrics-web/src/main/java/com/yammer/metrics/web/DefaultWebappMetricsFilter.java
+++ b/contribs/metrics-web/src/main/java/com/yammer/metrics/web/DefaultWebappMetricsFilter.java
@@ -1,5 +1,9 @@
 package com.yammer.metrics.web;
 
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.MetricsRegistry;
+
+import javax.servlet.FilterConfig;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -18,6 +22,8 @@ import java.util.Map;
  * }</pre>
  */
 public class DefaultWebappMetricsFilter extends WebappMetricsFilter {
+    public static final String REGISTRY_ATTRIBUTE = DefaultWebappMetricsFilter.class.getName() + ".registry";
+
     private static final String NAME_PREFIX = "responseCodes.";
     private static final int OK = 200;
     private static final int CREATED = 201;
@@ -30,7 +36,7 @@ public class DefaultWebappMetricsFilter extends WebappMetricsFilter {
      * Creates a new instance of the filter.
      */
     public DefaultWebappMetricsFilter() {
-        super(createMeterNamesByStatusCode(), NAME_PREFIX + "other");
+        super(REGISTRY_ATTRIBUTE, createMeterNamesByStatusCode(), NAME_PREFIX + "other");
     }
 
     private static Map<Integer, String> createMeterNamesByStatusCode() {

--- a/contribs/metrics-web/src/main/java/com/yammer/metrics/web/WebappMetricsFilter.java
+++ b/contribs/metrics-web/src/main/java/com/yammer/metrics/web/WebappMetricsFilter.java
@@ -1,10 +1,7 @@
 package com.yammer.metrics.web;
 
 import com.yammer.metrics.Metrics;
-import com.yammer.metrics.core.Counter;
-import com.yammer.metrics.core.Meter;
-import com.yammer.metrics.core.Timer;
-import com.yammer.metrics.core.TimerContext;
+import com.yammer.metrics.core.*;
 
 import javax.servlet.*;
 import javax.servlet.http.HttpServletResponse;
@@ -21,47 +18,72 @@ import java.util.concurrent.TimeUnit;
  * codes being returned.
  */
 public abstract class WebappMetricsFilter implements Filter {
-    private final ConcurrentMap<Integer, Meter> metersByStatusCode;
-    private final Meter otherMeter;
-    private final Counter activeRequests;
-    private final Timer requestTimer;
+    private final String otherMetricName;
+    private final Map<Integer, String> meterNamesByStatusCode;
+    private final String registryAttribute;
+
+    // initialized after call of init method
+    private ConcurrentMap<Integer, Meter> metersByStatusCode;
+    private Meter otherMeter;
+    private Counter activeRequests;
+    private Timer requestTimer;
+
 
     /**
      * Creates a new instance of the filter.
      *
+     * @param registryAttribute the attribute used to look up the metrics registry in the servlet context
      * @param meterNamesByStatusCode A map, keyed by status code, of meter names that we are
      *                               interested in.
      * @param otherMetricName        The name used for the catch-all meter.
      */
-    public WebappMetricsFilter(Map<Integer, String> meterNamesByStatusCode,
+    public WebappMetricsFilter(String registryAttribute, Map<Integer, String> meterNamesByStatusCode,
                                String otherMetricName) {
-        this.metersByStatusCode = new ConcurrentHashMap<Integer, Meter>(meterNamesByStatusCode
-                                                                                      .size());
-        for (Entry<Integer, String> entry : meterNamesByStatusCode.entrySet()) {
-            metersByStatusCode.put(entry.getKey(),
-                                   Metrics.newMeter(WebappMetricsFilter.class,
-                                                    entry.getValue(),
-                                                    "responses",
-                                                    TimeUnit.SECONDS));
-        }
-        this.otherMeter = Metrics.newMeter(WebappMetricsFilter.class,
-                                                 otherMetricName,
-                                                 "responses",
-                                                 TimeUnit.SECONDS);
-        this.activeRequests = Metrics.newCounter(WebappMetricsFilter.class, "activeRequests");
-        this.requestTimer = Metrics.newTimer(WebappMetricsFilter.class,
-                                             "requests",
-                                             TimeUnit.MILLISECONDS,
-                                             TimeUnit.SECONDS);
-
+        this.registryAttribute = registryAttribute;
+        this.otherMetricName = otherMetricName;
+        this.meterNamesByStatusCode = meterNamesByStatusCode;
     }
 
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
+        final MetricsRegistry metricsRegistry = getMetricsFactory(filterConfig);
+
+        this.metersByStatusCode = new ConcurrentHashMap<Integer, Meter>(meterNamesByStatusCode
+                .size());
+        for (Entry<Integer, String> entry : meterNamesByStatusCode.entrySet()) {
+            metersByStatusCode.put(entry.getKey(),
+                    metricsRegistry.newMeter(WebappMetricsFilter.class,
+                            entry.getValue(),
+                            "responses",
+                            TimeUnit.SECONDS));
+        }
+        this.otherMeter = metricsRegistry.newMeter(WebappMetricsFilter.class,
+                otherMetricName,
+                "responses",
+                TimeUnit.SECONDS);
+        this.activeRequests = metricsRegistry.newCounter(WebappMetricsFilter.class, "activeRequests");
+        this.requestTimer = metricsRegistry.newTimer(WebappMetricsFilter.class,
+                "requests",
+                TimeUnit.MILLISECONDS,
+                TimeUnit.SECONDS);
+
+    }
+
+    private MetricsRegistry getMetricsFactory(FilterConfig filterConfig) {
+        final MetricsRegistry metricsRegistry;
+
+        final Object o = filterConfig.getServletContext().getAttribute(this.registryAttribute);
+        if (o instanceof MetricsRegistry) {
+            metricsRegistry = (MetricsRegistry) o;
+        } else {
+            metricsRegistry = Metrics.defaultRegistry();
+        }
+        return metricsRegistry;
     }
 
     @Override
     public void destroy() {
+        
     }
 
     @Override


### PR DESCRIPTION
This pull request is related to ticket:  https://github.com/codahale/metrics/issues/210

During the init call the MetricsRegistry is obtained from the servlet context object.  

Two important considerations:
- The MetricsRegistry is read once during init.  Another design was to check the MetricsRegistry during doFilter and if it has changed the initialize all meters.  I did not want this because it could have a potentially negative impact on performance since the check and initialization would have to be synchronized.  
  - Since the MetricsRegistry is only read during init, some mechanism is required to initialize it for all servlets and filters before the filter is called.  In MetricsServlet this is not a problem because the servlet is initialized only called once it is called so another servlet can set the MetricsRegistry in the context for the MetricsServlet to use.  In the case of the WebappMetricsFilter another filter must set the MetricsRegistry.
  
  Since the WebappMetricsFilter uses an attribute key passed from subclass each attribute can have its own MetricsRegistry if that is desired.
