### PR TITLE
Allow disabling of the JmxReporter via a system property

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/Metrics.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/Metrics.java
@@ -17,8 +17,12 @@ public class Metrics {
     };
 
     static {
-        JmxReporter.startDefault(DEFAULT_REGISTRY);
-        Runtime.getRuntime().addShutdownHook(SHUTDOWN_HOOK);
+        String prop = System.getProperty("metrics.jmx.autostart");
+        boolean autostart = (prop == null || prop.isEmpty()) ? true : Boolean.parseBoolean(prop);
+        if (autostart) {
+            JmxReporter.startDefault(DEFAULT_REGISTRY);
+            Runtime.getRuntime().addShutdownHook(SHUTDOWN_HOOK);
+        }
     }
 
     private Metrics() { /* unused */ }


### PR DESCRIPTION
This pull request is related to #235, but takes a different approach.

When continually running tests with SBTs `~test` command, all runs after the first run cause `javax.management.InstanceAlreadyExistsException`s for each metric that is used during the test.

This patch reads the system property `metrics.jmx.autostart` and prevents only stats the `JmxReporter` if the system property is set to `false`.

Please let me know if you need any changes made.
