### PR TITLE
add an opentsdb reporter 

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/reporting/AbstractSocketReporter.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/reporting/AbstractSocketReporter.java
@@ -1,0 +1,288 @@
+package com.yammer.metrics.reporting;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.lang.Thread.State;
+import java.net.Socket;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Clock;
+import com.yammer.metrics.core.Counter;
+import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.Histogram;
+import com.yammer.metrics.core.Metered;
+import com.yammer.metrics.core.Metric;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricPredicate;
+import com.yammer.metrics.core.MetricProcessor;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.Sampling;
+import com.yammer.metrics.core.Summarizable;
+import com.yammer.metrics.core.Timer;
+import com.yammer.metrics.core.VirtualMachineMetrics;
+import com.yammer.metrics.stats.Snapshot;
+
+/**
+ * @author w.deborger@gmail.com
+ * 
+ * derived from metrics-ganglia
+ */
+public abstract class AbstractSocketReporter extends AbstractPollingReporter
+		implements MetricProcessor<Long> {
+
+	private static final Logger LOG = LoggerFactory
+			.getLogger(AbstractSocketReporter.class);
+
+	protected final String prefix;
+	protected final MetricPredicate predicate;
+	protected final Locale locale = Locale.US;
+	protected final Clock clock;
+	protected final SocketProvider socketProvider;
+	protected final VirtualMachineMetrics vm;
+	public boolean printVMMetrics = true;
+
+	/**
+	 * Creates a new {@link GraphiteReporter}.
+	 * 
+	 * @param metricsRegistry
+	 *            the metrics registry
+	 * @param prefix
+	 *            is prepended to all names reported to graphite
+	 * @param predicate
+	 *            filters metrics to be reported
+	 * @param socketProvider
+	 *            a {@link SocketProvider} instance
+	 * @param clock
+	 *            a {@link Clock} instance
+	 * @param vm
+	 *            a {@link VirtualMachineMetrics} instance
+	 * @throws IOException
+	 *             if there is an error connecting to the Graphite server
+	 */
+	public AbstractSocketReporter(MetricsRegistry metricsRegistry,
+			String prefix, MetricPredicate predicate,
+			SocketProvider socketProvider, Clock clock,
+			VirtualMachineMetrics vm, String name){
+		super(metricsRegistry, name);
+		this.socketProvider = socketProvider;
+		this.vm = vm;
+
+		this.clock = clock;
+
+		if (prefix != null) {
+			// Pre-append the "." so that we don't need to make anything
+			// conditional later.
+			this.prefix = prefix + ".";
+		} else {
+			this.prefix = "";
+		}
+		this.predicate = predicate;
+	}
+
+	@Override
+	public void shutdown() {
+		try {
+			socketProvider.get().close();
+		} catch (Exception e) {
+			LOG.warn("Error closing socket", e);
+		}
+		super.shutdown();
+	}
+
+	BufferedWriter writer = null;
+	long lastEpoch = -1;
+	
+	@Override
+	public synchronized void run() {
+		//FIXME passing epoch on stack and writer via field, messy
+		Socket socket = null;
+		try {
+			socket = this.socketProvider.get();
+			writer = new BufferedWriter(new OutputStreamWriter(
+					socket.getOutputStream()));
+
+			final long epoch = clock.getTime() / 1000;
+			if (this.printVMMetrics) {
+				printVmMetrics(epoch);
+			}
+			printRegularMetrics(epoch);
+			writer.flush();
+			lastEpoch = epoch;
+		} catch (Exception e) {
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Error writing to socket", e);
+			} else {
+				LOG.warn("Error writing to socket: {}", e.getMessage());
+			}
+			if (writer != null) {
+				try {
+					writer.flush();
+				} catch (IOException e1) {
+					LOG.error("Error while flushing writer:", e1);
+				}
+			}
+		}
+	}
+
+	protected void printRegularMetrics(final Long epoch) {
+		for (Entry<String, SortedMap<MetricName, Metric>> entry : getMetricsRegistry()
+				.getGroupedMetrics(predicate).entrySet()) {
+			for (Entry<MetricName, Metric> subEntry : entry.getValue()
+					.entrySet()) {
+				final Metric metric = subEntry.getValue();
+				if (metric != null) {
+					try {
+						metric.processWith(this, subEntry.getKey(), epoch);
+					} catch (Exception ignored) {
+						LOG.error("Error printing regular metrics:", ignored);
+					}
+				}
+			}
+		}
+	}
+
+	protected void printVmMetrics(long epoch) throws IOException {
+		sendFloat(epoch, new MetricName("jvm","memory","heap"),"usage", vm.getHeapUsage());
+		sendFloat(epoch, new MetricName("jvm","memory","non_heap"),"usage", vm.getNonHeapUsage());
+		for (Entry<String, Double> pool : vm.getMemoryPoolUsage().entrySet()) {
+			sendFloat(epoch, new MetricName("jvm","memory_pool",sanitizeString(pool.getKey())),"usage", pool.getValue());
+		}
+
+		sendInt(epoch, new MetricName("jvm","threads", "daemon_thread"),"count", vm.getDaemonThreadCount());
+		sendInt(epoch, new MetricName("jvm","threads", "thread"),"count", vm.getThreadCount());
+		sendInt(epoch, new MetricName("jvm","uptime","uptime"),"time", vm.getUptime());
+		sendFloat(epoch, new MetricName("jvm","fd","fd"),"usage", vm.getFileDescriptorUsage());
+
+		for (Entry<State, Double> entry : vm.getThreadStatePercentages()
+				.entrySet()) {
+			sendFloat(epoch,new MetricName("jvm","thread-states", entry.getKey().toString()
+					.toLowerCase()),"percent", entry.getValue());
+		}
+
+		for (Entry<String, VirtualMachineMetrics.GarbageCollectorStats> entry : vm
+				.getGarbageCollectors().entrySet()) {
+			sendInt(epoch, new MetricName("jvm","gc",sanitizeString(entry.getKey())),
+					"time",entry.getValue().getTime(TimeUnit.MILLISECONDS));
+			sendInt(epoch, new MetricName("jvm","gc",sanitizeString(entry.getKey())),"count", entry.getValue().getRuns());
+		}
+	}
+
+	public abstract void sendFloat(long timestamp, MetricName metricName,String valueName, double value) throws IOException ;
+	public abstract void sendInt(long timestamp, MetricName metricName,String valueName, long value) throws IOException ;
+	public abstract void sendString(long timestamp, MetricName metricName,String valueName, String value) throws IOException ;
+	public void sendObj(long timestamp,  MetricName metricName,String valueName, Object value) throws IOException {
+	        sendString(timestamp, metricName, valueName,String.format(locale, "%s", value));
+	}
+
+
+	protected String sanitizeName(MetricName name) {
+		final StringBuilder sb = new StringBuilder().append(name.getGroup())
+				.append('.').append(name.getType()).append('.');
+		if (name.hasScope()) {
+			sb.append(name.getScope()).append('.');
+		}
+		return sb.append(name.getName()).toString();
+	}
+
+	protected String sanitizeString(String s) {
+		return s.replace(' ', '-');
+	}
+
+	@Override
+	public void processGauge(MetricName name, Gauge<?> gauge, Long epoch)
+			throws IOException {
+		sendObj(epoch, name,"value", gauge.getValue());
+	}
+
+	@Override
+	public void processCounter(MetricName name, Counter counter, Long epoch)
+			throws IOException {
+		sendInt(epoch,name, "count", counter.getCount());
+	}
+
+	@Override
+	public void processMeter(MetricName name, Metered meter, Long epoch)
+			throws IOException {
+		sendInt(epoch, name, "count", meter.getCount());
+		sendFloat(epoch, name, "meanRate", meter.getMeanRate());
+		sendFloat(epoch, name, "1MinuteRate", meter.getOneMinuteRate());
+		sendFloat(epoch, name, "5MinuteRate",
+				meter.getFiveMinuteRate());
+		sendFloat(epoch, name, "15MinuteRate",
+				meter.getFifteenMinuteRate());
+	}
+
+	@Override
+	public void processHistogram(MetricName name, Histogram histogram,
+			Long epoch) throws IOException {
+		sendSummarizable(epoch, name, histogram);
+		sendSampling(epoch, name, histogram);
+	}
+
+	@Override
+	public void processTimer(MetricName name, Timer timer, Long epoch)
+			throws IOException {
+		processMeter(name, timer, epoch);
+		getInstantMean(name,timer,epoch);
+		
+		sendSummarizable(epoch, name, timer);
+		sendSampling(epoch, name, timer);
+	}
+
+	
+	protected void sendSummarizable(long epoch, MetricName sanitizedName,
+			Summarizable metric) throws IOException {
+		sendFloat(epoch, sanitizedName, "min", metric.getMin());
+		sendFloat(epoch, sanitizedName, "max", metric.getMax());
+		sendFloat(epoch, sanitizedName, "mean", metric.getMean());
+		sendFloat(epoch, sanitizedName, "stddev", metric.getStdDev());
+	}
+
+	protected void sendSampling(long epoch, MetricName sanitizedName,
+			Sampling metric) throws IOException {
+		final Snapshot snapshot = metric.getSnapshot();
+		sendFloat(epoch, sanitizedName, "median", snapshot.getMedian());
+		sendFloat(epoch, sanitizedName, "75percentile",
+				snapshot.get75thPercentile());
+		sendFloat(epoch, sanitizedName, "95percentile",
+				snapshot.get95thPercentile());
+		sendFloat(epoch, sanitizedName, "98percentile",
+				snapshot.get98thPercentile());
+		sendFloat(epoch, sanitizedName, "99percentile",
+				snapshot.get99thPercentile());
+		sendFloat(epoch, sanitizedName, "999percentile",
+				snapshot.get999thPercentile());
+	}
+	
+	
+	private Map<Timer,Double> last = new HashMap<Timer, Double>();
+	
+	private void getInstantMean(MetricName name, Timer timer, Long epoch) throws IOException {
+		Double prevV = last.get(timer);
+		if(prevV == null){
+			last.put(timer,timer.getSum());
+			return;
+		}
+		
+		double timeDelta = epoch-lastEpoch;
+		if(timeDelta == 0)
+			return;
+		
+		double newV = timer.getSum();
+		last.put(timer,newV);
+		sendFloat(epoch,name,"instantMean",(newV-prevV)/timeDelta); 
+		
+	}
+
+}

--- a/metrics-core/src/main/java/com/yammer/metrics/reporting/DefaultCachingSocketProvider.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/reporting/DefaultCachingSocketProvider.java
@@ -1,0 +1,28 @@
+package com.yammer.metrics.reporting;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+public class DefaultCachingSocketProvider implements SocketProvider {
+	
+	private String host;
+	private int port;
+	
+	public DefaultCachingSocketProvider(String host, int port) {
+		super();
+		this.host = host;
+		this.port = port;
+	}
+
+	private Socket connection;
+
+	public Socket get() throws UnknownHostException, IOException {
+		if (connection != null && !connection.isClosed())
+			return connection;
+		connection = new Socket(host, port);
+		return connection;
+	}
+
+
+}

--- a/metrics-core/src/main/java/com/yammer/metrics/reporting/SocketProvider.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/reporting/SocketProvider.java
@@ -1,0 +1,7 @@
+package com.yammer.metrics.reporting;
+
+import java.net.Socket;
+
+public interface SocketProvider {
+    Socket get() throws Exception;
+}

--- a/metrics-opentsdb/pom.xml
+++ b/metrics-opentsdb/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<artifactId>metrics-parent</artifactId>
+		<groupId>com.yammer.metrics</groupId>
+		<version>3.0.0-SNAPSHOT</version>
+	</parent>
+	
+	<groupId>com.yammer.metrics</groupId>
+	<artifactId>metrics-opentsdb</artifactId>
+	<version>3.0.0-SNAPSHOT</version>
+	
+	<name>metrics opentsdb</name>
+	<description>Provide opentsdb support for metrics</description>
+	
+	<dependencies>
+		<dependency>
+			<groupId>com.yammer.metrics</groupId>
+			<artifactId>metrics-core</artifactId>
+			<version>${project.version}</version>
+			<type>jar</type>
+			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>${slf4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-jdk14</artifactId>
+			<version>${slf4j.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.yammer.metrics</groupId>
+			<artifactId>metrics-core</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/metrics-opentsdb/src/main/java/com/yammer/metrics/reporting/TsdbReporter.java
+++ b/metrics-opentsdb/src/main/java/com/yammer/metrics/reporting/TsdbReporter.java
@@ -1,0 +1,208 @@
+package com.yammer.metrics.reporting;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.TimeUnit;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Clock;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricPredicate;
+import com.yammer.metrics.core.MetricProcessor;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.VirtualMachineMetrics;
+
+/**
+ * @author w.deborger@gmail.com
+ *
+ */
+public class TsdbReporter extends AbstractSocketReporter implements
+		MetricProcessor<Long> {
+	
+	
+	 /**
+     * Enables the TSDB reporter to send data for the default metrics registry to TSDB
+     * server with the specified period.
+     *
+     * @param period the period between successive outputs
+     * @param unit   the time unit of {@code period}
+     * @param host   the host name of TSDB server (carbon-cache agent)
+     * @param port   the port number on which the TSDB server is listening
+     */
+    public static void enable(long period, TimeUnit unit, String host, int port) {
+        enable(Metrics.defaultRegistry(), period, unit, host, port);
+    }
+
+    /**
+     * Enables the TSDB reporter to send data for the given metrics registry to TSDB server
+     * with the specified period.
+     *
+     * @param metricsRegistry the metrics registry
+     * @param period          the period between successive outputs
+     * @param unit            the time unit of {@code period}
+     * @param host            the host name of TSDB server (carbon-cache agent)
+     * @param port            the port number on which the TSDB server is listening
+     */
+    public static void enable(MetricsRegistry metricsRegistry, long period, TimeUnit unit, String host, int port) {
+        enable(metricsRegistry, period, unit, host, port, null);
+    }
+
+    /**
+     * Enables the TSDB reporter to send data to TSDB server with the specified period.
+     *
+     * @param period the period between successive outputs
+     * @param unit   the time unit of {@code period}
+     * @param host   the host name of TSDB server (carbon-cache agent)
+     * @param port   the port number on which the TSDB server is listening
+     * @param prefix the string which is prepended to all metric names
+     */
+    public static void enable(long period, TimeUnit unit, String host, int port, String prefix) {
+        enable(Metrics.defaultRegistry(), period, unit, host, port, prefix);
+    }
+
+    /**
+     * Enables the TSDB reporter to send data to TSDB server with the specified period.
+     *
+     * @param metricsRegistry the metrics registry
+     * @param period          the period between successive outputs
+     * @param unit            the time unit of {@code period}
+     * @param host            the host name of TSDB server (carbon-cache agent)
+     * @param port            the port number on which the TSDB server is listening
+     * @param prefix          the string which is prepended to all metric names
+     */
+    public static void enable(MetricsRegistry metricsRegistry, long period, TimeUnit unit, String host, int port, String prefix) {
+        enable(metricsRegistry, period, unit, host, port, prefix, MetricPredicate.ALL);
+    }
+
+    /**
+     * Enables the TSDB reporter to send data to TSDB server with the specified period.
+     *
+     * @param metricsRegistry the metrics registry
+     * @param period          the period between successive outputs
+     * @param unit            the time unit of {@code period}
+     * @param host            the host name of TSDB server (carbon-cache agent)
+     * @param port            the port number on which the TSDB server is listening
+     * @param prefix          the string which is prepended to all metric names
+     * @param predicate       filters metrics to be reported
+     */
+    public static void enable(MetricsRegistry metricsRegistry, long period, TimeUnit unit, String host, int port, String prefix, MetricPredicate predicate) {
+        try {
+            final TsdbReporter reporter = new TsdbReporter(metricsRegistry,
+                                                                   prefix,
+                                                                   predicate,
+                                                                   new DefaultCachingSocketProvider(host,
+                                                                                             port),
+                                                                   Clock.defaultClock());
+            reporter.start(period, unit);
+        } catch (Exception e) {
+            LOG.error("Error creating/starting TSDB reporter:", e);
+        }
+    }
+
+    
+    
+
+    private static final Logger LOG = LoggerFactory.getLogger(TsdbReporter.class);
+
+	
+	private String hostName;
+	
+	protected TsdbReporter(String host, int port) {
+		this(Metrics.defaultRegistry(),host,port);
+	}
+	
+	
+	protected TsdbReporter(MetricsRegistry metricsRegistry,String host, int port) {
+		this(metricsRegistry,null,MetricPredicate.ALL,new DefaultCachingSocketProvider(host,port),Clock.defaultClock(),VirtualMachineMetrics.getInstance());
+		
+	}
+
+	TsdbReporter(MetricsRegistry metricsRegistry,
+			String prefix, MetricPredicate predicate,
+			SocketProvider socketProvider, Clock clock,String hostname) {
+		super(metricsRegistry,prefix,predicate,socketProvider,clock,VirtualMachineMetrics.getInstance(),"TsdbReporter");
+		this.hostName = hostname;
+	}
+
+	
+	
+	protected TsdbReporter(MetricsRegistry metricsRegistry,
+			String prefix, MetricPredicate predicate,
+			SocketProvider socketProvider, Clock clock,
+			VirtualMachineMetrics vm) {
+		super(metricsRegistry,prefix,predicate,socketProvider,clock,vm,"TsdbReporter");
+		try {
+			this.hostName = InetAddress.getLocalHost().getHostName();
+		} catch (UnknownHostException e) {
+			LOG.error("could not get hostname", e);
+			throw new Error(e);
+		}
+	}
+
+	public TsdbReporter(MetricsRegistry registry, String prefix,
+			MetricPredicate all, SocketProvider socketProvider, Clock clock) {
+		this(registry,prefix,all,socketProvider,clock,VirtualMachineMetrics.getInstance());
+	}
+
+
+	private String makeName(MetricName metricName, String valueName) {
+		return prefix+String.format("%s.%s.%s",metricName.getGroup(),metricName.getType(),valueName);
+	}
+	
+
+	private String makeTags(MetricName metricName) {
+		StringBuilder sb = new StringBuilder();
+		
+		sb.append("name=");
+		sb.append(metricName.getName());
+		
+		sb.append(" host=");
+		sb.append(hostName);
+		
+		if(metricName.hasScope()){
+			sb.append(" scope=");
+			sb.append(metricName.getScope());
+		}
+		return sb.toString();
+	}
+	
+	@Override
+	public void sendFloat(long timestamp, MetricName metricName,
+			String valueName, double value) throws IOException {
+		String name = makeName(metricName,valueName);
+		String tags = makeTags(metricName);
+		send(String.format("put %s %d %f %s",name, timestamp,value,tags));
+	}
+
+	
+
+
+	private void send(String format) throws IOException {
+		writer.write(format);
+		writer.write('\n');
+	}
+
+	@Override
+	public void sendInt(long timestamp, MetricName metricName,
+			String valueName, long value) throws IOException {
+		String name = makeName(metricName,valueName);
+		String tags = makeTags(metricName);
+		send(String.format("put %s %d %d %s",name, timestamp,value,tags));
+	}
+
+	@Override
+	public void sendString(long timestamp, MetricName metricName,
+			String valueName, String value) throws IOException {
+		String name = makeName(metricName,valueName);
+		String tags = makeTags(metricName);
+		send(String.format("put %s %d %s %s",name, timestamp,value,tags));
+	}
+
+	
+
+}

--- a/metrics-opentsdb/src/test/java/com/yammer/metrics/reporting/TSDBReporterTest.java
+++ b/metrics-opentsdb/src/test/java/com/yammer/metrics/reporting/TSDBReporterTest.java
@@ -1,0 +1,96 @@
+package com.yammer.metrics.reporting;
+
+
+import com.yammer.metrics.core.Clock;
+import com.yammer.metrics.core.MetricPredicate;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.VirtualMachineMetrics;
+import com.yammer.metrics.reporting.AbstractPollingReporter;
+import com.yammer.metrics.reporting.SocketProvider;
+import com.yammer.metrics.reporting.TsdbReporter;
+import com.yammer.metrics.reporting.tests.AbstractPollingReporterTest;
+
+import java.io.OutputStream;
+import java.net.Socket;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TSDBReporterTest extends AbstractPollingReporterTest {
+    @Override
+    protected AbstractPollingReporter createReporter(MetricsRegistry registry, OutputStream out, Clock clock) throws Exception {
+        final Socket socket = mock(Socket.class);
+        when(socket.getOutputStream()).thenReturn(out);
+
+        final SocketProvider provider = mock(SocketProvider.class);
+        when(provider.get()).thenReturn(socket);
+
+        final TsdbReporter reporter = new TsdbReporter(registry,
+                                                               "prefix",
+                                                               MetricPredicate.ALL,
+                                                               provider,
+                                                               clock,"wally");
+        reporter.printVMMetrics = false;
+        return reporter;
+    }
+
+    @Override
+    public String[] expectedGaugeResult(String value) {
+        return new String[]{String.format("put prefix.java.lang.Object.value 5 %s name=metric host=wally", value)};
+    }
+
+    @Override
+    public String[] expectedTimerResult() {
+        return new String[]{
+                "put prefix.java.lang.Object.count 5 1 name=metric host=wally",
+                "put prefix.java.lang.Object.meanRate 5 2.000000 name=metric host=wally",
+                "put prefix.java.lang.Object.1MinuteRate 5 1.000000 name=metric host=wally",
+                "put prefix.java.lang.Object.5MinuteRate 5 5.000000 name=metric host=wally",
+                "put prefix.java.lang.Object.15MinuteRate 5 15.000000 name=metric host=wally",
+                "put prefix.java.lang.Object.min 5 1.000000 name=metric host=wally",
+                "put prefix.java.lang.Object.max 5 3.000000 name=metric host=wally",
+                "put prefix.java.lang.Object.mean 5 2.000000 name=metric host=wally",
+                "put prefix.java.lang.Object.stddev 5 1.500000 name=metric host=wally",
+                "put prefix.java.lang.Object.median 5 0.499500 name=metric host=wally",
+                "put prefix.java.lang.Object.75percentile 5 0.749750 name=metric host=wally",
+                "put prefix.java.lang.Object.95percentile 5 0.949950 name=metric host=wally",
+                "put prefix.java.lang.Object.98percentile 5 0.979980 name=metric host=wally",
+                "put prefix.java.lang.Object.99percentile 5 0.989990 name=metric host=wally",
+                "put prefix.java.lang.Object.999percentile 5 0.998999 name=metric host=wally"
+        };
+    }
+
+    @Override
+    public String[] expectedMeterResult() {
+        return new String[]{
+                "put prefix.java.lang.Object.count 5 1 name=metric host=wally",
+                "put prefix.java.lang.Object.meanRate 5 2.000000 name=metric host=wally",
+                "put prefix.java.lang.Object.1MinuteRate 5 1.000000 name=metric host=wally",
+                "put prefix.java.lang.Object.5MinuteRate 5 5.000000 name=metric host=wally",
+                "put prefix.java.lang.Object.15MinuteRate 5 15.000000 name=metric host=wally",
+        };
+    }
+
+    @Override
+    public String[] expectedHistogramResult() {
+        return new String[]{
+                "put prefix.java.lang.Object.min 5 1.000000 name=metric host=wally",
+                "put prefix.java.lang.Object.max 5 3.000000 name=metric host=wally",
+                "put prefix.java.lang.Object.mean 5 2.000000 name=metric host=wally",
+                "put prefix.java.lang.Object.stddev 5 1.500000 name=metric host=wally",
+                "put prefix.java.lang.Object.median 5 0.499500 name=metric host=wally",
+                "put prefix.java.lang.Object.75percentile 5 0.749750 name=metric host=wally",
+                "put prefix.java.lang.Object.95percentile 5 0.949950 name=metric host=wally",
+                "put prefix.java.lang.Object.98percentile 5 0.979980 name=metric host=wally",
+                "put prefix.java.lang.Object.99percentile 5 0.989990 name=metric host=wally",
+                "put prefix.java.lang.Object.999percentile 5 0.998999 name=metric host=wally"
+        };
+    }
+
+    @Override
+    public String[] expectedCounterResult(long count) {
+        return new String[]{
+                String.format("put prefix.java.lang.Object.count 5 %d name=metric host=wally", count)
+        };
+    }
+}

--- a/metrics-opentsdb/src/test/java/com/yammer/metrics/reporting/ToTSDBTest.java
+++ b/metrics-opentsdb/src/test/java/com/yammer/metrics/reporting/ToTSDBTest.java
@@ -1,0 +1,71 @@
+package com.yammer.metrics.reporting;
+
+
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Clock;
+import com.yammer.metrics.core.Counter;
+import com.yammer.metrics.core.Gauge;
+import com.yammer.metrics.core.MetricName;
+import com.yammer.metrics.core.MetricPredicate;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.Timer;
+import com.yammer.metrics.core.TimerContext;
+import com.yammer.metrics.core.VirtualMachineMetrics;
+import com.yammer.metrics.reporting.AbstractPollingReporter;
+import com.yammer.metrics.reporting.SocketProvider;
+import com.yammer.metrics.reporting.TsdbReporter;
+import com.yammer.metrics.reporting.JmxReporter.GaugeMBean;
+import com.yammer.metrics.reporting.tests.AbstractPollingReporterTest;
+
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author wouterdb
+ *
+ *	http://HOST:4242/q?start=3m-ago&ignore=67&m=sum:com.yammer.metrics.reporting.ToTSDBTest.value&o=axis%20x1y2&m=sum:test.count.count{name=cte}&o=axis%20x1y2&m=sum:rate:test.count.count{name=rise}&o=&m=sum:test.time.instantMean&o=&m=sum:test.time.mean&o=&m=sum:10m-avg:test.time.instantMean&o=&yrange=[0:2.5]&y2range=[0:120]&wxh=1660x666&png
+ */
+public class ToTSDBTest extends Gauge<Long> implements Runnable  {
+	
+	public static void main(String[] args) {
+		TsdbReporter.enable(2,TimeUnit.SECONDS, args[0], 4242);
+		new Thread(new ToTSDBTest()).run();
+	}
+
+	@Override
+	public void run() {
+		MetricsRegistry reg = Metrics.defaultRegistry();
+		reg.newGauge(new MetricName(getClass(), "gauge"), this);
+		reg.newCounter(new MetricName("test","count","cte")).inc(75);
+		
+		Counter riser = reg.newCounter(new MetricName("test","count","rise"));
+		Timer wait = reg.newTimer(new MetricName("test","time","wait"),TimeUnit.SECONDS,TimeUnit.SECONDS);
+		
+		long start = System.currentTimeMillis();
+		while(true){
+			TimerContext tcx = wait.time();
+			riser.inc(2);
+			start += 1000;
+			long now=System.currentTimeMillis();
+			try {
+				long sleeptime = start-now+(long)(Math.random()*50);
+				Thread.sleep(sleeptime);
+			} catch (InterruptedException e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+			tcx.stop();
+		}
+		
+	}
+
+	@Override
+	public Long getValue() {
+		return (System.nanoTime()%100000000000L) / 1000000000L;
+	}
+   
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <module>metrics-scala_2.9.1</module>
         <module>metrics-servlet</module>
         <module>metrics-web</module>
+        <module>metrics-opentsdb</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
Based on the graphite reporter I have written an opentsdb reporter.

I also factored out the code shared with the graphite reporter to AbstractSocketReporter.
This class cloud also be used by the graphite reporter, but this would change the naming scheme for graphite vm metrics. 
