### PR TITLE
Add support for formatted messages to HealthChecks

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/core/HealthCheck.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/HealthCheck.java
@@ -32,6 +32,21 @@ public abstract class HealthCheck {
         }
 
         /**
+         * Returns a healthy {@link Result} with a formatted message.
+         *
+         * Message formatting follows the same rules as 
+         * {@link String#format(String, Object...)}.
+         *
+         * @param message a message format
+         * @param args    the arguments apply to the message format
+         * @return a healthy {@link Result} with an additional message
+         * @see String#format(String, Object...)
+         */
+        public static Result healthy(String message, Object... args) {
+            return healthy(String.format(message, args));
+        }
+
+        /**
          * Returns an unhealthy {@link Result} with the given message.
          *
          * @param message    an informative message describing how the health check failed
@@ -39,6 +54,21 @@ public abstract class HealthCheck {
          */
         public static Result unhealthy(String message) {
             return new Result(false, message, null);
+        }
+
+        /**
+         * Returns an unhealthy {@link Result} with a formatted message.
+         *
+         * Message formatting follows the same rules as 
+         * {@link String#format(String, Object...)}.
+         *
+         * @param message a message format
+         * @param args    the arguments apply to the message format
+         * @return an unhealthy {@link Result} with an additional message
+         * @see String#format(String, Object...)
+         */
+        public static Result unhealthy(String message, Object... args) {
+            return unhealthy(String.format(message, args));
         }
 
         /**

--- a/metrics-core/src/test/java/com/yammer/metrics/core/tests/HealthCheckTest.java
+++ b/metrics-core/src/test/java/com/yammer/metrics/core/tests/HealthCheckTest.java
@@ -63,6 +63,20 @@ public class HealthCheckTest {
     }
 
     @Test
+    public void canHaveHealthyResultsWithFormattedMessages() throws Exception {
+        final Result result = Result.healthy("foo %s", "bar");
+
+        assertThat(result.isHealthy(),
+                    is(true));
+        
+        assertThat(result.getMessage(),
+                    is("foo bar"));
+
+        assertThat(result.getError(),
+                    is(nullValue()));
+    }
+
+    @Test
     public void canHaveUnhealthyResults() throws Exception {
         final Result result = Result.unhealthy("bad");
 
@@ -74,6 +88,20 @@ public class HealthCheckTest {
 
         assertThat(result.getError(),
                    is(nullValue()));
+    }
+
+    @Test
+    public void canHaveUnhealthyResultsWithFormattedMessages() throws Exception {
+        final Result result = Result.unhealthy("foo %s %d", "bar", 123);
+
+        assertThat(result.isHealthy(),
+                    is(false));
+        
+        assertThat(result.getMessage(),
+                    is("foo bar 123"));
+
+        assertThat(result.getError(),
+                    is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
This adds convenience methods to automatically format `HealthCheck` messages using `String.format(format, args)`:

For healthy `HeathCheck`s:

``` java
Result.healthy("latency: %d", latency);
```

For unhealthy `HealthCheck`s:

``` java
Result.unhealthy("timed out after %dms, connecting to %s:%d",
    timeout, host, port);
```
