### PR TITLE
Added support for passing an external ScheduledExecutorService

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -67,9 +67,8 @@ public abstract class ScheduledReporter implements Closeable {
                                 MetricFilter filter,
                                 TimeUnit rateUnit,
                                 TimeUnit durationUnit) {
-        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory(name + '-'
-                + FACTORY_ID.incrementAndGet()));
-		this(registry, name, filter, rateUnit, durationUnit, executor);
+		this(registry, name, filter, rateUnit, durationUnit,
+                Executors.newSingleThreadScheduledExecutor(new NamedThreadFactory(name + '-' + FACTORY_ID.incrementAndGet())));
     }
 	
     /**


### PR DESCRIPTION
This allows for reusing threads amongst reporters. Because there could
be potentially multiple threads in the ScheduledExecutorService, the
report() method needs to be synchronized so that we do not initiate
multiple report tasks at the same time.
