### PR TITLE
Add offset to Clock.UserTimeClock against overflow

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/Clock.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Clock.java
@@ -37,12 +37,17 @@ public abstract class Clock {
     }
 
     /**
-     * A clock implementation which returns the current time in epoch nanoseconds.
+     * A clock implementation which returns the elapsed time in nanoseconds.
      */
     public static class UserTimeClock extends Clock {
+        // System.nanoTime can be arbitrary, so offset from a starting point
+        // so the values are not very large (or negative.) All we want is
+        // elapsed time.
+        private static final long OFFSET = System.nanoTime();
+
         @Override
         public long getTick() {
-            return System.nanoTime();
+            return System.nanoTime() - OFFSET;
         }
     }
 

--- a/metrics-core/src/test/java/com/codahale/metrics/ClockTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ClockTest.java
@@ -29,9 +29,13 @@ public class ClockTest {
                 .isEqualTo(System.currentTimeMillis(),
                            offset(100.0));
 
-        assertThat((double) clock.getTick())
-                .isEqualTo(System.nanoTime(),
-                           offset(100000.0));
+        long na = System.nanoTime();
+        long ca = clock.getTick();
+        long nb = System.nanoTime();
+        long cb = clock.getTick();
+
+        assertThat((double) (cb-ca))
+                .isEqualTo(nb-na, offset(100000.0));
     }
 
     @Test


### PR DESCRIPTION
UserTimeClock returns elapsed time from an arbitrary starting time, not
epoch. This means value could be negative or arbitrarily large (not in
line with System.currentTimeMillis.) Other metrics classes, such as
SlidingTimeWindowReservoir multiply the Clock.getTicks with some value
to create a collision buffer. If nanoTime is large enough, this can
overflow and break the window.

To work around this, this commit modifies Clock.UserTimeClock to return
elapsed time since the UserTimeClock class was classloaded. It is still
elapsed time and increasing, but it will be a smaller value and therefore
less likely to overflow. Unless the JVM has a really long uptime. Hmm...