### PR TITLE
Docs histogram - lacking ending bracket

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -152,7 +152,7 @@ percentiles.
 
 .. code-block:: java
 
-    private final Histogram responseSizes = metrics.histogram(name(RequestHandler.class, "response-sizes");
+    private final Histogram responseSizes = metrics.histogram(name(RequestHandler.class, "response-sizes"));
 
     public void handleRequest(Request request, Response response) {
         // etc


### PR DESCRIPTION
Added ending bracket to histogram example code.
