### PR TITLE
Added a default status code 200

### DIFF
--- a/metrics-web/src/main/java/com/yammer/metrics/web/WebappMetricsFilter.java
+++ b/metrics-web/src/main/java/com/yammer/metrics/web/WebappMetricsFilter.java
@@ -113,7 +113,7 @@ public abstract class WebappMetricsFilter implements Filter {
     }
 
     private static class StatusExposingServletResponse extends HttpServletResponseWrapper {
-	// The Servlet spec says: calling setStatus is optional, if no status is set, the default is 200.
+        // The Servlet spec says: calling setStatus is optional, if no status is set, the default is 200.
         private int httpStatus = 200;
 
         public StatusExposingServletResponse(HttpServletResponse response) {


### PR DESCRIPTION
The Servlet spec says: calling setStatus is optional, if no status is set, the default is 200. The code should comply with this, because otherwise, all request will be sorted to the responseCode.other bucket
