### PR TITLE
Escape slahes on ganglia metric names

### DIFF
--- a/metrics-ganglia/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java
+++ b/metrics-ganglia/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java
@@ -284,7 +284,7 @@ public class GangliaReporter extends ScheduledReporter {
         final Object obj = gauge.getValue();
         try {
             for(GMetric gmetric: gmetrics) {
-                gmetric.announce(name(prefix, name), String.valueOf(obj), detectType(obj), "",
+                gmetric.announce(name(prefix, escapeSlashes(name)), String.valueOf(obj), detectType(obj), "",
                     GMetricSlope.BOTH, tMax, dMax, group);
             }
         } catch (GangliaException e) {
@@ -333,6 +333,11 @@ public class GangliaReporter extends ScheduledReporter {
     }
 
     private String prefix(String name, String n) {
-        return name(prefix, name, n);
+        return name(prefix, escapeSlashes(name), n);
+    }
+
+    // ganglia metric names can't contain slashes.
+    private String escapeSlashes(String name) {
+        return name.replace("\\", "_");
     }
 }

--- a/metrics-ganglia/src/test/java/com/codahale/metrics/ganglia/GangliaReporterTest.java
+++ b/metrics-ganglia/src/test/java/com/codahale/metrics/ganglia/GangliaReporterTest.java
@@ -37,6 +37,18 @@ public class GangliaReporterTest {
     }
 
     @Test
+    public void escapeSlashesInMetricNames() throws Exception {
+        reporter.report(map("gauge_with\\slashes", gauge("value")),
+                        this.<Counter>map(),
+                        this.<Histogram>map(),
+                        this.<Meter>map(),
+                        this.<Timer>map());
+
+        verify(ganglia).announce("m.gauge_with_slashes", "value", GMetricType.STRING, "", GMetricSlope.BOTH, 60, 0, "");
+        verifyNoMoreInteractions(ganglia);
+    }
+
+    @Test
     public void reportsByteGaugeValues() throws Exception {
         reporter.report(map("gauge", gauge((byte) 1)),
                         this.<Counter>map(),


### PR DESCRIPTION
When gmetad sees a metric with a slash on it, it takes it as part of the rrd file directory and crashes because "no such file or directory". This also affects other metrics properly named that are retrieved with the 'slashy' one.
