### PR TITLE
Replace Google Caliper with Oracle JMH

### DIFF
--- a/metrics-benchmarks/README.md
+++ b/metrics-benchmarks/README.md
@@ -1,0 +1,24 @@
+Benchmarks are based on [Oracle Java Microbenchmark Harness](http://openjdk.java.net/projects/code-tools/jmh/).
+
+### Results interpretation
+
+Please be cautious with conclusions based on microbenchmarking as there are plenty possible pitfalls for goals, test compositions, input data, an envionment and the analyze itself.
+
+### Command line launching
+
+Execute all benchmark methods with 4 worker threads:
+
+    mvn clean install
+    java -jar target/benchmarks.jar  ".*" -t 4
+
+or specify a filter for benchmark methods and the number of forks and warmup/measurements iterations, e.g.:
+
+    java -jar target/benchmarks.jar  -t 4  -f 3 -i 10 -wi 5  ".*CounterBenchmark.*"
+    java -jar target/benchmarks.jar  -t 4  -f 3 -i 10 -wi 5  ".*ReservoirBenchmark.*"
+    java -jar target/benchmarks.jar  -t 4  -f 3 -i 10 -wi 5  ".*MeterBenchmark.*"
+
+### Command line options
+
+The whole list of command line options is available by:
+
+    java -jar target/benchmarks.jar -h

--- a/metrics-benchmarks/findbugs-exclude.xml
+++ b/metrics-benchmarks/findbugs-exclude.xml
@@ -1,0 +1,5 @@
+<FindBugsFilter>
+    <Match>
+        <Package name="com.codahale.metrics.benchmarks.generated" />
+    </Match>
+</FindBugsFilter>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -21,20 +21,15 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>14.0.1</version>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>0.5.3</version>
         </dependency>
         <dependency>
-            <groupId>com.google.caliper</groupId>
-            <artifactId>caliper</artifactId>
-            <version>1.0-beta-1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>0.5.3</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 
@@ -47,6 +42,36 @@
                 <version>2.7</version>
                 <configuration>
                     <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <!-- generate an uber .jar for standalone benchmarking -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.2</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>benchmarks</finalName>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.openjdk.jmh.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!-- exclude jmh generated classes designed to trick jvm like "unused fields" padding -->
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+                <configuration>
+                    <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile> 
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Dear Coda,

There is a recent tool from Oracle JVM engineers [Oracle JMH](http://openjdk.java.net/projects/code-tools/jmh) , which is used for JDK benchmarking and verification. It has the advantage over Caliper by options for organizing multi-threaded benchmarking.

I've applied it on the current `update()` tests as [metrics-core-benchmarking](https://github.com/ceetav/metrics-core-benchmarking) with light syntax adaptation.  The sample benchmarking output is available [here](https://gist.github.com/ceetav/55de5d8e9f7cd785be2f) and it looks more informative especially for contention examination.

Do you think it make sense for the pull request?

Regards,
ceetav
