### PR TITLE
Clarified documentation on MetricsServletContextListener.

### DIFF
--- a/docs/source/manual/servlets.rst
+++ b/docs/source/manual/servlets.rst
@@ -72,7 +72,7 @@ MetricsServletContextListener
 =============================
 
 ``MetricsServletContextListener`` is a ServletContextListener that can be used to set up registries
-that are required by the ``AdminServlet``. It instantiates ``MetricRegistry`` and
-``HealthCheckRegistry``, and adds them to the ServletContext as attributes.
+that are required by the ``AdminServlet``. It receieves ``MetricRegistry`` and
+``HealthCheckRegistry`` instances as constructor parameters, and adds them to the ServletContext as attributes.
 
 


### PR DESCRIPTION
MetricsServletContextListener does not instantiate any registries of its own, it merely injects provided registries into the servlet context.
