### PR TITLE
Update docs to prevent null pointer exception when instrumenting log4j

### DIFF
--- a/docs/source/manual/log4j.rst
+++ b/docs/source/manual/log4j.rst
@@ -10,5 +10,6 @@ which records the rate of logged events by their logging level.
 You can add it to the root logger programmatically:
 
 .. code-block:: java
-
-    LogManager.getRootLogger().addAppender(new InstrumentedAppender(registry));
+    InstrumentedAppender appender = new InstrumentedAppender(registry);
+    appender.activateOptions();
+    LogManager.getRootLogger().addAppender(appender);


### PR DESCRIPTION
Ran into null pointer exceptions using v3.0.1 when using slf4j 1.6.4 and log4j 1.2.16 due to activateOptions not having been called, causing counters to be instantiated, before attempting to log things.

```
java.lang.ExceptionInInitializerError: null
    at com.codahale.metrics.log4j.InstrumentedAppender.append(InstrumentedAppender.java:61)
    at org.apache.log4j.AppenderSkeleton.doAppend(AppenderSkeleton.java:251)
    at org.apache.log4j.helpers.AppenderAttachableImpl.appendLoopOnAppenders(AppenderAttachableImpl.java:66)
    at org.apache.log4j.Category.callAppenders(Category.java:206)
    at org.apache.log4j.Category.forcedLog(Category.java:391)
    at org.apache.log4j.Category.log(Category.java:856)
    at org.slf4j.impl.Log4jLoggerAdapter.info(Log4jLoggerAdapter.java:305)
```

Failing example:

``` fail.java
        LogManager.getRootLogger().addAppender(new InstrumentedAppender(registry));
        LoggerFactory.getLogger(Metrics.class).info("Test");
```

Passing example:

``` pass.java
        InstrumentedAppender appender = new InstrumentedAppender(registry);
        appender.activateOptions();
        LogManager.getRootLogger().addAppender(appender);
        LoggerFactory.getLogger(Metrics.class).info("Test");
```
