### PR TITLE
Windows : JVM Integration for Metrics : FileDescriptorRatioGaugeTest failure

### DIFF
--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/FileDescriptorRatioGaugeTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/FileDescriptorRatioGaugeTest.java
@@ -3,9 +3,11 @@ package com.codahale.metrics.jvm;
 import org.junit.Test;
 
 import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 
 import static org.fest.assertions.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 
 @SuppressWarnings("UnusedDeclaration")
@@ -60,7 +62,10 @@ public class FileDescriptorRatioGaugeTest {
     }
 
     @Test
-    public void autoDetectsTheOperationSystemBean() throws Exception {
+    public void validateFileDescriptorRatioPresenceOnNixPlatforms() throws Exception {
+        OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
+        assumeTrue(osBean instanceof com.sun.management.UnixOperatingSystemMXBean);
+        
         assertThat(new FileDescriptorRatioGauge().getValue())
                 .isGreaterThanOrEqualTo(0.0)
                 .isLessThanOrEqualTo(1.0);


### PR DESCRIPTION
There is FileDescriptorRatioGaugeTest failure as getOpenFileDescriptorCount() and getMaxFileDescriptorCount() are not available on Windows.

```
Metrics Parent .................................... SUCCESS [23.791s]
Annotations for Metrics ........................... SUCCESS [21.101s]
Metrics Core ...................................... SUCCESS [21.090s]
JVM Integration for Metrics ....................... FAILURE [2.254s]
```

```
-------------------------------------------------------------------------------
Test set: com.codahale.metrics.jvm.FileDescriptorRatioGaugeTest
-------------------------------------------------------------------------------
Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.222 sec <<< FAILURE!
autoDetectsTheOperationSystemBean(com.codahale.metrics.jvm.FileDescriptorRatioGaugeTest)  Time elapsed: 0.004 sec  <<< FAILURE!
java.lang.AssertionError: expected:<NaN> to be less than or equal to:<1.0>
    at com.codahale.metrics.jvm.FileDescriptorRatioGaugeTest.autoDetectsTheOperationSystemBean(FileDescriptorRatioGaugeTest.java:64)
```
