### PR TITLE
expose Sum field of Histogram and Timers as JMX attribute

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/reporting/JmxReporter.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/reporting/JmxReporter.java
@@ -163,6 +163,8 @@ public class JmxReporter extends AbstractReporter implements MetricsRegistryList
 
         double getStdDev();
 
+        double getSum();
+
         double get50thPercentile();
 
         double get75thPercentile();
@@ -221,6 +223,11 @@ public class JmxReporter extends AbstractReporter implements MetricsRegistryList
         @Override
         public double getStdDev() {
             return metric.getStdDev();
+        }
+
+        @Override
+        public double getSum() {
+            return metric.getSum();
         }
 
         @Override
@@ -297,6 +304,11 @@ public class JmxReporter extends AbstractReporter implements MetricsRegistryList
         @Override
         public double getStdDev() {
             return metric.getStdDev();
+        }
+
+        @Override
+        public double getSum() {
+            return metric.getSum();
         }
 
         @Override


### PR DESCRIPTION
Histograms maintain a Sum field which is used in calculating the Mean. The JmxReporter currently exposes just the Count and Mean fields.

It would be useful if the Sum was also exposed, for use in RRDTool-based monitoring systems where there is a desire to store the rate of change of the fields (Count and Sum) which can then be used to build charts of, for example, recent response times of API requests.
