### PR TITLE
Fix Gauge javadoc

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/Gauge.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Gauge.java
@@ -7,7 +7,7 @@ package com.codahale.metrics;
  * <pre><code>
  * final Queue&lt;String&gt; queue = new ConcurrentLinkedQueue&lt;String&gt;();
  * final Gauge&lt;Integer&gt; queueDepth = new Gauge&lt;Integer&gt;() {
- *     public Integer value() {
+ *     public Integer getValue() {
  *         return queue.size();
  *     }
  * };


### PR DESCRIPTION
The gauge docs incorrectly list value instead of getValue

Yes - I used the editor on github to do this - was just easiest for a quick doc change.
