### PR TITLE
InstrumentedHandler: Remove duplicate calls to activeRequests.dec()

### DIFF
--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -134,7 +134,6 @@ public class InstrumentedHandler extends HandlerWrapper {
             public void onComplete(AsyncEvent event) throws IOException {
                 final HttpChannelState state = (HttpChannelState) event.getAsyncContext();
                 final Request request = state.getBaseRequest();
-                activeRequests.dec();
                 updateResponses(request);
                 if (!state.isDispatched()) {
                     activeSuspended.dec();
@@ -181,7 +180,6 @@ public class InstrumentedHandler extends HandlerWrapper {
                 }
                 activeSuspended.inc();
             } else if (state.isInitial()) {
-                activeRequests.dec();
                 requests.update(dispatched, TimeUnit.MILLISECONDS);
                 updateResponses(request);
             }


### PR DESCRIPTION
I've been playing with InstrumentedHandler and noticed that the active-requests counter decreased by one on every request. I believe this is the correct fix: The counter is decremented inside updateResponses(), but the callers for this function also did the same thing.
