### PR TITLE
Windows : Metrics Utility Servlets : AdminServletTest failure

### DIFF
--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/AdminServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/AdminServlet.java
@@ -29,7 +29,7 @@ public class AdminServlet extends HttpServlet {
             "    <li><a href=\"{6}{7}\">Healthcheck</a></li>\n" +
             "  </ul>\n" +
             "</body>\n" +
-            "</html>";
+            "</html>\n";
     private static final String CONTENT_TYPE = "text/html";
     private static final long serialVersionUID = -2850794040708785318L;
 
@@ -73,7 +73,7 @@ public class AdminServlet extends HttpServlet {
         resp.setContentType(CONTENT_TYPE);
         final PrintWriter writer = resp.getWriter();
         try {
-            writer.println(MessageFormat.format(TEMPLATE, path, metricsUri, path, pingUri, path,
+            writer.print(MessageFormat.format(TEMPLATE, path, metricsUri, path, pingUri, path,
                                                 threadsUri, path, healthcheckUri,
                                                 serviceName == null ? "" : " (" + serviceName + ")"));
         } finally {


### PR DESCRIPTION
Caused by Windows line endings, as AdminServlet println() generates last line ending as \r\n vs test expected \n.

```
Metrics Integration for Log4j ..................... SUCCESS [7.424s]
Metrics Integration for Logback ................... SUCCESS [7.323s]
Metrics Integration for Servlets .................. SUCCESS [6.816s]
Metrics Utility Servlets .......................... FAILURE [2.315s]
```

```
-------------------------------------------------------------------------------
Test set: com.codahale.metrics.servlets.AdminServletTest
-------------------------------------------------------------------------------
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.62 sec <<< FAILURE!
returnsA200(com.codahale.metrics.servlets.AdminServletTest)  Time elapsed: 0.001 sec  <<< FAILURE!
org.junit.ComparisonFailure: expected:<.../ul>
</body>
</html>[]
'> but was:<.../ul>
</body>
</html>[
]
'>
    at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
    at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
    at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
    at com.codahale.metrics.servlets.AdminServletTest.returnsA200(AdminServletTest.java:37)
```
