### PR TITLE
Documentation update for registring context listeners in servlets packag...

### DIFF
--- a/docs/source/manual/servlets.rst
+++ b/docs/source/manual/servlets.rst
@@ -71,11 +71,11 @@ AdminServlet
 You will need to add your ``MetricRegistry`` and ``HealthCheckRegistry`` instances to the servlet
 context as attributes named ``com.codahale.metrics.servlets.MetricsServlet.registry`` and
 ``com.codahale.metrics.servlets.HealthCheckServlet.registry``, respectively. You can do this using
-the Servlet API by extending ``AdminServletContextListener``:
+the Servlet API by extending ``MetricsServlet.ContextListener`` for MetricRegistry:
 
 .. code-block:: java
 
-    public class MyAdminServletContextListener extends AdminServletContextListener {
+    public class MyMetricsServletServletContextListener extends MetricsServlet.ContextListener {
         public static final MetricRegistry METRIC_REGISTRY = new MetricRegistry();
         public static final HealthCheckRegistry HEALTH_CHECK_REGISTRY = new HealthCheckRegistry();
 
@@ -89,3 +89,58 @@ the Servlet API by extending ``AdminServletContextListener``:
             return HEALTH_CHECK_REGISTRY;
         }
     }
+
+And by extending ``HealthCheckServlet.ContextListener`` for HealthCheckRegistry:
+
+.. code-block:: java
+
+    public class MyHealthCheckServletContextListener extends HealthCheckServlet.ContextListener {
+
+        public static final HealthCheckRegistry HEALTH_CHECK_REGISTRY = new HealthCheckRegistry();
+
+        @Override
+        protected HealthCheckRegistry getHealthCheckRegistry() {
+            return HEALTH_CHECK_REGISTRY;
+        }
+    }
+
+Then you will need to register servlet context listeners either in you ``web.xml`` or annotating the class with ``@WebListener`` if you are in servlet 3.0 environment. In ``web.xml``:
+
+.. code-block:: xml
+
+	<listener>
+		<listener-class>com.example.MyMetricsServletServletContextListener</listener-class>
+	</listener>
+
+You will also need to register ``AdminServlet`` in your ``web.xml``:
+
+.. code-block:: xml
+
+ 	<servlet>
+		<servlet-name>CodahaleMetrics</servlet-name>
+		<servlet-class>com.codahale.metrics.servlets.AdminServlet</servlet-class>
+		<init-param>
+			<param-name>metrics-uri</param-name>
+			<param-value>/metrics</param-value>
+		</init-param>
+		<init-param>
+			<param-name>ping-uri</param-name>
+			<param-value>/ping</param-value>
+		</init-param>
+		<init-param>
+			<param-name>healthcheck-uri</param-name>
+			<param-value>/health</param-value>
+		</init-param>
+		<init-param>
+			<param-name>threads-uri</param-name>
+			<param-value>/threads</param-value>
+		</init-param>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>CodahaleMetrics</servlet-name>
+		<url-pattern>/codahale/metrics/*</url-pattern>
+	</servlet-mapping>
+
+Then you can access the servlet by accessing ``http://localhost:8080/YOUAPPNAME/codahale/metrics/``
+
+


### PR DESCRIPTION
I have updated the documentation so that the deprecated method in 3.0.1 AdminServletContextListener is not referenced.
Also extended some explanation on how to register listeners and servlets in web.xml.
Feel free to change or correct whatever you might consider.
Regards
