### PR TITLE
Use getClass() in place of AbstractInstrumentedFilter.class

### DIFF
--- a/metrics-servlet/src/main/java/com/codahale/metrics/servlet/AbstractInstrumentedFilter.java
+++ b/metrics-servlet/src/main/java/com/codahale/metrics/servlet/AbstractInstrumentedFilter.java
@@ -52,18 +52,19 @@ public abstract class AbstractInstrumentedFilter implements Filter {
     @Override
     public void init(FilterConfig filterConfig) throws ServletException {
         final MetricRegistry metricsRegistry = getMetricsFactory(filterConfig);
+        final Class<?> identifyingClass = getClass();
 
         this.metersByStatusCode = new ConcurrentHashMap<Integer, Meter>(meterNamesByStatusCode
                 .size());
         for (Entry<Integer, String> entry : meterNamesByStatusCode.entrySet()) {
             metersByStatusCode.put(entry.getKey(),
-                    metricsRegistry.meter(name(AbstractInstrumentedFilter.class, entry.getValue())));
+                    metricsRegistry.meter(name(identifyingClass, entry.getValue())));
         }
-        this.otherMeter = metricsRegistry.meter(name(AbstractInstrumentedFilter.class,
+        this.otherMeter = metricsRegistry.meter(name(identifyingClass,
                                                      otherMetricName));
-        this.activeRequests = metricsRegistry.counter(name(AbstractInstrumentedFilter.class,
+        this.activeRequests = metricsRegistry.counter(name(identifyingClass,
                                                            "activeRequests"));
-        this.requestTimer = metricsRegistry.timer(name(AbstractInstrumentedFilter.class,
+        this.requestTimer = metricsRegistry.timer(name(identifyingClass,
                                                        "requests"));
 
     }


### PR DESCRIPTION
AbstractInstrumentedFilter's init() method currently names itself using a direct reference to `AbstractInstrumentedFilter.class`, thereby ignoring any potential name-change from subclassing it.

This PR changes init() to use getClass() instead, which will produce the child class's FQDN when naming the timers and meters. This allows using different subclasses to prevent those metrics from all using the exact same name.
