### PR TITLE
Add a threshold/minimum value to report before converting results to 0

### DIFF
--- a/metrics-ganglia/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java
+++ b/metrics-ganglia/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java
@@ -292,7 +292,9 @@ public class GangliaReporter extends ScheduledReporter {
         }
     }
 
+    private static final double MIN_VAL = 1E-300;
     private void announce(String name, String group, double value, String units) throws GangliaException {
+        if (value < MIN_VAL) value = 0.0;
         for (GMetric gmetric: gmetrics) {
             gmetric.announce(name, Double.toString(value), GMetricType.DOUBLE, units, GMetricSlope.BOTH,
                 tMax, dMax, group);


### PR DESCRIPTION
So I've been using the ganglia reporter to send a bunch of captured metrics.  However, I see a bunch of errors in my syslog on the gmetad server that is capturing /creating the RRDs for these metrics.  The errors look like this:
 RRD_update (/var/lib/ganglia/test/rrds/Cloud ETL/ignite-small34.ignite.net/packet.interaction.m15_rate.rrd): /var/lib/ganglia/test/rrds/Cloud ETL/ignite-small34.ignite.net/packet.interaction.m15_rate.rrd: converting '4.44659081257E-313' to float: Numerical result out of range

So in an effort to prevent downstream RRD underflow, I am proposing this small change to put a 'floor' on the smallest value that will be sent...converting smaller values to 0.0
