### PR TITLE
Adding workaround for Google App Engine - where some JRE classes are blacklisted

### DIFF
--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/ThreadDumpServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/ThreadDumpServlet.java
@@ -11,10 +11,11 @@ import java.io.OutputStream;
 import java.lang.management.ManagementFactory;
 
 /**
-* An HTTP servlets which outputs a {@code text/plain} dump of all threads in the VM. Only responds
-* to {@code GET} requests.
-*/
+ * An HTTP servlets which outputs a {@code text/plain} dump of all threads in
+ * the VM. Only responds to {@code GET} requests.
+ */
 public class ThreadDumpServlet extends HttpServlet {
+
     private static final long serialVersionUID = -2690343532336103046L;
     private static final String CONTENT_TYPE = "text/plain";
 
@@ -22,15 +23,24 @@ public class ThreadDumpServlet extends HttpServlet {
 
     @Override
     public void init() throws ServletException {
-        this.threadDump = new ThreadDump(ManagementFactory.getThreadMXBean());
+        try {
+            // Some PaaS like Google App Engine blacklist java.lang.managament
+            this.threadDump = new ThreadDump(ManagementFactory.getThreadMXBean());
+        } catch (NoClassDefFoundError ncdfe) {
+            this.threadDump = null; // we won't be able to provide thread dump
+        }
     }
 
     @Override
     protected void doGet(HttpServletRequest req,
-                         HttpServletResponse resp) throws ServletException, IOException {
+            HttpServletResponse resp) throws ServletException, IOException {
         resp.setStatus(HttpServletResponse.SC_OK);
         resp.setContentType(CONTENT_TYPE);
         resp.setHeader("Cache-Control", "must-revalidate,no-cache,no-store");
+        if (threadDump == null) {
+            resp.getWriter().println("Sorry your runtime environment does not allow to dump threads.");
+            return;
+        }
         final OutputStream output = resp.getOutputStream();
         try {
             threadDump.dump(output);


### PR DESCRIPTION
Hello,

I've tried to use metrics-servlets in a PaaS environments, where java.lang.management classes a re blacklisted to secure the running environment. I could possibly map each servlet in web.xml, but I like more to have a single servlet definition to AdminServlet. Therefore I added try catch around java.lang.managament class usage so in environments that like Google App Engine restricts them, we see "Sorry thread dump is not supported" message.
