### PR TITLE
allow to specify a custom prefix for InstrumentedHandler for jetty9

### DIFF
--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -29,6 +29,7 @@ public class InstrumentedHandler extends HandlerWrapper {
     private final MetricRegistry metricRegistry;
 
     private String name;
+    private final String prefix;
 
     // the requests handled by this handler, excluding active
     private Timer requests;
@@ -73,8 +74,20 @@ public class InstrumentedHandler extends HandlerWrapper {
      *
      */
     public InstrumentedHandler(MetricRegistry registry) {
-        this.metricRegistry = registry;
+        this(registry, null);
     }
+
+	/**
+	 * Create a new instrumented handler using a given metrics registry.
+	 *
+	 * @param registry   the registry for the metrics
+	 * @param prefix     the prefix to use for the metrics names
+	 *
+	 */
+	public InstrumentedHandler(MetricRegistry registry, String prefix) {
+		this.metricRegistry = registry;
+		this.prefix = prefix;
+	}
 
     public String getName() {
         return name;
@@ -88,7 +101,7 @@ public class InstrumentedHandler extends HandlerWrapper {
     protected void doStart() throws Exception {
         super.doStart();
 
-        final String prefix = name(getHandler().getClass(), name);
+        final String prefix = this.prefix == null ? name(getHandler().getClass(), name) : name(this.prefix, name);
 
         this.requests = metricRegistry.timer(name(prefix, "requests"));
         this.dispatches = metricRegistry.timer(name(prefix, "dispatches"));


### PR DESCRIPTION
similar to how it's done for jetty8 in #354
