### PR TITLE
Allow metrics registry to be serializable

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/Clock.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Clock.java
@@ -1,12 +1,13 @@
 package com.codahale.metrics;
 
+import java.io.Serializable;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 
 /**
  * An abstraction for how time passes. It is passed to {@link Timer} to track timing.
  */
-public abstract class Clock {
+public abstract class Clock implements Serializable {
     /**
      * Returns the current time tick.
      *

--- a/metrics-core/src/main/java/com/codahale/metrics/EWMA.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/EWMA.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics;
 
+import java.io.Serializable;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.Math.exp;
@@ -13,7 +14,11 @@ import static java.lang.Math.exp;
  *      Your Average Average</a>
  * @see <a href="http://en.wikipedia.org/wiki/Moving_average#Exponential_moving_average">EMA</a>
  */
-public class EWMA {
+public class EWMA implements Serializable {
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 6123523451074139965L;
     private static final int INTERVAL = 5;
     private static final double SECONDS_PER_MINUTE = 60.0;
     private static final int ONE_MINUTE = 1;

--- a/metrics-core/src/main/java/com/codahale/metrics/JmxAttributeGauge.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JmxAttributeGauge.java
@@ -8,7 +8,11 @@ import java.lang.management.ManagementFactory;
 /**
  * A {@link Gauge} implementation which queries a {@link MBeanServer} for an attribute of an object.
  */
-public class JmxAttributeGauge implements Gauge<Object> {
+public class JmxAttributeGauge implements Gauge<Object>,NoCopyMetric {
+    /**
+   * 
+   */
+  private static final long serialVersionUID = -1054929768844472837L;
     private final MBeanServer mBeanServer;
     private final ObjectName objectName;
     private final String attributeName;

--- a/metrics-core/src/main/java/com/codahale/metrics/Metric.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Metric.java
@@ -1,8 +1,11 @@
 package com.codahale.metrics;
 
+import java.io.Serializable;
+
+
 /**
  * A tag interface to indicate that a class is a metric.
  */
-public interface Metric {
+public interface Metric extends Serializable {
 
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/NoCopyGauge.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NoCopyGauge.java
@@ -1,0 +1,13 @@
+/**
+ * 
+ */
+package com.codahale.metrics;
+
+
+/**
+ * @author git_user_name <git_user_email>
+ *
+ */
+public abstract class NoCopyGauge<T> implements Gauge<T>,NoCopyMetric {
+
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/NoCopyMetric.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NoCopyMetric.java
@@ -1,0 +1,9 @@
+package com.codahale.metrics;
+
+
+/**
+ * A tag interface to indicate that a class is a metric that should be be copied/serialized.
+ */
+public interface NoCopyMetric extends Metric {
+
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/NoCopyRatioGauge.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NoCopyRatioGauge.java
@@ -1,0 +1,13 @@
+/**
+ * 
+ */
+package com.codahale.metrics;
+
+
+/**
+ * @author git_user_name <git_user_email>
+ *
+ */
+public abstract class NoCopyRatioGauge extends RatioGauge implements NoCopyMetric {
+
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/Reservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Reservoir.java
@@ -1,9 +1,11 @@
 package com.codahale.metrics;
 
+import java.io.Serializable;
+
 /**
  * A statistically representative reservoir of a data stream.
  */
-public interface Reservoir {
+public interface Reservoir extends Serializable {
     /**
      * Returns the number of values recorded.
      *

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/FileDescriptorRatioGauge.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/FileDescriptorRatioGauge.java
@@ -1,16 +1,20 @@
 package com.codahale.metrics.jvm;
 
-import com.codahale.metrics.RatioGauge;
-
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import com.codahale.metrics.NoCopyMetric;
+import com.codahale.metrics.RatioGauge;
+
 /**
  * A gauge for the ratio of used to total file descriptors.
  */
-public class FileDescriptorRatioGauge extends RatioGauge {
+public class FileDescriptorRatioGauge extends RatioGauge implements NoCopyMetric {
+    /**
+   * 
+   */
     private final OperatingSystemMXBean os;
 
     /**

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/GarbageCollectorMetricSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/GarbageCollectorMetricSet.java
@@ -1,15 +1,23 @@
 package com.codahale.metrics.jvm;
 
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricSet;
+import static com.codahale.metrics.MetricRegistry.name;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
-import static com.codahale.metrics.MetricRegistry.name;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.NoCopyGauge;
 
 /**
  * A set of gauges for the counts and elapsed times of garbage collections.
@@ -40,14 +48,14 @@ public class GarbageCollectorMetricSet implements MetricSet {
         final Map<String, Metric> gauges = new HashMap<String, Metric>();
         for (final GarbageCollectorMXBean gc : garbageCollectors) {
             final String name = WHITESPACE.matcher(gc.getName()).replaceAll("-");
-            gauges.put(name(name, "count"), new Gauge<Long>() {
+            gauges.put(name(name, "count"), new NoCopyGauge<Long> () {
                 @Override
                 public Long getValue() {
                     return gc.getCollectionCount();
                 }
             });
 
-            gauges.put(name(name, "time"), new Gauge<Long>() {
+            gauges.put(name(name, "time"), new NoCopyGauge<Long>() {
                 @Override
                 public Long getValue() {
                     return gc.getCollectionTime();
@@ -56,4 +64,14 @@ public class GarbageCollectorMetricSet implements MetricSet {
         }
         return Collections.unmodifiableMap(gauges);
     }
+    private void writeObject(ObjectOutputStream o)
+        throws IOException {  
+        
+      }
+      
+      private void readObject(ObjectInputStream o)
+        throws IOException, ClassNotFoundException {  
+        
+      }
+
 }

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/MemoryUsageGaugeSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/MemoryUsageGaugeSet.java
@@ -1,18 +1,24 @@
 package com.codahale.metrics.jvm;
 
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricSet;
-import com.codahale.metrics.RatioGauge;
+import static com.codahale.metrics.MetricRegistry.name;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
-import static com.codahale.metrics.MetricRegistry.name;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.NoCopyGauge;
+import com.codahale.metrics.NoCopyMetric;
+import com.codahale.metrics.NoCopyRatioGauge;
 
 /**
  * A set of gauges for JVM memory usage, including stats on heap vs. non-heap memory, plus
@@ -39,7 +45,7 @@ public class MemoryUsageGaugeSet implements MetricSet {
     public Map<String, Metric> getMetrics() {
         final Map<String, Metric> gauges = new HashMap<String, Metric>();
 
-        gauges.put("total.init", new Gauge<Long>() {
+        gauges.put("total.init", new NoCopyGauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getInit() +
@@ -47,7 +53,7 @@ public class MemoryUsageGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("total.used", new Gauge<Long>() {
+        gauges.put("total.used", new NoCopyGauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getUsed() +
@@ -55,7 +61,7 @@ public class MemoryUsageGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("total.max", new Gauge<Long>() {
+        gauges.put("total.max", new NoCopyGauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getMax() +
@@ -63,7 +69,7 @@ public class MemoryUsageGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("total.committed", new Gauge<Long>() {
+        gauges.put("total.committed", new NoCopyGauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getCommitted() +
@@ -72,35 +78,35 @@ public class MemoryUsageGaugeSet implements MetricSet {
         });
 
 
-        gauges.put("heap.init", new Gauge<Long>() {
+        gauges.put("heap.init", new NoCopyGauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getInit();
             }
         });
 
-        gauges.put("heap.used", new Gauge<Long>() {
+        gauges.put("heap.used", new NoCopyGauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getUsed();
             }
         });
 
-        gauges.put("heap.max", new Gauge<Long>() {
+        gauges.put("heap.max", new NoCopyGauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getMax();
             }
         });
 
-        gauges.put("heap.committed", new Gauge<Long>() {
+        gauges.put("heap.committed", new NoCopyGauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getCommitted();
             }
         });
 
-        gauges.put("heap.usage", new RatioGauge() {
+        gauges.put("heap.usage", new NoCopyRatioGauge() {
             @Override
             protected Ratio getRatio() {
                 final MemoryUsage usage = mxBean.getHeapMemoryUsage();
@@ -108,35 +114,35 @@ public class MemoryUsageGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("non-heap.init", new Gauge<Long>() {
+        gauges.put("non-heap.init", new NoCopyGauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getNonHeapMemoryUsage().getInit();
             }
         });
 
-        gauges.put("non-heap.used", new Gauge<Long>() {
+        gauges.put("non-heap.used", new NoCopyGauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getNonHeapMemoryUsage().getUsed();
             }
         });
 
-        gauges.put("non-heap.max", new Gauge<Long>() {
+        gauges.put("non-heap.max", new NoCopyGauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getNonHeapMemoryUsage().getMax();
             }
         });
 
-        gauges.put("non-heap.committed", new Gauge<Long>() {
+        gauges.put("non-heap.committed", new NoCopyGauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getNonHeapMemoryUsage().getCommitted();
             }
         });
 
-        gauges.put("non-heap.usage", new RatioGauge() {
+        gauges.put("non-heap.usage", new NoCopyRatioGauge() {
             @Override
             protected Ratio getRatio() {
                 final MemoryUsage usage = mxBean.getNonHeapMemoryUsage();
@@ -148,8 +154,8 @@ public class MemoryUsageGaugeSet implements MetricSet {
             gauges.put(name("pools",
                             WHITESPACE.matcher(pool.getName()).replaceAll("-"),
                             "usage"),
-                       new RatioGauge() {
-                           @Override
+                       new NoCopyRatioGauge() {
+                          @Override
                            protected Ratio getRatio() {
                                final long max = pool.getUsage().getMax() == -1 ?
                                        pool.getUsage().getCommitted() :

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ThreadStatesGaugeSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ThreadStatesGaugeSet.java
@@ -1,8 +1,6 @@
 package com.codahale.metrics.jvm;
 
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Metric;
-import com.codahale.metrics.MetricSet;
+import static com.codahale.metrics.MetricRegistry.name;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
@@ -12,7 +10,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static com.codahale.metrics.MetricRegistry.name;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.NoCopyGauge;
 
 /**
  * A set of gauges for the number of threads in their various states and deadlock detection.
@@ -46,29 +46,29 @@ public class ThreadStatesGaugeSet implements MetricSet {
 
         for (final Thread.State state : Thread.State.values()) {
             gauges.put(name(state.toString().toLowerCase(), "count"),
-                       new Gauge<Object>() {
-                           @Override
+                       new NoCopyGauge<Object>() {
+                          @Override
                            public Object getValue() {
                                return getThreadCount(state);
                            }
                        });
         }
 
-        gauges.put("count", new Gauge<Integer>() {
+        gauges.put("count", new NoCopyGauge<Integer>() {
             @Override
             public Integer getValue() {
                 return threads.getThreadCount();
             }
         });
 
-        gauges.put("daemon.count", new Gauge<Integer>() {
+        gauges.put("daemon.count", new NoCopyGauge<Integer>() {
             @Override
             public Integer getValue() {
                 return threads.getDaemonThreadCount();
             }
         });
 
-        gauges.put("deadlocks", new Gauge<Set<String>>() {
+        gauges.put("deadlocks", new NoCopyGauge<Set<String>>() {
             @Override
             public Set<String> getValue() {
                 return deadlockDetector.getDeadlockedThreads();


### PR DESCRIPTION
I had a use case where I wanted to collect all my metrics into a centralized location.  Ideally, I want to eventually be able to 'merge' selected metrics together from multiple instances.  Towards that end, I needed a MetricRegistry to be serializable, as that seemed to be the most straightforward way to transfer what I wanted around...serialize my MetricsRegistry and send it...  In order to accomplish this, I did the following:

1) Have com.codahale.metrics.Metric extend Serializable
2) Introduce a new marker interface, com.codahale.metrics.NoCopyMetric
3) Create custom serialization logic in MetricsRegistry that will
serialize all metrics that do NOT have the NoCopyMetric marker
4) Add some other NoCopy\* signatures 
5) Modify some of the pre-creatable metrics that could not be serialized
to be marked as NoCopy
