### PR TITLE
FileDescriptorGauge should use Java 1.6 exceptions

### DIFF
--- a/metrics-jvm/src/main/java/com/yammer/metrics/jvm/FileDescriptorRatioGauge.java
+++ b/metrics-jvm/src/main/java/com/yammer/metrics/jvm/FileDescriptorRatioGauge.java
@@ -4,6 +4,7 @@ import com.yammer.metrics.RatioGauge;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 /**
@@ -33,12 +34,16 @@ public class FileDescriptorRatioGauge extends RatioGauge {
         try {
             return Ratio.of(invoke("getOpenFileDescriptorCount"),
                             invoke("getMaxFileDescriptorCount"));
-        } catch (ReflectiveOperationException e) {
+        } catch (NoSuchMethodException e) {
+            return Ratio.of(Double.NaN, Double.NaN);
+        } catch (IllegalAccessException e) {
+            return Ratio.of(Double.NaN, Double.NaN);
+        } catch (InvocationTargetException e) {
             return Ratio.of(Double.NaN, Double.NaN);
         }
     }
 
-    private long invoke(String name) throws ReflectiveOperationException {
+    private long invoke(String name) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         final Method method = os.getClass().getDeclaredMethod(name);
         method.setAccessible(true);
         return (Long) method.invoke(os);

--- a/metrics-jvm/src/test/java/com/yammer/metrics/jvm/tests/FileDescriptorRatioGaugeTest.java
+++ b/metrics-jvm/src/test/java/com/yammer/metrics/jvm/tests/FileDescriptorRatioGaugeTest.java
@@ -37,11 +37,6 @@ public class FileDescriptorRatioGaugeTest {
             return 0;
         }
 
-        @Override
-        public ObjectName getObjectName() {
-            return null;
-        }
-
         // these duplicate methods from UnixOperatingSystem
 
         private long getOpenFileDescriptorCount() {


### PR DESCRIPTION
`ReflectiveOperationException` is a Java 1.7+ exception, but we compile to Java 1.6. The build was breaking because of this.
