### PR TITLE
Make LongAdder public, not package-protected

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/LongAdder.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/LongAdder.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * @since 1.8
  */
 @SuppressWarnings("all")
-class LongAdder extends Striped64 implements Serializable {
+public class LongAdder extends Striped64 implements Serializable {
     private static final long serialVersionUID = 7249069246863182397L;
 
     /**


### PR DESCRIPTION
This makes the LongAdder class public instead of package protected.  (I can't think of a reason why it shouldn't be public, and not being public can inhibit custom Meter implementations.)
