### PR TITLE
Add ConfigurableMeter Class

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ConfigurableMeter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ConfigurableMeter.java
@@ -1,0 +1,122 @@
+package com.codahale.metrics;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.lang.Math.exp;
+
+/**
+ * A meter metric which measures mean throughput and exponentially-weighted moving averages over any
+ * user-specified intervals.
+ *
+ * @see EWMA
+ */
+public class ConfigurableMeter
+{
+    private static final int INTERVAL = 5;
+    private static final long TICK_INTERVAL = TimeUnit.SECONDS.toNanos(5);
+    private final Map<Long, EWMA> ewmasByRate;
+
+    private final LongAdder count = new LongAdder();
+    private final long startTime;
+    private final AtomicLong lastTick;
+    private final Clock clock;
+
+    /**
+     * Creates a new {@link ConfigurableMeter} with the default clock.
+     *
+     * @param intervalUnit the time unit that all of the intervals will be expressed in
+     * @param intervals the intervals over which this meter should calculate a rate
+     */
+    public ConfigurableMeter(TimeUnit intervalUnit, long[] intervals) {
+        this(Clock.defaultClock(), intervalUnit, intervals);
+    }
+
+    /**
+     * Creates a new {@link ConfigurableMeter}.
+     *
+     * @param clock the clock to use for the meter ticks
+     * @param intervalUnit the time unit that all of the intervals will be expressed in
+     * @param intervals the intervals over which this meter should calculate a rate
+     */
+    public ConfigurableMeter(Clock clock, TimeUnit intervalUnit, long[] intervals) {
+        this.clock = clock;
+        this.ewmasByRate = new HashMap<Long, EWMA>(intervals.length);
+        for (long interval : intervals) {
+            long intervalInSeconds = intervalUnit.toSeconds(interval);
+            double alpha = 1 - exp(((double) -INTERVAL) / intervalInSeconds);
+            ewmasByRate.put(intervalInSeconds, new EWMA(alpha, INTERVAL, TimeUnit.SECONDS));
+        }
+        this.startTime = this.clock.getTick();
+        this.lastTick = new AtomicLong(startTime);
+    }
+
+    /**
+     * Mark the occurrence of an event.
+     */
+    public void mark() {
+        mark(1);
+    }
+
+    /**
+     * Mark the occurrence of a given number of events.
+     *
+     * @param n the number of events
+     */
+    public void mark(long n) {
+        tickIfNecessary();
+        count.add(n);
+        for (EWMA ewma : ewmasByRate.values())
+            ewma.update(n);
+    }
+
+    protected void tickIfNecessary() {
+        final long oldTick = lastTick.get();
+        final long newTick = clock.getTick();
+        final long age = newTick - oldTick;
+        if (age > TICK_INTERVAL) {
+            final long newIntervalStartTick = newTick - age % TICK_INTERVAL;
+            if (lastTick.compareAndSet(oldTick, newIntervalStartTick)) {
+                final long requiredTicks = age / TICK_INTERVAL;
+                for (long i = 0; i < requiredTicks; i++) {
+                    for (EWMA ewma : ewmasByRate.values())
+                        ewma.tick();
+                }
+            }
+        }
+    }
+
+    public long getCount() {
+        return count.sum();
+    }
+
+    public double getMeanRate() {
+        if (getCount() == 0) {
+            return 0.0;
+        } else {
+            final double elapsed = (clock.getTick() - startTime);
+            return getCount() / elapsed * TimeUnit.SECONDS.toNanos(1);
+        }
+    }
+
+    /**
+     * Gets the metered rate over the specified interval, which must match one of the intervals provided
+     * when constructing this object.
+     * @param interval the interval for which a rate should be returned
+     * @param intervalUnit the unit of time that the interval is expressed in
+     * @return the metered rate in terms of actions per second
+     * @throws InvalidInterval if an interval is specified that does not match one of the intervals
+     *         used when constructing this object
+     */
+    public double getRate(long interval, TimeUnit intervalUnit) throws InvalidInterval {
+        tickIfNecessary();
+        EWMA ewma = ewmasByRate.get(intervalUnit.toSeconds(interval));
+        if (ewma == null)
+            throw new InvalidInterval();
+        return ewma.getRate(TimeUnit.SECONDS);
+    }
+
+    class InvalidInterval extends Exception { }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/Meter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Meter.java
@@ -9,17 +9,7 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * @see EWMA
  */
-public class Meter implements Metered {
-    private static final long TICK_INTERVAL = TimeUnit.SECONDS.toNanos(5);
-
-    private final EWMA m1Rate = EWMA.oneMinuteEWMA();
-    private final EWMA m5Rate = EWMA.fiveMinuteEWMA();
-    private final EWMA m15Rate = EWMA.fifteenMinuteEWMA();
-
-    private final LongAdder count = new LongAdder();
-    private final long startTime;
-    private final AtomicLong lastTick;
-    private final Clock clock;
+public class Meter extends ConfigurableMeter implements Metered {
 
     /**
      * Creates a new {@link Meter}.
@@ -34,78 +24,33 @@ public class Meter implements Metered {
      * @param clock      the clock to use for the meter ticks
      */
     public Meter(Clock clock) {
-        this.clock = clock;
-        this.startTime = this.clock.getTick();
-        this.lastTick = new AtomicLong(startTime);
-    }
-
-    /**
-     * Mark the occurrence of an event.
-     */
-    public void mark() {
-        mark(1);
-    }
-
-    /**
-     * Mark the occurrence of a given number of events.
-     *
-     * @param n the number of events
-     */
-    public void mark(long n) {
-        tickIfNecessary();
-        count.add(n);
-        m1Rate.update(n);
-        m5Rate.update(n);
-        m15Rate.update(n);
-    }
-
-    private void tickIfNecessary() {
-        final long oldTick = lastTick.get();
-        final long newTick = clock.getTick();
-        final long age = newTick - oldTick;
-        if (age > TICK_INTERVAL) {
-            final long newIntervalStartTick = newTick - age % TICK_INTERVAL;
-            if (lastTick.compareAndSet(oldTick, newIntervalStartTick)) {
-                final long requiredTicks = age / TICK_INTERVAL;
-                for (long i = 0; i < requiredTicks; i++) {
-                    m1Rate.tick();
-                    m5Rate.tick();
-                    m15Rate.tick();
-                }
-            }
-        }
-    }
-
-    @Override
-    public long getCount() {
-        return count.sum();
+        super(clock, TimeUnit.MINUTES, new long[] {1, 5, 15});
     }
 
     @Override
     public double getFifteenMinuteRate() {
-        tickIfNecessary();
-        return m15Rate.getRate(TimeUnit.SECONDS);
+        try {
+            return getRate(15, TimeUnit.MINUTES);
+        } catch (InvalidInterval exc) {
+            return 0.0; // not possible
+        }
     }
 
     @Override
     public double getFiveMinuteRate() {
-        tickIfNecessary();
-        return m5Rate.getRate(TimeUnit.SECONDS);
-    }
-
-    @Override
-    public double getMeanRate() {
-        if (getCount() == 0) {
-            return 0.0;
-        } else {
-            final double elapsed = (clock.getTick() - startTime);
-            return getCount() / elapsed * TimeUnit.SECONDS.toNanos(1);
+        try {
+            return getRate(5, TimeUnit.MINUTES);
+        } catch (InvalidInterval exc) {
+            return 0.0; // not possible
         }
     }
 
     @Override
     public double getOneMinuteRate() {
-        tickIfNecessary();
-        return m1Rate.getRate(TimeUnit.SECONDS);
+        try {
+            return getRate(1, TimeUnit.MINUTES);
+        } catch (InvalidInterval exc) {
+            return 0.0; // not possible
+        }
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/ConfigurableMeterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ConfigurableMeterTest.java
@@ -1,0 +1,46 @@
+package com.codahale.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.api.Assertions.offset;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ConfigurableMeterTest
+{
+    private final Clock clock = mock(Clock.class);
+    private final ConfigurableMeter meter = new ConfigurableMeter(clock, TimeUnit.SECONDS, new long[] {30, 60, 120});
+
+    @Before
+    public void setUp() throws Exception {
+        when(clock.getTick()).thenReturn(0L, TimeUnit.SECONDS.toNanos(10));
+    }
+
+    @Test
+    public void getRateWithGoodInterval() throws ConfigurableMeter.InvalidInterval {
+        meter.getRate(30, TimeUnit.SECONDS);
+        meter.getRate(60, TimeUnit.SECONDS);
+        meter.getRate(1, TimeUnit.MINUTES);
+    }
+
+    @Test(expected = ConfigurableMeter.InvalidInterval.class)
+    public void getRateWithBadInterval() throws ConfigurableMeter.InvalidInterval {
+        meter.getRate(13, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void marksEventsAndUpdatesRatesAndCount() throws Exception {
+        meter.mark();
+        meter.mark(2);
+
+        assertThat(meter.getMeanRate())
+                .isEqualTo(0.3, offset(0.001));
+
+        assertThat(meter.getRate(1, TimeUnit.MINUTES))
+                .isEqualTo(0.1840, offset(0.001));
+    }
+}


### PR DESCRIPTION
As mentioned in #446, the purpose of this is to add a version of the Meter class which allows custom EWMA windows to be specified.  The new ``ConfigurableMeter`` class does that and now ``Meter`` extends that class.

Because the ``Metered`` interface explicitly specifies 1, 5, and 15 minute rates, the API for this is a bit of an awkward fit.  If there are any changes I can make to resolve this, please let me know.

Thanks, and I look forward to feedback!