### PR TITLE
InstrumentedHandler: Remove duplicate calls to requests.update(...)

### DIFF
--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -184,7 +184,6 @@ public class InstrumentedHandler extends HandlerWrapper {
                 }
                 activeSuspended.inc();
             } else if (state.isInitial()) {
-                requests.update(dispatched, TimeUnit.MILLISECONDS);
                 updateResponses(request);
             }
             // else onCompletion will handle it.


### PR DESCRIPTION
The timer is updated inside updateResponses(). This causes the count of this
timer to be double what it should be, and probably biased the times for the
exponentially decaying reservoirs.

Commit 33113e55cb fixed this same bug for activeRequests.
