### PR TITLE
Flush Graphite on close

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
@@ -74,7 +74,6 @@ public class Graphite implements Closeable {
             writer.write(' ');
             writer.write(Long.toString(timestamp));
             writer.write('\n');
-            writer.flush();
             this.failures = 0;
         } catch (IOException e) {
             failures++;
@@ -93,6 +92,9 @@ public class Graphite implements Closeable {
 
     @Override
     public void close() throws IOException {
+        if (writer != null) {
+            writer.flush();
+        }
         if (socket != null) {
             socket.close();
         }

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteTest.java
@@ -69,6 +69,7 @@ public class GraphiteTest {
     public void writesValuesToGraphite() throws Exception {
         graphite.connect();
         graphite.send("name", "value", 100);
+        graphite.close();
 
         assertThat(output.toString())
                 .isEqualTo("name value 100\n");
@@ -78,6 +79,7 @@ public class GraphiteTest {
     public void sanitizesNames() throws Exception {
         graphite.connect();
         graphite.send("name woo", "value", 100);
+        graphite.close();
 
         assertThat(output.toString())
                 .isEqualTo("name-woo value 100\n");
@@ -87,6 +89,7 @@ public class GraphiteTest {
     public void sanitizesValues() throws Exception {
         graphite.connect();
         graphite.send("name", "value woo", 100);
+        graphite.close();
 
         assertThat(output.toString())
                 .isEqualTo("name value-woo 100\n");


### PR DESCRIPTION
When a large number of metrics needs to be reported, flushing
Graphite.writer in each call to send() limits metric reporting throughput.

A non-rigorous benchmark shows a 2X improvement in throughput
when reporting metrics to graphite.
