### PR TITLE
metrics-jetty8: Avoid NPE if InstrumentedQueuedThreadPool gauges are read too early

### DIFF
--- a/metrics-jetty8/src/main/java/com/codahale/metrics/jetty8/InstrumentedQueuedThreadPool.java
+++ b/metrics-jetty8/src/main/java/com/codahale/metrics/jetty8/InstrumentedQueuedThreadPool.java
@@ -34,7 +34,7 @@ public class InstrumentedQueuedThreadPool extends QueuedThreadPool {
             public Integer getValue() {
                 // This assumes the QueuedThreadPool is using a BlockingArrayQueue or
                 // ArrayBlockingQueue for its queue, and is therefore a constant-time operation.
-                return getQueue().size();
+                return getQueue() != null ? getQueue().size() : 0;
             }
         });
         registry.register(name(QueuedThreadPool.class, "utilization-max"), new RatioGauge() {


### PR DESCRIPTION
It's possible to create a QueuedThreadPool instance with the _jobs variable being null. This fix avoids the NPE if the gauge is read before _jobs has been assigned.
