### PR TITLE
HealthCheckServlet should not return 500 error code

### DIFF
--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
@@ -89,14 +89,7 @@ public class HealthCheckServlet extends HttpServlet {
         resp.setHeader("Cache-Control", "must-revalidate,no-cache,no-store");
         if (results.isEmpty()) {
             resp.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
-        } else {
-            if (isAllHealthy(results)) {
-                resp.setStatus(HttpServletResponse.SC_OK);
-            } else {
-                resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            }
         }
-
         final OutputStream output = resp.getOutputStream();
         try {
             getWriter(req).writeValue(output, results);

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
@@ -74,7 +74,7 @@ public class HealthCheckServletTest extends AbstractServletTest {
     }
 
     @Test
-    public void returnsA500IfAnyHealthChecksAreUnhealthy() throws Exception {
+    public void returnsA200IfAnyHealthChecksAreUnhealthy() throws Exception {
         registry.register("fun", new HealthCheck() {
             @Override
             protected Result check() throws Exception {
@@ -92,7 +92,7 @@ public class HealthCheckServletTest extends AbstractServletTest {
         processRequest();
 
         assertThat(response.getStatus())
-                .isEqualTo(500);
+                .isEqualTo(200);
         assertThat(response.getContent())
                 .isEqualTo("{\"fun\":{\"healthy\":true,\"message\":\"whee\"},\"notFun\":{\"healthy\":false,\"message\":\"whee\"}}");
         assertThat(response.get(HttpHeader.CONTENT_TYPE))


### PR DESCRIPTION
The HealthCheckServlet returns an HTTP 500 error code if any healthcheck is invalid, in the "doGet" method.

This is not a correct behavior, from the HttpServletResponse docs:

"Status code (500) indicating an error inside the HTTP server which prevented it from fulfilling the request."

If a healthcheck goes wrong, there isn't a problem inside the HTTP server, in fact the HealthCheckServlet correctly handled the request:
- The return code should be 200 (HTTP OK)
- This will make it possible to use correclty the HealthCheckServlet with some JS libraries like AngularJS (for AngularJS, if you have a 500 code, everything is wrong -> in my case only one of 3 healthchecks is wrong)
