### PR TITLE
Specify the base name of the metrics as a filter init-param for the metrics captured in the AbstractInstrumentedFilter

### DIFF
--- a/docs/source/manual/servlet.rst
+++ b/docs/source/manual/servlet.rst
@@ -5,8 +5,9 @@ Instrumenting Web Applications
 ##############################
 
 The ``metrics-servlet`` module provides a Servlet filter which has meters for status codes, a
-counter for the number of active requests, and a timer for request duration. You can use it in your
-``web.xml`` like this:
+counter for the number of active requests, and a timer for request duration. By default the filter
+will use ``com.codahale.metrics.servlet.InstrumentedFilter`` as the base name of the metrics.
+You can use the filter in your ``web.xml`` like this:
 
 .. code-block:: xml
 
@@ -17,6 +18,26 @@ counter for the number of active requests, and a timer for request duration. You
     <filter-mapping>
         <filter-name>instrumentedFilter</filter-name>
         <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+
+An optional filter init-param ``name-prefix`` can be specified to override the base name
+of the metrics associated with the filter mapping. This can be helpful if you need to instrument
+multiple url patterns and give each a unique name.
+
+.. code-block:: xml
+
+    <filter>
+        <filter-name>instrumentedFilter</filter-name>
+        <filter-class>com.codahale.metrics.servlet.InstrumentedFilter</filter-class>
+        <init-param>
+            <param-name>name-prefix</param-name>
+            <param-value>authentication</param-value>
+        </init-param>
+    </filter>
+    <filter-mapping>
+        <filter-name>instrumentedFilter</filter-name>
+        <url-pattern>/auth/*</url-pattern>
     </filter-mapping>
 
 You will need to add your ``MetricRegistry`` to the servlet context as an attribute named


### PR DESCRIPTION
This PR adds the ability to specify the base name of the metrics collected by an instance of the AbstractInstrumentedFilter as a filter init-param, `prefix-name`. If no init-param is specified, it will fall back to the name of the filter class.

This is also handy in the case where multiple instances of the InstrumentedFilter need to be used to instrument different url-patterns. An example is seen below:

```
<filter>
        <filter-name>instrumentedFilter</filter-name>
        <filter-class>com.codahale.metrics.servlet.InstrumentedFilter</filter-class>
        <init-param>
            <param-name>name-prefix</param-name>
            <param-value>foo</param-value>
        </init-param>
    </filter>
    <filter-mapping>
        <filter-name>instrumentedFilter</filter-name>
        <url-pattern>/foo/*</url-pattern>
    </filter-mapping>
   <filter>
        <filter-name>instrumentedFilter2</filter-name>
        <filter-class>com.codahale.metrics.servlet.InstrumentedFilter</filter-class>
        <init-param>
            <param-name>name-prefix</param-name>
            <param-value>bar</param-value>
        </init-param>
    </filter>
    <filter-mapping>
        <filter-name>instrumentedFilter2</filter-name>
        <url-pattern>/bar/*</url-pattern>
    </filter-mapping>
```
