### PR TITLE
Replace Jetty-specific Request with HttpServlet{Request,Response} in InstrumentedHandler

### DIFF
--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -133,6 +133,8 @@ public class InstrumentedHandler extends HandlerWrapper {
         this.otherRequests = metricRegistry.timer(name(prefix, "other-requests"));
 
         this.listener = new AsyncListener() {
+            private long startTime;
+
             @Override
             public void onTimeout(AsyncEvent event) throws IOException {
                 asyncTimeouts.mark();
@@ -140,6 +142,7 @@ public class InstrumentedHandler extends HandlerWrapper {
 
             @Override
             public void onStartAsync(AsyncEvent event) throws IOException {
+                startTime = System.currentTimeMillis();
                 event.getAsyncContext().addListener(this);
             }
 
@@ -150,8 +153,9 @@ public class InstrumentedHandler extends HandlerWrapper {
             @Override
             public void onComplete(AsyncEvent event) throws IOException {
                 final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
-                final Request request = (Request) state.getRequest();
-                updateResponses(request);
+                final HttpServletRequest request = (HttpServletRequest) state.getRequest();
+                final HttpServletResponse response = (HttpServletResponse) state.getResponse();
+                updateResponses(request, response, startTime);
                 if (state.getHttpChannelState().getState() != HttpChannelState.State.DISPATCHED) {
                     activeSuspended.dec();
                 }
@@ -197,7 +201,7 @@ public class InstrumentedHandler extends HandlerWrapper {
                 }
                 activeSuspended.inc();
             } else if (state.isInitial()) {
-                updateResponses(request);
+                updateResponses(httpRequest, httpResponse, start);
             }
             // else onCompletion will handle it.
         }
@@ -233,13 +237,13 @@ public class InstrumentedHandler extends HandlerWrapper {
         }
     }
 
-    private void updateResponses(Request request) {
-        final int response = request.getResponse().getStatus() / 100;
-        if (response >= 1 && response <= 5) {
-            responses[response - 1].mark();
+    private void updateResponses(HttpServletRequest request, HttpServletResponse response, long start) {
+        final int responseStatus = response.getStatus() / 100;
+        if (responseStatus >= 1 && responseStatus <= 5) {
+            responses[responseStatus - 1].mark();
         }
         activeRequests.dec();
-        final long elapsedTime = System.currentTimeMillis() - request.getTimeStamp();
+        final long elapsedTime = System.currentTimeMillis() - start;
         requests.update(elapsedTime, TimeUnit.MILLISECONDS);
         requestTimer(request.getMethod()).update(elapsedTime, TimeUnit.MILLISECONDS);
     }


### PR DESCRIPTION
Some frameworks like [Atmosphere](http://async-io.org/) bring their own `ServletRequest` and `ServletResponse` implementations which clash with Jetty's `Request` class.

This PR replaces the Jetty specific `Request` class with the standard `HttpServletRequest` and `HttpServletResponse` interfaces. This should fix #444 and similar bugs.
