### PR TITLE
Return elapsed nanoseconds on TimerContext.stop()

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/core/TimerContext.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/TimerContext.java
@@ -25,9 +25,11 @@ public class TimerContext {
     }
 
     /**
-     * Stops recording the elapsed time and updates the timer.
+     * Stops recording the elapsed time, updates the timer and returns the elapsed time
      */
-    public void stop() {
-        timer.update(clock.getTick() - startTime, TimeUnit.NANOSECONDS);
+    public long stop() {
+        final long elapsedNanos = clock.getTick() - startTime;
+        timer.update(elapsedNanos, TimeUnit.NANOSECONDS);
+        return elapsedNanos;
     }
 }


### PR DESCRIPTION
I would find it very useful if TimerContext's stop method would return the elapsed nanoseconds, that way I can log it immediately.
