### PR TITLE
Fix for empty lines in CSV output from histograms

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/reporting/CsvReporter.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/reporting/CsvReporter.java
@@ -208,7 +208,6 @@ public class CsvReporter extends AbstractPollingReporter implements
                               .append(snapshot.get99thPercentile()).append(',')
                               .append(snapshot.get999thPercentile()).toString())
                 .println();
-        stream.println();
         stream.flush();
     }
 


### PR DESCRIPTION
I made a simple fix for a problem where each line in the CSV output for Histograms had an extra blank line after it.
