### PR TITLE
metrics-jetty9: Simple fix for #435, check if class cast is possible

### DIFF
--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -132,11 +132,14 @@ public class InstrumentedHandler extends HandlerWrapper {
 
             @Override
             public void onComplete(AsyncEvent event) throws IOException {
-                final HttpChannelState state = (HttpChannelState) event.getAsyncContext();
-                final Request request = state.getBaseRequest();
-                updateResponses(request);
-                if (!state.isDispatched()) {
-                    activeSuspended.dec();
+                HttpChannelState state = null;
+                if (HttpChannelState.class.isAssignableFrom(event.getAsyncContext().getClass())) {
+                    state = (HttpChannelState) event.getAsyncContext();
+                    final Request request = state.getBaseRequest();
+                    updateResponses(request);
+                    if (!state.isDispatched()) {
+                        activeSuspended.dec();
+                    }
                 }
             }
         };


### PR DESCRIPTION
This fix makes the ClassCastException go away, but it probably causes the activeSuspended
counter have wrong values.

Someone who knows how things work need to improve this fix.
