### PR TITLE
conversions between java and scala metrics

### DIFF
--- a/metrics-scala_2.9.1/src/main/scala/com/yammer/metrics/scala/Converters.scala
+++ b/metrics-scala_2.9.1/src/main/scala/com/yammer/metrics/scala/Converters.scala
@@ -1,0 +1,24 @@
+package com.yammer.metrics.scala
+
+import com.yammer.metrics.core.{ Counter => JCounter, Histogram => JHistogram, Meter => JMeter, Timer => JTimer }
+
+/**
+ * This class includes some useful implicit conversions similar to the ones in <code>scala.collection.JavaConverters</code>.
+ *
+ * Usage:
+ *  <code> import com.yammer.metrics.scala.Converters._</code>
+ *  <code> val counter = Metrics.newCounter(classOf[QueueManager], "pending-jobs").asScala</code>
+ *
+ * Note: The conversions need to be in scope in order to work (see import in previous example).
+ *
+ */
+object Converters {
+  implicit def counter2scala(metric: JCounter) = new Convertible[JCounter, Counter](metric)(new Counter(_))
+  implicit def histogram2scala(metric: JHistogram) = new Convertible[JHistogram, Histogram](metric)(new Histogram(_))
+  implicit def meter2scala(metric: JMeter) = new Convertible[JMeter, Meter](metric)(new Meter(_))
+  implicit def timer2scala(metric: JTimer) = new Convertible[JTimer, Timer](metric)(new Timer(_))
+}
+
+class Convertible[T,U](metric: T)(op: (T) => U) {
+  def asScala = op(metric)
+}


### PR DESCRIPTION
A simpler and more "scala way" of getting the scala wrappers of the Metrics objects:

``` scala
import com.yammer.metrics.scala.Converters._
val counter = Metrics.newCounter(classOf[QueueManager], "pending-jobs").asScala
```

Works with all metric objects. It's the roughly equivalent of `JavaConverters` in the `scala.collection` package.
