### PR TITLE
A MetricRegistry can have a metric prefix strategy.  Also, ConsoleAppend...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ bin
 *.iml
 *.ipr
 *.iws
+pom.xml.versionsBackup
+*/pom.xml.versionsBackup

--- a/README.md
+++ b/README.md
@@ -12,3 +12,24 @@ License
 Copyright (c) 2010-2013 Coda Hale, Yammer.com
 
 Published under Apache Software License 2.0, see LICENSE
+
+
+Note to Self(s)
+--------------
+update project:
+  * git pull --rebase
+
+to bump the version:
+  * mvn versions:set -DnewVersion=1.0.3-SNAPSHOT
+
+ensure all the modules get it:
+  * mvn  versions:update-child-modules
+
+commit the junk
+  * git commit -m "notes about the junk"
+
+push the junk
+  * git push origin
+
+celebrate
+  * yay.

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
@@ -170,57 +170,61 @@ public class ConsoleReporter extends ScheduledReporter {
                        SortedMap<String, Histogram> histograms,
                        SortedMap<String, Meter> meters,
                        SortedMap<String, Timer> timers) {
-        final String dateTime = dateFormat.format(new Date(clock.getTime()));
-        printWithBanner(dateTime, '=');
-        output.println();
 
-        if (!gauges.isEmpty()) {
-            printWithBanner("-- Gauges", '-');
-            for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
-                output.println(entry.getKey());
-                printGauge(entry);
-            }
+        synchronized (output){
+            final String dateTime = dateFormat.format(new Date(clock.getTime()));
+            printWithBanner(dateTime, '=');
             output.println();
+
+            if (!gauges.isEmpty()) {
+                printWithBanner("-- Gauges", '-');
+                for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+                    output.println(entry.getKey());
+                    printGauge(entry);
+                }
+                output.println();
+            }
+
+            if (!counters.isEmpty()) {
+                printWithBanner("-- Counters", '-');
+                for (Map.Entry<String, Counter> entry : counters.entrySet()) {
+                    output.println(entry.getKey());
+                    printCounter(entry);
+                }
+                output.println();
+            }
+
+            if (!histograms.isEmpty()) {
+                printWithBanner("-- Histograms", '-');
+                for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
+                    output.println(entry.getKey());
+                    printHistogram(entry.getValue());
+                }
+                output.println();
+            }
+
+            if (!meters.isEmpty()) {
+                printWithBanner("-- Meters", '-');
+                for (Map.Entry<String, Meter> entry : meters.entrySet()) {
+                    output.println(entry.getKey());
+                    printMeter(entry.getValue());
+                }
+                output.println();
+            }
+
+            if (!timers.isEmpty()) {
+                printWithBanner("-- Timers", '-');
+                for (Map.Entry<String, Timer> entry : timers.entrySet()) {
+                    output.println(entry.getKey());
+                    printTimer(entry.getValue());
+                }
+                output.println();
+            }
+
+            output.println();
+            output.flush();
         }
 
-        if (!counters.isEmpty()) {
-            printWithBanner("-- Counters", '-');
-            for (Map.Entry<String, Counter> entry : counters.entrySet()) {
-                output.println(entry.getKey());
-                printCounter(entry);
-            }
-            output.println();
-        }
-
-        if (!histograms.isEmpty()) {
-            printWithBanner("-- Histograms", '-');
-            for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
-                output.println(entry.getKey());
-                printHistogram(entry.getValue());
-            }
-            output.println();
-        }
-
-        if (!meters.isEmpty()) {
-            printWithBanner("-- Meters", '-');
-            for (Map.Entry<String, Meter> entry : meters.entrySet()) {
-                output.println(entry.getKey());
-                printMeter(entry.getValue());
-            }
-            output.println();
-        }
-
-        if (!timers.isEmpty()) {
-            printWithBanner("-- Timers", '-');
-            for (Map.Entry<String, Timer> entry : timers.entrySet()) {
-                output.println(entry.getKey());
-                printTimer(entry.getValue());
-            }
-            output.println();
-        }
-
-        output.println();
-        output.flush();
     }
 
     private void printMeter(Meter meter) {

--- a/metrics-core/src/main/java/com/codahale/metrics/JmxAttributeGauge.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JmxAttributeGauge.java
@@ -1,15 +1,16 @@
 package com.codahale.metrics;
 
+import java.io.IOException;
 import javax.management.JMException;
-import javax.management.MBeanServer;
+import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 
 /**
- * A {@link Gauge} implementation which queries a {@link MBeanServer} for an attribute of an object.
+ * A {@link Gauge} implementation which queries an {@link MBeanServerConnection} for an attribute of an object.
  */
 public class JmxAttributeGauge implements Gauge<Object> {
-    private final MBeanServer mBeanServer;
+    private final MBeanServerConnection mBeanServerConn;
     private final ObjectName objectName;
     private final String attributeName;
 
@@ -26,12 +27,12 @@ public class JmxAttributeGauge implements Gauge<Object> {
     /**
      * Creates a new JmxAttributeGauge.
      *
-     * @param mBeanServer      the {@link MBeanServer}
+     * @param mBeanServerConn  the {@link MBeanServerConnection}
      * @param objectName       the name of the object
      * @param attributeName    the name of the object's attribute
      */
-    public JmxAttributeGauge(MBeanServer mBeanServer, ObjectName objectName, String attributeName) {
-        this.mBeanServer = mBeanServer;
+    public JmxAttributeGauge(MBeanServerConnection mBeanServerConn, ObjectName objectName, String attributeName) {
+        this.mBeanServerConn = mBeanServerConn;
         this.objectName = objectName;
         this.attributeName = attributeName;
     }
@@ -39,7 +40,9 @@ public class JmxAttributeGauge implements Gauge<Object> {
     @Override
     public Object getValue() {
         try {
-            return mBeanServer.getAttribute(objectName, attributeName);
+            return mBeanServerConn.getAttribute(objectName, attributeName);
+        } catch (IOException e) {
+            return null;
         } catch (JMException e) {
             return null;
         }

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricPrefixStrategy.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricPrefixStrategy.java
@@ -1,0 +1,13 @@
+package com.codahale.metrics;
+
+/**
+ * A strategy for Metric prefixes for situations where dimensions of a metric may be dynamic.
+ *
+ * User: wendel.schultz (swps)
+ * Date: 10/3/13
+ */
+public interface MetricPrefixStrategy {
+
+    public String getMetricPrefix();
+
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -399,7 +399,7 @@ public class MetricRegistry implements MetricSet {
         }
     }
 
-    private String getFullName(String name){
+    public String getFullName(String name){
 
         final String fullName;
         if(prefixStrategy == null){

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -152,6 +152,50 @@ public class MetricRegistry implements MetricSet {
     }
 
     /**
+     * Creates a new {@link Counter} and registers it under the given name.
+     *
+     * @param name     the first element of the name
+     * @param names    the remaining elements of the name
+     * @return a new {@link Counter}
+     */
+    public Counter counter(String name, String... names) {
+        return getOrAdd(name(name, names), MetricBuilder.COUNTERS);
+    }
+
+    /**
+     * Creates a new {@link Histogram} and registers it under the given name.
+     *
+     * @param name     the first element of the name
+     * @param names    the remaining elements of the name
+     * @return a new {@link Histogram}
+     */
+    public Histogram histogram(String name, String... names) {
+        return getOrAdd(name(name, names), MetricBuilder.HISTOGRAMS);
+    }
+
+    /**
+     * Creates a new {@link Meter} and registers it under the given name.
+     *
+     * @param name     the first element of the name
+     * @param names    the remaining elements of the name
+     * @return a new {@link Meter}
+     */
+    public Meter meter(String name, String... names) {
+        return getOrAdd(name(name, names), MetricBuilder.METERS);
+    }
+
+    /**
+     * Creates a new {@link Timer} and registers it under the given name.
+     *
+     * @param name     the first element of the name
+     * @param names    the remaining elements of the name
+     * @return a new {@link Timer}
+     */
+    public Timer timer(String name, String... names) {
+        return getOrAdd(name(name, names), MetricBuilder.TIMERS);
+    }
+
+    /**
      * Removes the metric with the given name.
      *
      * @param name the name of the metric

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -313,21 +313,24 @@ public class MetricRegistry implements MetricSet {
 
     @SuppressWarnings("unchecked")
     private <T extends Metric> T getOrAdd(String name, MetricBuilder<T> builder) {
-        name = getFullName(name);
-        final Metric metric = metrics.get(name);
+        final String fullName = getFullName(name);
+        final Metric metric = metrics.get(fullName);
+        final Metric added;
         if (builder.isInstance(metric)) {
             return (T) metric;
         } else if (metric == null) {
             try {
                 return register(name, builder.newMetric());
             } catch (IllegalArgumentException e) {
-                final Metric added = metrics.get(name);
+                added = metrics.get(fullName);
                 if (builder.isInstance(added)) {
                     return (T) added;
                 }
             }
+        } else {
+            added = null;
         }
-        throw new IllegalArgumentException(name + " is already used for a different type of metric");
+        throw new IllegalArgumentException(name + " is already used for a different type of metric: " + metric + ", added: " + added);
     }
 
     @SuppressWarnings("unchecked")

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -411,6 +411,22 @@ public class MetricRegistry implements MetricSet {
         return fullName;
     }
 
+    /**
+     * will use configured prefix to determine full metric name, then looks up the full name.
+     */
+    public boolean containsMetricName(String name){
+        final String fullName = getFullName(name);
+
+        return containsFullMetricName(fullName);
+    }
+
+    /**
+     * looks for a metric named exactly this; ignores configured metric prefix name.
+     */
+    public boolean containsFullMetricName(String fullName){
+        return metrics.containsKey(fullName);
+    }
+
     @Override
     public Map<String, Metric> getMetrics() {
         return Collections.unmodifiableMap(metrics);

--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -1,5 +1,8 @@
 package com.codahale.metrics;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Closeable;
 import java.util.Locale;
 import java.util.SortedMap;
@@ -18,6 +21,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @see Slf4jReporter
  */
 public abstract class ScheduledReporter implements Closeable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledReporter.class);
     /**
      * A simple named thread factory.
      */
@@ -114,12 +118,17 @@ public abstract class ScheduledReporter implements Closeable {
     /**
      * Report the current values of all metrics in the registry.
      */
-    public void report() {
-        report(registry.getGauges(filter),
-               registry.getCounters(filter),
-               registry.getHistograms(filter),
-               registry.getMeters(filter),
-               registry.getTimers(filter));
+    public synchronized void report() {
+        try {
+            report(registry.getGauges(filter),
+                    registry.getCounters(filter),
+                    registry.getHistograms(filter),
+                    registry.getMeters(filter),
+                    registry.getTimers(filter));
+        } catch (Exception e){
+            registry.meter("MetricReporting.Errors");
+            LOGGER.error("Error reporting metrics.", e);
+        }
     }
 
     /**

--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -44,6 +44,8 @@ public abstract class ScheduledReporter implements Closeable {
         }
     }
 
+    private static final AtomicInteger FACTORY_ID = new AtomicInteger();
+
     private final MetricRegistry registry;
     private final ScheduledExecutorService executor;
     private final MetricFilter filter;
@@ -67,7 +69,7 @@ public abstract class ScheduledReporter implements Closeable {
                                 TimeUnit durationUnit) {
         this.registry = registry;
         this.filter = filter;
-        this.executor = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory(name));
+        this.executor = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory(name + '-' + FACTORY_ID.incrementAndGet()));
         this.rateFactor = rateUnit.toSeconds(1);
         this.rateUnit = calculateRateUnit(rateUnit);
         this.durationFactor = 1.0 / durationUnit.toNanos(1);

--- a/metrics-core/src/main/java/com/codahale/metrics/Timer.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Timer.java
@@ -14,12 +14,22 @@ public class Timer implements Metered, Sampling {
      *
      * @see Timer#time()
      */
-    public static class Context implements Closeable {
+    public interface Context extends Closeable {
+
+        /**
+         * Stops recording the elapsed time, updates the timer and returns the elapsed time in
+         * nanoseconds.
+         */
+        public long stop();
+
+    }
+
+    public static class ContextImpl implements Context {
         private final Timer timer;
         private final Clock clock;
         private final long startTime;
 
-        private Context(Timer timer, Clock clock) {
+        private ContextImpl(Timer timer, Clock clock) {
             this.timer = timer;
             this.clock = clock;
             this.startTime = clock.getTick();
@@ -109,7 +119,7 @@ public class Timer implements Metered, Sampling {
      * @see Context
      */
     public Context time() {
-        return new Context(this, clock);
+        return new ContextImpl(this, clock);
     }
 
     @Override

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/CompositeReportingMetricRegistry.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/CompositeReportingMetricRegistry.java
@@ -1,0 +1,126 @@
+package com.codahale.metrics.graphite;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+
+import java.util.Collections;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * User: wendel.schultz
+ * Date: 11/6/13
+ */
+public class CompositeReportingMetricRegistry extends MetricRegistry {
+    private final MetricRegistry[] metricRegistries;
+
+    public CompositeReportingMetricRegistry(final MetricRegistry... metricRegistries) {
+        if(metricRegistries == null || metricRegistries.length == 0) {
+            throw new IllegalArgumentException("Must provide metric registries");
+        }
+        this.metricRegistries = metricRegistries;
+    }
+
+
+    /**
+     * Returns a map of all the gauges in the registry and their names which match the given filter.
+     *
+     * @param filter the metric filter to match
+     * @return all the gauges in the registry
+     */
+    @Override
+    public SortedMap<String, Gauge> getGauges(final MetricFilter filter) {
+
+        final SortedMap<String, Gauge> metrics = new TreeMap<String, Gauge>();
+
+        for(MetricRegistry registry: metricRegistries){
+            metrics.putAll(registry.getGauges(filter));
+        }
+
+        return Collections.unmodifiableSortedMap(metrics);
+    }
+
+    /**
+     * Returns a map of all the counters in the registry and their names which match the given
+     * filter.
+     *
+     * @param filter the metric filter to match
+     * @return all the counters in the registry
+     */
+    @Override
+    public SortedMap<String, Counter> getCounters(final MetricFilter filter) {
+        final SortedMap<String, Counter> metrics = new TreeMap<String, Counter>();
+
+        for(MetricRegistry registry: metricRegistries){
+            metrics.putAll(registry.getCounters(filter));
+        }
+
+        return Collections.unmodifiableSortedMap(metrics);
+    }
+
+    /**
+     * Returns a map of all the histograms in the registry and their names which match the given
+     * filter.
+     *
+     * @param filter the metric filter to match
+     * @return all the histograms in the registry
+     */
+    @Override
+    public SortedMap<String, Histogram> getHistograms(final MetricFilter filter) {
+        final SortedMap<String, Histogram> metrics = new TreeMap<String, Histogram>();
+
+        for(MetricRegistry registry: metricRegistries){
+            metrics.putAll(registry.getHistograms(filter));
+        }
+
+        return Collections.unmodifiableSortedMap(metrics);
+    }
+
+    /**
+     * Returns a map of all the meters in the registry and their names which match the given filter.
+     *
+     * @param filter the metric filter to match
+     * @return all the meters in the registry
+     */
+    @Override
+    public SortedMap<String, Meter> getMeters(final MetricFilter filter) {
+        final SortedMap<String, Meter> metrics = new TreeMap<String, Meter>();
+
+        for(MetricRegistry registry: metricRegistries){
+            metrics.putAll(registry.getMeters(filter));
+        }
+
+        return Collections.unmodifiableSortedMap(metrics);
+    }
+
+    /**
+     * Returns a map of all the timers in the registry and their names which match the given filter.
+     *
+     * @param filter the metric filter to match
+     * @return all the timers in the registry
+     */
+    @Override
+    public SortedMap<String, Timer> getTimers(final MetricFilter filter) {
+        final SortedMap<String, Timer> metrics = new TreeMap<String, Timer>();
+
+        for(MetricRegistry registry: metricRegistries){
+            metrics.putAll(registry.getTimers(filter));
+        }
+
+        return Collections.unmodifiableSortedMap(metrics);
+    }
+
+    public int getMeasuredMetricsCount(){
+        int count = 0;
+        for(MetricRegistry registry: metricRegistries){
+            count += registry.getMetrics().size();
+        }
+
+        return count;
+    }
+}

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
@@ -27,8 +27,8 @@ public class Graphite implements Closeable {
     private final SocketFactory socketFactory;
     private final Charset charset;
 
-    private Socket socket;
-    private Writer writer;
+    private volatile Socket socket;
+    Writer writer;
     private int failures;
 
     /**
@@ -79,7 +79,13 @@ public class Graphite implements Closeable {
             throw new IllegalStateException("Already connected");
         }
 
-        this.socket = socketFactory.createSocket(address.getAddress(), address.getPort());
+        final InetSocketAddress resolvedAddress;
+        if(address.isUnresolved()){
+            resolvedAddress = new InetSocketAddress(address.getHostName(), address.getPort());
+        } else {
+            resolvedAddress = address;
+        }
+        this.socket = socketFactory.createSocket(resolvedAddress.getAddress(), resolvedAddress.getPort());
         this.writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), charset));
     }
 

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
@@ -1,16 +1,24 @@
 package com.codahale.metrics.graphite;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.net.SocketFactory;
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.charset.Charset;
 import java.util.regex.Pattern;
 
 /**
- * A client to a Carbon server.
+ * A client to a Carbon server.  Absolutely not thread safe.
  */
 public class Graphite implements Closeable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(Graphite.class);
     private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
     // this may be optimistic about Carbon/Graphite
     private static final Charset UTF_8 = Charset.forName("UTF-8");
@@ -64,6 +72,9 @@ public class Graphite implements Closeable {
      * @throws IOException           if there is an error connecting
      */
     public void connect() throws IllegalStateException, IOException {
+        if(LOGGER.isDebugEnabled()){
+            LOGGER.debug("Connecting " + this);
+        }
         if (socket != null) {
             throw new IllegalStateException("Already connected");
         }
@@ -80,16 +91,27 @@ public class Graphite implements Closeable {
      * @param timestamp the timestamp of the metric
      * @throws IOException if there was an error sending the metric
      */
-    public void send(String name, String value, long timestamp) throws IOException {
+    public int send(String name, String value, long timestamp) throws IOException {
+        if(LOGGER.isDebugEnabled()){
+            LOGGER.debug("GraphiteSender: " + name + " : " + value);
+        }
+        final int byteCount;
         try {
-            writer.write(sanitize(name));
-            writer.write(' ');
-            writer.write(sanitize(value));
-            writer.write(' ');
-            writer.write(Long.toString(timestamp));
-            writer.write('\n');
+            final StringBuilder lineItem = new StringBuilder();
+            lineItem.append(sanitize(name))
+                    .append(' ')
+                    .append(sanitize(value))
+                    .append(' ')
+                    .append(Long.toString(timestamp))
+                    .append('\n');
+            final String metricString = lineItem.toString();
+            final char[] chars = metricString.toCharArray();
+            byteCount = chars.length;
+            writer.write(chars);
             writer.flush();
             this.failures = 0;
+
+            return byteCount;
         } catch (IOException e) {
             failures++;
             throw e;
@@ -107,6 +129,9 @@ public class Graphite implements Closeable {
 
     @Override
     public void close() throws IOException {
+        if(LOGGER.isDebugEnabled()){
+            LOGGER.debug("Closing " + this);
+        }
         if (socket != null) {
             socket.close();
         }
@@ -116,5 +141,17 @@ public class Graphite implements Closeable {
 
     protected String sanitize(String s) {
         return WHITESPACE.matcher(s).replaceAll("-");
+    }
+
+    @Override
+    public String toString() {
+        return "Graphite{" +
+                "address=" + address +
+                ", socketFactory=" + socketFactory +
+                ", charset=" + charset +
+                ", socket=" + socket +
+                ", writer=" + writer +
+                ", failures=" + failures +
+                '}';
     }
 }

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteHistogramProfile.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteHistogramProfile.java
@@ -1,0 +1,158 @@
+package com.codahale.metrics.graphite;
+
+/**
+ * Specifies which data points to send to Graphite
+ */
+public class GraphiteHistogramProfile {
+
+    private final boolean count;
+    private final boolean max;
+    private final boolean mean;
+    private final boolean min;
+    private final boolean stdDev;
+    private final boolean percentile50th;
+    private final boolean percentile75th;
+    private final boolean percentile95th;
+    private final boolean percentile98th;
+    private final boolean percentile99th;
+    private final boolean percentile999th;
+
+    private GraphiteHistogramProfile(Builder builder) {
+        this.count = builder.count;
+        this.max = builder.max;
+        this.mean = builder.mean;
+        this.min = builder.min;
+        this.stdDev = builder.stdDev;
+        this.percentile50th = builder.percentile50th;
+        this.percentile75th = builder.percentile75th;
+        this.percentile95th = builder.percentile95th;
+        this.percentile98th = builder.percentile98th;
+        this.percentile99th = builder.percentile99th;
+        this.percentile999th = builder.percentile999th;
+    }
+
+    public boolean isCount() {
+        return count;
+    }
+
+    public boolean isMax() {
+        return max;
+    }
+
+    public boolean isMean() {
+        return mean;
+    }
+
+    public boolean isMin() {
+        return min;
+    }
+
+    public boolean isStdDev() {
+        return stdDev;
+    }
+
+    public boolean is50thPercentile() {
+        return percentile50th;
+    }
+
+    public boolean is75thPercentile() {
+        return percentile75th;
+    }
+
+    public boolean is95thPercentile() {
+        return percentile95th;
+    }
+
+    public boolean is98thPercentile() {
+        return percentile98th;
+    }
+
+    public boolean is99thPercentile() {
+        return percentile99th;
+    }
+
+    public boolean is999thPercentile() {
+        return percentile999th;
+    }
+
+    public static class Builder {
+
+        private boolean count = true;
+        private boolean max = true;
+        private boolean mean;
+        private boolean min = true;
+        private boolean stdDev;
+        private boolean percentile50th;
+        private boolean percentile75th;
+        private boolean percentile95th = true;
+        private boolean percentile98th;
+        private boolean percentile99th;
+        private boolean percentile999th;
+
+        public Builder count(boolean count) {
+            this.count = count;
+            return this;
+        }
+
+        public Builder max(boolean max) {
+            this.max = max;
+            return this;
+        }
+
+        public Builder mean(boolean mean) {
+            this.mean = mean;
+            return this;
+        }
+
+        public Builder min(boolean min) {
+            this.min = min;
+            return this;
+        }
+
+        public Builder stdDev(boolean stdDev) {
+            this.stdDev = stdDev;
+            return this;
+        }
+
+        public Builder percentile50th(boolean percentile50th) {
+            this.percentile50th = percentile50th;
+            return this;
+        }
+
+        public Builder percentile75th(boolean percentile75th) {
+            this.percentile75th = percentile75th;
+            return this;
+        }
+
+        public Builder percentile95th(boolean percentile95th) {
+            this.percentile95th = percentile95th;
+            return this;
+        }
+
+        public Builder percentile98th(boolean percentile98th) {
+            this.percentile98th = percentile98th;
+            return this;
+        }
+
+        public Builder percentile99th(boolean percentile99th) {
+            this.percentile99th = percentile99th;
+            return this;
+        }
+
+        public Builder percentile999th(boolean percentile999th) {
+            this.percentile999th = percentile999th;
+            return this;
+        }
+
+        public GraphiteHistogramProfile build() {
+            if (!count && !max && !mean && !min && !stdDev
+                    && !percentile50th && !percentile75th && !percentile95th && !percentile98th && !percentile99th && !percentile999th) {
+
+                throw new IllegalStateException("Must enable at least one data point");
+            }
+            return new GraphiteHistogramProfile(this);
+        }
+
+    }
+
+}

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteMeterProfile.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteMeterProfile.java
@@ -1,0 +1,84 @@
+package com.codahale.metrics.graphite;
+
+/**
+ * Specifies which data points to send to Graphite
+ */
+public class GraphiteMeterProfile {
+
+    private final boolean count;
+    private final boolean oneMinuteRate;
+    private final boolean fiveMinuteRate;
+    private final boolean fifteenMinuteRate;
+    private final boolean meanRate;
+
+    private GraphiteMeterProfile(Builder builder) {
+        this.count = builder.count;
+        this.oneMinuteRate = builder.oneMinuteRate;
+        this.fiveMinuteRate = builder.fiveMinuteRate;
+        this.fifteenMinuteRate = builder.fifteenMinuteRate;
+        this.meanRate = builder.meanRate;
+    }
+
+    public boolean isCount() {
+        return count;
+    }
+
+    public boolean isOneMinuteRate() {
+        return oneMinuteRate;
+    }
+
+    public boolean isFiveMinuteRate() {
+        return fiveMinuteRate;
+    }
+
+    public boolean isFifteenMinuteRate() {
+        return fifteenMinuteRate;
+    }
+
+    public boolean isMeanRate() {
+        return meanRate;
+    }
+
+    public static class Builder {
+
+        private boolean count = true;
+        private boolean oneMinuteRate = true;
+        private boolean fiveMinuteRate;
+        private boolean fifteenMinuteRate;
+        private boolean meanRate;
+
+        public Builder count(boolean count) {
+            this.count = count;
+            return this;
+        }
+
+        public Builder oneMinuteRate(boolean oneMinuteRate) {
+            this.oneMinuteRate = oneMinuteRate;
+            return this;
+        }
+
+        public Builder fiveMinuteRate(boolean fiveMinuteRate) {
+            this.fiveMinuteRate = fiveMinuteRate;
+            return this;
+        }
+
+        public Builder fifteenMinuteRate(boolean fifteenMinuteRate) {
+            this.fifteenMinuteRate = fifteenMinuteRate;
+            return this;
+        }
+
+        public Builder meanRate(boolean meanRate) {
+            this.meanRate = meanRate;
+            return this;
+        }
+
+        public GraphiteMeterProfile build() {
+            if (!count && !oneMinuteRate && !fiveMinuteRate && !fifteenMinuteRate && !meanRate) {
+                throw new IllegalStateException("Must enable at least one data point");
+            }
+            return new GraphiteMeterProfile(this);
+        }
+
+    }
+
+}

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -330,15 +330,15 @@ public class GraphiteReporter extends ScheduledReporter {
         byteCount += graphite.send(prefix(name, "m1_rate"),
                       format(convertRate(meter.getOneMinuteRate())),
                       timestamp);
-        byteCount += graphite.send(prefix(name, "m5_rate"),
-                      format(convertRate(meter.getFiveMinuteRate())),
-                      timestamp);
-        byteCount += graphite.send(prefix(name, "m15_rate"),
-                      format(convertRate(meter.getFifteenMinuteRate())),
-                      timestamp);
-        byteCount += graphite.send(prefix(name, "mean_rate"),
-                      format(convertRate(meter.getMeanRate())),
-                      timestamp);
+//        byteCount += graphite.send(prefix(name, "m5_rate"),
+//                      format(convertRate(meter.getFiveMinuteRate())),
+//                      timestamp);
+//        byteCount += graphite.send(prefix(name, "m15_rate"),
+//                      format(convertRate(meter.getFifteenMinuteRate())),
+//                      timestamp);
+//        byteCount += graphite.send(prefix(name, "mean_rate"),
+//                      format(convertRate(meter.getMeanRate())),
+//                      timestamp);
 
         return byteCount;
     }

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -274,7 +274,7 @@ public class GraphiteReporter extends ScheduledReporter {
             LOGGER.error("Unable to report metrics to Graphite", graphite, e);
         } finally {
             try {
-                publishDurationMS.set(startTime - clock.getTime());
+                publishDurationMS.set(clock.getTime() - startTime);
 
                 graphite.close();
             } catch (IOException e) {
@@ -293,21 +293,21 @@ public class GraphiteReporter extends ScheduledReporter {
         byteCount += graphite.send(prefix(name, "stddev"),
                       format(convertDuration(snapshot.getStdDev())),
                       timestamp);
-        byteCount += graphite.send(prefix(name, "p50"),
-                      format(convertDuration(snapshot.getMedian())),
-                      timestamp);
-        byteCount += graphite.send(prefix(name, "p75"),
-                      format(convertDuration(snapshot.get75thPercentile())),
-                      timestamp);
+//        byteCount += graphite.send(prefix(name, "p50"),
+//                      format(convertDuration(snapshot.getMedian())),
+//                      timestamp);
+//        byteCount += graphite.send(prefix(name, "p75"),
+//                      format(convertDuration(snapshot.get75thPercentile())),
+//                      timestamp);
         byteCount += graphite.send(prefix(name, "p95"),
                       format(convertDuration(snapshot.get95thPercentile())),
                       timestamp);
-        byteCount += graphite.send(prefix(name, "p98"),
-                      format(convertDuration(snapshot.get98thPercentile())),
-                      timestamp);
-        byteCount += graphite.send(prefix(name, "p99"),
-                      format(convertDuration(snapshot.get99thPercentile())),
-                      timestamp);
+//        byteCount += graphite.send(prefix(name, "p98"),
+//                      format(convertDuration(snapshot.get98thPercentile())),
+//                      timestamp);
+//        byteCount += graphite.send(prefix(name, "p99"),
+//                      format(convertDuration(snapshot.get99thPercentile())),
+//                      timestamp);
         byteCount += graphite.send(prefix(name, "p999"),
                       format(convertDuration(snapshot.get999thPercentile())),
                       timestamp);
@@ -344,11 +344,11 @@ public class GraphiteReporter extends ScheduledReporter {
         byteCount += graphite.send(prefix(name, "mean"), format(snapshot.getMean()), timestamp);
         byteCount += graphite.send(prefix(name, "min"), format(snapshot.getMin()), timestamp);
         byteCount += graphite.send(prefix(name, "stddev"), format(snapshot.getStdDev()), timestamp);
-        byteCount += graphite.send(prefix(name, "p50"), format(snapshot.getMedian()), timestamp);
-        byteCount += graphite.send(prefix(name, "p75"), format(snapshot.get75thPercentile()), timestamp);
+//        byteCount += graphite.send(prefix(name, "p50"), format(snapshot.getMedian()), timestamp);
+//        byteCount += graphite.send(prefix(name, "p75"), format(snapshot.get75thPercentile()), timestamp);
         byteCount += graphite.send(prefix(name, "p95"), format(snapshot.get95thPercentile()), timestamp);
-        byteCount += graphite.send(prefix(name, "p98"), format(snapshot.get98thPercentile()), timestamp);
-        byteCount += graphite.send(prefix(name, "p99"), format(snapshot.get99thPercentile()), timestamp);
+//        byteCount += graphite.send(prefix(name, "p98"), format(snapshot.get98thPercentile()), timestamp);
+//        byteCount += graphite.send(prefix(name, "p99"), format(snapshot.get99thPercentile()), timestamp);
         byteCount += graphite.send(prefix(name, "p999"), format(snapshot.get999thPercentile()), timestamp);
 
         return byteCount;

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteTimerProfile.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteTimerProfile.java
@@ -1,0 +1,207 @@
+package com.codahale.metrics.graphite;
+
+/**
+ * Specifies which data points to send to Graphite
+ */
+public class GraphiteTimerProfile {
+
+    private final boolean count;
+    private final boolean oneMinuteRate;
+    private final boolean fiveMinuteRate;
+    private final boolean fifteenMinuteRate;
+    private final boolean meanRate;
+    private final boolean max;
+    private final boolean mean;
+    private final boolean min;
+    private final boolean stdDev;
+    private final boolean percentile50th;
+    private final boolean percentile75th;
+    private final boolean percentile95th;
+    private final boolean percentile98th;
+    private final boolean percentile99th;
+    private final boolean percentile999th;
+
+    private GraphiteTimerProfile(Builder builder) {
+        this.count = builder.count;
+        this.oneMinuteRate = builder.oneMinuteRate;
+        this.fiveMinuteRate = builder.fiveMinuteRate;
+        this.fifteenMinuteRate = builder.fifteenMinuteRate;
+        this.meanRate = builder.meanRate;
+        this.max = builder.max;
+        this.mean = builder.mean;
+        this.min = builder.min;
+        this.stdDev = builder.stdDev;
+        this.percentile50th = builder.percentile50th;
+        this.percentile75th = builder.percentile75th;
+        this.percentile95th = builder.percentile95th;
+        this.percentile98th = builder.percentile98th;
+        this.percentile99th = builder.percentile99th;
+        this.percentile999th = builder.percentile999th;
+    }
+
+    public boolean isCount() {
+        return count;
+    }
+
+    public boolean isOneMinuteRate() {
+        return oneMinuteRate;
+    }
+
+    public boolean isFiveMinuteRate() {
+        return fiveMinuteRate;
+    }
+
+    public boolean isFifteenMinuteRate() {
+        return fifteenMinuteRate;
+    }
+
+    public boolean isMeanRate() {
+        return meanRate;
+    }
+
+    public boolean isMax() {
+        return max;
+    }
+
+    public boolean isMean() {
+        return mean;
+    }
+
+    public boolean isMin() {
+        return min;
+    }
+
+    public boolean isStdDev() {
+        return stdDev;
+    }
+
+    public boolean is50thPercentile() {
+        return percentile50th;
+    }
+
+    public boolean is75thPercentile() {
+        return percentile75th;
+    }
+
+    public boolean is95thPercentile() {
+        return percentile95th;
+    }
+
+    public boolean is98thPercentile() {
+        return percentile98th;
+    }
+
+    public boolean is99thPercentile() {
+        return percentile99th;
+    }
+
+    public boolean is999thPercentile() {
+        return percentile999th;
+    }
+
+    public static class Builder {
+
+        private boolean count = true;
+        private boolean oneMinuteRate = true;
+        private boolean fiveMinuteRate;
+        private boolean fifteenMinuteRate;
+        private boolean meanRate;
+        private boolean max = true;
+        private boolean mean;
+        private boolean min = true;
+        private boolean stdDev;
+        private boolean percentile50th;
+        private boolean percentile75th;
+        private boolean percentile95th = true;
+        private boolean percentile98th;
+        private boolean percentile99th;
+        private boolean percentile999th;
+
+        public Builder count(boolean count) {
+            this.count = count;
+            return this;
+        }
+
+        public Builder oneMinuteRate(boolean oneMinuteRate) {
+            this.oneMinuteRate = oneMinuteRate;
+            return this;
+        }
+
+        public Builder fiveMinuteRate(boolean fiveMinuteRate) {
+            this.fiveMinuteRate = fiveMinuteRate;
+            return this;
+        }
+
+        public Builder fifteenMinuteRate(boolean fifteenMinuteRate) {
+            this.fifteenMinuteRate = fifteenMinuteRate;
+            return this;
+        }
+
+        public Builder meanRate(boolean meanRate) {
+            this.meanRate = meanRate;
+            return this;
+        }
+
+        public Builder max(boolean max) {
+            this.max = max;
+            return this;
+        }
+
+        public Builder mean(boolean mean) {
+            this.mean = mean;
+            return this;
+        }
+
+        public Builder min(boolean min) {
+            this.min = min;
+            return this;
+        }
+
+        public Builder stdDev(boolean stdDev) {
+            this.stdDev = stdDev;
+            return this;
+        }
+
+        public Builder percentile50th(boolean percentile50th) {
+            this.percentile50th = percentile50th;
+            return this;
+        }
+
+        public Builder percentile75th(boolean percentile75th) {
+            this.percentile75th = percentile75th;
+            return this;
+        }
+
+        public Builder percentile95th(boolean percentile95th) {
+            this.percentile95th = percentile95th;
+            return this;
+        }
+
+        public Builder percentile98th(boolean percentile98th) {
+            this.percentile98th = percentile98th;
+            return this;
+        }
+
+        public Builder percentile99th(boolean percentile99th) {
+            this.percentile99th = percentile99th;
+            return this;
+        }
+
+        public Builder percentile999th(boolean percentile999th) {
+            this.percentile999th = percentile999th;
+            return this;
+        }
+
+        public GraphiteTimerProfile build() {
+            if (!count && !oneMinuteRate && !fiveMinuteRate && !fifteenMinuteRate && !meanRate
+                    && !max && !mean && !min && !stdDev
+                    && !percentile50th && !percentile75th && !percentile95th && !percentile98th && !percentile99th && !percentile999th) {
+
+                throw new IllegalStateException("Must enable at least one data point");
+            }
+            return new GraphiteTimerProfile(this);
+        }
+
+    }
+
+}

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -222,9 +222,9 @@ public class GraphiteReporterTest {
         inOrder.verify(graphite).connect();
         inOrder.verify(graphite).send("prefix.meter.count", "1", timestamp);
         inOrder.verify(graphite).send("prefix.meter.m1_rate", "2.00", timestamp);
-        inOrder.verify(graphite).send("prefix.meter.m5_rate", "3.00", timestamp);
-        inOrder.verify(graphite).send("prefix.meter.m15_rate", "4.00", timestamp);
-        inOrder.verify(graphite).send("prefix.meter.mean_rate", "5.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.meter.m5_rate", "3.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.meter.m15_rate", "4.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.meter.mean_rate", "5.00", timestamp);
         inOrder.verify(graphite).close();
 
         verifyNoMoreInteractions(graphite);
@@ -274,9 +274,9 @@ public class GraphiteReporterTest {
         inOrder.verify(graphite).send("prefix.timer.p999", "1000.00", timestamp);
         inOrder.verify(graphite).send("prefix.timer.count", "1", timestamp);
         inOrder.verify(graphite).send("prefix.timer.m1_rate", "3.00", timestamp);
-        inOrder.verify(graphite).send("prefix.timer.m5_rate", "4.00", timestamp);
-        inOrder.verify(graphite).send("prefix.timer.m15_rate", "5.00", timestamp);
-        inOrder.verify(graphite).send("prefix.timer.mean_rate", "2.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.timer.m5_rate", "4.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.timer.m15_rate", "5.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.timer.mean_rate", "2.00", timestamp);
         inOrder.verify(graphite).close();
 
         verifyNoMoreInteractions(graphite);

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -192,11 +192,11 @@ public class GraphiteReporterTest {
         inOrder.verify(graphite).send("prefix.histogram.mean", "3.00", timestamp);
         inOrder.verify(graphite).send("prefix.histogram.min", "4", timestamp);
         inOrder.verify(graphite).send("prefix.histogram.stddev", "5.00", timestamp);
-        inOrder.verify(graphite).send("prefix.histogram.p50", "6.00", timestamp);
-        inOrder.verify(graphite).send("prefix.histogram.p75", "7.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.histogram.p50", "6.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.histogram.p75", "7.00", timestamp);
         inOrder.verify(graphite).send("prefix.histogram.p95", "8.00", timestamp);
-        inOrder.verify(graphite).send("prefix.histogram.p98", "9.00", timestamp);
-        inOrder.verify(graphite).send("prefix.histogram.p99", "10.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.histogram.p98", "9.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.histogram.p99", "10.00", timestamp);
         inOrder.verify(graphite).send("prefix.histogram.p999", "11.00", timestamp);
         inOrder.verify(graphite).close();
 
@@ -266,11 +266,11 @@ public class GraphiteReporterTest {
         inOrder.verify(graphite).send("prefix.timer.mean", "200.00", timestamp);
         inOrder.verify(graphite).send("prefix.timer.min", "300.00", timestamp);
         inOrder.verify(graphite).send("prefix.timer.stddev", "400.00", timestamp);
-        inOrder.verify(graphite).send("prefix.timer.p50", "500.00", timestamp);
-        inOrder.verify(graphite).send("prefix.timer.p75", "600.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.timer.p50", "500.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.timer.p75", "600.00", timestamp);
         inOrder.verify(graphite).send("prefix.timer.p95", "700.00", timestamp);
-        inOrder.verify(graphite).send("prefix.timer.p98", "800.00", timestamp);
-        inOrder.verify(graphite).send("prefix.timer.p99", "900.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.timer.p98", "800.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.timer.p99", "900.00", timestamp);
         inOrder.verify(graphite).send("prefix.timer.p999", "1000.00", timestamp);
         inOrder.verify(graphite).send("prefix.timer.count", "1", timestamp);
         inOrder.verify(graphite).send("prefix.timer.m1_rate", "3.00", timestamp);

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -189,15 +189,15 @@ public class GraphiteReporterTest {
         inOrder.verify(graphite).connect();
         inOrder.verify(graphite).send("prefix.histogram.count", "1", timestamp);
         inOrder.verify(graphite).send("prefix.histogram.max", "2", timestamp);
-        inOrder.verify(graphite).send("prefix.histogram.mean", "3.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.histogram.mean", "3.00", timestamp);
         inOrder.verify(graphite).send("prefix.histogram.min", "4", timestamp);
-        inOrder.verify(graphite).send("prefix.histogram.stddev", "5.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.histogram.stddev", "5.00", timestamp);
 //        inOrder.verify(graphite).send("prefix.histogram.p50", "6.00", timestamp);
 //        inOrder.verify(graphite).send("prefix.histogram.p75", "7.00", timestamp);
         inOrder.verify(graphite).send("prefix.histogram.p95", "8.00", timestamp);
 //        inOrder.verify(graphite).send("prefix.histogram.p98", "9.00", timestamp);
 //        inOrder.verify(graphite).send("prefix.histogram.p99", "10.00", timestamp);
-        inOrder.verify(graphite).send("prefix.histogram.p999", "11.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.histogram.p999", "11.00", timestamp);
         inOrder.verify(graphite).close();
 
         verifyNoMoreInteractions(graphite);
@@ -262,21 +262,21 @@ public class GraphiteReporterTest {
 
         final InOrder inOrder = inOrder(graphite);
         inOrder.verify(graphite).connect();
-        inOrder.verify(graphite).send("prefix.timer.max", "100.00", timestamp);
-        inOrder.verify(graphite).send("prefix.timer.mean", "200.00", timestamp);
-        inOrder.verify(graphite).send("prefix.timer.min", "300.00", timestamp);
-        inOrder.verify(graphite).send("prefix.timer.stddev", "400.00", timestamp);
-//        inOrder.verify(graphite).send("prefix.timer.p50", "500.00", timestamp);
-//        inOrder.verify(graphite).send("prefix.timer.p75", "600.00", timestamp);
-        inOrder.verify(graphite).send("prefix.timer.p95", "700.00", timestamp);
-//        inOrder.verify(graphite).send("prefix.timer.p98", "800.00", timestamp);
-//        inOrder.verify(graphite).send("prefix.timer.p99", "900.00", timestamp);
-        inOrder.verify(graphite).send("prefix.timer.p999", "1000.00", timestamp);
         inOrder.verify(graphite).send("prefix.timer.count", "1", timestamp);
         inOrder.verify(graphite).send("prefix.timer.m1_rate", "3.00", timestamp);
 //        inOrder.verify(graphite).send("prefix.timer.m5_rate", "4.00", timestamp);
 //        inOrder.verify(graphite).send("prefix.timer.m15_rate", "5.00", timestamp);
 //        inOrder.verify(graphite).send("prefix.timer.mean_rate", "2.00", timestamp);
+        inOrder.verify(graphite).send("prefix.timer.max", "100.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.timer.mean", "200.00", timestamp);
+        inOrder.verify(graphite).send("prefix.timer.min", "300.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.timer.stddev", "400.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.timer.p50", "500.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.timer.p75", "600.00", timestamp);
+        inOrder.verify(graphite).send("prefix.timer.p95", "700.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.timer.p98", "800.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.timer.p99", "900.00", timestamp);
+//        inOrder.verify(graphite).send("prefix.timer.p999", "1000.00", timestamp);
         inOrder.verify(graphite).close();
 
         verifyNoMoreInteractions(graphite);

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteTest.java
@@ -11,6 +11,8 @@ import java.net.Socket;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.assertions.api.Fail.failBecauseExceptionWasNotThrown;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.*;
@@ -18,9 +20,11 @@ import static org.mockito.Mockito.*;
 public class GraphiteTest {
     private final SocketFactory socketFactory = mock(SocketFactory.class);
     private final InetSocketAddress address = new InetSocketAddress("example.com", 1234);
+    private final InetSocketAddress unresolvedAddress = InetSocketAddress.createUnresolved("example.com", 1234);
     private final Graphite graphite = new Graphite(address, socketFactory);
 
     private final Socket socket = mock(Socket.class);
+    private final Socket unresolvedSocket = mock(Socket.class);
     private final ByteArrayOutputStream output = new ByteArrayOutputStream();
 
     @Before
@@ -30,13 +34,28 @@ public class GraphiteTest {
         when(socketFactory.createSocket(any(InetAddress.class),
                                         anyInt())).thenReturn(socket);
 
+        when(socketFactory.createSocket(anyString(), anyInt())).thenReturn(unresolvedSocket);
+
     }
 
     @Test
     public void connectsToGraphite() throws Exception {
         graphite.connect();
 
+        assertFalse(address.isUnresolved());  // this is the createSocket() method used when the name resovles
         verify(socketFactory).createSocket(address.getAddress(), address.getPort());
+
+        assertNotNull(graphite.writer);
+    }
+
+    @Test
+    public void connectsToGraphiteWithUnresolvedAddress() throws Exception {
+        final Graphite graphite = new Graphite(unresolvedAddress, socketFactory);
+        graphite.connect();
+
+        verify(socketFactory).createSocket(any(InetAddress.class), eq(1234));
+
+        assertNotNull(graphite.writer);
     }
 
     @Test

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -29,6 +29,7 @@ public class InstrumentedHandler extends HandlerWrapper {
     private final MetricRegistry metricRegistry;
 
     private String name;
+    private final String prefix;
 
     // the requests handled by this handler, excluding active
     private Timer requests;
@@ -73,8 +74,20 @@ public class InstrumentedHandler extends HandlerWrapper {
      *
      */
     public InstrumentedHandler(MetricRegistry registry) {
-        this.metricRegistry = registry;
+        this(registry, null);
     }
+
+	/**
+	 * Create a new instrumented handler using a given metrics registry.
+	 *
+	 * @param registry   the registry for the metrics
+	 * @param prefix     the prefix to use for the metrics names
+	 *
+	 */
+	public InstrumentedHandler(MetricRegistry registry, String prefix) {
+		this.metricRegistry = registry;
+		this.prefix = prefix;
+	}
 
     public String getName() {
         return name;
@@ -88,7 +101,7 @@ public class InstrumentedHandler extends HandlerWrapper {
     protected void doStart() throws Exception {
         super.doStart();
 
-        final String prefix = name(getHandler().getClass(), name);
+        final String prefix = this.prefix == null ? name(getHandler().getClass(), name) : name(this.prefix, name);
 
         this.requests = metricRegistry.timer(name(prefix, "requests"));
         this.dispatches = metricRegistry.timer(name(prefix, "dispatches"));

--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -197,7 +197,6 @@ public class InstrumentedHandler extends HandlerWrapper {
                 }
                 activeSuspended.inc();
             } else if (state.isInitial()) {
-                requests.update(dispatched, TimeUnit.MILLISECONDS);
                 updateResponses(request);
             }
             // else onCompletion will handle it.

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/CpuMetricSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/CpuMetricSet.java
@@ -3,7 +3,6 @@ package com.codahale.metrics.jvm;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricSet;
-import org.springframework.stereotype.Component;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
@@ -13,11 +12,10 @@ import java.util.Map;
 /**
  * A block-level metric set including CPU metrics.
  */
-@Component
 public class CpuMetricSet implements MetricSet {
 
     public Map<String, Metric> getMetrics() {
-        final Map<String, Metric> metrics = new HashMap<>();
+        final Map<String, Metric> metrics = new HashMap<String, Metric>();
         final OperatingSystemMXBean mxBean = ManagementFactory.getOperatingSystemMXBean();
 
         metrics.put("numCores", new Gauge<Integer>(){

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/CpuMetricSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/CpuMetricSet.java
@@ -1,0 +1,37 @@
+package com.codahale.metrics.jvm;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import org.springframework.stereotype.Component;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A block-level metric set including CPU metrics.
+ */
+@Component
+public class CpuMetricSet implements MetricSet {
+
+    public Map<String, Metric> getMetrics() {
+        final Map<String, Metric> metrics = new HashMap<>();
+        final OperatingSystemMXBean mxBean = ManagementFactory.getOperatingSystemMXBean();
+
+        metrics.put("numCores", new Gauge<Integer>(){
+            public Integer getValue() {
+                return mxBean.getAvailableProcessors();
+            }
+        });
+        metrics.put("loadAverage", new Gauge<Double>(){
+            public Double getValue() {
+                return mxBean.getSystemLoadAverage();
+            }
+        });
+
+        return metrics;
+    }
+
+}

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/RuntimeMetricSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/RuntimeMetricSet.java
@@ -3,7 +3,6 @@ package com.codahale.metrics.jvm;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricSet;
-import org.springframework.stereotype.Component;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
@@ -13,11 +12,10 @@ import java.util.Map;
 /**
  * A block-level metric set including runtime metrics.
  */
-@Component
 public class RuntimeMetricSet implements MetricSet {
 
     public Map<String, Metric> getMetrics() {
-        final Map<String, Metric> metrics = new HashMap<>();
+        final Map<String, Metric> metrics = new HashMap<String, Metric>();
         final RuntimeMXBean mxBean = ManagementFactory.getRuntimeMXBean();
 
         metrics.put("startTime", new Gauge<Long>(){

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/RuntimeMetricSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/RuntimeMetricSet.java
@@ -1,0 +1,37 @@
+package com.codahale.metrics.jvm;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import org.springframework.stereotype.Component;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A block-level metric set including runtime metrics.
+ */
+@Component
+public class RuntimeMetricSet implements MetricSet {
+
+    public Map<String, Metric> getMetrics() {
+        final Map<String, Metric> metrics = new HashMap<>();
+        final RuntimeMXBean mxBean = ManagementFactory.getRuntimeMXBean();
+
+        metrics.put("startTime", new Gauge<Long>(){
+            public Long getValue() {
+                return mxBean.getStartTime();
+            }
+        });
+        metrics.put("upTime", new Gauge<Long>(){
+            public Long getValue() {
+                return mxBean.getUptime();
+            }
+        });
+
+        return metrics;
+    }
+
+}

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/StandardSystemMetricSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/StandardSystemMetricSet.java
@@ -1,0 +1,34 @@
+package com.codahale.metrics.jvm;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.MetricSet;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Memory Usage, GC, Threads, Files, CPU, Runtime metric sets.
+ *
+ * User: wendel.schultz
+ * Date: 6/11/14
+ */
+public class StandardSystemMetricSet  implements MetricSet {
+
+    @Override
+    public Map<String, Metric> getMetrics() {
+        final Map<String, Metric> metrics = new HashMap<String, Metric>();
+        metrics.put("MemoryUsage", new MemoryUsageGaugeSet());
+        metrics.put("GC", new GarbageCollectorMetricSet());
+        metrics.put("Threads", new ThreadStatesGaugeSet());
+        metrics.put("Files.usedToOpenRatio", new FileDescriptorRatioGauge());
+        metrics.put("CPU", new CpuMetricSet());
+        metrics.put("Runtime", new RuntimeMetricSet());
+
+        return metrics;
+    }
+
+    public static void standardRegistration(MetricRegistry registry){
+        registry.register("JVM", new StandardSystemMetricSet());
+    }
+}

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ThreadStatesGaugeSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ThreadStatesGaugeSet.java
@@ -75,7 +75,7 @@ public class ThreadStatesGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("deadlockCount", new Gauge<Integer>() {
+        gauges.put("deadlocked.count", new Gauge<Integer>() {
             @Override
             public Integer getValue() {
                 return deadlockDetector.getDeadlockedThreads().size();

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ThreadStatesGaugeSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ThreadStatesGaugeSet.java
@@ -75,6 +75,13 @@ public class ThreadStatesGaugeSet implements MetricSet {
             }
         });
 
+        gauges.put("deadlockCount", new Gauge<Integer>() {
+            @Override
+            public Integer getValue() {
+                return deadlockDetector.getDeadlockedThreads().size();
+            }
+        });
+
         return Collections.unmodifiableMap(gauges);
     }
 

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadStatesGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadStatesGaugeSetTest.java
@@ -62,7 +62,8 @@ public class ThreadStatesGaugeSetTest {
                               "blocked.count",
                               "waiting.count",
                               "daemon.count",
-                              "runnable.count");
+                              "runnable.count",
+                              "deadlocked.count");
     }
 
     @Test
@@ -83,6 +84,9 @@ public class ThreadStatesGaugeSetTest {
                 .isEqualTo(1);
 
         assertThat(((Gauge) gauges.getMetrics().get("terminated.count")).getValue())
+                .isEqualTo(1);
+
+        assertThat(((Gauge) gauges.getMetrics().get("deadlocked.count")).getValue())
                 .isEqualTo(1);
     }
 

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-SNAPSHOT</version>
+        <version>3.1.0-FORKED-1</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-2</version>
+        <version>3.1.0-FORKED-3</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-5</version>
+        <version>3.1.0-FORKED-6</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-7</version>
+        <version>3.1.0-FORKED-8</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-4</version>
+        <version>3.1.0-FORKED-5</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-6</version>
+        <version>3.1.0-FORKED-7</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-3</version>
+        <version>3.1.0-FORKED-4</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-1</version>
+        <version>3.1.0-FORKED-2</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10</version>
+        <version>3.1.0-FORKED-11</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-8</version>
+        <version>3.1.0-FORKED-9</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-10-SNAPSHOT</version>
+        <version>3.1.0-FORKED-10</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-12</version>
+        <version>3.1.0-FORKED-14</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-9</version>
+        <version>3.1.0-FORKED-10-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.codahale.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.0-FORKED-11</version>
+        <version>3.1.0-FORKED-12</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-FORKED-4</version>
+    <version>3.1.0-FORKED-5</version>
     <packaging>pom</packaging>
     <name>Metrics Parent</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <artifactId>metrics-parent</artifactId>
     <version>3.1.0-FORKED-10</version>
     <packaging>pom</packaging>
-    <name>Metrics Parent</name>
+    <name>Yammer Metrics Fork</name>
     <description>
         The Metrics library.
     </description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-FORKED-10-SNAPSHOT</version>
+    <version>3.1.0-FORKED-10</version>
     <packaging>pom</packaging>
     <name>Metrics Parent</name>
     <description>
@@ -69,7 +69,7 @@
         <connection>scm:git:ssh://github.com/infusionsoft/yammer-metrics.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/infusionsoft/yammer-metrics.git</developerConnection>
         <url>https://github.com/infusionsoft/yammer-metrics.git</url>
-        <tag>HEAD</tag>
+        <tag>v3.1.0-FORKED-10</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-FORKED-12</version>
+    <version>3.1.0-FORKED-14</version>
     <packaging>pom</packaging>
     <name>Yammer Metrics Fork</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-FORKED-1</version>
+    <version>3.1.0-FORKED-2</version>
     <packaging>pom</packaging>
     <name>Metrics Parent</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-FORKED-9</version>
+    <version>3.1.0-FORKED-10-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Metrics Parent</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-FORKED-10</version>
+    <version>3.1.0-FORKED-11-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Metrics Parent</name>
     <description>
@@ -69,7 +69,7 @@
         <connection>scm:git:ssh://github.com/infusionsoft/yammer-metrics.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/infusionsoft/yammer-metrics.git</developerConnection>
         <url>https://github.com/infusionsoft/yammer-metrics.git</url>
-        <tag>v3.1.0-FORKED-10</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-FORKED-10</version>
+    <version>3.1.0-FORKED-11</version>
     <packaging>pom</packaging>
     <name>Yammer Metrics Fork</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-FORKED-8</version>
+    <version>3.1.0-FORKED-9</version>
     <packaging>pom</packaging>
     <name>Metrics Parent</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-FORKED-3</version>
+    <version>3.1.0-FORKED-4</version>
     <packaging>pom</packaging>
     <name>Metrics Parent</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-FORKED-7</version>
+    <version>3.1.0-FORKED-8</version>
     <packaging>pom</packaging>
     <name>Metrics Parent</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-FORKED-6</version>
+    <version>3.1.0-FORKED-7</version>
     <packaging>pom</packaging>
     <name>Metrics Parent</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-FORKED-5</version>
+    <version>3.1.0-FORKED-6</version>
     <packaging>pom</packaging>
     <name>Metrics Parent</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0-FORKED-1</version>
     <packaging>pom</packaging>
     <name>Metrics Parent</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:git://github.com/codahale/metrics.git</connection>
-        <developerConnection>scm:git:git@github.com:codahale/metrics.git</developerConnection>
-        <url>http://github.com/codahale/metrics/</url>
+        <connection>scm:git:ssh://github.com/infusionsoft/yammer-metrics.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/infusionsoft/yammer-metrics.git</developerConnection>
+        <url>https://github.com/infusionsoft/yammer-metrics.git</url>
         <tag>HEAD</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-FORKED-2</version>
+    <version>3.1.0-FORKED-3</version>
     <packaging>pom</packaging>
     <name>Metrics Parent</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-FORKED-11-SNAPSHOT</version>
+    <version>3.1.0-FORKED-10</version>
     <packaging>pom</packaging>
     <name>Metrics Parent</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,9 @@
         <jackson.version>2.2.2</jackson.version>
         <jetty8.version>8.1.11.v20130520</jetty8.version>
         <jetty9.version>9.0.4.v20130625</jetty9.version>
+
+        <repository.url>https://scm.infusiontest.com/nexus/content/repositories/thirdparty</repository.url>
+
     </properties>
 
     <developers>
@@ -75,15 +78,10 @@
     </issueManagement>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Nexus Release Repository</name>
-            <url>http://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>builds</id>
+            <name>Infusionsoft Third-party Build Repository</name>
+            <url>${repository.url}</url>
         </repository>
     </distributionManagement>
 
@@ -274,4 +272,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.codahale.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.0-FORKED-11</version>
+    <version>3.1.0-FORKED-12</version>
     <packaging>pom</packaging>
     <name>Yammer Metrics Fork</name>
     <description>


### PR DESCRIPTION
...er synchronizes over the output stream to ensure thread-safe appending.

My use case includes many client tenants in each JVM, and there are a few per-client metrics we'd like to expose, but don't want to modify the metric annotations currently in place.  This allows the MetricRegistry to prepend a metric prefix for metrics in play.

remove() may be suspicious.  I guess it depends on what you think of the feature itself as to what "correct" looks like.