### PR TITLE
Allow older versions of slf4j and servlet API in OSGi imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
                 <configuration>
                     <instructions>
                         <Import-Package><![CDATA[
+                            javax.servlet*;version="[2.5.0,4.0.0)",
                             org.slf4j*;version="[1.6.0,2.0.0)",
                             *
                         ]]>


### PR DESCRIPTION
The OSGi import for SLF4J is defaulted to 1.7-2.0 by Maven. Since 1.7 is
binary compatible with 1.6, users of the Metrics API should not be required
to use 1.7+. Modify the import to indicate use of 1.6+ is acceptable.

Similarly, the build uses the Servlet API 3+ due to its dependency on Jetty 8.
However, there is no capability used by metrics that is dependent on
Servlet 3. Modify the build to allow the OSGi bundles created to be used
in a Servlet 2.5+ environment.
