### PR TITLE
In metrics-web, allow group and type to be passed to MetricName from filter init params

### DIFF
--- a/metrics-web/src/main/java/com/yammer/metrics/web/DefaultWebappMetricsFilter.java
+++ b/metrics-web/src/main/java/com/yammer/metrics/web/DefaultWebappMetricsFilter.java
@@ -10,6 +10,15 @@ import java.util.Map;
  * <filter>
  *     <filter-name>webappMetricsFilter</filter-name>
  *     <filter-class>com.yammer.metrics.web.DefaultWebappMetricsFilter</filter-class>
+ *     <!-- init params are optional -->
+ *     <init-param>
+ *         <param-name>name.group</param-name>
+ *         <param-value>com.mycompany</param-value>
+ *     </init-param>
+ *     <init-param>
+ *         <param-name>name.type</param-name>
+ *         <param-value>http</param-value>
+ *     </init-param>
  * </filter>
  * <filter-mapping>
  *     <filter-name>webappMetricsFilter</filter-name>


### PR DESCRIPTION
We push metrics to other systems like statsd/Graphite, so using a custom metric name here is important so we know what service we're talking about.
