### PR TITLE
Sanitize Metric prefix in GraphiteReporter

### DIFF
--- a/metrics-graphite/src/main/java/com/yammer/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/yammer/metrics/graphite/GraphiteReporter.java
@@ -195,7 +195,7 @@ public class GraphiteReporter extends AbstractPollingReporter implements MetricP
 
         if (prefix != null) {
             // Pre-append the "." so that we don't need to make anything conditional later.
-            this.prefix = prefix + ".";
+            this.prefix = sanitizeString(prefix) + ".";
         } else {
             this.prefix = "";
         }


### PR DESCRIPTION
If the prefix accidentally contains spaces, it will be rejected by
Graphite/Carbon with the following error:

invalid line received from client ip:port, ignoring
