### PR TITLE
Fix the Github ribbon

### DIFF
--- a/docs/source/_themes/yammerdoc/layout.html
+++ b/docs/source/_themes/yammerdoc/layout.html
@@ -70,7 +70,7 @@
 <body>
     <a href="{{theme_github_page}}">
         <img style="position: absolute; top: 0; right: 0; border: 0;"
-             src="https://a248.e.akamai.net/assets.github.com/img/e6bef7a091f5f3138b8cd40bc3e114258dd68ddf/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67"
+             src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png"
              alt="Fork me on GitHub"></a>
     <div class="navbar">
         <div class="navbar-inner container-fluid" id="top-bar">


### PR DESCRIPTION
The current "Fork me on GitHub" ribbon is 404ing.
