### PR TITLE
Ability to get the elapsed time of a Timer.Context without stopping it.

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/Timer.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Timer.java
@@ -43,7 +43,7 @@ public class Timer implements Metered, Sampling {
         /**
          * Returns the elapsed time so far, in nanoseconds.
          */
-        public getElapsedTime() {
+        public long getElapsedTime() {
             return clock.getTick() - startTime;
         }
     }


### PR DESCRIPTION
A typical use case: a timed task hangs and the timer context never gets stopped, taking up resources forever. We need a way to know for how long the context has run to be able to detect the hanging and act accordingly (stop or drop the context, etc.).
Another option would be making the fields in Context public. This would provide even more control, but I didn't want to alter the design that much.
