### PR TITLE
Allow custom name for metrics in InstrumentedHandler

### DIFF
--- a/metrics-jetty8/src/main/java/com/yammer/metrics/jetty8/InstrumentedHandler.java
+++ b/metrics-jetty8/src/main/java/com/yammer/metrics/jetty8/InstrumentedHandler.java
@@ -50,7 +50,7 @@ public class InstrumentedHandler extends HandlerWrapper {
      * @param underlying the handler about which metrics will be collected
      */
     public InstrumentedHandler(MetricRegistry registry, Handler underlying) {
-    	this(registry, underlying, underlying.getClass().getName());
+    	this(registry, underlying, name(underlying.getClass()));
     }
 
     /**


### PR DESCRIPTION
We run into a problem where we have a Jetty server with multiple handlers for different context paths (i.e. /static_content, /servlets etc.) and then we can't use the default Jetty handlers because the metric names collide as they all use org.eclipse.jetty.servlet.ServletContextHandler.
This small change allows us to customize the name per handler.
