### PR TITLE
Report to N gmetric instances

### DIFF
--- a/metrics-ganglia/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java
+++ b/metrics-ganglia/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java
@@ -8,6 +8,8 @@ import info.ganglia.gmetric4j.gmetric.GangliaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
@@ -126,20 +128,20 @@ public class GangliaReporter extends ScheduledReporter {
          * @param ganglia the client to use for announcing metrics
          * @return a {@link GangliaReporter}
          */
-        public GangliaReporter build(GMetric ganglia) {
-            return new GangliaReporter(registry, ganglia, prefix, tMax, dMax, rateUnit, durationUnit, filter);
+        public GangliaReporter build(GMetric... gmetrics) {
+            return new GangliaReporter(registry, Arrays.asList(gmetrics), prefix, tMax, dMax, rateUnit, durationUnit, filter);
         }
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GangliaReporter.class);
 
-    private final GMetric ganglia;
+    private final List<GMetric> gmetrics;
     private final String prefix;
     private final int tMax;
     private final int dMax;
 
     private GangliaReporter(MetricRegistry registry,
-                            GMetric ganglia,
+                            List<GMetric> gmetrics,
                             String prefix,
                             int tMax,
                             int dMax,
@@ -147,7 +149,7 @@ public class GangliaReporter extends ScheduledReporter {
                             TimeUnit durationUnit,
                             MetricFilter filter) {
         super(registry, "ganglia-reporter", filter, rateUnit, durationUnit);
-        this.ganglia = ganglia;
+        this.gmetrics = gmetrics;
         this.prefix = prefix;
         this.tMax = tMax;
         this.dMax = dMax;
@@ -270,34 +272,28 @@ public class GangliaReporter extends ScheduledReporter {
         final String group = group(name);
         final Object obj = gauge.getValue();
         try {
-            ganglia.announce(name(prefix, name), String.valueOf(obj), detectType(obj), "",
-                             GMetricSlope.BOTH, tMax, dMax, group);
+            for(GMetric gmetric: gmetrics) {
+                gmetric.announce(name(prefix, name), String.valueOf(obj), detectType(obj), "",
+                    GMetricSlope.BOTH, tMax, dMax, group);
+            }
         } catch (GangliaException e) {
             LOGGER.warn("Unable to report gauge {}", name, e);
         }
     }
 
     private void announce(String name, String group, double value, String units) throws GangliaException {
-        ganglia.announce(name,
-                         Double.toString(value),
-                         GMetricType.DOUBLE,
-                         units,
-                         GMetricSlope.BOTH,
-                         tMax,
-                         dMax,
-                         group);
+        for (GMetric gmetric: gmetrics) {
+            gmetric.announce(name, Double.toString(value), GMetricType.DOUBLE, units, GMetricSlope.BOTH,
+                tMax, dMax, group);
+        }
     }
 
     private void announce(String name, String group, long value, String units) throws GangliaException {
         final String v = Long.toString(value);
-        ganglia.announce(name,
-                         v,
-                         GMetricType.DOUBLE,
-                         units,
-                         GMetricSlope.BOTH,
-                         tMax,
-                         dMax,
-                         group);
+        for(GMetric gmetric: gmetrics) {
+            gmetric.announce(name, v, GMetricType.DOUBLE, units, GMetricSlope.BOTH,
+                tMax, dMax, group);
+        }
     }
 
     private GMetricType detectType(Object o) {


### PR DESCRIPTION
In unicast configurations it's useful (in fact, desirable) to report to more than one gmond instance. This is the default behavior of the `gmetric` command line tool.

This patch allows the `GangliaReporter` to work with unicast architectures with more than one gmond collector.
