### PR TITLE
add an instrumented ScheduledExecutorService

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/InstrumentedScheduledExecutorService.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/InstrumentedScheduledExecutorService.java
@@ -1,0 +1,291 @@
+package com.codahale.metrics;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * An {@link ScheduledExecutorService} that monitors the number of tasks submitted, running,
+ * completed and also keeps a {@link Timer} for the task duration.
+ * <p/>
+ * It will register the metrics using the given (or auto-generated) name as classifier, e.g:
+ * "your-executor-service.submitted", "your-executor-service.running", etc.
+ */
+public class InstrumentedScheduledExecutorService implements ScheduledExecutorService {
+    private static final AtomicLong nameCounter = new AtomicLong();
+
+    private final ScheduledExecutorService delegate;
+
+    private final Meter submitted;
+    private final Counter running;
+    private final Meter completed;
+    private final Timer duration;
+
+    private final Meter scheduledOnce;
+    private final Meter scheduledRepetitively;
+    private final Counter scheduledOverrun;
+    private final Histogram percentOfPeriod;
+
+    /**
+     * Wraps an {@link ScheduledExecutorService} uses an auto-generated default name.
+     *
+     * @param delegate {@link ScheduledExecutorService} to wrap.
+     * @param registry {@link MetricRegistry} that will contain the metrics.
+     */
+    public InstrumentedScheduledExecutorService(ScheduledExecutorService delegate, MetricRegistry registry) {
+        this(delegate, registry, "instrumented-scheduled-executor-service-" + nameCounter.incrementAndGet());
+    }
+
+    /**
+     * Wraps an {@link ScheduledExecutorService} with an explicit name.
+     *
+     * @param delegate {@link ScheduledExecutorService} to wrap.
+     * @param registry {@link MetricRegistry} that will contain the metrics.
+     * @param name     name for this executor service.
+     */
+    public InstrumentedScheduledExecutorService(ScheduledExecutorService delegate, MetricRegistry registry, String name) {
+        this.delegate = delegate;
+
+        this.submitted = registry.meter(MetricRegistry.name(name, "submitted"));
+
+        this.running = registry.counter(MetricRegistry.name(name, "running"));
+        this.completed = registry.meter(MetricRegistry.name(name, "completed"));
+        this.duration = registry.timer(MetricRegistry.name(name, "duration"));
+
+        this.scheduledOnce = registry.meter(MetricRegistry.name(name, "scheduled.once"));
+        this.scheduledRepetitively = registry.meter(MetricRegistry.name(name, "scheduled.repetitively"));
+        this.scheduledOverrun = registry.counter(MetricRegistry.name(name, "scheduled.overrun"));
+        this.percentOfPeriod = registry.histogram(MetricRegistry.name(name, "scheduled.percent-of-period"));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        scheduledOnce.mark();
+        return delegate.schedule(new InstrumentedRunnable(command), delay, unit);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        scheduledOnce.mark();
+        return delegate.schedule(new InstrumentedCallable<V>(callable), delay, unit);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        scheduledRepetitively.mark();
+        return delegate.scheduleAtFixedRate(new InstrumentedPeriodicRunnable(command, period, unit), initialDelay, period, unit);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        scheduledRepetitively.mark();
+        return delegate.scheduleAtFixedRate(new InstrumentedRunnable(command), initialDelay, delay, unit);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        submitted.mark();
+        return delegate.submit(new InstrumentedCallable<T>(task));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        submitted.mark();
+        return delegate.submit(new InstrumentedRunnable(task), result);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Future<?> submit(Runnable task) {
+        submitted.mark();
+        return delegate.submit(new InstrumentedRunnable(task));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        submitted.mark(tasks.size());
+        Collection<? extends Callable<T>> instrumented = instrument(tasks);
+        return delegate.invokeAll(instrumented);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        submitted.mark(tasks.size());
+        Collection<? extends Callable<T>> instrumented = instrument(tasks);
+        return delegate.invokeAll(instrumented, timeout, unit);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        submitted.mark(tasks.size());
+        Collection<? extends Callable<T>> instrumented = instrument(tasks);
+        return delegate.invokeAny(instrumented);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        submitted.mark(tasks.size());
+        Collection<? extends Callable<T>> instrumented = instrument(tasks);
+        return delegate.invokeAny(instrumented, timeout, unit);
+    }
+
+    private <T> Collection<? extends Callable<T>> instrument(Collection<? extends Callable<T>> tasks) {
+        final List<InstrumentedCallable<T>> instrumented = new ArrayList<InstrumentedCallable<T>>(tasks.size());
+        for (Callable<T> task : tasks) {
+            instrumented.add(new InstrumentedCallable(task));
+        }
+        return instrumented;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void execute(Runnable command) {
+        submitted.mark();
+        delegate.execute(new InstrumentedRunnable(command));
+    }
+
+    private class InstrumentedRunnable implements Runnable {
+        private final Runnable command;
+
+        InstrumentedRunnable(Runnable command) {
+            this.command = command;
+        }
+
+        @Override
+        public void run() {
+            running.inc();
+            final Timer.Context context = duration.time();
+            try {
+                command.run();
+            } finally {
+                context.stop();
+                running.dec();
+                completed.mark();
+            }
+        }
+    }
+
+    private class InstrumentedPeriodicRunnable implements Runnable {
+        private final Runnable command;
+        private final long periodInNanos;
+
+        InstrumentedPeriodicRunnable(Runnable command, long period, TimeUnit unit) {
+            this.command = command;
+            this.periodInNanos = unit.toNanos(period);
+        }
+
+        @Override
+        public void run() {
+            running.inc();
+            final Timer.Context context = duration.time();
+            try {
+                command.run();
+            } finally {
+                final long elapsed = context.stop();
+                running.dec();
+                completed.mark();
+                if (elapsed > periodInNanos) {
+                    scheduledOverrun.inc();
+                }
+                percentOfPeriod.update((100L * elapsed) / periodInNanos);
+            }
+        }
+    }
+
+    private class InstrumentedCallable<T> implements Callable<T> {
+        private final Callable<T> task;
+
+        InstrumentedCallable(Callable<T> task) {
+            this.task = task;
+        }
+
+        @Override
+        public T call() throws Exception {
+            running.inc();
+            final Timer.Context context = duration.time();
+            try {
+                return task.call();
+            } finally {
+                context.stop();
+                running.dec();
+                completed.mark();
+            }
+        }
+    }
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/InstrumentedScheduledExecutorServiceTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/InstrumentedScheduledExecutorServiceTest.java
@@ -1,0 +1,263 @@
+package com.codahale.metrics;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.concurrent.*;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class InstrumentedScheduledExecutorServiceTest {
+    private final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
+    private final MetricRegistry registry = new MetricRegistry();
+    private final InstrumentedScheduledExecutorService instrumentedScheduledExecutor = new InstrumentedScheduledExecutorService(scheduledExecutor, registry, "xs");
+
+    final Meter submitted = registry.meter("xs.submitted");
+
+    final Counter running = registry.counter("xs.running");
+    final Meter completed = registry.meter("xs.completed");
+    final Timer duration = registry.timer("xs.duration");
+
+    final Meter scheduledOnce = registry.meter("xs.scheduled.once");
+    final Meter scheduledRepetitively = registry.meter("xs.scheduled.repetitively");
+    final Counter scheduledOverrun = registry.counter("xs.scheduled.overrun");
+    final Histogram percentOfPeriod = registry.histogram("xs.scheduled.percent-of-period");
+
+    @Test
+    public void testSubmitRunnable() throws Exception {
+        assertThat(submitted.getCount()).isZero();
+
+        assertThat(running.getCount()).isZero();
+        assertThat(completed.getCount()).isZero();
+        assertThat(duration.getCount()).isZero();
+
+        assertThat(scheduledOnce.getCount()).isZero();
+        assertThat(scheduledRepetitively.getCount()).isZero();
+        assertThat(scheduledOverrun.getCount()).isZero();
+        assertThat(percentOfPeriod.getCount()).isZero();
+
+        Future<?> theFuture = instrumentedScheduledExecutor.submit(new Runnable() {
+            public void run() {
+                assertThat(submitted.getCount()).isEqualTo(1);
+
+                assertThat(running.getCount()).isEqualTo(1);
+                assertThat(completed.getCount()).isZero();
+                assertThat(duration.getCount()).isZero();
+
+                assertThat(scheduledOnce.getCount()).isZero();
+                assertThat(scheduledRepetitively.getCount()).isZero();
+                assertThat(scheduledOverrun.getCount()).isZero();
+                assertThat(percentOfPeriod.getCount()).isZero();
+            }
+        });
+
+        theFuture.get();
+
+        assertThat(submitted.getCount()).isEqualTo(1);
+
+        assertThat(running.getCount()).isZero();
+        assertThat(completed.getCount()).isEqualTo(1);
+        assertThat(duration.getCount()).isEqualTo(1);
+        assertThat(duration.getSnapshot().size()).isEqualTo(1);
+
+        assertThat(scheduledOnce.getCount()).isZero();
+        assertThat(scheduledRepetitively.getCount()).isZero();
+        assertThat(scheduledOverrun.getCount()).isZero();
+        assertThat(percentOfPeriod.getCount()).isZero();
+    }
+
+    @Test
+    public void testScheduleRunnable() throws Exception {
+        assertThat(submitted.getCount()).isZero();
+
+        assertThat(running.getCount()).isZero();
+        assertThat(completed.getCount()).isZero();
+        assertThat(duration.getCount()).isZero();
+
+        assertThat(scheduledOnce.getCount()).isZero();
+        assertThat(scheduledRepetitively.getCount()).isZero();
+        assertThat(scheduledOverrun.getCount()).isZero();
+        assertThat(percentOfPeriod.getCount()).isZero();
+
+        ScheduledFuture<?> theFuture = instrumentedScheduledExecutor.schedule(new Runnable() {
+            public void run() {
+                assertThat(submitted.getCount()).isZero();
+
+                assertThat(running.getCount()).isEqualTo(1);
+                assertThat(completed.getCount()).isZero();
+                assertThat(duration.getCount()).isZero();
+
+                assertThat(scheduledOnce.getCount()).isEqualTo(1);
+                assertThat(scheduledRepetitively.getCount()).isZero();
+                assertThat(scheduledOverrun.getCount()).isZero();
+                assertThat(percentOfPeriod.getCount()).isZero();
+            }
+        }, 10L, TimeUnit.MILLISECONDS);
+
+        theFuture.get();
+
+        assertThat(submitted.getCount()).isZero();
+
+        assertThat(running.getCount()).isZero();
+        assertThat(completed.getCount()).isEqualTo(1);
+        assertThat(duration.getCount()).isEqualTo(1);
+        assertThat(duration.getSnapshot().size()).isEqualTo(1);
+
+        assertThat(scheduledOnce.getCount()).isEqualTo(1);
+        assertThat(scheduledRepetitively.getCount()).isZero();
+        assertThat(scheduledOverrun.getCount()).isZero();
+        assertThat(percentOfPeriod.getCount()).isZero();
+    }
+
+    @Test
+    public void testSubmitCallable() throws Exception {
+        assertThat(submitted.getCount()).isZero();
+
+        assertThat(running.getCount()).isZero();
+        assertThat(completed.getCount()).isZero();
+        assertThat(duration.getCount()).isZero();
+
+        assertThat(scheduledOnce.getCount()).isZero();
+        assertThat(scheduledRepetitively.getCount()).isZero();
+        assertThat(scheduledOverrun.getCount()).isZero();
+        assertThat(percentOfPeriod.getCount()).isZero();
+
+        final Object obj = new Object();
+
+        Future<Object> theFuture = instrumentedScheduledExecutor.submit(new Callable<Object>() {
+            public Object call() {
+                assertThat(submitted.getCount()).isEqualTo(1);
+
+                assertThat(running.getCount()).isEqualTo(1);
+                assertThat(completed.getCount()).isZero();
+                assertThat(duration.getCount()).isZero();
+
+                assertThat(scheduledOnce.getCount()).isZero();
+                assertThat(scheduledRepetitively.getCount()).isZero();
+                assertThat(scheduledOverrun.getCount()).isZero();
+                assertThat(percentOfPeriod.getCount()).isZero();
+
+                return obj;
+            }
+        });
+
+        assertThat(theFuture.get()).isEqualTo(obj);
+
+        assertThat(submitted.getCount()).isEqualTo(1);
+
+        assertThat(running.getCount()).isZero();
+        assertThat(completed.getCount()).isEqualTo(1);
+        assertThat(duration.getCount()).isEqualTo(1);
+        assertThat(duration.getSnapshot().size()).isEqualTo(1);
+
+        assertThat(scheduledOnce.getCount()).isZero();
+        assertThat(scheduledRepetitively.getCount()).isZero();
+        assertThat(scheduledOverrun.getCount()).isZero();
+        assertThat(percentOfPeriod.getCount()).isZero();
+    }
+
+    @Test
+    public void testScheduleCallable() throws Exception {
+        assertThat(submitted.getCount()).isZero();
+
+        assertThat(running.getCount()).isZero();
+        assertThat(completed.getCount()).isZero();
+        assertThat(duration.getCount()).isZero();
+
+        assertThat(scheduledOnce.getCount()).isZero();
+        assertThat(scheduledRepetitively.getCount()).isZero();
+        assertThat(scheduledOverrun.getCount()).isZero();
+        assertThat(percentOfPeriod.getCount()).isZero();
+
+        final Object obj = new Object();
+
+        ScheduledFuture<Object> theFuture = instrumentedScheduledExecutor.schedule(new Callable<Object>() {
+            public Object call() {
+                assertThat(submitted.getCount()).isZero();
+
+                assertThat(running.getCount()).isEqualTo(1);
+                assertThat(completed.getCount()).isZero();
+                assertThat(duration.getCount()).isZero();
+
+                assertThat(scheduledOnce.getCount()).isEqualTo(1);
+                assertThat(scheduledRepetitively.getCount()).isZero();
+                assertThat(scheduledOverrun.getCount()).isZero();
+                assertThat(percentOfPeriod.getCount()).isZero();
+
+                return obj;
+            }
+        }, 10L, TimeUnit.MILLISECONDS);
+
+        assertThat(theFuture.get()).isEqualTo(obj);
+
+        assertThat(submitted.getCount()).isZero();
+
+        assertThat(running.getCount()).isZero();
+        assertThat(completed.getCount()).isEqualTo(1);
+        assertThat(duration.getCount()).isEqualTo(1);
+        assertThat(duration.getSnapshot().size()).isEqualTo(1);
+
+        assertThat(scheduledOnce.getCount()).isEqualTo(1);
+        assertThat(scheduledRepetitively.getCount()).isZero();
+        assertThat(scheduledOverrun.getCount()).isZero();
+        assertThat(percentOfPeriod.getCount()).isZero();
+    }
+
+    @Test
+    public void testScheduleFixedRateCallable() throws Exception {
+        assertThat(submitted.getCount()).isZero();
+
+        assertThat(running.getCount()).isZero();
+        assertThat(completed.getCount()).isZero();
+        assertThat(duration.getCount()).isZero();
+
+        assertThat(scheduledOnce.getCount()).isZero();
+        assertThat(scheduledRepetitively.getCount()).isZero();
+        assertThat(scheduledOverrun.getCount()).isZero();
+        assertThat(percentOfPeriod.getCount()).isZero();
+
+        ScheduledFuture<?> theFuture = instrumentedScheduledExecutor.scheduleAtFixedRate(new Runnable() {
+            public void run() {
+                assertThat(submitted.getCount()).isZero();
+
+                assertThat(running.getCount()).isEqualTo(1);
+
+                assertThat(scheduledOnce.getCount()).isEqualTo(0);
+                assertThat(scheduledRepetitively.getCount()).isEqualTo(1);
+
+                try {
+                    TimeUnit.MILLISECONDS.sleep(50);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+
+                return;
+            }
+        }, 10L, 10L, TimeUnit.MILLISECONDS);
+
+        TimeUnit.MILLISECONDS.sleep(100);
+        theFuture.cancel(true);
+        TimeUnit.MILLISECONDS.sleep(100);
+
+        assertThat(submitted.getCount()).isZero();
+
+        assertThat(running.getCount()).isZero();
+        assertThat(completed.getCount()).isNotEqualTo(0);
+        assertThat(duration.getCount()).isNotEqualTo(0);
+        assertThat(duration.getSnapshot().size()).isNotEqualTo(0);
+
+        assertThat(scheduledOnce.getCount()).isZero();
+        assertThat(scheduledRepetitively.getCount()).isEqualTo(1);
+        assertThat(scheduledOverrun.getCount()).isNotEqualTo(0);
+        assertThat(percentOfPeriod.getCount()).isNotEqualTo(0);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        instrumentedScheduledExecutor.shutdown();
+        if (!instrumentedScheduledExecutor.awaitTermination(2, TimeUnit.SECONDS)) {
+            System.err.println("InstrumentedScheduledExecutorService did not terminate.");
+        }
+    }
+
+}


### PR DESCRIPTION
The instrumented decorator for ScheduledExecutorService follows the instrumented decorator for ExecutorService. It uses the same four metrics, as well as adding an additional four.

The original four:
- "submitted": is a meter only for invocations of `execute`, `submit`, `invokeAll`, and `invokeAny`.
- "running": is a counter for _all_ running tasks.
- "completed": is a meter for _all_ task completions.
- "duration": is a timer for the execution time of _all_ tasks.

The new four:
- "scheduled.once": is a meter only for invocations of `schedule`.
- "scheduled.repeatedly": is a meter only for invocations of `scheduleAtFixedRate` and `scheduleWithFixedDelay`.
- "scheduled.overrun": is a counter for tasks started by `scheduleAtFixedRate`. The counter is incremented whenever the execution time of a task is greater than the scheduled period (thus causing delayed execution of the next task).
- "percent-of-period": is a histogram for tasks started by `scheduleAtFixedRate` and records the execution time of a task as a percentage of the scheduled period.
