### PR TITLE
In metrics-jetty8 InstrumentedHandler call updateResponses onComplete of...

### DIFF
--- a/metrics-jetty8/src/main/java/com/codahale/metrics/jetty8/InstrumentedHandler.java
+++ b/metrics-jetty8/src/main/java/com/codahale/metrics/jetty8/InstrumentedHandler.java
@@ -132,6 +132,11 @@ public class InstrumentedHandler extends HandlerWrapper {
         this.listener = new ContinuationListener() {
             @Override
             public void onComplete(Continuation continuation) {
+                final Request request = ((AsyncContinuation) continuation).getBaseRequest();
+                updateResponses(request);
+                if (!continuation.isResumed()) {
+                    activeSuspendedRequests.dec();
+                }
                 expires.mark();
             }
 


### PR DESCRIPTION
... the ContinuationListener

I noticed that activeRequests seems to grow unbounded when used with an asyc request. In the Jetty9 AsyncListener#onComplete updateResponses is being called - is there a reason this isn't already being called for jetty8?
