### PR TITLE
JMX Reporter: Avoid javax.management.InstanceAlreadyExistsException when registering.

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/reporting/JmxReporter.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/reporting/JmxReporter.java
@@ -457,6 +457,10 @@ public class JmxReporter extends AbstractReporter implements MetricsRegistryList
 
     private void registerBean(MetricName name, MetricMBean bean, ObjectName objectName)
             throws MBeanRegistrationException, OperationsException {
+
+        if ( server.isRegistered(objectName) ){
+            server.unregisterMBean(objectName);
+        }
         server.registerMBean(bean, objectName);
         registeredBeans.put(name, objectName);
     }


### PR DESCRIPTION
# JmxReporter

When **Registering a Bean** we check if its _ObjectName_ is already registered, if it is we unregister before registering the _ObjectName_ again avoiding an `javax.management.InstanceAlreadyExistsException`.
