### PR TITLE
Implement Closeable interface in reporters

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.management.*;
+import java.io.Closeable;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
 import java.util.Locale;
@@ -15,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * A reporter which listens for new metrics and exposes them as namespaced MBeans.
  */
-public class JmxReporter {
+public class JmxReporter implements Closeable {
     /**
      * Returns a new {@link Builder} for {@link JmxReporter}.
      *
@@ -702,5 +703,13 @@ public class JmxReporter {
     public void stop() {
         registry.removeListener(listener);
         listener.unregisterAll();
+    }
+
+    /**
+     * Stops the reporter.
+     */
+    @Override
+    public void close() {
+        stop();
     }
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics;
 
+import java.io.Closeable;
 import java.util.Locale;
 import java.util.SortedMap;
 import java.util.concurrent.Executors;
@@ -16,7 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @see CsvReporter
  * @see Slf4jReporter
  */
-public abstract class ScheduledReporter {
+public abstract class ScheduledReporter implements Closeable {
     /**
      * A simple named thread factory.
      */
@@ -98,6 +99,14 @@ public abstract class ScheduledReporter {
         } catch (InterruptedException ignored) {
             // do nothing
         }
+    }
+
+    /**
+     * Stops the reporter and shuts down its thread of execution.
+     */
+    @Override
+    public void close() {
+        stop();
     }
 
     /**


### PR DESCRIPTION
Hey Coda,

In working on getting metrics-spring to support reporters, I'm tying reporters to the Spring lifecycle so they shut down when the Spring context closes, and having the reporters implement Closeable would help with that.

Thanks!
