### PR TITLE
loosen type requirements for JmxAttributeGauge constructor

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/JmxAttributeGauge.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JmxAttributeGauge.java
@@ -1,15 +1,16 @@
 package com.codahale.metrics;
 
+import java.io.IOException;
 import javax.management.JMException;
-import javax.management.MBeanServer;
+import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 
 /**
- * A {@link Gauge} implementation which queries a {@link MBeanServer} for an attribute of an object.
+ * A {@link Gauge} implementation which queries an {@link MBeanServerConnection} for an attribute of an object.
  */
 public class JmxAttributeGauge implements Gauge<Object> {
-    private final MBeanServer mBeanServer;
+    private final MBeanServerConnection mBeanServerConn;
     private final ObjectName objectName;
     private final String attributeName;
 
@@ -26,12 +27,12 @@ public class JmxAttributeGauge implements Gauge<Object> {
     /**
      * Creates a new JmxAttributeGauge.
      *
-     * @param mBeanServer      the {@link MBeanServer}
+     * @param mBeanServerConn  the {@link MBeanServerConnection}
      * @param objectName       the name of the object
      * @param attributeName    the name of the object's attribute
      */
-    public JmxAttributeGauge(MBeanServer mBeanServer, ObjectName objectName, String attributeName) {
-        this.mBeanServer = mBeanServer;
+    public JmxAttributeGauge(MBeanServerConnection mBeanServerConn, ObjectName objectName, String attributeName) {
+        this.mBeanServerConn = mBeanServerConn;
         this.objectName = objectName;
         this.attributeName = attributeName;
     }
@@ -39,7 +40,9 @@ public class JmxAttributeGauge implements Gauge<Object> {
     @Override
     public Object getValue() {
         try {
-            return mBeanServer.getAttribute(objectName, attributeName);
+            return mBeanServerConn.getAttribute(objectName, attributeName);
+        } catch (IOException e) {
+            return null;
         } catch (JMException e) {
             return null;
         }


### PR DESCRIPTION
Previously an MBeanServer was required to create a JmxAttributeGauge object
even though instances of JmxAttributeGauge only use methods from the
MBeanServer's super-interface, MBeanServerConnection. Relaxing this constraint
allows passing a JmxAttributeGauge any MBeanServerConnection (e.g. the
connection returned by JMXConnector.getMBeanServerConnection).
