### PR TITLE
Expose timer/histogram sum as JMX attribute

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/reporting/JmxReporter.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/reporting/JmxReporter.java
@@ -156,6 +156,8 @@ public class JmxReporter extends AbstractReporter implements MetricsRegistryList
         double getMax();
 
         double getMean();
+        
+        double getSum();
 
         double getStdDev();
 
@@ -212,6 +214,11 @@ public class JmxReporter extends AbstractReporter implements MetricsRegistryList
         @Override
         public double getMean() {
             return metric.getMean();
+        }
+        
+        @Override
+        public double getSum() {
+        	return metric.getSum();
         }
 
         @Override
@@ -288,6 +295,11 @@ public class JmxReporter extends AbstractReporter implements MetricsRegistryList
         @Override
         public double getMean() {
             return metric.getMean();
+        }
+        
+        @Override
+        public double getSum() {
+        	return metric.getSum();
         }
 
         @Override


### PR DESCRIPTION
Please consider exposing the sum of histrograms/timers as a JMX metric. For timers, this is especially useful when using metrics collection software that computes deltas between data collection runs.
