### PR TITLE
Added a graphite reporter spring custom namespace parser 

### DIFF
--- a/contribs/metrics-spring/pom.xml
+++ b/contribs/metrics-spring/pom.xml
@@ -31,6 +31,12 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.yammer.metrics</groupId>
+            <artifactId>metrics-graphite</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <version>${spring.version}</version>

--- a/contribs/metrics-spring/src/main/java/com/yammer/metrics/spring/ConfigurableMethodInvocationMetricNameFactory.java
+++ b/contribs/metrics-spring/src/main/java/com/yammer/metrics/spring/ConfigurableMethodInvocationMetricNameFactory.java
@@ -1,0 +1,54 @@
+package com.yammer.metrics.spring;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.util.StringUtils;
+
+import com.yammer.metrics.core.MetricName;
+
+/**
+ * A configurable implementation of the
+ * {@link MethodInvocationMetricNameFactory} which accepts required parameters
+ * in the constructor and optional parameters as setters which can be used
+ * easily within a spring context definition. Based on which optional parameters
+ * are provided the appropriate {@link MetricName} constructor will be invoked
+ * 
+ * @author erez
+ * 
+ */
+public class ConfigurableMethodInvocationMetricNameFactory implements
+		MethodInvocationMetricNameFactory {
+
+	private String group;
+	private String type;
+	private String scope;
+	private String mbeanName;
+
+	public ConfigurableMethodInvocationMetricNameFactory(String group,
+			String type) {
+		this.group = group;
+		this.type = type;
+	}
+
+	public void setScope(String scope) {
+		this.scope = scope;
+	}
+
+	public void setMbeanName(String mbeanName) {
+		this.mbeanName = mbeanName;
+	}
+
+	@Override
+	public MetricName createMetricName(MethodInvocation invocation) {
+		if (StringUtils.hasText(scope) && StringUtils.hasText(mbeanName)) {
+			return new MetricName(group, type,
+					invocation.getMethod().getName(), scope, mbeanName);
+		}
+
+		if (StringUtils.hasText(scope)) {
+			return new MetricName(group, type,
+					invocation.getMethod().getName(), scope);
+		}
+		return new MetricName(group, type, invocation.getMethod().getName());
+	}
+
+}

--- a/contribs/metrics-spring/src/main/java/com/yammer/metrics/spring/GraphiteReporterFactory.java
+++ b/contribs/metrics-spring/src/main/java/com/yammer/metrics/spring/GraphiteReporterFactory.java
@@ -1,0 +1,48 @@
+package com.yammer.metrics.spring;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import com.yammer.metrics.core.Clock;
+import com.yammer.metrics.core.MetricPredicate;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.reporting.GraphiteReporter;
+import com.yammer.metrics.reporting.GraphiteReporter.DefaultSocketProvider;
+
+public class GraphiteReporterFactory {
+
+  public static GraphiteReporter createInstance(final MetricsRegistry registery, final String host,
+      final Integer port, final TimeUnit timeUnit, final Long period, final Boolean autoStart)
+      throws IOException {
+    final GraphiteReporter graphiteReporter = new GraphiteReporter(registery, host, port, null);
+    if (autoStart) {
+      graphiteReporter.start(period, timeUnit);
+    }
+    return graphiteReporter;
+
+  }
+
+  public static GraphiteReporter createInstance(final MetricsRegistry registery, final String host,
+      final Integer port, final TimeUnit timeUnit, final Long period, final Boolean autoStart,
+      final String prefix) throws IOException {
+    final GraphiteReporter graphiteReporter = new GraphiteReporter(registery, host, port, prefix);
+    if (autoStart) {
+      graphiteReporter.start(period, timeUnit);
+    }
+    return graphiteReporter;
+
+  }
+
+  public static GraphiteReporter createInstance(final MetricsRegistry registery, final String host,
+      final Integer port, final TimeUnit timeUnit, final Long period, final Boolean autoStart,
+      final String prefix, final MetricPredicate predicate) throws IOException {
+    final GraphiteReporter graphiteReporter = new GraphiteReporter(registery, prefix, predicate,
+        new DefaultSocketProvider(host, port), Clock.defaultClock());
+    if (autoStart) {
+      graphiteReporter.start(period, timeUnit);
+    }
+    return graphiteReporter;
+
+  }
+
+}

--- a/contribs/metrics-spring/src/main/java/com/yammer/metrics/spring/MethodInvocationMetricNameFactory.java
+++ b/contribs/metrics-spring/src/main/java/com/yammer/metrics/spring/MethodInvocationMetricNameFactory.java
@@ -1,0 +1,28 @@
+package com.yammer.metrics.spring;
+
+import org.aopalliance.intercept.MethodInvocation;
+
+import com.yammer.metrics.core.MetricName;
+
+/**
+ * A factory for a {@link MetricName} name object based on a
+ * {@link MethodInvocation}, since in AOP based interceptor providing the
+ * {@link MethodInvocation#getClass()} usually returns a spring class, classes
+ * wishing to use reflection can provide a configurable interceptor which
+ * customizes the group, type and name creation
+ * 
+ * @author erez
+ * 
+ */
+
+public interface MethodInvocationMetricNameFactory {
+  /**
+   * Create a metric name based on a {@link MethodInvocation}
+   * 
+   * @param invocation
+   *          the instance of the invocation
+   * @return
+   */
+  MetricName createMetricName(MethodInvocation invocation);
+
+}

--- a/contribs/metrics-spring/src/main/java/com/yammer/metrics/spring/MetricsTimerMethodInterceptor.java
+++ b/contribs/metrics-spring/src/main/java/com/yammer/metrics/spring/MetricsTimerMethodInterceptor.java
@@ -1,0 +1,61 @@
+package com.yammer.metrics.spring;
+
+import java.util.concurrent.TimeUnit;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.util.Assert;
+
+import com.yammer.metrics.annotation.Timed;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.Timer;
+import com.yammer.metrics.core.TimerContext;
+
+/**
+ * An implementation of a {@link MethodInterceptor} which creates a
+ * {@link Timer} for each invocation measuring execution times. This class
+ * utilizes a {@link MethodInvocationMetricNameFactory} for customizing metric
+ * names based on invocation instances.
+ * <p>
+ * This interceptor can be used in xml-based configurations and for interception
+ * of third-party libraries which cannot use the {@link Timed} annotation
+ * 
+ * @author erez
+ * @see MethodInvocationMetricNameFactory
+ */
+public class MetricsTimerMethodInterceptor implements MethodInterceptor {
+  private final MetricsRegistry metricsRegistry;
+
+  private TimeUnit durationUnit = TimeUnit.MILLISECONDS;
+  private TimeUnit rateUnit = TimeUnit.MICROSECONDS;
+  private final MethodInvocationMetricNameFactory metricNameFactory;
+
+  public MetricsTimerMethodInterceptor(final MetricsRegistry metricsRegistry,
+      final MethodInvocationMetricNameFactory metricNameFactory) {
+    Assert.notNull(metricsRegistry, "metricsRegistry cannot be null");
+    Assert.notNull(metricNameFactory, "metricNameFactory cannot be null");
+    this.metricsRegistry = metricsRegistry;
+    this.metricNameFactory = metricNameFactory;
+  }
+
+  public void setDurationUnit(final TimeUnit durationUnit) {
+    this.durationUnit = durationUnit;
+  }
+
+  public void setRateUnit(final TimeUnit rateUnit) {
+    this.rateUnit = rateUnit;
+  }
+
+  @Override
+  public Object invoke(final MethodInvocation invocation) throws Throwable {
+    final Timer timer = metricsRegistry.newTimer(metricNameFactory.createMetricName(invocation),
+        durationUnit, rateUnit);
+    final TimerContext context = timer.time();
+    try {
+      return invocation.proceed();
+    } finally {
+      context.stop();
+    }
+  }
+
+}

--- a/contribs/metrics-spring/src/main/java/com/yammer/metrics/spring/config/GraphiteReporterBeanDefinitionParser.java
+++ b/contribs/metrics-spring/src/main/java/com/yammer/metrics/spring/config/GraphiteReporterBeanDefinitionParser.java
@@ -1,0 +1,128 @@
+package com.yammer.metrics.spring.config;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.xml.AbstractSingleBeanDefinitionParser;
+import org.springframework.beans.factory.xml.ParserContext;
+import org.springframework.util.StringUtils;
+import org.w3c.dom.Element;
+
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.spring.GraphiteReporterFactory;
+
+/**
+ * An implementation of {@link AbstractSingleBeanDefinitionParser} which
+ * initializes a graphite reporter. This class depends on the existence of the
+ * <code>metrics-graphite</code> dependency.
+ * 
+ * <p>
+ * An example bean definition:
+ * 
+ * <pre>
+ * &lt;metrics:graphite-reporter metrics-registry="metrics" host="my.graphite.com" port="2003" timeUnit="SECONDS" period="1" /&gt;
+ * </pre>
+ * 
+ * @author erez
+ * 
+ */
+public class GraphiteReporterBeanDefinitionParser extends AbstractSingleBeanDefinitionParser {
+
+  private static final String METRICS_REGISTRY_ATTRIBUTE = "metrics-registry";
+  private static final String HOST_ATTRIBUTE = "host";
+  private static final String PORT_ATTRIBUTE = "port";
+  private static final String PREFIX_ATTRIBUTE = "prefix";
+  private static final String PERIOD_ATTRIBUTE = "period";
+  private static final String TIMEUNIT_ATTRIBUTE = "timeUnit";
+  private static final String PREDICATE_ATTRIBUTE = "predicate";
+  private static final String AUTOSTART_ATTRIBUTE = "autoStart";
+
+  @Override
+  protected Class<?> getBeanClass(final Element element) {
+    return GraphiteReporterFactory.class;
+  }
+
+  @Override
+  protected boolean shouldGenerateIdAsFallback() {
+    return true;
+  }
+
+  @Override
+  protected void doParse(final Element element, final ParserContext parserContext,
+      final BeanDefinitionBuilder builder) {
+    builder.setFactoryMethod("createInstance");
+    final String registry = element.getAttribute(METRICS_REGISTRY_ATTRIBUTE);
+    if (StringUtils.hasText(registry)) {
+      builder.addConstructorArgReference(registry);
+    } else {
+      builder.addConstructorArgValue(new MetricsRegistry());
+    }
+
+    final String host = element.getAttribute(HOST_ATTRIBUTE);
+    if (StringUtils.hasText(host)) {
+      builder.addConstructorArgValue(host);
+    } else {
+      parserContext.getReaderContext().error("Attribute 'host' must not be empty", element);
+      return;
+    }
+
+    final String port = element.getAttribute(PORT_ATTRIBUTE);
+    if (StringUtils.hasText(port)) {
+      builder.addConstructorArgValue(Integer.valueOf(port));
+    } else {
+      parserContext.getReaderContext().error("Attribute 'port' must not be empty", element);
+      return;
+    }
+
+    final String timeUnit = element.getAttribute(TIMEUNIT_ATTRIBUTE);
+    if (StringUtils.hasText(timeUnit)) {
+      final TimeUnit tu = TimeUnit.valueOf(timeUnit.toUpperCase());
+      if (null == tu) {
+        parserContext.getReaderContext().error(
+            "Attribute 'timeUnit' has invalid value: " + timeUnit
+                + ", which cannot be parsed as java.util.concurrent.TimeUnit", element);
+        return;
+      }
+      builder.addConstructorArgValue(tu);
+    } else {
+      parserContext.getReaderContext().error("Attribute 'timeUnit' must not be empty", element);
+      return;
+    }
+
+    final String period = element.getAttribute(PERIOD_ATTRIBUTE);
+    if (StringUtils.hasText(period)) {
+      builder.addConstructorArgValue(Long.valueOf(period));
+    } else {
+      parserContext.getReaderContext().error("Attribute 'period' must not be empty", element);
+      return;
+    }
+
+    final String autoStart = element.getAttribute(AUTOSTART_ATTRIBUTE);
+    if (StringUtils.hasText(autoStart)) {
+      builder.addConstructorArgValue(Boolean.valueOf(autoStart));
+    } else {
+      builder.addConstructorArgValue(true);
+    }
+
+    final String prefix = element.getAttribute(PREFIX_ATTRIBUTE);
+    if (StringUtils.hasText(prefix)) {
+      builder.addConstructorArgValue(prefix);
+    }
+
+    final String predicate = element.getAttribute(PREDICATE_ATTRIBUTE);
+    if (StringUtils.hasText(predicate)) {
+      builder.addConstructorArgReference(predicate);
+    }
+  }
+
+}
+
+/**
+ * <xsd:attribute name="metrics-registry" type="xsd:string" use="required"/>
+ * <xsd:attribute name="host" type="xsd:string" use="required"/> <xsd:attribute
+ * name="port" type="xsd:int" use="required"/> <xsd:attribute name="prefix"
+ * type="xsd:string" use="optional"/> <xsd:attribute name="priod" type="xsd:int"
+ * use="optional"/> <xsd:attribute name="timeunit" type="xsd:string"
+ * use="optional"/> <xsd:attribute name="predicate" type="xsd:string"
+ * use="optional"/> </xsd:complexType>/
+ */

--- a/contribs/metrics-spring/src/main/java/com/yammer/metrics/spring/config/MetricsNamespaceHandler.java
+++ b/contribs/metrics-spring/src/main/java/com/yammer/metrics/spring/config/MetricsNamespaceHandler.java
@@ -12,6 +12,7 @@ public class MetricsNamespaceHandler extends NamespaceHandlerSupport {
         registerBeanDefinitionParser("health-check-registry",
                                      new HealthCheckRegistryBeanDefinitionParser());
         registerBeanDefinitionParser("jmx-reporter", new JmxReporterBeanDefinitionParser());
+        registerBeanDefinitionParser("graphite-reporter", new GraphiteReporterBeanDefinitionParser());
     }
 
 }

--- a/contribs/metrics-spring/src/main/resources/com/yammer/metrics/spring/config/metrics.xsd
+++ b/contribs/metrics-spring/src/main/resources/com/yammer/metrics/spring/config/metrics.xsd
@@ -1,40 +1,92 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsd:schema xmlns="http://www.yammer.com/schema/metrics"
-            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-            xmlns:beans="http://www.springframework.org/schema/beans"
-            targetNamespace="http://www.yammer.com/schema/metrics"
-            elementFormDefault="qualified" attributeFormDefault="unqualified">
+<xsd:schema xmlns="http://www.yammer.com/schema/metrics" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:beans="http://www.springframework.org/schema/beans" targetNamespace="http://www.yammer.com/schema/metrics"
+  elementFormDefault="qualified" attributeFormDefault="unqualified">
 
-    <xsd:import namespace="http://www.springframework.org/schema/beans"/>
+  <xsd:import namespace="http://www.springframework.org/schema/beans" />
 
-    <xsd:element name="annotation-driven">
-        <xsd:complexType>
-            <xsd:attribute name="metrics-registry" type="xsd:string" use="optional"/>
-            <xsd:attribute name="health-check-registry" type="xsd:string" use="optional"/>
-            <xsd:attribute name="scope" type="xsd:string" use="optional"/>
-            <xsd:attribute name="expose-proxy" type="xsd:boolean" use="optional"/>
-            <xsd:attribute name="proxy-target-class" type="xsd:boolean" use="optional"/>
-        </xsd:complexType>
-    </xsd:element>
+  <xsd:element name="annotation-driven">
+    <xsd:complexType>
+      <xsd:attribute name="metrics-registry" type="xsd:string" use="optional" />
+      <xsd:attribute name="health-check-registry" type="xsd:string" use="optional" />
+      <xsd:attribute name="scope" type="xsd:string" use="optional" />
+      <xsd:attribute name="expose-proxy" type="xsd:boolean" use="optional" />
+      <xsd:attribute name="proxy-target-class" type="xsd:boolean" use="optional" />
+    </xsd:complexType>
+  </xsd:element>
 
-    <xsd:element name="metrics-registry">
-        <xsd:complexType>
-            <xsd:attribute name="id" type="xsd:string" use="required"/>
-            <xsd:attribute name="clock" type="xsd:string" use="optional"/>
-        </xsd:complexType>
-    </xsd:element>
+  <xsd:element name="metrics-registry">
+    <xsd:complexType>
+      <xsd:attribute name="id" type="xsd:string" use="required" />
+      <xsd:attribute name="clock" type="xsd:string" use="optional" />
+    </xsd:complexType>
+  </xsd:element>
 
-    <xsd:element name="health-check-registry">
-        <xsd:complexType>
-            <xsd:attribute name="id" type="xsd:string" use="required"/>
-        </xsd:complexType>
-    </xsd:element>
+  <xsd:element name="health-check-registry">
+    <xsd:complexType>
+      <xsd:attribute name="id" type="xsd:string" use="required" />
+    </xsd:complexType>
+  </xsd:element>
 
-    <xsd:element name="jmx-reporter">
-        <xsd:complexType>
-            <xsd:attribute name="id" type="xsd:string" use="optional"/>
-            <xsd:attribute name="metrics-registry" type="xsd:string" use="required"/>
-        </xsd:complexType>
-    </xsd:element>
+  <xsd:element name="jmx-reporter">
+    <xsd:complexType>
+      <xsd:attribute name="id" type="xsd:string" use="optional" />
+      <xsd:attribute name="metrics-registry" type="xsd:string" use="required" />
+    </xsd:complexType>
+  </xsd:element>
 
+  <xsd:element name="graphite-reporter">
+    <xsd:complexType>
+      <xsd:attribute name="id" type="xsd:string" use="optional" />
+      <xsd:attribute name="host" type="xsd:string" use="required">
+        <xsd:annotation>
+          <xsd:documentation>The graphite server name</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="port" type="xsd:int" use="required">
+        <xsd:annotation>
+          <xsd:documentation>The graphite server port</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="period" type="xsd:int" use="required">
+        <xsd:annotation>
+          <xsd:documentation>The time period to report to graphite, correlated to the timeUnit attribute which
+            determines the unit for this value
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="timeUnit" type="xsd:string" use="required">
+        <xsd:annotation>
+          <xsd:documentation>
+            a enumerated value from java.util.concurrent.TimeUnit (case insensitive), correlated with
+            the period attribute
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="metrics-registry" type="xsd:string" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>A reference to the metrics registry bean id, if none is provided a default instance will be
+            created
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="autoStart" type="xsd:boolean" use="optional" default="true">
+        <xsd:annotation>
+          <xsd:documentation>determines weather the reporter is automatically started when context is loaded (note that
+            if this is set to false then timeUnit and period attributes are ignored)
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="prefix" type="xsd:string" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>an optional prefix to the graphite entry</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="predicate" type="xsd:string" use="optional">
+        <xsd:annotation>
+          <xsd:documentation>a reference to a predicate bean name</xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
 </xsd:schema>

--- a/contribs/metrics-spring/src/test/java/com/yammer/metrics/spring/GraphiteReporterTest.java
+++ b/contribs/metrics-spring/src/test/java/com/yammer/metrics/spring/GraphiteReporterTest.java
@@ -1,0 +1,31 @@
+package com.yammer.metrics.spring;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import com.yammer.metrics.reporting.GraphiteReporter;
+
+public class GraphiteReporterTest {
+
+  ClassPathXmlApplicationContext ctx;
+
+  @Before
+  public void init() {
+    this.ctx = new ClassPathXmlApplicationContext("classpath:graphite-reporter.xml");
+  }
+
+  @After
+  public void destroy() {
+    // ctx.getBean(GraphiteReporter.class).shutdown();
+  }
+
+  @Test
+  public void testMeteredInterface() {
+    final GraphiteReporter gr = ctx.getBean(GraphiteReporter.class);
+    Assert.assertNotNull("Expected to be able to get the graphite reporter from the context.", gr);
+  }
+
+}

--- a/contribs/metrics-spring/src/test/resources/graphite-reporter.xml
+++ b/contribs/metrics-spring/src/test/resources/graphite-reporter.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xmlns:metrics="http://www.yammer.com/schema/metrics"
+	xsi:schemaLocation="
+			http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.1.xsd
+			http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd
+			http://www.yammer.com/schema/metrics http://www.yammer.com/schema/metrics/metrics.xsd">
+
+    <metrics:metrics-registry id="metrics" />
+    <metrics:graphite-reporter metrics-registry="metrics" host="my.graphite.com" port="2003" period="1" timeUnit="seconds" />
+
+</beans>


### PR DESCRIPTION
Creates an instance of a graphite reporter:

```
<metrics:graphite-reporter metrics-registry="metrics" host="my.graphite.com" port="2003" period="1" timeUnit="seconds" />
```
