### PR TITLE
SlidingWindowReservoir - ArrayOutOfBoundsException thrown if # of Reservoir examples exceeds Integer max value.

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/SlidingWindowReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SlidingWindowReservoir.java
@@ -8,7 +8,6 @@ import static java.lang.Math.min;
  */
 public class SlidingWindowReservoir implements Reservoir {
     private final long[] measurements;
-    private boolean fullWindow;
     private long count;
 
     /**
@@ -23,20 +22,12 @@ public class SlidingWindowReservoir implements Reservoir {
 
     @Override
     public synchronized int size() {
-    	if(fullWindow){
-    		return measurements.length;
-    	}else{
-    		return (int) min(count, measurements.length);
-    	}
+        return (int) min(count, measurements.length);
     }
 
     @Override
     public synchronized void update(long value) {
-        measurements[(int) count++] = value;
-    	if(count >= measurements.length){
-    		count = 0;
-    		fullWindow = true;
-    	}
+        measurements[(int) (count++ % measurements.length)] = value;
     }
 
     @Override


### PR DESCRIPTION
Running a Histogram backed by a SlidingWindowReservoir, if I let the server process run long enough, the Histogram eventually fails with the following:

java.lang.ArrayIndexOutOfBoundsException: -3647
at com.codahale.metrics.SlidingWindowReservoir.update(SlidingWindowReservoir.java:30) ~[metrics-core-3.0.1.jar:3.0.1]
at com.codahale.metrics.Histogram.update(Histogram.java:39) ~[metrics-core-3.0.1.jar:3.0.1]
at com.codahale.metrics.Histogram.update(Histogram.java:29) ~[metrics-core-3.0.1.jar:3.0.1]

This appears related to converting the count being kept within the Reservoir object to an Integer prior to the modulo operation to identify the measurement to update/replace.
