### PR TITLE
Backport CsvReporter fixes and MetricName changes from master

### DIFF
--- a/metrics-core/src/main/java/com/yammer/metrics/core/MetricName.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/core/MetricName.java
@@ -155,7 +155,7 @@ public class MetricName implements Comparable<MetricName> {
 
     @Override
     public String toString() {
-        return mBeanName;
+        return group + '.' + type + '.' + name + (scope == null ? "" : '.' + scope);
     }
 
     @Override

--- a/metrics-core/src/main/java/com/yammer/metrics/reporting/CsvReporter.java
+++ b/metrics-core/src/main/java/com/yammer/metrics/reporting/CsvReporter.java
@@ -134,7 +134,7 @@ public class CsvReporter extends AbstractPollingReporter implements
      * @throws IOException if there is an error opening the stream
      */
     protected PrintStream createStreamForMetric(MetricName metricName) throws IOException {
-        final File newFile = new File(outputDir, metricName.getName() + ".csv");
+        final File newFile = new File(outputDir, metricName.toString() + ".csv");
         if (newFile.createNewFile()) {
             return new PrintStream(new FileOutputStream(newFile));
         }

--- a/metrics-core/src/test/java/com/yammer/metrics/core/tests/MetricNameTest.java
+++ b/metrics-core/src/test/java/com/yammer/metrics/core/tests/MetricNameTest.java
@@ -45,7 +45,7 @@ public class MetricNameTest {
     @Test
     public void isHumanReadable() throws Exception {
         assertThat(name.toString(),
-                   is("bean"));
+                   is("group.type.name.scope"));
     }
 
     @Test


### PR DESCRIPTION
The changes in this pull request backport two things from master:
- Modify `CsvReporter` to name files based on `MetricName.toString()` per codahale/metrics@2453bb45eb4cb710784c450c21d50b5dbec6309f
  
  Fixes the issue where the CsvReport fails will multiple metrics with the same name.
- Modify `MetricName.toString` and associated tests to follow the pattern in master (i.e., use group, type, name, and scope for the metric name) instead of the mbean name.
  
  Makes `.csv` files created by `CsvReporter` easily accessible from the command line, as the previous implementation results in `"` characters in the produced filenames.
