### PR TITLE
Add heroku support

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
@@ -24,7 +24,7 @@ public class Graphite implements Closeable {
     protected Writer writer;
     protected int failures;
 
-    protected String metricPrefix;
+    protected String prefix;
 
     /**
      * Creates a new client which connects to the given address using the default


### PR DESCRIPTION
Heroku's Graphite support requires the API key to be prefixed to the metric name.
This change allows for the easy support for this, as well as changing fields to protected so that the class can more easily be subclassed.
