### PR TITLE
Added ElementType.TYPE to Timed, Metered & ExceptionMetered Target annotation

### DIFF
--- a/metrics-annotation/src/main/java/com/yammer/metrics/annotation/ExceptionMetered.java
+++ b/metrics-annotation/src/main/java/com/yammer/metrics/annotation/ExceptionMetered.java
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  * "exceptions". The meter will be marked every time an exception is thrown.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.TYPE})
 public @interface ExceptionMetered {
     /**
      * The default suffix for meter names.

--- a/metrics-annotation/src/main/java/com/yammer/metrics/annotation/Metered.java
+++ b/metrics-annotation/src/main/java/com/yammer/metrics/annotation/Metered.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
  * {@code #fancyName(String)} method is invoked, the meter will be marked.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.TYPE})
 public @interface Metered {
     /**
      * The group of the timer.

--- a/metrics-annotation/src/main/java/com/yammer/metrics/annotation/Timed.java
+++ b/metrics-annotation/src/main/java/com/yammer/metrics/annotation/Timed.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
  * {@code #fancyName(String)} method is invoked, the method's execution will be timed.
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.TYPE})
 public @interface Timed {
     /**
      * The group of the timer.

--- a/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/ExceptionMeteredResourceTest.java
+++ b/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/ExceptionMeteredResourceTest.java
@@ -1,0 +1,80 @@
+package com.yammer.metrics.jersey.tests;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.Test;
+
+import com.sun.jersey.api.container.MappableContainerException;
+import com.sun.jersey.test.framework.AppDescriptor;
+import com.sun.jersey.test.framework.JerseyTest;
+import com.sun.jersey.test.framework.LowLevelAppDescriptor;
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Meter;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.jersey.InstrumentedResourceMethodDispatchAdapter;
+import com.yammer.metrics.jersey.tests.resources.ExceptionMeteredResource;
+
+/**
+ * Tests importing {@link InstrumentedResourceMethodDispatchAdapter} as a
+ * singleton in a Jersey {@link com.sun.jersey.api.core.ResourceConfig}
+ */
+public class ExceptionMeteredResourceTest extends JerseyTest {
+	static {
+		Logger.getLogger("com.sun.jersey").setLevel(Level.OFF);
+	}
+
+	private MetricsRegistry registry;
+
+	@Override
+	protected AppDescriptor configure() {
+        return new LowLevelAppDescriptor.Builder(
+                InstrumentedResourceMethodDispatchAdapter.class,
+                ExceptionMeteredResource.class
+        ).build();		
+	}
+
+	@Test
+	public void exceptionMeteredFirstIsExceptionMetered() {
+		final Meter meter = Metrics.newMeter(ExceptionMeteredResource.class, "exceptionMeteredFirstExceptions", "blah", TimeUnit.SECONDS);
+
+		assertThat(resource().path("exception-metered-first").get(String.class), is("fuh"));
+
+		assertThat(meter.count(), is(0L));
+
+		try {
+			resource().path("exception-metered-first").queryParam("splode", "true").get(String.class);
+			fail("should have thrown a MappableContainerException, but didn't");
+		} catch (MappableContainerException e) {
+			assertThat(e.getCause(), is(instanceOf(IOException.class)));
+		}
+
+		assertThat(meter.count(), is(1L));
+	}
+
+	@Test
+	public void exceptionMeteredSecondIsExceptionMetered() {
+		final Meter meter = Metrics.newMeter(ExceptionMeteredResource.class, "exceptionMeteredSecondExceptions", "blah", TimeUnit.SECONDS);
+
+		assertThat(resource().path("exception-metered-second").get(String.class), is("fuh"));
+
+		assertThat(meter.count(), is(0L));
+
+		try {
+			resource().path("exception-metered-second").queryParam("splode", "true").get(String.class);
+			fail("should have thrown a MappableContainerException, but didn't");
+		} catch (MappableContainerException e) {
+			assertThat(e.getCause(), is(instanceOf(IOException.class)));
+		}
+
+		assertThat(meter.count(), is(1L));
+	}
+
+}

--- a/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/MeteredResourceTest.java
+++ b/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/MeteredResourceTest.java
@@ -1,0 +1,56 @@
+package com.yammer.metrics.jersey.tests;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.Test;
+
+import com.sun.jersey.test.framework.AppDescriptor;
+import com.sun.jersey.test.framework.JerseyTest;
+import com.sun.jersey.test.framework.LowLevelAppDescriptor;
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Meter;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.jersey.InstrumentedResourceMethodDispatchAdapter;
+import com.yammer.metrics.jersey.tests.resources.MeteredResource;
+
+/**
+ * Tests importing {@link InstrumentedResourceMethodDispatchAdapter} as a
+ * singleton in a Jersey {@link com.sun.jersey.api.core.ResourceConfig}
+ */
+public class MeteredResourceTest extends JerseyTest {
+	static {
+		Logger.getLogger("com.sun.jersey").setLevel(Level.OFF);
+	}
+
+	private MetricsRegistry registry;
+
+	@Override
+	protected AppDescriptor configure() {
+        return new LowLevelAppDescriptor.Builder(
+                InstrumentedResourceMethodDispatchAdapter.class,
+                MeteredResource.class
+        ).build();
+	}
+
+	@Test
+	public void meteredFirstIsMetered() {
+		assertThat(resource().path("metered-first").get(String.class), is("yay-first"));
+
+		final Meter meter = Metrics.newMeter(MeteredResource.class, "meteredFirst", "blah", TimeUnit.SECONDS);
+		assertThat(meter.count(), is(1L));
+	}
+
+	@Test
+	public void meteredSecondIsMetered() {
+		assertThat(resource().path("metered-second").get(String.class), is("yay-second"));
+
+		final Meter meter = Metrics.newMeter(MeteredResource.class, "meteredSecond", "blah", TimeUnit.SECONDS);
+		assertThat(meter.count(), is(1L));
+	}
+
+}

--- a/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/TimedResourceTest.java
+++ b/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/TimedResourceTest.java
@@ -1,0 +1,55 @@
+package com.yammer.metrics.jersey.tests;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.junit.Test;
+
+import com.sun.jersey.test.framework.AppDescriptor;
+import com.sun.jersey.test.framework.JerseyTest;
+import com.sun.jersey.test.framework.LowLevelAppDescriptor;
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.Timer;
+import com.yammer.metrics.jersey.InstrumentedResourceMethodDispatchAdapter;
+import com.yammer.metrics.jersey.tests.resources.TimedResource;
+
+/**
+ * Tests importing {@link InstrumentedResourceMethodDispatchAdapter} as a
+ * singleton in a Jersey {@link com.sun.jersey.api.core.ResourceConfig}
+ */
+public class TimedResourceTest extends JerseyTest {
+	static {
+		Logger.getLogger("com.sun.jersey").setLevel(Level.OFF);
+	}
+
+	private MetricsRegistry registry;
+
+	@Override
+	protected AppDescriptor configure() {
+        return new LowLevelAppDescriptor.Builder(
+                InstrumentedResourceMethodDispatchAdapter.class,
+                TimedResource.class
+        ).build();
+	}
+
+	@Test
+	public void timedFirstIsTimed() {
+		assertThat(resource().path("timed-first").get(String.class), is("yay-first"));
+
+		final Timer timer = Metrics.newTimer(TimedResource.class, "timedFirst");
+		assertThat(timer.count(), is(1L));
+	}
+
+	@Test
+	public void timedSecondIsTimed() {
+		assertThat(resource().path("timed-second").get(String.class), is("yay-second"));
+
+		final Timer timer = Metrics.newTimer(TimedResource.class, "timedSecond");
+		assertThat(timer.count(), is(1L));
+	}
+
+}

--- a/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/resources/ExceptionMeteredResource.java
+++ b/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/resources/ExceptionMeteredResource.java
@@ -1,0 +1,36 @@
+package com.yammer.metrics.jersey.tests.resources;
+
+import java.io.IOException;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import com.yammer.metrics.annotation.ExceptionMetered;
+
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+@ExceptionMetered(cause = IOException.class)
+public class ExceptionMeteredResource {
+	@GET
+	@Path("/exception-metered-first")
+	public String exceptionMeteredFirst(@QueryParam("splode") @DefaultValue("false") boolean splode) throws IOException {
+		if (splode) {
+			throw new IOException("AUGH");
+		}
+		return "fuh";
+	}
+
+	@GET
+	@Path("/exception-metered-second")
+	public String exceptionMeteredSecond(@QueryParam("splode") @DefaultValue("false") boolean splode) throws IOException {
+		if (splode) {
+			throw new IOException("AUGH");
+		}
+		return "fuh";
+	}
+
+}

--- a/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/resources/MeteredResource.java
+++ b/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/resources/MeteredResource.java
@@ -1,0 +1,25 @@
+package com.yammer.metrics.jersey.tests.resources;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.yammer.metrics.annotation.Metered;
+
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+@Metered
+public class MeteredResource {
+	@GET
+	@Path("/metered-first")
+	public String meteredFirst() {
+		return "yay-first";
+	}
+
+	@GET
+	@Path("/metered-second")
+	public String meteredSecond() {
+		return "yay-second";
+	}
+}

--- a/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/resources/TimedResource.java
+++ b/metrics-jersey/src/test/java/com/yammer/metrics/jersey/tests/resources/TimedResource.java
@@ -1,0 +1,25 @@
+package com.yammer.metrics.jersey.tests.resources;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.yammer.metrics.annotation.Timed;
+
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+@Timed
+public class TimedResource {
+	@GET
+	@Path("/timed-first")
+	public String timedFirst() {
+		return "yay-first";
+	}
+
+	@GET
+	@Path("/timed-second")
+	public String timedSecond() {
+		return "yay-second";
+	}
+}


### PR DESCRIPTION
Hi Coda,
I started using metrics this week and its been working great so far. I am able to instrument my webapp and jax-rs resources and was able to publish metrics to Graphite pretty quickly. Thanks for "metrics" and for the wonderful presentation (http://codahale.com/codeconf-2011-04-09-metrics-metrics-everywhere.pdf). 

I have some 20+ JAX-RS/Jersey Resources implemented in 5 different Services, and I'm trying to instrument all of them by annotating the method with @Timed. Problem is - its repetitive and the annotation is in every Service and every Method. 

It'll be nice to have a functionality where I could just annotate the Service at the Class level and if the "InstrumentedResourceMethodDispatchProvider" could look for the annotation at the class level and instrument the method. 

I've attempted to code this. Please review and give feedback: 
1) Currently, I'm looking for the annotation at the class level first, followed by looking for it at the Method level - the Method level takes precedence if found. 
2) Should I use a separate annotation for class level may be?? (@TimedService ??)

thanks,
Stephen

PS : New to github and this is my first pull request, so apologize in advance if I'm not doing some things correctly. I'd like to contribute, so would appreciate guidance. Thx.
