### PR TITLE
Timer.Context constructor to public

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/Timer.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Timer.java
@@ -19,7 +19,7 @@ public class Timer implements Metered, Sampling {
         private final Clock clock;
         private final long startTime;
 
-        private Context(Timer timer, Clock clock) {
+        public Context(Timer timer, Clock clock) {
             this.timer = timer;
             this.clock = clock;
             this.startTime = clock.getTick();


### PR DESCRIPTION
Hello codahale/metrics!

Is there a reason why this constructor on the public static inner class Timer.Context is private ?  ( I need to implement a no-op subclass of Timer )

thanks!
Andras
