### PR TITLE
Skip metrics-sigar tests on platforms where Sigar cannot be loaded.

### DIFF
--- a/contribs/metrics-sigar/src/test/java/com/yammer/metrics/sigar/tests/CheckSigarLoadsOk.java
+++ b/contribs/metrics-sigar/src/test/java/com/yammer/metrics/sigar/tests/CheckSigarLoadsOk.java
@@ -1,0 +1,24 @@
+package com.yammer.metrics.sigar.tests;
+
+import org.hyperic.sigar.Sigar;
+import org.junit.BeforeClass;
+
+import static org.junit.Assume.assumeNoException;
+
+/**
+ * Created: 12/05/07 17:28
+ *
+ * @author chris
+ */
+public abstract class CheckSigarLoadsOk {
+
+    @BeforeClass
+    public static final void canLoadSigarCheck() {
+        try {
+            Sigar.load();
+        } catch (Throwable e) {
+            assumeNoException(e);
+        }
+    }
+
+}

--- a/contribs/metrics-sigar/src/test/java/com/yammer/metrics/sigar/tests/CpuMetricsTest.java
+++ b/contribs/metrics-sigar/src/test/java/com/yammer/metrics/sigar/tests/CpuMetricsTest.java
@@ -4,6 +4,7 @@ import com.yammer.metrics.sigar.CpuMetrics;
 import com.yammer.metrics.sigar.CpuMetrics.CpuTime;
 import com.yammer.metrics.sigar.SigarMetrics;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.closeTo;
@@ -13,8 +14,13 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-public class CpuMetricsTest {
-    private final CpuMetrics cm = SigarMetrics.getInstance().cpu();
+public class CpuMetricsTest extends CheckSigarLoadsOk {
+    private CpuMetrics cm;
+
+    @Before
+    public void setUp() {
+        cm = SigarMetrics.getInstance().cpu();
+    }
 
     @Test
     public void cpuCoreCountIsGreaterThanZero() throws Exception {

--- a/contribs/metrics-sigar/src/test/java/com/yammer/metrics/sigar/tests/FilesystemMetricsTest.java
+++ b/contribs/metrics-sigar/src/test/java/com/yammer/metrics/sigar/tests/FilesystemMetricsTest.java
@@ -7,19 +7,22 @@ import com.yammer.metrics.sigar.FilesystemMetrics;
 import com.yammer.metrics.sigar.FilesystemMetrics.FileSystem;
 import com.yammer.metrics.sigar.SigarMetrics;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-public class FilesystemMetricsTest {
-    private final FilesystemMetrics fsm = SigarMetrics.getInstance().filesystems();
-
+public class FilesystemMetricsTest extends CheckSigarLoadsOk {
     private final double MARGIN_BYTES = 1024 * 1024 * 50; // 50MB
+
+    private FilesystemMetrics fsm;
+
+    @Before
+    public void setUp() {
+        fsm = SigarMetrics.getInstance().filesystems();
+    }
 
     @Test
     public void usageNumbersApproximatelyMatchThoseReturnedByJavaFile() throws Exception {

--- a/contribs/metrics-sigar/src/test/java/com/yammer/metrics/sigar/tests/MemoryMetricsTest.java
+++ b/contribs/metrics-sigar/src/test/java/com/yammer/metrics/sigar/tests/MemoryMetricsTest.java
@@ -5,6 +5,7 @@ import com.yammer.metrics.sigar.MemoryMetrics.MainMemory;
 import com.yammer.metrics.sigar.MemoryMetrics.SwapSpace;
 import com.yammer.metrics.sigar.SigarMetrics;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.closeTo;
@@ -16,8 +17,13 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 import static org.junit.Assert.assertThat;
 
-public class MemoryMetricsTest {
-    private final MemoryMetrics mm = SigarMetrics.getInstance().memory();
+public class MemoryMetricsTest extends CheckSigarLoadsOk {
+    private MemoryMetrics mm;
+
+    @Before
+    public void setUp() {
+        mm = SigarMetrics.getInstance().memory();
+    }
 
     @Test
     public void totalMemoryIsGreaterThanZero() throws Exception {

--- a/contribs/metrics-sigar/src/test/java/com/yammer/metrics/sigar/tests/SigarMetricsTest.java
+++ b/contribs/metrics-sigar/src/test/java/com/yammer/metrics/sigar/tests/SigarMetricsTest.java
@@ -9,7 +9,7 @@ import static org.hamcrest.Matchers.is;
 
 import static org.junit.Assert.assertThat;
 
-public class SigarMetricsTest {
+public class SigarMetricsTest extends CheckSigarLoadsOk {
 
     @Test
     public void pidIsGreaterThanZero() throws Exception {

--- a/contribs/metrics-sigar/src/test/java/com/yammer/metrics/sigar/tests/UlimitMetricsTest.java
+++ b/contribs/metrics-sigar/src/test/java/com/yammer/metrics/sigar/tests/UlimitMetricsTest.java
@@ -6,19 +6,18 @@ import com.yammer.metrics.sigar.SigarMetrics;
 
 import org.junit.Test;
 
-import static org.hamcrest.Matchers.closeTo;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.lessThan;
-
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
 
-public class UlimitMetricsTest {
-    private final UlimitMetrics um = SigarMetrics.getInstance().ulimit();
+public class UlimitMetricsTest extends CheckSigarLoadsOk {
 
     @Test
     public void openFilesLimitIsGreaterThanZero() throws Exception {
-        assertThat(um.ulimit().openFiles(), is(greaterThan(0L)));
+        // skip this test on Windows platforms
+        assumeThat(System.getProperty("os.name").toLowerCase(), not(containsString("windows")));
+
+        assertThat(SigarMetrics.getInstance().ulimit().ulimit().openFiles(), is(greaterThan(0L)));
     }
+
 }


### PR DESCRIPTION
A fix for the problem pointed out by @martel here:
https://github.com/codahale/metrics/pull/233#issuecomment-5456978

Check that we can correctly load Sigar on the current platform before trying to run the tests.

Failure to do so was causing the build to fail on Windows.
