### PR TITLE
Return elapsed nanoseconds on TimerContext.stop().

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/core/TimerContext.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/TimerContext.java
@@ -25,9 +25,11 @@ public class TimerContext {
     }
 
     /**
-     * Stops recording the elapsed time and updates the timer.
+     * Stops recording the elapsed time, updates the timer and returns the elapsed time
      */
-    public void stop() {
-        timer.update(clock.tick() - startTime, TimeUnit.NANOSECONDS);
+    public long stop() {
+        final long elapsedNanos = clock.tick() - startTime;
+        timer.update(elapsedNanos, TimeUnit.NANOSECONDS);
+        return elapsedNanos;
     }
 }


### PR DESCRIPTION
This allows, for instance, for the elapsed time to be logged
immediately.

This is a back-port of pull-request #271, for the 2.x branch.
