### PR TITLE
use default constructors for ServletContextListeners

### DIFF
--- a/metrics-servlet/src/main/java/com/codahale/metrics/servlet/MetricsContextListener.java
+++ b/metrics-servlet/src/main/java/com/codahale/metrics/servlet/MetricsContextListener.java
@@ -6,11 +6,7 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
 public class MetricsContextListener implements ServletContextListener {
-    private final MetricRegistry registry;
-
-    public MetricsContextListener(MetricRegistry registry) {
-        this.registry = registry;
-    }
+    private final MetricRegistry registry = new MetricRegistry();
 
     @Override
     public void contextInitialized(ServletContextEvent sce) {

--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/MetricsServletContextListener.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/MetricsServletContextListener.java
@@ -13,14 +13,8 @@ import javax.servlet.ServletContextListener;
  * such as in a web.xml, along with a servlet mapping for AdminServlet.
  */
 public class MetricsServletContextListener implements ServletContextListener {
-    public final MetricRegistry metricRegistry;
-    public final HealthCheckRegistry healthCheckRegistry;
-
-    public MetricsServletContextListener(MetricRegistry metricRegistry,
-                                         HealthCheckRegistry healthCheckRegistry) {
-        this.metricRegistry = metricRegistry;
-        this.healthCheckRegistry = healthCheckRegistry;
-    }
+    public final MetricRegistry metricRegistry = new MetricRegistry();
+    public final HealthCheckRegistry healthCheckRegistry = new HealthCheckRegistry();
 
     @Override
     public void contextInitialized(ServletContextEvent servletContextEvent) {

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletContextListenerTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletContextListenerTest.java
@@ -1,7 +1,5 @@
 package com.codahale.metrics.servlets;
 
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.health.HealthCheckRegistry;
 import org.eclipse.jetty.testing.ServletTester;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,8 +10,7 @@ import static org.fest.assertions.api.Assertions.assertThat;
 public class MetricsServletContextListenerTest extends AbstractServletTest {
     @Override
     protected void setUp(ServletTester tester) {
-        tester.addEventListener(new MetricsServletContextListener(new MetricRegistry(),
-                                                                  new HealthCheckRegistry()));
+        tester.addEventListener(new MetricsServletContextListener());
         tester.addServlet(MetricsServlet.class, "/metrics");
     }
 


### PR DESCRIPTION
Container must be able to instantiate ServletContextListeners using
default constructor
