### PR TITLE
issue-542: support for mBean servers that rewrite the supplied ObjectName upon regi...

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
@@ -4,13 +4,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.management.*;
+
 import java.io.Closeable;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -476,23 +476,45 @@ public class JmxReporter implements Reporter, Closeable {
         private final MBeanServer mBeanServer;
         private final MetricFilter filter;
         private final MetricTimeUnits timeUnits;
-        private final Set<ObjectName> registered;
+        private final Map<ObjectName,ObjectName> registered;
 
         private JmxListener(MBeanServer mBeanServer, String name, MetricFilter filter, MetricTimeUnits timeUnits) {
             this.mBeanServer = mBeanServer;
             this.name = name;
             this.filter = filter;
             this.timeUnits = timeUnits;
-            this.registered = new CopyOnWriteArraySet<ObjectName>();
+            this.registered = new ConcurrentHashMap<ObjectName,ObjectName>();
         }
 
+        private void registerMBean(Object mBean, ObjectName objectName) throws InstanceAlreadyExistsException, JMException {
+			ObjectInstance objectInstance = mBeanServer.registerMBean(mBean, objectName);
+			if (objectInstance != null) {
+				// the websphere mbeanserver rewrites the objectname to include
+				// cell, node & server info
+				// make sure we capture the new objectName for unregistration
+				registered.put(objectName, objectInstance.getObjectName());
+			} else {
+				registered.put(objectName, objectName);
+			}
+
+		}
+
+		private void unregisterMBean(ObjectName originalObjectName) throws InstanceNotFoundException,
+				MBeanRegistrationException {
+			ObjectName storedObjectName = registered.remove(originalObjectName);
+			if (storedObjectName != null) {
+				mBeanServer.unregisterMBean(storedObjectName);
+			} else {
+				mBeanServer.unregisterMBean(originalObjectName);
+			}
+		}
+        
         @Override
         public void onGaugeAdded(String name, Gauge<?> gauge) {
             try {
                 if (filter.matches(name, gauge)) {
                     final ObjectName objectName = createName("gauges", name);
-                    mBeanServer.registerMBean(new JmxGauge(gauge, objectName), objectName);
-                    registered.add(objectName);
+                    registerMBean(new JmxGauge(gauge, objectName), objectName);
                 }
             } catch (InstanceAlreadyExistsException e) {
                 LOGGER.debug("Unable to register gauge", e);
@@ -505,8 +527,7 @@ public class JmxReporter implements Reporter, Closeable {
         public void onGaugeRemoved(String name) {
             try {
                 final ObjectName objectName = createName("gauges", name);
-                mBeanServer.unregisterMBean(objectName);
-                registered.remove(objectName);
+                unregisterMBean(objectName);
             } catch (InstanceNotFoundException e) {
                 LOGGER.debug("Unable to unregister gauge", e);
             } catch (MBeanRegistrationException e) {
@@ -519,8 +540,7 @@ public class JmxReporter implements Reporter, Closeable {
             try {
                 if (filter.matches(name, counter)) {
                     final ObjectName objectName = createName("counters", name);
-                    mBeanServer.registerMBean(new JmxCounter(counter, objectName), objectName);
-                    registered.add(objectName);
+                    registerMBean(new JmxCounter(counter, objectName), objectName);
                 }
             } catch (InstanceAlreadyExistsException e) {
                 LOGGER.debug("Unable to register counter", e);
@@ -533,8 +553,7 @@ public class JmxReporter implements Reporter, Closeable {
         public void onCounterRemoved(String name) {
             try {
                 final ObjectName objectName = createName("counters", name);
-                mBeanServer.unregisterMBean(objectName);
-                registered.remove(objectName);
+                unregisterMBean(objectName);                
             } catch (InstanceNotFoundException e) {
                 LOGGER.debug("Unable to unregister counter", e);
             } catch (MBeanRegistrationException e) {
@@ -547,8 +566,7 @@ public class JmxReporter implements Reporter, Closeable {
             try {
                 if (filter.matches(name, histogram)) {
                     final ObjectName objectName = createName("histograms", name);
-                    mBeanServer.registerMBean(new JmxHistogram(histogram, objectName), objectName);
-                    registered.add(objectName);
+                    registerMBean(new JmxHistogram(histogram, objectName), objectName);
                 }
             } catch (InstanceAlreadyExistsException e) {
                 LOGGER.debug("Unable to register histogram", e);
@@ -561,8 +579,7 @@ public class JmxReporter implements Reporter, Closeable {
         public void onHistogramRemoved(String name) {
             try {
                 final ObjectName objectName = createName("histograms", name);
-                mBeanServer.unregisterMBean(objectName);
-                registered.remove(objectName);
+                unregisterMBean(objectName);
             } catch (InstanceNotFoundException e) {
                 LOGGER.debug("Unable to unregister histogram", e);
             } catch (MBeanRegistrationException e) {
@@ -575,8 +592,7 @@ public class JmxReporter implements Reporter, Closeable {
             try {
                 if (filter.matches(name, meter)) {
                     final ObjectName objectName = createName("meters", name);
-                    mBeanServer.registerMBean(new JmxMeter(meter, objectName, timeUnits.rateFor(name)), objectName);
-                    registered.add(objectName);
+                    registerMBean(new JmxMeter(meter, objectName, timeUnits.rateFor(name)), objectName);
                 }
             } catch (InstanceAlreadyExistsException e) {
                 LOGGER.debug("Unable to register meter", e);
@@ -589,8 +605,7 @@ public class JmxReporter implements Reporter, Closeable {
         public void onMeterRemoved(String name) {
             try {
                 final ObjectName objectName = createName("meters", name);
-                mBeanServer.unregisterMBean(objectName);
-                registered.remove(objectName);
+                unregisterMBean(objectName);
             } catch (InstanceNotFoundException e) {
                 LOGGER.debug("Unable to unregister meter", e);
             } catch (MBeanRegistrationException e) {
@@ -603,8 +618,7 @@ public class JmxReporter implements Reporter, Closeable {
             try {
                 if (filter.matches(name, timer)) {
                     final ObjectName objectName = createName("timers", name);
-                    mBeanServer.registerMBean(new JmxTimer(timer, objectName, timeUnits.rateFor(name), timeUnits.durationFor(name)), objectName);
-                    registered.add(objectName);
+                    registerMBean(new JmxTimer(timer, objectName, timeUnits.rateFor(name), timeUnits.durationFor(name)), objectName);
                 }
             } catch (InstanceAlreadyExistsException e) {
                 LOGGER.debug("Unable to register timer", e);
@@ -617,8 +631,7 @@ public class JmxReporter implements Reporter, Closeable {
         public void onTimerRemoved(String name) {
             try {
                 final ObjectName objectName = createName("timers", name);
-                mBeanServer.unregisterMBean(objectName);
-                registered.remove(objectName);
+                unregisterMBean(objectName);
             } catch (InstanceNotFoundException e) {
                 LOGGER.debug("Unable to unregister timer", e);
             } catch (MBeanRegistrationException e) {
@@ -640,9 +653,9 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         void unregisterAll() {
-            for (ObjectName name : registered) {
+            for (ObjectName name : registered.keySet()) {
                 try {
-                    mBeanServer.unregisterMBean(name);
+                    unregisterMBean(name);
                 } catch (InstanceNotFoundException e) {
                     LOGGER.debug("Unable to unregister metric", e);
                 } catch (MBeanRegistrationException e) {


### PR DESCRIPTION
...stration

The JMXReporter doesn't pick up the ObjectName WebSphere is creating based upon the supplied ObjectName; hence the ObjectName used during unregistration is causing it to fail.

If you look at the jmx javadoc: http://docs.oracle.com/javase/7/docs/api/javax/management/MBeanServer.html#registerMBean(java.lang.Object,%20javax.management.ObjectName)
You can see that the registerMBean method returns an ObjectInstance, that will contain the correct ObjectName that should be used for the unregister.
