### PR TITLE
MetricSet impls: add metricNamePrefix to ctors so that users can control where their metrics sit in the namespace

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/JvmAttributeGaugeSet.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JvmAttributeGaugeSet.java
@@ -7,38 +7,61 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
+import static com.codahale.metrics.MetricRegistry.name;
+
 /**
  * A set of gauges for the JVM name, vendor, and uptime.
  */
 public class JvmAttributeGaugeSet implements MetricSet {
     private final RuntimeMXBean runtime;
+    private final String metricNamePrefix;
 
     /**
      * Creates a new set of gauges.
      */
     public JvmAttributeGaugeSet() {
-        this(ManagementFactory.getRuntimeMXBean());
+        this(ManagementFactory.getRuntimeMXBean(), null);
+    }
+
+    /**
+     * Creates a new set of gauges.
+     * 
+     * @param metricNamePrefix prefix for metric names, can be <code>null</code>
+     */
+    public JvmAttributeGaugeSet(String metricNamePrefix) {
+        this(ManagementFactory.getRuntimeMXBean(), metricNamePrefix);
     }
 
     /**
      * Creates a new set of gauges with the given {@link RuntimeMXBean}.
      */
     public JvmAttributeGaugeSet(RuntimeMXBean runtime) {
+        this(runtime, null);
+    }
+    
+    /**
+     * Creates a new set of gauges with the given {@link RuntimeMXBean}.
+     * 
+     * @param metricNamePrefix prefix for metric names, can be <code>null</code>
+     */
+    public JvmAttributeGaugeSet(RuntimeMXBean runtime, String metricNamePrefix) {
+        super();
         this.runtime = runtime;
+        this.metricNamePrefix = metricNamePrefix;
     }
 
     @Override
     public Map<String, Metric> getMetrics() {
         final Map<String, Metric> gauges = new HashMap<String, Metric>();
 
-        gauges.put("name", new Gauge<String>() {
+        gauges.put(name(metricNamePrefix, "name"), new Gauge<String>() {
             @Override
             public String getValue() {
                 return runtime.getName();
             }
         });
 
-        gauges.put("vendor", new Gauge<String>() {
+        gauges.put(name(metricNamePrefix, "vendor"), new Gauge<String>() {
             @Override
             public String getValue() {
                 return String.format(Locale.US,
@@ -50,7 +73,7 @@ public class JvmAttributeGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("uptime", new Gauge<Long>() {
+        gauges.put(name(metricNamePrefix, "uptime"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return runtime.getUptime();

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/BufferPoolMetricSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/BufferPoolMetricSet.java
@@ -27,9 +27,16 @@ public class BufferPoolMetricSet implements MetricSet {
     private static final String[] POOLS = { "direct", "mapped" };
 
     private final MBeanServer mBeanServer;
+    private final String mMetricNamePrefix;
 
     public BufferPoolMetricSet(MBeanServer mBeanServer) {
+        this(mBeanServer, null);
+    }
+
+    public BufferPoolMetricSet(MBeanServer mBeanServer, String mMetricNamePrefix) {
+        super();
         this.mBeanServer = mBeanServer;
+        this.mMetricNamePrefix = mMetricNamePrefix;
     }
 
     @Override
@@ -42,7 +49,7 @@ public class BufferPoolMetricSet implements MetricSet {
                 try {
                     final ObjectName on = new ObjectName("java.nio:type=BufferPool,name=" + pool);
                     mBeanServer.getMBeanInfo(on);
-                    gauges.put(name(pool, name),
+                    gauges.put(name(mMetricNamePrefix, pool, name),
                                new JmxAttributeGauge(mBeanServer, on, attribute));
                 } catch (JMException ignored) {
                     LOGGER.debug("Unable to load buffer pool MBeans, possibly running on Java 6");

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/GarbageCollectorMetricSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/GarbageCollectorMetricSet.java
@@ -18,12 +18,22 @@ public class GarbageCollectorMetricSet implements MetricSet {
     private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
 
     private final List<GarbageCollectorMXBean> garbageCollectors;
+    private final String metricNamePrefix;
 
     /**
      * Creates a new set of gauges for all discoverable garbage collectors.
      */
     public GarbageCollectorMetricSet() {
-        this(ManagementFactory.getGarbageCollectorMXBeans());
+        this(ManagementFactory.getGarbageCollectorMXBeans(), null);
+    }
+
+    /**
+     * Creates a new set of gauges for all discoverable garbage collectors.
+     * 
+     * @param metricNamePrefix     prefix for metric names, can be <code>null</code>
+     */
+    public GarbageCollectorMetricSet(String metricNamePrefix) {
+        this(ManagementFactory.getGarbageCollectorMXBeans(), metricNamePrefix);
     }
 
     /**
@@ -32,7 +42,19 @@ public class GarbageCollectorMetricSet implements MetricSet {
      * @param garbageCollectors    the garbage collectors
      */
     public GarbageCollectorMetricSet(Collection<GarbageCollectorMXBean> garbageCollectors) {
+        this(garbageCollectors, null);
+    }
+
+    /**
+     * Creates a new set of gauges for the given collection of garbage collectors.
+     *
+     * @param garbageCollectors    the garbage collectors
+     * @param metricNamePrefix     prefix for metric names, can be <code>null</code>
+     */
+    public GarbageCollectorMetricSet(Collection<GarbageCollectorMXBean> garbageCollectors, String metricNamePrefix) {
+        super();
         this.garbageCollectors = new ArrayList<GarbageCollectorMXBean>(garbageCollectors);
+        this.metricNamePrefix = metricNamePrefix;
     }
 
     @Override
@@ -40,14 +62,14 @@ public class GarbageCollectorMetricSet implements MetricSet {
         final Map<String, Metric> gauges = new HashMap<String, Metric>();
         for (final GarbageCollectorMXBean gc : garbageCollectors) {
             final String name = WHITESPACE.matcher(gc.getName()).replaceAll("-");
-            gauges.put(name(name, "count"), new Gauge<Long>() {
+            gauges.put(name(metricNamePrefix, name, "count"), new Gauge<Long>() {
                 @Override
                 public Long getValue() {
                     return gc.getCollectionCount();
                 }
             });
 
-            gauges.put(name(name, "time"), new Gauge<Long>() {
+            gauges.put(name(metricNamePrefix, name, "time"), new Gauge<Long>() {
                 @Override
                 public Long getValue() {
                     return gc.getCollectionTime();

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/MemoryUsageGaugeSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/MemoryUsageGaugeSet.java
@@ -23,23 +23,37 @@ public class MemoryUsageGaugeSet implements MetricSet {
 
     private final MemoryMXBean mxBean;
     private final List<MemoryPoolMXBean> memoryPools;
+    private final String metricNamePrefix;
 
     public MemoryUsageGaugeSet() {
+        this(null);
+    }
+    
+    public MemoryUsageGaugeSet(String metricNamePrefix) {
         this(ManagementFactory.getMemoryMXBean(),
-             ManagementFactory.getMemoryPoolMXBeans());
+             ManagementFactory.getMemoryPoolMXBeans(), 
+             metricNamePrefix);
     }
 
     public MemoryUsageGaugeSet(MemoryMXBean mxBean,
                                Collection<MemoryPoolMXBean> memoryPools) {
+        this(mxBean, memoryPools, null);
+    }
+    
+    public MemoryUsageGaugeSet(MemoryMXBean mxBean, 
+                               Collection<MemoryPoolMXBean> memoryPools, 
+                               String metricNamePrefix) {
+        super();
         this.mxBean = mxBean;
         this.memoryPools = new ArrayList<MemoryPoolMXBean>(memoryPools);
+        this.metricNamePrefix = metricNamePrefix;
     }
 
     @Override
     public Map<String, Metric> getMetrics() {
         final Map<String, Metric> gauges = new HashMap<String, Metric>();
 
-        gauges.put("total.init", new Gauge<Long>() {
+        gauges.put(name(metricNamePrefix, "total.init"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getInit() +
@@ -47,7 +61,7 @@ public class MemoryUsageGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("total.used", new Gauge<Long>() {
+        gauges.put(name(metricNamePrefix, "total.used"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getUsed() +
@@ -55,7 +69,7 @@ public class MemoryUsageGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("total.max", new Gauge<Long>() {
+        gauges.put(name(metricNamePrefix, "total.max"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getMax() +
@@ -63,7 +77,7 @@ public class MemoryUsageGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("total.committed", new Gauge<Long>() {
+        gauges.put(name(metricNamePrefix, "total.committed"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getCommitted() +
@@ -72,35 +86,35 @@ public class MemoryUsageGaugeSet implements MetricSet {
         });
 
 
-        gauges.put("heap.init", new Gauge<Long>() {
+        gauges.put(name(metricNamePrefix, "heap.init"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getInit();
             }
         });
 
-        gauges.put("heap.used", new Gauge<Long>() {
+        gauges.put(name(metricNamePrefix, "heap.used"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getUsed();
             }
         });
 
-        gauges.put("heap.max", new Gauge<Long>() {
+        gauges.put(name(metricNamePrefix, "heap.max"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getMax();
             }
         });
 
-        gauges.put("heap.committed", new Gauge<Long>() {
+        gauges.put(name(metricNamePrefix, "heap.committed"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getCommitted();
             }
         });
 
-        gauges.put("heap.usage", new RatioGauge() {
+        gauges.put(name(metricNamePrefix, "heap.usage"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 final MemoryUsage usage = mxBean.getHeapMemoryUsage();
@@ -108,35 +122,35 @@ public class MemoryUsageGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("non-heap.init", new Gauge<Long>() {
+        gauges.put(name(metricNamePrefix, "non-heap.init"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getNonHeapMemoryUsage().getInit();
             }
         });
 
-        gauges.put("non-heap.used", new Gauge<Long>() {
+        gauges.put(name(metricNamePrefix, "non-heap.used"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getNonHeapMemoryUsage().getUsed();
             }
         });
 
-        gauges.put("non-heap.max", new Gauge<Long>() {
+        gauges.put(name(metricNamePrefix, "non-heap.max"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getNonHeapMemoryUsage().getMax();
             }
         });
 
-        gauges.put("non-heap.committed", new Gauge<Long>() {
+        gauges.put(name(metricNamePrefix, "non-heap.committed"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getNonHeapMemoryUsage().getCommitted();
             }
         });
 
-        gauges.put("non-heap.usage", new RatioGauge() {
+        gauges.put(name(metricNamePrefix, "non-heap.usage"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 final MemoryUsage usage = mxBean.getNonHeapMemoryUsage();
@@ -145,7 +159,8 @@ public class MemoryUsageGaugeSet implements MetricSet {
         });
 
         for (final MemoryPoolMXBean pool : memoryPools) {
-            gauges.put(name("pools",
+            gauges.put(name(metricNamePrefix, 
+                            "pools",
                             WHITESPACE.matcher(pool.getName()).replaceAll("-"),
                             "usage"),
                        new RatioGauge() {


### PR DESCRIPTION
Add ctors taking String metricNamePrefix to all MetricSet impls, so that users can control where the metrics are added in the namespace.  

Eg registering `new MemoryUsageGaugeSet("jvm.memory")` gives a metric `jvm.memory.total.used` instead of `total.used`, etc.

Existing ctors work as before: metrics in set are added at root of namespace.
