### PR TITLE
Fixing small typo in getting started guide

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -172,7 +172,7 @@ duration.
 
 .. code-block:: java
 
-    private final Timer responses = metrics.timer(name(RequestHandler.class, "responses");
+    private final Timer responses = metrics.timer(name(RequestHandler.class, "responses"));
 
     public String handleRequest(Request request, Response response) {
         final Timer.Context context = responses.time();


### PR DESCRIPTION
There is an unmatched parentheses in the getting started guide, not a big deal, but figured why not fix it?
