### PR TITLE
Running individual HealthChecks and getting registered names

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/core/HealthCheckRegistry.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/HealthCheckRegistry.java
@@ -4,6 +4,7 @@ import com.yammer.metrics.core.HealthCheck.Result;
 
 import java.util.Collections;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -43,6 +44,15 @@ public class HealthCheckRegistry {
     }
 
     /**
+     * Returns a set of names of all registered {@link HealthCheck} instances
+     *
+     * @return a set of names
+     */
+    public Set<String> getRegisteredNames() {
+        return Collections.unmodifiableSet(healthChecks.keySet());
+    }
+
+    /**
      * Runs the registered health checks and returns a map of the results.
      *
      * @return a map of the health check results
@@ -50,9 +60,29 @@ public class HealthCheckRegistry {
     public SortedMap<String, Result> runHealthChecks() {
         final SortedMap<String, Result> results = new TreeMap<String, Result>();
         for (Entry<String, HealthCheck> entry : healthChecks.entrySet()) {
-            final Result result = entry.getValue().execute();
-            results.put(entry.getKey(), result);
+            results.put(entry.getKey(), runHealthCheck(entry.getValue()));
         }
         return Collections.unmodifiableSortedMap(results);
     }
+
+    /**
+     * Runs HealthCheck registered under the parameter name
+     *
+     * @param name the name of the {@link HealthCheck} instance
+     * @return health check result
+     */
+    public Result runHealthCheck(String name) {
+        return runHealthCheck(healthChecks.get(name));
+    }
+
+    /**
+     * Runs provided HealthCheck
+     *
+     * @param healthCheck the {@link HealthCheck} instance
+     * @return health check result
+     */
+    private Result runHealthCheck(HealthCheck healthCheck) {
+        return healthCheck.execute();
+    }
+
 }

--- a/metrics-core/src/test/java/com/yammer/metrics/core/tests/HealthCheckRegistryTest.java
+++ b/metrics-core/src/test/java/com/yammer/metrics/core/tests/HealthCheckRegistryTest.java
@@ -6,12 +6,16 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Map;
+import java.util.Set;
 
 import static com.yammer.metrics.core.HealthCheck.Result;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class HealthCheckRegistryTest {
@@ -57,5 +61,24 @@ public class HealthCheckRegistryTest {
 
         assertThat(results,
                    hasEntry("hc2", r2));
+    }
+
+    @Test
+    public void runsNamedHealthCheck() throws Exception {
+
+        registry.runHealthCheck("hc2");
+
+        verify(hc2.execute());
+
+    }
+
+    @Test
+    public void getsRegisteredNames() throws Exception {
+
+        Set<String> registeredNames = registry.getRegisteredNames();
+
+        assertThat(registeredNames.size(), is(2));
+        assertThat(registeredNames, hasItems("hc1", "hc2"));
+
     }
 }


### PR DESCRIPTION
I'm trying to create a website for checking health status of our internal projects similar to the one Mozilla has set up for their own services: http://status.mozilla.com/

I would like to be able to make a separate request for each of the checks in order to make it naturally asynchronous. But in order to do that, I need to be able to run individual health checks via HealthChecks interface, like:

``` java
    public static Result runHealthCheck(String name) {
        return DEFAULT_REGISTRY.runHealthCheck(String name);
    }
```

Moreover, it would be great to be able to get all registered HealthCheck names:

``` java
    public static Set<String> getHealthCheckNames() {
        return DEFAULT_REGISTRY.getRegisteredNames();
    }
```

It's a trivial change that would help me a lot. 
