### PR TITLE
Introduce MetricName type to encapsulate more information about metrics.

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
@@ -165,18 +165,18 @@ public class ConsoleReporter extends ScheduledReporter {
     }
 
     @Override
-    public void report(SortedMap<String, Gauge> gauges,
-                       SortedMap<String, Counter> counters,
-                       SortedMap<String, Histogram> histograms,
-                       SortedMap<String, Meter> meters,
-                       SortedMap<String, Timer> timers) {
+    public void report(SortedMap<MetricName, Gauge> gauges,
+                       SortedMap<MetricName, Counter> counters,
+                       SortedMap<MetricName, Histogram> histograms,
+                       SortedMap<MetricName, Meter> meters,
+                       SortedMap<MetricName, Timer> timers) {
         final String dateTime = dateFormat.format(new Date(clock.getTime()));
         printWithBanner(dateTime, '=');
         output.println();
 
         if (!gauges.isEmpty()) {
             printWithBanner("-- Gauges", '-');
-            for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+            for (Map.Entry<MetricName, Gauge> entry : gauges.entrySet()) {
                 output.println(entry.getKey());
                 printGauge(entry);
             }
@@ -185,7 +185,7 @@ public class ConsoleReporter extends ScheduledReporter {
 
         if (!counters.isEmpty()) {
             printWithBanner("-- Counters", '-');
-            for (Map.Entry<String, Counter> entry : counters.entrySet()) {
+            for (Map.Entry<MetricName, Counter> entry : counters.entrySet()) {
                 output.println(entry.getKey());
                 printCounter(entry);
             }
@@ -194,7 +194,7 @@ public class ConsoleReporter extends ScheduledReporter {
 
         if (!histograms.isEmpty()) {
             printWithBanner("-- Histograms", '-');
-            for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
+            for (Map.Entry<MetricName, Histogram> entry : histograms.entrySet()) {
                 output.println(entry.getKey());
                 printHistogram(entry.getValue());
             }
@@ -203,7 +203,7 @@ public class ConsoleReporter extends ScheduledReporter {
 
         if (!meters.isEmpty()) {
             printWithBanner("-- Meters", '-');
-            for (Map.Entry<String, Meter> entry : meters.entrySet()) {
+            for (Map.Entry<MetricName, Meter> entry : meters.entrySet()) {
                 output.println(entry.getKey());
                 printMeter(entry.getValue());
             }
@@ -212,7 +212,7 @@ public class ConsoleReporter extends ScheduledReporter {
 
         if (!timers.isEmpty()) {
             printWithBanner("-- Timers", '-');
-            for (Map.Entry<String, Timer> entry : timers.entrySet()) {
+            for (Map.Entry<MetricName, Timer> entry : timers.entrySet()) {
                 output.println(entry.getKey());
                 printTimer(entry.getValue());
             }
@@ -231,11 +231,11 @@ public class ConsoleReporter extends ScheduledReporter {
         output.printf(locale, "    15-minute rate = %2.2f events/%s%n", convertRate(meter.getFifteenMinuteRate()), getRateUnit());
     }
 
-    private void printCounter(Map.Entry<String, Counter> entry) {
+    private void printCounter(Map.Entry<MetricName, Counter> entry) {
         output.printf(locale, "             count = %d%n", entry.getValue().getCount());
     }
 
-    private void printGauge(Map.Entry<String, Gauge> entry) {
+    private void printGauge(Map.Entry<MetricName, Gauge> entry) {
         output.printf(locale, "             value = %s%n", entry.getValue().getValue());
     }
 

--- a/metrics-core/src/main/java/com/codahale/metrics/CsvReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/CsvReporter.java
@@ -139,35 +139,35 @@ public class CsvReporter extends ScheduledReporter {
     }
 
     @Override
-    public void report(SortedMap<String, Gauge> gauges,
-                       SortedMap<String, Counter> counters,
-                       SortedMap<String, Histogram> histograms,
-                       SortedMap<String, Meter> meters,
-                       SortedMap<String, Timer> timers) {
+    public void report(SortedMap<MetricName, Gauge> gauges,
+                       SortedMap<MetricName, Counter> counters,
+                       SortedMap<MetricName, Histogram> histograms,
+                       SortedMap<MetricName, Meter> meters,
+                       SortedMap<MetricName, Timer> timers) {
         final long timestamp = TimeUnit.MILLISECONDS.toSeconds(clock.getTime());
 
-        for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+        for (Map.Entry<MetricName, Gauge> entry : gauges.entrySet()) {
             reportGauge(timestamp, entry.getKey(), entry.getValue());
         }
 
-        for (Map.Entry<String, Counter> entry : counters.entrySet()) {
+        for (Map.Entry<MetricName, Counter> entry : counters.entrySet()) {
             reportCounter(timestamp, entry.getKey(), entry.getValue());
         }
 
-        for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
+        for (Map.Entry<MetricName, Histogram> entry : histograms.entrySet()) {
             reportHistogram(timestamp, entry.getKey(), entry.getValue());
         }
 
-        for (Map.Entry<String, Meter> entry : meters.entrySet()) {
+        for (Map.Entry<MetricName, Meter> entry : meters.entrySet()) {
             reportMeter(timestamp, entry.getKey(), entry.getValue());
         }
 
-        for (Map.Entry<String, Timer> entry : timers.entrySet()) {
+        for (Map.Entry<MetricName, Timer> entry : timers.entrySet()) {
             reportTimer(timestamp, entry.getKey(), entry.getValue());
         }
     }
 
-    private void reportTimer(long timestamp, String name, Timer timer) {
+    private void reportTimer(long timestamp, MetricName name, Timer timer) {
         final Snapshot snapshot = timer.getSnapshot();
 
         report(timestamp,
@@ -193,7 +193,7 @@ public class CsvReporter extends ScheduledReporter {
                getDurationUnit());
     }
 
-    private void reportMeter(long timestamp, String name, Meter meter) {
+    private void reportMeter(long timestamp, MetricName name, Meter meter) {
         report(timestamp,
                name,
                "count,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit",
@@ -206,7 +206,7 @@ public class CsvReporter extends ScheduledReporter {
                getRateUnit());
     }
 
-    private void reportHistogram(long timestamp, String name, Histogram histogram) {
+    private void reportHistogram(long timestamp, MetricName name, Histogram histogram) {
         final Snapshot snapshot = histogram.getSnapshot();
 
         report(timestamp,
@@ -226,15 +226,15 @@ public class CsvReporter extends ScheduledReporter {
                snapshot.get999thPercentile());
     }
 
-    private void reportCounter(long timestamp, String name, Counter counter) {
+    private void reportCounter(long timestamp, MetricName name, Counter counter) {
         report(timestamp, name, "count", "%d", counter.getCount());
     }
 
-    private void reportGauge(long timestamp, String name, Gauge gauge) {
+    private void reportGauge(long timestamp, MetricName name, Gauge gauge) {
         report(timestamp, name, "value", "%s", gauge.getValue());
     }
 
-    private void report(long timestamp, String name, String header, String line, Object... values) {
+    private void report(long timestamp, MetricName name, String header, String line, Object... values) {
         try {
             final File file = new File(directory, sanitize(name) + ".csv");
             final boolean fileAlreadyExists = file.exists();
@@ -254,7 +254,7 @@ public class CsvReporter extends ScheduledReporter {
         }
     }
 
-    protected String sanitize(String name) {
-        return name;
+    protected String sanitize(MetricName name) {
+        return name.getKey();
     }
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
@@ -508,7 +508,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onGaugeAdded(String name, Gauge<?> gauge) {
+        public void onGaugeAdded(MetricName name, Gauge<?> gauge) {
             try {
                 if (filter.matches(name, gauge)) {
                     final ObjectName objectName = createName("gauges", name);
@@ -522,7 +522,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onGaugeRemoved(String name) {
+        public void onGaugeRemoved(MetricName name) {
             try {
                 final ObjectName objectName = createName("gauges", name);
                 unregisterMBean(objectName);
@@ -534,7 +534,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onCounterAdded(String name, Counter counter) {
+        public void onCounterAdded(MetricName name, Counter counter) {
             try {
                 if (filter.matches(name, counter)) {
                     final ObjectName objectName = createName("counters", name);
@@ -548,7 +548,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onCounterRemoved(String name) {
+        public void onCounterRemoved(MetricName name) {
             try {
                 final ObjectName objectName = createName("counters", name);
                 unregisterMBean(objectName);
@@ -560,7 +560,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onHistogramAdded(String name, Histogram histogram) {
+        public void onHistogramAdded(MetricName name, Histogram histogram) {
             try {
                 if (filter.matches(name, histogram)) {
                     final ObjectName objectName = createName("histograms", name);
@@ -574,7 +574,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onHistogramRemoved(String name) {
+        public void onHistogramRemoved(MetricName name) {
             try {
                 final ObjectName objectName = createName("histograms", name);
                 unregisterMBean(objectName);
@@ -586,11 +586,11 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onMeterAdded(String name, Meter meter) {
+        public void onMeterAdded(MetricName name, Meter meter) {
             try {
                 if (filter.matches(name, meter)) {
                     final ObjectName objectName = createName("meters", name);
-                    registerMBean(new JmxMeter(meter, objectName, timeUnits.rateFor(name)), objectName);
+                    registerMBean(new JmxMeter(meter, objectName, timeUnits.rateFor(name.getKey())), objectName);
                 }
             } catch (InstanceAlreadyExistsException e) {
                 LOGGER.debug("Unable to register meter", e);
@@ -600,7 +600,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onMeterRemoved(String name) {
+        public void onMeterRemoved(MetricName name) {
             try {
                 final ObjectName objectName = createName("meters", name);
                 unregisterMBean(objectName);
@@ -612,11 +612,11 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onTimerAdded(String name, Timer timer) {
+        public void onTimerAdded(MetricName name, Timer timer) {
             try {
                 if (filter.matches(name, timer)) {
                     final ObjectName objectName = createName("timers", name);
-                    registerMBean(new JmxTimer(timer, objectName, timeUnits.rateFor(name), timeUnits.durationFor(name)), objectName);
+                    registerMBean(new JmxTimer(timer, objectName, timeUnits.rateFor(name.getKey()), timeUnits.durationFor(name.getKey())), objectName);
                 }
             } catch (InstanceAlreadyExistsException e) {
                 LOGGER.debug("Unable to register timer", e);
@@ -626,7 +626,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onTimerRemoved(String name) {
+        public void onTimerRemoved(MetricName name) {
             try {
                 final ObjectName objectName = createName("timers", name);
                 unregisterMBean(objectName);
@@ -637,12 +637,12 @@ public class JmxReporter implements Reporter, Closeable {
             }
         }
 
-        private ObjectName createName(String type, String name) {
+        private ObjectName createName(String type, MetricName name) {
             try {
-                return new ObjectName(this.name, "name", name);
+                return new ObjectName(this.name, "name", name.getKey());
             } catch (MalformedObjectNameException e) {
                 try {
-                    return new ObjectName(this.name, "name", ObjectName.quote(name));
+                    return new ObjectName(this.name, "name", ObjectName.quote(name.getKey()));
                 } catch (MalformedObjectNameException e1) {
                     LOGGER.warn("Unable to register {} {}", type, name, e1);
                     throw new RuntimeException(e1);

--- a/metrics-core/src/main/java/com/codahale/metrics/JvmAttributeGaugeSet.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JvmAttributeGaugeSet.java
@@ -28,17 +28,17 @@ public class JvmAttributeGaugeSet implements MetricSet {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        final Map<String, Metric> gauges = new HashMap<String, Metric>();
+    public Map<MetricName, Metric> getMetrics() {
+        final Map<MetricName, Metric> gauges = new HashMap<MetricName, Metric>();
 
-        gauges.put("name", new Gauge<String>() {
+        gauges.put(MetricName.build("name"), new Gauge<String>() {
             @Override
             public String getValue() {
                 return runtime.getName();
             }
         });
 
-        gauges.put("vendor", new Gauge<String>() {
+        gauges.put(MetricName.build("vendor"), new Gauge<String>() {
             @Override
             public String getValue() {
                 return String.format(Locale.US,
@@ -50,7 +50,7 @@ public class JvmAttributeGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("uptime", new Gauge<Long>() {
+        gauges.put(MetricName.build("uptime"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return runtime.getUptime();

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricFilter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricFilter.java
@@ -9,7 +9,7 @@ public interface MetricFilter {
      */
     MetricFilter ALL = new MetricFilter() {
         @Override
-        public boolean matches(String name, Metric metric) {
+        public boolean matches(MetricName name, Metric metric) {
             return true;
         }
     };
@@ -21,5 +21,5 @@ public interface MetricFilter {
      * @param metric    the metric
      * @return {@code true} if the metric matches the filter
      */
-    boolean matches(String name, Metric metric);
+    boolean matches(MetricName name, Metric metric);
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricName.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricName.java
@@ -1,0 +1,297 @@
+package com.codahale.metrics;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * A metric name with the ability to include semantic tags.
+ *
+ * This replaces the previous style where metric names where strictly
+ * dot-separated strings.
+ *
+ * @author udoprog
+ */
+public class MetricName implements Comparable<MetricName> {
+    public static final String SEPARATOR = ".";
+    public static final Map<String, String> EMPTY_TAGS = Collections.unmodifiableMap(new HashMap<String, String>());
+    public static final MetricName EMPTY = new MetricName();
+
+    private final String key;
+    private final Map<String, String> tags;
+
+    public MetricName() {
+        this.key = null;
+        this.tags = EMPTY_TAGS;
+    }
+
+    public MetricName(String key) {
+        this.key = key;
+        this.tags = EMPTY_TAGS;
+    }
+
+    public MetricName(String key, Map<String, String> tags) {
+        this.key = key;
+        this.tags = checkTags(tags);
+    }
+
+    private Map<String, String> checkTags(Map<String, String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return EMPTY_TAGS;
+        }
+
+        return Collections.unmodifiableMap(tags);
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    /**
+     * Build the MetricName that is this with another path appended to it.
+     *
+     * The new MetricName inherits the tags of this one.
+     *
+     * @param p The extra path element to add to the new metric.
+     * @return A new metric name relative to the original by the path specified
+     *         in p.
+     */
+    public MetricName resolve(String p) {
+        final String next;
+
+        if (p != null && !p.isEmpty()) {
+            if (key != null && !key.isEmpty()) {
+                next = key + SEPARATOR + p;
+            } else {
+                next = p;
+            }
+        } else {
+            next = this.key;
+        }
+
+        return new MetricName(next, tags);
+    }
+
+    /**
+     * Add tags to a metric name and return the newly created MetricName.
+     *
+     * @param add Tags to add.
+     * @return A newly created metric name with the specified tags associated with it.
+     */
+    public MetricName tagged(Map<String, String> add) {
+        final Map<String, String> tags = new HashMap<String, String>(add);
+        tags.putAll(this.tags);
+        return new MetricName(key, tags);
+    }
+
+    /**
+     * Same as {@link #tagged(Map)}, but takes a variadic list
+     * of arguments.
+     *
+     * @see #tagged(Map)
+     * @param pairs An even list of strings acting as key-value pairs.
+     * @return A newly created metric name with the specified tags associated
+     *         with it.
+     */
+    public MetricName tagged(String... pairs) {
+        if (pairs == null) {
+            return this;
+        }
+
+        if (pairs.length % 2 != 0) {
+            throw new IllegalArgumentException("Argument count must be even");
+        }
+
+        final Map<String, String> add = new HashMap<String, String>();
+
+        for (int i = 0; i < pairs.length; i += 2) {
+            add.put(pairs[i], pairs[i+1]);
+        }
+
+        return tagged(add);
+    }
+
+    /**
+     * Join the specified set of metric names.
+     *
+     * @param parts Multiple metric names to join using the separator.
+     * @return A newly created metric name which has the name of the specified
+     *         parts and includes all tags of all child metric names.
+     **/
+    public static MetricName join(MetricName... parts) {
+        final StringBuilder nameBuilder = new StringBuilder();
+        final Map<String, String> tags = new HashMap<String, String>();
+
+        boolean first = true;
+
+        for (MetricName part : parts) {
+            final String name = part.getKey();
+
+            if (name != null && !name.isEmpty()) {
+                if (first) {
+                    first = false;
+                } else {
+                    nameBuilder.append(SEPARATOR);
+                }
+
+                nameBuilder.append(name);
+            }
+
+            if (!part.getTags().isEmpty())
+                tags.putAll(part.getTags());
+        }
+
+        return new MetricName(nameBuilder.toString(), tags);
+    }
+
+    /**
+     * Build a new metric name using the specific path components.
+     *
+     * @param parts Path of the new metric name.
+     * @return A newly created metric name with the specified path.
+     **/
+    public static MetricName build(String... parts) {
+        if (parts == null || parts.length == 0)
+            return MetricName.EMPTY;
+
+        if (parts.length == 1)
+            return new MetricName(parts[0], EMPTY_TAGS);
+
+        return new MetricName(buildName(parts), EMPTY_TAGS);
+    }
+
+    private static String buildName(String... names) {
+        final StringBuilder builder = new StringBuilder();
+        boolean first = true;
+
+        for (String name : names) {
+            if (name == null || name.isEmpty())
+                continue;
+
+            if (first) {
+                first = false;
+            } else {
+                builder.append(SEPARATOR);
+            }
+
+            builder.append(name);
+        }
+
+        return builder.toString();
+    }
+
+    @Override
+    public String toString() {
+        if (tags.isEmpty()) {
+            return key + "{}";
+        }
+
+        return key + tags;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((key == null) ? 0 : key.hashCode());
+        result = prime * result + ((tags == null) ? 0 : tags.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+
+        if (obj == null)
+            return false;
+
+        if (getClass() != obj.getClass())
+            return false;
+
+        MetricName other = (MetricName) obj;
+
+        if (key == null) {
+            if (other.key != null)
+                return false;
+        } else if (!key.equals(other.key))
+            return false;
+
+        if (!tags.equals(other.tags))
+            return false;
+
+        return true;
+    }
+
+    @Override
+    public int compareTo(MetricName o) {
+        if (o == null)
+            return -1;
+
+        int c = compareName(key, o.getKey());
+
+        if (c != 0)
+            return c;
+
+        return compareTags(tags, o.getTags());
+    }
+
+    private int compareName(String left, String right) {
+        if (left == null && right == null)
+            return 0;
+
+        if (left == null)
+            return 1;
+
+        if (right == null)
+            return -1;
+
+        return left.compareTo(right);
+    }
+
+    private int compareTags(Map<String, String> left, Map<String, String> right) {
+        if (left == null && right == null)
+            return 0;
+
+        if (left == null)
+            return 1;
+
+        if (right == null)
+            return -1;
+
+        final Iterable<String> keys = uniqueSortedKeys(left, right);
+
+        for (final String key : keys) {
+            final String a = left.get(key);
+            final String b = right.get(key);
+
+            if (a == null && b == null)
+                continue;
+
+            if (a == null)
+                return -1;
+
+            if (b == null)
+                return 1;
+
+            int c = a.compareTo(b);
+
+            if (c != 0)
+                return c;
+        }
+
+        return 0;
+    }
+
+    private Iterable<String> uniqueSortedKeys(Map<String, String> left, Map<String, String> right) {
+        final Set<String> set = new TreeSet<String>(left.keySet());
+        set.addAll(right.keySet());
+        return set;
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -10,45 +10,43 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class MetricRegistry implements MetricSet {
     /**
-     * Concatenates elements to form a dotted name, eliding any null values or empty strings.
-     *
-     * @param name     the first element of the name
-     * @param names    the remaining elements of the name
-     * @return {@code name} and {@code names} concatenated by periods
+     * @see #name(String, String...)
      */
-    public static String name(String name, String... names) {
-        final StringBuilder builder = new StringBuilder();
-        append(builder, name);
-        if (names != null) {
-            for (String s : names) {
-                append(builder, s);
-            }
-        }
-        return builder.toString();
-    }
-
-    /**
-     * Concatenates a class name and elements to form a dotted name, eliding any null values or
-     * empty strings.
-     *
-     * @param klass    the first element of the name
-     * @param names    the remaining elements of the name
-     * @return {@code klass} and {@code names} concatenated by periods
-     */
-    public static String name(Class<?> klass, String... names) {
+    public static MetricName name(Class<?> klass, String... names) {
         return name(klass.getName(), names);
     }
 
-    private static void append(StringBuilder builder, String part) {
-        if (part != null && !part.isEmpty()) {
-            if (builder.length() > 0) {
-                builder.append('.');
-            }
-            builder.append(part);
+    /**
+     * Shorthand method for backwards compatibility in creating metric names.
+     *
+     * Uses {@link MetricName#build(String...)} for its
+     * heavy lifting.
+     *
+     * @see MetricName#build(String...)
+     * @param name The first element of the name
+     * @param names The remaining elements of the name
+     * @return A metric name matching the specified components.
+     */
+    public static MetricName name(String name, String... names) {
+        final int length;
+
+        if (names == null) {
+            length = 0;
+        } else {
+            length = names.length;
         }
+
+        final String[] parts = new String[length + 1];
+        parts[0] = name;
+
+        for (int i = 0; i < length; i++) {
+            parts[i+1] = names[i];
+        }
+
+        return MetricName.build(parts);
     }
 
-    private final ConcurrentMap<String, Metric> metrics;
+    private final ConcurrentMap<MetricName, Metric> metrics;
     private final List<MetricRegistryListener> listeners;
 
     /**
@@ -66,8 +64,16 @@ public class MetricRegistry implements MetricSet {
      *
      * @return a new {@link ConcurrentMap}
      */
-    protected ConcurrentMap<String, Metric> buildMap() {
-        return new ConcurrentHashMap<String, Metric>();
+    protected ConcurrentMap<MetricName, Metric> buildMap() {
+        return new ConcurrentHashMap<MetricName, Metric>();
+    }
+
+    /**
+     * @see #register(MetricName, Metric)
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends Metric> T register(String name, T metric) throws IllegalArgumentException {
+        return register(MetricName.build(name), metric);
     }
 
     /**
@@ -80,7 +86,7 @@ public class MetricRegistry implements MetricSet {
      * @throws IllegalArgumentException if the name is already registered
      */
     @SuppressWarnings("unchecked")
-    public <T extends Metric> T register(String name, T metric) throws IllegalArgumentException {
+    public <T extends Metric> T register(MetricName name, T metric) throws IllegalArgumentException {
         if (metric instanceof MetricSet) {
             registerAll(name, (MetricSet) metric);
         } else {
@@ -91,6 +97,7 @@ public class MetricRegistry implements MetricSet {
                 throw new IllegalArgumentException("A metric named " + name + " already exists");
             }
         }
+
         return metric;
     }
 
@@ -105,13 +112,27 @@ public class MetricRegistry implements MetricSet {
     }
 
     /**
+     * @see #counter(MetricName)
+     */
+    public Counter counter(String name) {
+        return getOrAdd(MetricName.build(name), MetricBuilder.COUNTERS);
+    }
+
+    /**
      * Creates a new {@link Counter} and registers it under the given name.
      *
      * @param name the name of the metric
      * @return a new {@link Counter}
      */
-    public Counter counter(String name) {
+    public Counter counter(MetricName name) {
         return getOrAdd(name, MetricBuilder.COUNTERS);
+    }
+
+    /**
+     * @see #histogram(MetricName)
+     */
+    public Histogram histogram(String name) {
+        return getOrAdd(MetricName.build(name), MetricBuilder.HISTOGRAMS);
     }
 
     /**
@@ -120,8 +141,15 @@ public class MetricRegistry implements MetricSet {
      * @param name the name of the metric
      * @return a new {@link Histogram}
      */
-    public Histogram histogram(String name) {
+    public Histogram histogram(MetricName name) {
         return getOrAdd(name, MetricBuilder.HISTOGRAMS);
+    }
+
+    /**
+     * @see #meter(MetricName)
+     */
+    public Meter meter(String name) {
+        return getOrAdd(MetricName.build(name), MetricBuilder.METERS);
     }
 
     /**
@@ -130,8 +158,15 @@ public class MetricRegistry implements MetricSet {
      * @param name the name of the metric
      * @return a new {@link Meter}
      */
-    public Meter meter(String name) {
+    public Meter meter(MetricName name) {
         return getOrAdd(name, MetricBuilder.METERS);
+    }
+
+    /**
+     * @see #timer(MetricName)
+     */
+    public Timer timer(String name) {
+        return getOrAdd(MetricName.build(name), MetricBuilder.TIMERS);
     }
 
     /**
@@ -140,7 +175,7 @@ public class MetricRegistry implements MetricSet {
      * @param name the name of the metric
      * @return a new {@link Timer}
      */
-    public Timer timer(String name) {
+    public Timer timer(MetricName name) {
         return getOrAdd(name, MetricBuilder.TIMERS);
     }
 
@@ -150,7 +185,7 @@ public class MetricRegistry implements MetricSet {
      * @param name the name of the metric
      * @return whether or not the metric was removed
      */
-    public boolean remove(String name) {
+    public boolean remove(MetricName name) {
         final Metric metric = metrics.remove(name);
         if (metric != null) {
             onMetricRemoved(name, metric);
@@ -165,7 +200,7 @@ public class MetricRegistry implements MetricSet {
      * @param filter a filter
      */
     public void removeMatching(MetricFilter filter) {
-        for (Map.Entry<String, Metric> entry : metrics.entrySet()) {
+        for (Map.Entry<MetricName, Metric> entry : metrics.entrySet()) {
             if (filter.matches(entry.getKey(), entry.getValue())) {
                 remove(entry.getKey());
             }
@@ -183,7 +218,7 @@ public class MetricRegistry implements MetricSet {
     public void addListener(MetricRegistryListener listener) {
         listeners.add(listener);
 
-        for (Map.Entry<String, Metric> entry : metrics.entrySet()) {
+        for (Map.Entry<MetricName, Metric> entry : metrics.entrySet()) {
             notifyListenerOfAddedMetric(listener, entry.getValue(), entry.getKey());
         }
     }
@@ -202,8 +237,8 @@ public class MetricRegistry implements MetricSet {
      *
      * @return the names of all the metrics
      */
-    public SortedSet<String> getNames() {
-        return Collections.unmodifiableSortedSet(new TreeSet<String>(metrics.keySet()));
+    public SortedSet<MetricName> getNames() {
+        return Collections.unmodifiableSortedSet(new TreeSet<MetricName>(metrics.keySet()));
     }
 
     /**
@@ -211,7 +246,7 @@ public class MetricRegistry implements MetricSet {
      *
      * @return all the gauges in the registry
      */
-    public SortedMap<String, Gauge> getGauges() {
+    public SortedMap<MetricName, Gauge> getGauges() {
         return getGauges(MetricFilter.ALL);
     }
 
@@ -221,7 +256,7 @@ public class MetricRegistry implements MetricSet {
      * @param filter    the metric filter to match
      * @return all the gauges in the registry
      */
-    public SortedMap<String, Gauge> getGauges(MetricFilter filter) {
+    public SortedMap<MetricName, Gauge> getGauges(MetricFilter filter) {
         return getMetrics(Gauge.class, filter);
     }
 
@@ -230,7 +265,7 @@ public class MetricRegistry implements MetricSet {
      *
      * @return all the counters in the registry
      */
-    public SortedMap<String, Counter> getCounters() {
+    public SortedMap<MetricName, Counter> getCounters() {
         return getCounters(MetricFilter.ALL);
     }
 
@@ -241,7 +276,7 @@ public class MetricRegistry implements MetricSet {
      * @param filter    the metric filter to match
      * @return all the counters in the registry
      */
-    public SortedMap<String, Counter> getCounters(MetricFilter filter) {
+    public SortedMap<MetricName, Counter> getCounters(MetricFilter filter) {
         return getMetrics(Counter.class, filter);
     }
 
@@ -250,7 +285,7 @@ public class MetricRegistry implements MetricSet {
      *
      * @return all the histograms in the registry
      */
-    public SortedMap<String, Histogram> getHistograms() {
+    public SortedMap<MetricName, Histogram> getHistograms() {
         return getHistograms(MetricFilter.ALL);
     }
 
@@ -261,7 +296,7 @@ public class MetricRegistry implements MetricSet {
      * @param filter    the metric filter to match
      * @return all the histograms in the registry
      */
-    public SortedMap<String, Histogram> getHistograms(MetricFilter filter) {
+    public SortedMap<MetricName, Histogram> getHistograms(MetricFilter filter) {
         return getMetrics(Histogram.class, filter);
     }
 
@@ -270,7 +305,7 @@ public class MetricRegistry implements MetricSet {
      *
      * @return all the meters in the registry
      */
-    public SortedMap<String, Meter> getMeters() {
+    public SortedMap<MetricName, Meter> getMeters() {
         return getMeters(MetricFilter.ALL);
     }
 
@@ -280,7 +315,7 @@ public class MetricRegistry implements MetricSet {
      * @param filter    the metric filter to match
      * @return all the meters in the registry
      */
-    public SortedMap<String, Meter> getMeters(MetricFilter filter) {
+    public SortedMap<MetricName, Meter> getMeters(MetricFilter filter) {
         return getMetrics(Meter.class, filter);
     }
 
@@ -289,7 +324,7 @@ public class MetricRegistry implements MetricSet {
      *
      * @return all the timers in the registry
      */
-    public SortedMap<String, Timer> getTimers() {
+    public SortedMap<MetricName, Timer> getTimers() {
         return getTimers(MetricFilter.ALL);
     }
 
@@ -299,12 +334,12 @@ public class MetricRegistry implements MetricSet {
      * @param filter    the metric filter to match
      * @return all the timers in the registry
      */
-    public SortedMap<String, Timer> getTimers(MetricFilter filter) {
+    public SortedMap<MetricName, Timer> getTimers(MetricFilter filter) {
         return getMetrics(Timer.class, filter);
     }
 
     @SuppressWarnings("unchecked")
-    private <T extends Metric> T getOrAdd(String name, MetricBuilder<T> builder) {
+    private <T extends Metric> T getOrAdd(MetricName name, MetricBuilder<T> builder) {
         final Metric metric = metrics.get(name);
         if (builder.isInstance(metric)) {
             return (T) metric;
@@ -322,9 +357,9 @@ public class MetricRegistry implements MetricSet {
     }
 
     @SuppressWarnings("unchecked")
-    private <T extends Metric> SortedMap<String, T> getMetrics(Class<T> klass, MetricFilter filter) {
-        final TreeMap<String, T> timers = new TreeMap<String, T>();
-        for (Map.Entry<String, Metric> entry : metrics.entrySet()) {
+    private <T extends Metric> SortedMap<MetricName, T> getMetrics(Class<T> klass, MetricFilter filter) {
+        final TreeMap<MetricName, T> timers = new TreeMap<MetricName, T>();
+        for (Map.Entry<MetricName, Metric> entry : metrics.entrySet()) {
             if (klass.isInstance(entry.getValue()) && filter.matches(entry.getKey(),
                                                                      entry.getValue())) {
                 timers.put(entry.getKey(), (T) entry.getValue());
@@ -333,13 +368,13 @@ public class MetricRegistry implements MetricSet {
         return Collections.unmodifiableSortedMap(timers);
     }
 
-    private void onMetricAdded(String name, Metric metric) {
+    private void onMetricAdded(MetricName name, Metric metric) {
         for (MetricRegistryListener listener : listeners) {
             notifyListenerOfAddedMetric(listener, metric, name);
         }
     }
 
-    private void notifyListenerOfAddedMetric(MetricRegistryListener listener, Metric metric, String name) {
+    private void notifyListenerOfAddedMetric(MetricRegistryListener listener, Metric metric, MetricName name) {
         if (metric instanceof Gauge) {
             listener.onGaugeAdded(name, (Gauge<?>) metric);
         } else if (metric instanceof Counter) {
@@ -355,13 +390,13 @@ public class MetricRegistry implements MetricSet {
         }
     }
 
-    private void onMetricRemoved(String name, Metric metric) {
+    private void onMetricRemoved(MetricName name, Metric metric) {
         for (MetricRegistryListener listener : listeners) {
             notifyListenerOfRemovedMetric(name, metric, listener);
         }
     }
 
-    private void notifyListenerOfRemovedMetric(String name, Metric metric, MetricRegistryListener listener) {
+    private void notifyListenerOfRemovedMetric(MetricName name, Metric metric, MetricRegistryListener listener) {
         if (metric instanceof Gauge) {
             listener.onGaugeRemoved(name);
         } else if (metric instanceof Counter) {
@@ -377,18 +412,21 @@ public class MetricRegistry implements MetricSet {
         }
     }
 
-    private void registerAll(String prefix, MetricSet metrics) throws IllegalArgumentException {
-        for (Map.Entry<String, Metric> entry : metrics.getMetrics().entrySet()) {
+    private void registerAll(MetricName prefix, MetricSet metrics) throws IllegalArgumentException {
+        if (prefix == null)
+            prefix = MetricName.EMPTY;
+
+        for (Map.Entry<MetricName, Metric> entry : metrics.getMetrics().entrySet()) {
             if (entry.getValue() instanceof MetricSet) {
-                registerAll(name(prefix, entry.getKey()), (MetricSet) entry.getValue());
+                registerAll(MetricName.join(prefix, entry.getKey()), (MetricSet) entry.getValue());
             } else {
-                register(name(prefix, entry.getKey()), entry.getValue());
+                register(MetricName.join(prefix, entry.getKey()), entry.getValue());
             }
         }
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
+    public Map<MetricName, Metric> getMetrics() {
         return Collections.unmodifiableMap(metrics);
     }
 

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistryListener.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistryListener.java
@@ -11,43 +11,43 @@ public interface MetricRegistryListener extends EventListener {
      */
     abstract class Base implements MetricRegistryListener {
         @Override
-        public void onGaugeAdded(String name, Gauge<?> gauge) {
+        public void onGaugeAdded(MetricName name, Gauge<?> gauge) {
         }
 
         @Override
-        public void onGaugeRemoved(String name) {
+        public void onGaugeRemoved(MetricName name) {
         }
 
         @Override
-        public void onCounterAdded(String name, Counter counter) {
+        public void onCounterAdded(MetricName name, Counter counter) {
         }
 
         @Override
-        public void onCounterRemoved(String name) {
+        public void onCounterRemoved(MetricName name) {
         }
 
         @Override
-        public void onHistogramAdded(String name, Histogram histogram) {
+        public void onHistogramAdded(MetricName name, Histogram histogram) {
         }
 
         @Override
-        public void onHistogramRemoved(String name) {
+        public void onHistogramRemoved(MetricName name) {
         }
 
         @Override
-        public void onMeterAdded(String name, Meter meter) {
+        public void onMeterAdded(MetricName name, Meter meter) {
         }
 
         @Override
-        public void onMeterRemoved(String name) {
+        public void onMeterRemoved(MetricName name) {
         }
 
         @Override
-        public void onTimerAdded(String name, Timer timer) {
+        public void onTimerAdded(MetricName name, Timer timer) {
         }
 
         @Override
-        public void onTimerRemoved(String name) {
+        public void onTimerRemoved(MetricName name) {
         }
     }
 
@@ -57,14 +57,14 @@ public interface MetricRegistryListener extends EventListener {
      * @param name  the gauge's name
      * @param gauge the gauge
      */
-    void onGaugeAdded(String name, Gauge<?> gauge);
+    void onGaugeAdded(MetricName name, Gauge<?> gauge);
 
     /**
      * Called when a {@link Gauge} is removed from the registry.
      *
      * @param name the gauge's name
      */
-    void onGaugeRemoved(String name);
+    void onGaugeRemoved(MetricName name);
 
     /**
      * Called when a {@link Counter} is added to the registry.
@@ -72,14 +72,14 @@ public interface MetricRegistryListener extends EventListener {
      * @param name    the counter's name
      * @param counter the counter
      */
-    void onCounterAdded(String name, Counter counter);
+    void onCounterAdded(MetricName name, Counter counter);
 
     /**
      * Called when a {@link Counter} is removed from the registry.
      *
      * @param name the counter's name
      */
-    void onCounterRemoved(String name);
+    void onCounterRemoved(MetricName name);
 
     /**
      * Called when a {@link Histogram} is added to the registry.
@@ -87,14 +87,14 @@ public interface MetricRegistryListener extends EventListener {
      * @param name      the histogram's name
      * @param histogram the histogram
      */
-    void onHistogramAdded(String name, Histogram histogram);
+    void onHistogramAdded(MetricName name, Histogram histogram);
 
     /**
      * Called when a {@link Histogram} is removed from the registry.
      *
      * @param name the histogram's name
      */
-    void onHistogramRemoved(String name);
+    void onHistogramRemoved(MetricName name);
 
     /**
      * Called when a {@link Meter} is added to the registry.
@@ -102,14 +102,14 @@ public interface MetricRegistryListener extends EventListener {
      * @param name  the meter's name
      * @param meter the meter
      */
-    void onMeterAdded(String name, Meter meter);
+    void onMeterAdded(MetricName name, Meter meter);
 
     /**
      * Called when a {@link Meter} is removed from the registry.
      *
      * @param name the meter's name
      */
-    void onMeterRemoved(String name);
+    void onMeterRemoved(MetricName name);
 
     /**
      * Called when a {@link Timer} is added to the registry.
@@ -117,12 +117,12 @@ public interface MetricRegistryListener extends EventListener {
      * @param name  the timer's name
      * @param timer the timer
      */
-    void onTimerAdded(String name, Timer timer);
+    void onTimerAdded(MetricName name, Timer timer);
 
     /**
      * Called when a {@link Timer} is removed from the registry.
      *
      * @param name the timer's name
      */
-    void onTimerRemoved(String name);
+    void onTimerRemoved(MetricName name);
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricSet.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricSet.java
@@ -13,5 +13,5 @@ public interface MetricSet extends Metric {
      *
      * @return the metrics
      */
-    Map<String, Metric> getMetrics();
+    Map<MetricName, Metric> getMetrics();
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -143,11 +143,11 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
      * @param meters     all of the meters in the registry
      * @param timers     all of the timers in the registry
      */
-    public abstract void report(SortedMap<String, Gauge> gauges,
-                                SortedMap<String, Counter> counters,
-                                SortedMap<String, Histogram> histograms,
-                                SortedMap<String, Meter> meters,
-                                SortedMap<String, Timer> timers);
+    public abstract void report(SortedMap<MetricName, Gauge> gauges,
+                                SortedMap<MetricName, Counter> counters,
+                                SortedMap<MetricName, Histogram> histograms,
+                                SortedMap<MetricName, Meter> meters,
+                                SortedMap<MetricName, Timer> timers);
 
     protected String getRateUnit() {
         return rateUnit;

--- a/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
@@ -127,33 +127,33 @@ public class Slf4jReporter extends ScheduledReporter {
     }
 
     @Override
-    public void report(SortedMap<String, Gauge> gauges,
-                       SortedMap<String, Counter> counters,
-                       SortedMap<String, Histogram> histograms,
-                       SortedMap<String, Meter> meters,
-                       SortedMap<String, Timer> timers) {
-        for (Entry<String, Gauge> entry : gauges.entrySet()) {
+    public void report(SortedMap<MetricName, Gauge> gauges,
+                       SortedMap<MetricName, Counter> counters,
+                       SortedMap<MetricName, Histogram> histograms,
+                       SortedMap<MetricName, Meter> meters,
+                       SortedMap<MetricName, Timer> timers) {
+        for (Entry<MetricName, Gauge> entry : gauges.entrySet()) {
             logGauge(entry.getKey(), entry.getValue());
         }
 
-        for (Entry<String, Counter> entry : counters.entrySet()) {
+        for (Entry<MetricName, Counter> entry : counters.entrySet()) {
             logCounter(entry.getKey(), entry.getValue());
         }
 
-        for (Entry<String, Histogram> entry : histograms.entrySet()) {
+        for (Entry<MetricName, Histogram> entry : histograms.entrySet()) {
             logHistogram(entry.getKey(), entry.getValue());
         }
 
-        for (Entry<String, Meter> entry : meters.entrySet()) {
+        for (Entry<MetricName, Meter> entry : meters.entrySet()) {
             logMeter(entry.getKey(), entry.getValue());
         }
 
-        for (Entry<String, Timer> entry : timers.entrySet()) {
+        for (Entry<MetricName, Timer> entry : timers.entrySet()) {
             logTimer(entry.getKey(), entry.getValue());
         }
     }
 
-    private void logTimer(String name, Timer timer) {
+    private void logTimer(MetricName name, Timer timer) {
         final Snapshot snapshot = timer.getSnapshot();
         logger.info(marker,
                     "type=TIMER, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, " +
@@ -179,7 +179,7 @@ public class Slf4jReporter extends ScheduledReporter {
                     getDurationUnit());
     }
 
-    private void logMeter(String name, Meter meter) {
+    private void logMeter(MetricName name, Meter meter) {
         logger.info(marker,
                     "type=METER, name={}, count={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}",
                     name,
@@ -191,7 +191,7 @@ public class Slf4jReporter extends ScheduledReporter {
                     getRateUnit());
     }
 
-    private void logHistogram(String name, Histogram histogram) {
+    private void logHistogram(MetricName name, Histogram histogram) {
         final Snapshot snapshot = histogram.getSnapshot();
         logger.info(marker,
                     "type=HISTOGRAM, name={}, count={}, min={}, max={}, mean={}, stddev={}, " +
@@ -210,11 +210,11 @@ public class Slf4jReporter extends ScheduledReporter {
                     snapshot.get999thPercentile());
     }
 
-    private void logCounter(String name, Counter counter) {
+    private void logCounter(MetricName name, Counter counter) {
         logger.info(marker, "type=COUNTER, name={}, count={}", name, counter.getCount());
     }
 
-    private void logGauge(String name, Gauge gauge) {
+    private void logGauge(MetricName name, Gauge gauge) {
         logger.info(marker, "type=GAUGE, name={}, value={}", name, gauge.getValue());
     }
 

--- a/metrics-core/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
@@ -52,7 +52,7 @@ public class ConsoleReporterTest {
                         "3/17/13 6:04:36 PM =============================================================",
                         "",
                         "-- Gauges ----------------------------------------------------------------------",
-                        "gauge",
+                        "gauge{}",
                         "             value = 1",
                         "",
                         ""
@@ -75,7 +75,7 @@ public class ConsoleReporterTest {
                         "3/17/13 6:04:36 PM =============================================================",
                         "",
                         "-- Counters --------------------------------------------------------------------",
-                        "test.counter",
+                        "test.counter{}",
                         "             count = 100",
                         "",
                         ""
@@ -112,7 +112,7 @@ public class ConsoleReporterTest {
                         "3/17/13 6:04:36 PM =============================================================",
                         "",
                         "-- Histograms ------------------------------------------------------------------",
-                        "test.histogram",
+                        "test.histogram{}",
                         "             count = 1",
                         "               min = 4",
                         "               max = 2",
@@ -149,7 +149,7 @@ public class ConsoleReporterTest {
                         "3/17/13 6:04:36 PM =============================================================",
                         "",
                         "-- Meters ----------------------------------------------------------------------",
-                        "test.meter",
+                        "test.meter{}",
                         "             count = 1",
                         "         mean rate = 2.00 events/second",
                         "     1-minute rate = 3.00 events/second",
@@ -195,7 +195,7 @@ public class ConsoleReporterTest {
                         "3/17/13 6:04:36 PM =============================================================",
                         "",
                         "-- Timers ----------------------------------------------------------------------",
-                        "test.another.timer",
+                        "test.another.timer{}",
                         "             count = 1",
                         "         mean rate = 2.00 calls/second",
                         "     1-minute rate = 3.00 calls/second",
@@ -228,13 +228,13 @@ public class ConsoleReporterTest {
         return bytes.toString("UTF-8");
     }
 
-    private <T> SortedMap<String, T> map() {
-        return new TreeMap<String, T>();
+    private <T> SortedMap<MetricName, T> map() {
+        return new TreeMap<MetricName, T>();
     }
 
-    private <T> SortedMap<String, T> map(String name, T metric) {
-        final TreeMap<String, T> map = new TreeMap<String, T>();
-        map.put(name, metric);
+    private <T> SortedMap<MetricName, T> map(String name, T metric) {
+        final TreeMap<MetricName, T> map = new TreeMap<MetricName, T>();
+        map.put(MetricName.build(name), metric);
         return map;
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/CsvReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/CsvReporterTest.java
@@ -192,13 +192,13 @@ public class CsvReporterTest {
         return builder.toString();
     }
 
-    private <T> SortedMap<String, T> map() {
-        return new TreeMap<String, T>();
+    private <T> SortedMap<MetricName, T> map() {
+        return new TreeMap<MetricName, T>();
     }
 
-    private <T> SortedMap<String, T> map(String name, T metric) {
-        final TreeMap<String, T> map = new TreeMap<String, T>();
-        map.put(name, metric);
+    private <T> SortedMap<MetricName, T> map(String name, T metric) {
+        final TreeMap<MetricName, T> map = new TreeMap<MetricName, T>();
+        map.put(MetricName.build(name), metric);
         return map;
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/JvmAttributeGaugeSetTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/JvmAttributeGaugeSetTest.java
@@ -27,12 +27,15 @@ public class JvmAttributeGaugeSetTest {
     @Test
     public void hasASetOfGauges() throws Exception {
         assertThat(gauges.getMetrics().keySet())
-                .containsOnly("vendor", "name", "uptime");
+                .containsOnly(
+                        MetricName.build("vendor"),
+                        MetricName.build("name"),
+                        MetricName.build("uptime"));
     }
 
     @Test
     public void hasAGaugeForTheJVMName() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("name");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(MetricName.build("name"));
 
         assertThat(gauge.getValue())
                 .isEqualTo("9928@example.com");
@@ -40,7 +43,7 @@ public class JvmAttributeGaugeSetTest {
 
     @Test
     public void hasAGaugeForTheJVMVendor() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("vendor");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(MetricName.build("vendor"));
 
         assertThat(gauge.getValue())
                 .isEqualTo("Oracle Corporation Java HotSpot(TM) 64-Bit Server VM 23.7-b01 (1.7)");
@@ -48,7 +51,7 @@ public class JvmAttributeGaugeSetTest {
 
     @Test
     public void hasAGaugeForTheJVMUptime() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("uptime");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(MetricName.build("uptime"));
 
         assertThat(gauge.getValue())
                 .isEqualTo(100L);
@@ -56,7 +59,7 @@ public class JvmAttributeGaugeSetTest {
 
     @Test
     public void autoDiscoversTheRuntimeBean() throws Exception {
-        final Gauge gauge = (Gauge) new JvmAttributeGaugeSet().getMetrics().get("uptime");
+        final Gauge gauge = (Gauge) new JvmAttributeGaugeSet().getMetrics().get(MetricName.build("uptime"));
 
         assertThat((Long) gauge.getValue())
                 .isPositive();

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricFilterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricFilterTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.mock;
 public class MetricFilterTest {
     @Test
     public void theAllFilterMatchesAllMetrics() throws Exception {
-        assertThat(MetricFilter.ALL.matches("", mock(Metric.class)))
+        assertThat(MetricFilter.ALL.matches(MetricName.build(""), mock(Metric.class)))
                 .isTrue();
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricNameTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricNameTest.java
@@ -1,0 +1,89 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+public class MetricNameTest {
+    @Test
+    public void testEmpty() throws Exception {
+        assertThat(MetricName.EMPTY.getTags()).isEqualTo(MetricName.EMPTY_TAGS);
+        assertThat(MetricName.EMPTY.getKey()).isEqualTo(null);
+        assertThat(new MetricName().getTags()).isEqualTo(MetricName.EMPTY_TAGS);
+
+        assertThat(MetricName.EMPTY).isEqualTo(new MetricName());
+        assertThat(MetricName.build()).isEqualTo(MetricName.EMPTY);
+        assertThat(MetricName.EMPTY.resolve(null)).isEqualTo(MetricName.EMPTY);
+    }
+
+    @Test
+    public void testEmptyResolve() throws Exception {
+        final MetricName name = new MetricName();
+        assertThat(name.resolve("foo")).isEqualTo(new MetricName("foo"));
+    }
+
+    @Test
+    public void testResolveToEmpty() throws Exception {
+        final MetricName name = new MetricName("foo");
+        assertThat(name.resolve(null)).isEqualTo(new MetricName("foo"));
+    }
+
+    @Test
+    public void testResolve() throws Exception {
+        final MetricName name = new MetricName("foo");
+        assertThat(name.resolve("bar")).isEqualTo(new MetricName("foo.bar"));
+    }
+
+    @Test
+    public void testResolveBothEmpty() throws Exception {
+        final MetricName name = new MetricName(null);
+        assertThat(name.resolve(null)).isEqualTo(new MetricName());
+    }
+
+    @Test
+    public void testAddTagsVarious() {
+        final Map<String, String> refTags = new HashMap<String, String>();
+        refTags.put("foo", "bar");
+        final MetricName test = MetricName.EMPTY.tagged("foo", "bar");
+        final MetricName test2 = MetricName.EMPTY.tagged(refTags);
+
+        assertThat(test).isEqualTo(new MetricName(null, refTags));
+        assertThat(test.getTags()).isEqualTo(refTags);
+
+        assertThat(test2).isEqualTo(new MetricName(null, refTags));
+        assertThat(test2.getTags()).isEqualTo(refTags);
+    }
+
+    @Test
+    public void testTaggedMoreArguments() {
+        final Map<String, String> refTags = new HashMap<String, String>();
+        refTags.put("foo", "bar");
+        refTags.put("baz", "biz");
+        assertThat(MetricName.EMPTY.tagged("foo", "bar", "baz", "biz").getTags()).isEqualTo(refTags);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testTaggedNotPairs() {
+        MetricName.EMPTY.tagged("foo");
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void testTaggedNotPairs2() {
+        MetricName.EMPTY.tagged("foo", "bar", "baz");
+    }
+
+    @Test
+    public void testCompareTo() {
+        final MetricName a = MetricName.EMPTY.tagged("foo", "bar");
+        final MetricName b = MetricName.EMPTY.tagged("foo", "baz");
+
+        assertThat(a.compareTo(b)).isLessThan(0);
+        assertThat(b.compareTo(a)).isGreaterThan(0);
+        assertThat(b.compareTo(b)).isEqualTo(0);
+        assertThat(b.resolve("key").compareTo(b)).isLessThan(0);
+        assertThat(b.compareTo(b.resolve("key"))).isGreaterThan(0);
+    }
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryListenerTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryListenerTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class MetricRegistryListenerTest {
+    private static final MetricName BLAH = MetricName.build("blah");
+    
     private final Gauge gauge = mock(Gauge.class);
     private final Counter counter = mock(Counter.class);
     private final Histogram histogram = mock(Histogram.class);
@@ -17,45 +19,45 @@ public class MetricRegistryListenerTest {
 
     @Test
     public void noOpsOnGaugeAdded() throws Exception {
-        listener.onGaugeAdded("blah", gauge);
+        listener.onGaugeAdded(BLAH, gauge);
 
         verifyZeroInteractions(gauge);
     }
 
     @Test
     public void noOpsOnCounterAdded() throws Exception {
-        listener.onCounterAdded("blah", counter);
+        listener.onCounterAdded(BLAH, counter);
 
         verifyZeroInteractions(counter);
     }
 
     @Test
     public void noOpsOnHistogramAdded() throws Exception {
-        listener.onHistogramAdded("blah", histogram);
+        listener.onHistogramAdded(BLAH, histogram);
 
         verifyZeroInteractions(histogram);
     }
 
     @Test
     public void noOpsOnMeterAdded() throws Exception {
-        listener.onMeterAdded("blah", meter);
+        listener.onMeterAdded(BLAH, meter);
 
         verifyZeroInteractions(meter);
     }
 
     @Test
     public void noOpsOnTimerAdded() throws Exception {
-        listener.onTimerAdded("blah", timer);
+        listener.onTimerAdded(BLAH, timer);
 
         verifyZeroInteractions(timer);
     }
 
     @Test
     public void doesNotExplodeWhenMetricsAreRemoved() throws Exception {
-        listener.onGaugeRemoved("blah");
-        listener.onCounterRemoved("blah");
-        listener.onHistogramRemoved("blah");
-        listener.onMeterRemoved("blah");
-        listener.onTimerRemoved("blah");
+        listener.onGaugeRemoved(BLAH);
+        listener.onCounterRemoved(BLAH);
+        listener.onHistogramRemoved(BLAH);
+        listener.onMeterRemoved(BLAH);
+        listener.onTimerRemoved(BLAH);
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
@@ -12,6 +12,14 @@ import static org.fest.assertions.data.MapEntry.entry;
 import static org.mockito.Mockito.*;
 
 public class MetricRegistryTest {
+    private static final MetricName TIMER2 = MetricName.build("timer");
+    private static final MetricName METER2 = MetricName.build("meter");
+    private static final MetricName HISTOGRAM2 = MetricName.build("histogram");
+    private static final MetricName COUNTER = MetricName.build("counter");
+    private static final MetricName COUNTER2 = MetricName.build("counter2");
+    private static final MetricName GAUGE = MetricName.build("gauge");
+    private static final MetricName GAUGE2 = MetricName.build("gauge2");
+    private static final MetricName THING = MetricName.build("thing");
     private final MetricRegistryListener listener = mock(MetricRegistryListener.class);
     private final MetricRegistry registry = new MetricRegistry();
     @SuppressWarnings("unchecked")
@@ -28,225 +36,225 @@ public class MetricRegistryTest {
 
     @Test
     public void registeringAGaugeTriggersANotification() throws Exception {
-        assertThat(registry.register("thing", gauge))
+        assertThat(registry.register(THING, gauge))
                 .isEqualTo(gauge);
 
-        verify(listener).onGaugeAdded("thing", gauge);
+        verify(listener).onGaugeAdded(THING, gauge);
     }
 
     @Test
     public void removingAGaugeTriggersANotification() throws Exception {
-        registry.register("thing", gauge);
+        registry.register(THING, gauge);
 
-        assertThat(registry.remove("thing"))
+        assertThat(registry.remove(THING))
                 .isTrue();
 
-        verify(listener).onGaugeRemoved("thing");
+        verify(listener).onGaugeRemoved(THING);
     }
 
     @Test
     public void registeringACounterTriggersANotification() throws Exception {
-        assertThat(registry.register("thing", counter))
+        assertThat(registry.register(THING, counter))
                 .isEqualTo(counter);
 
-        verify(listener).onCounterAdded("thing", counter);
+        verify(listener).onCounterAdded(THING, counter);
     }
 
     @Test
     public void accessingACounterRegistersAndReusesTheCounter() throws Exception {
-        final Counter counter1 = registry.counter("thing");
-        final Counter counter2 = registry.counter("thing");
+        final Counter counter1 = registry.counter(THING);
+        final Counter counter2 = registry.counter(THING);
 
         assertThat(counter1)
                 .isSameAs(counter2);
 
-        verify(listener).onCounterAdded("thing", counter1);
+        verify(listener).onCounterAdded(THING, counter1);
     }
 
     @Test
     public void removingACounterTriggersANotification() throws Exception {
-        registry.register("thing", counter);
+        registry.register(THING, counter);
 
-        assertThat(registry.remove("thing"))
+        assertThat(registry.remove(THING))
                 .isTrue();
 
-        verify(listener).onCounterRemoved("thing");
+        verify(listener).onCounterRemoved(THING);
     }
 
     @Test
     public void registeringAHistogramTriggersANotification() throws Exception {
-        assertThat(registry.register("thing", histogram))
+        assertThat(registry.register(THING, histogram))
                 .isEqualTo(histogram);
 
-        verify(listener).onHistogramAdded("thing", histogram);
+        verify(listener).onHistogramAdded(THING, histogram);
     }
 
     @Test
     public void accessingAHistogramRegistersAndReusesIt() throws Exception {
-        final Histogram histogram1 = registry.histogram("thing");
-        final Histogram histogram2 = registry.histogram("thing");
+        final Histogram histogram1 = registry.histogram(THING);
+        final Histogram histogram2 = registry.histogram(THING);
 
         assertThat(histogram1)
                 .isSameAs(histogram2);
 
-        verify(listener).onHistogramAdded("thing", histogram1);
+        verify(listener).onHistogramAdded(THING, histogram1);
     }
 
     @Test
     public void removingAHistogramTriggersANotification() throws Exception {
-        registry.register("thing", histogram);
+        registry.register(THING, histogram);
 
-        assertThat(registry.remove("thing"))
+        assertThat(registry.remove(THING))
                 .isTrue();
 
-        verify(listener).onHistogramRemoved("thing");
+        verify(listener).onHistogramRemoved(THING);
     }
 
     @Test
     public void registeringAMeterTriggersANotification() throws Exception {
-        assertThat(registry.register("thing", meter))
+        assertThat(registry.register(THING, meter))
                 .isEqualTo(meter);
 
-        verify(listener).onMeterAdded("thing", meter);
+        verify(listener).onMeterAdded(THING, meter);
     }
 
     @Test
     public void accessingAMeterRegistersAndReusesIt() throws Exception {
-        final Meter meter1 = registry.meter("thing");
-        final Meter meter2 = registry.meter("thing");
+        final Meter meter1 = registry.meter(THING);
+        final Meter meter2 = registry.meter(THING);
 
         assertThat(meter1)
                 .isSameAs(meter2);
 
-        verify(listener).onMeterAdded("thing", meter1);
+        verify(listener).onMeterAdded(THING, meter1);
     }
 
     @Test
     public void removingAMeterTriggersANotification() throws Exception {
-        registry.register("thing", meter);
+        registry.register(THING, meter);
 
-        assertThat(registry.remove("thing"))
+        assertThat(registry.remove(THING))
                 .isTrue();
 
-        verify(listener).onMeterRemoved("thing");
+        verify(listener).onMeterRemoved(THING);
     }
 
     @Test
     public void registeringATimerTriggersANotification() throws Exception {
-        assertThat(registry.register("thing", timer))
+        assertThat(registry.register(THING, timer))
                 .isEqualTo(timer);
 
-        verify(listener).onTimerAdded("thing", timer);
+        verify(listener).onTimerAdded(THING, timer);
     }
 
     @Test
     public void accessingATimerRegistersAndReusesIt() throws Exception {
-        final Timer timer1 = registry.timer("thing");
-        final Timer timer2 = registry.timer("thing");
+        final Timer timer1 = registry.timer(THING);
+        final Timer timer2 = registry.timer(THING);
 
         assertThat(timer1)
                 .isSameAs(timer2);
 
-        verify(listener).onTimerAdded("thing", timer1);
+        verify(listener).onTimerAdded(THING, timer1);
     }
 
     @Test
     public void removingATimerTriggersANotification() throws Exception {
-        registry.register("thing", timer);
+        registry.register(THING, timer);
 
-        assertThat(registry.remove("thing"))
+        assertThat(registry.remove(THING))
                 .isTrue();
 
-        verify(listener).onTimerRemoved("thing");
+        verify(listener).onTimerRemoved(THING);
     }
 
     @Test
     public void addingAListenerWithExistingMetricsCatchesItUp() throws Exception {
-        registry.register("gauge", gauge);
-        registry.register("counter", counter);
-        registry.register("histogram", histogram);
-        registry.register("meter", meter);
-        registry.register("timer", timer);
+        registry.register(GAUGE2, gauge);
+        registry.register(COUNTER2, counter);
+        registry.register(HISTOGRAM2, histogram);
+        registry.register(METER2, meter);
+        registry.register(TIMER2, timer);
 
         final MetricRegistryListener other = mock(MetricRegistryListener.class);
         registry.addListener(other);
 
-        verify(other).onGaugeAdded("gauge", gauge);
-        verify(other).onCounterAdded("counter", counter);
-        verify(other).onHistogramAdded("histogram", histogram);
-        verify(other).onMeterAdded("meter", meter);
-        verify(other).onTimerAdded("timer", timer);
+        verify(other).onGaugeAdded(GAUGE2, gauge);
+        verify(other).onCounterAdded(COUNTER2, counter);
+        verify(other).onHistogramAdded(HISTOGRAM2, histogram);
+        verify(other).onMeterAdded(METER2, meter);
+        verify(other).onTimerAdded(TIMER2, timer);
     }
 
     @Test
     public void aRemovedListenerDoesNotReceiveUpdates() throws Exception {
-        registry.register("gauge", gauge);
+        registry.register(GAUGE, gauge);
         registry.removeListener(listener);
-        registry.register("gauge2", gauge);
+        registry.register(GAUGE2, gauge);
 
-        verify(listener, never()).onGaugeAdded("gauge2", gauge);
+        verify(listener, never()).onGaugeAdded(GAUGE2, gauge);
     }
 
     @Test
     public void hasAMapOfRegisteredGauges() throws Exception {
-        registry.register("gauge", gauge);
+        registry.register(GAUGE2, gauge);
 
         assertThat(registry.getGauges())
-                .contains(entry("gauge", gauge));
+                .contains(entry(GAUGE2, gauge));
     }
 
     @Test
     public void hasAMapOfRegisteredCounters() throws Exception {
-        registry.register("counter", counter);
+        registry.register(COUNTER2, counter);
 
         assertThat(registry.getCounters())
-                .contains(entry("counter", counter));
+                .contains(entry(COUNTER2, counter));
     }
 
     @Test
     public void hasAMapOfRegisteredHistograms() throws Exception {
-        registry.register("histogram", histogram);
+        registry.register(HISTOGRAM2, histogram);
 
         assertThat(registry.getHistograms())
-                .contains(entry("histogram", histogram));
+                .contains(entry(HISTOGRAM2, histogram));
     }
 
     @Test
     public void hasAMapOfRegisteredMeters() throws Exception {
-        registry.register("meter", meter);
+        registry.register(METER2, meter);
 
         assertThat(registry.getMeters())
-                .contains(entry("meter", meter));
+                .contains(entry(METER2, meter));
     }
 
     @Test
     public void hasAMapOfRegisteredTimers() throws Exception {
-        registry.register("timer", timer);
+        registry.register(TIMER2, timer);
 
         assertThat(registry.getTimers())
-                .contains(entry("timer", timer));
+                .contains(entry(TIMER2, timer));
     }
 
     @Test
     public void hasASetOfRegisteredMetricNames() throws Exception {
-        registry.register("gauge", gauge);
-        registry.register("counter", counter);
-        registry.register("histogram", histogram);
-        registry.register("meter", meter);
-        registry.register("timer", timer);
+        registry.register(GAUGE2, gauge);
+        registry.register(COUNTER2, counter);
+        registry.register(HISTOGRAM2, histogram);
+        registry.register(METER2, meter);
+        registry.register(TIMER2, timer);
 
         assertThat(registry.getNames())
-                .containsOnly("gauge", "counter", "histogram", "meter", "timer");
+                .containsOnly(GAUGE2, COUNTER2, HISTOGRAM2, METER2, TIMER2);
     }
 
     @Test
     public void registersMultipleMetrics() throws Exception {
         final MetricSet metrics = new MetricSet() {
             @Override
-            public Map<String, Metric> getMetrics() {
-                final Map<String, Metric> metrics = new HashMap<String, Metric>();
-                metrics.put("gauge", gauge);
-                metrics.put("counter", counter);
+            public Map<MetricName, Metric> getMetrics() {
+                final Map<MetricName, Metric> metrics = new HashMap<MetricName, Metric>();
+                metrics.put(GAUGE2, gauge);
+                metrics.put(COUNTER2, counter);
                 return metrics;
             }
         };
@@ -254,17 +262,20 @@ public class MetricRegistryTest {
         registry.registerAll(metrics);
 
         assertThat(registry.getNames())
-                .containsOnly("gauge", "counter");
+                .containsOnly(GAUGE2, COUNTER2);
     }
 
     @Test
     public void registersMultipleMetricsWithAPrefix() throws Exception {
+        final MetricName myCounter = MetricName.build("my.counter");
+        final MetricName myGauge = MetricName.build("my.gauge");
+
         final MetricSet metrics = new MetricSet() {
             @Override
-            public Map<String, Metric> getMetrics() {
-                final Map<String, Metric> metrics = new HashMap<String, Metric>();
-                metrics.put("gauge", gauge);
-                metrics.put("counter", counter);
+            public Map<MetricName, Metric> getMetrics() {
+                final Map<MetricName, Metric> metrics = new HashMap<MetricName, Metric>();
+                metrics.put(GAUGE, gauge);
+                metrics.put(COUNTER, counter);
                 return metrics;
             }
         };
@@ -272,79 +283,82 @@ public class MetricRegistryTest {
         registry.register("my", metrics);
 
         assertThat(registry.getNames())
-                .containsOnly("my.gauge", "my.counter");
+                .containsOnly(myGauge, myCounter);
     }
 
     @Test
     public void registersRecursiveMetricSets() throws Exception {
         final MetricSet inner = new MetricSet() {
             @Override
-            public Map<String, Metric> getMetrics() {
-                final Map<String, Metric> metrics = new HashMap<String, Metric>();
-                metrics.put("gauge", gauge);
+            public Map<MetricName, Metric> getMetrics() {
+                final Map<MetricName, Metric> metrics = new HashMap<MetricName, Metric>();
+                metrics.put(GAUGE, gauge);
                 return metrics;
             }
         };
 
         final MetricSet outer = new MetricSet() {
             @Override
-            public Map<String, Metric> getMetrics() {
-                final Map<String, Metric> metrics = new HashMap<String, Metric>();
-                metrics.put("inner", inner);
-                metrics.put("counter", counter);
+            public Map<MetricName, Metric> getMetrics() {
+                final Map<MetricName, Metric> metrics = new HashMap<MetricName, Metric>();
+                metrics.put(MetricName.build("inner"), inner);
+                metrics.put(COUNTER, counter);
                 return metrics;
             }
         };
 
         registry.register("my", outer);
 
+        final MetricName myCounter = MetricName.build("my.counter");
+        final MetricName myInnerGauge = MetricName.build("my.inner.gauge");
+
         assertThat(registry.getNames())
-                .containsOnly("my.inner.gauge", "my.counter");
+                .containsOnly(myInnerGauge, myCounter);
     }
 
     @Test
     public void registersMetricsFromAnotherRegistry() throws Exception {
         MetricRegistry other = new MetricRegistry();
-        other.register("gauge", gauge);
+        other.register(GAUGE, gauge);
         registry.register("nested", other);
-        assertThat(registry.getNames()).containsOnly("nested.gauge");
+        assertThat(registry.getNames()).containsOnly(MetricName.build("nested.gauge"));
     }
 
     @Test
     public void concatenatesStringsToFormADottedName() throws Exception {
         assertThat(name("one", "two", "three"))
-                .isEqualTo("one.two.three");
+                .isEqualTo(MetricName.build("one.two.three"));
     }
 
     @Test
     @SuppressWarnings("NullArgumentToVariableArgMethod")
     public void elidesNullValuesFromNamesWhenOnlyOneNullPassedIn() throws Exception {
         assertThat(name("one", null))
-                .isEqualTo("one");
+                .isEqualTo(MetricName.build("one"));
     }
 
     @Test
     public void elidesNullValuesFromNamesWhenManyNullsPassedIn() throws Exception {
         assertThat(name("one", null, null))
-                .isEqualTo("one");
+                .isEqualTo(MetricName.build("one"));
     }
 
     @Test
     public void elidesNullValuesFromNamesWhenNullAndNotNullPassedIn() throws Exception {
         assertThat(name("one", null, "three"))
-                .isEqualTo("one.three");
+                .isEqualTo(MetricName.build("one.three"));
     }
 
     @Test
     public void elidesEmptyStringsFromNames() throws Exception {
         assertThat(name("one", "", "three"))
-                .isEqualTo("one.three");
+                .isEqualTo(MetricName.build("one.three"));
     }
 
     @Test
     public void concatenatesClassNamesWithStringsToFormADottedName() throws Exception {
         assertThat(name(MetricRegistryTest.class, "one", "two"))
-                .isEqualTo("com.codahale.metrics.MetricRegistryTest.one.two");
+                .isEqualTo(MetricName.build("com.codahale.metrics.MetricRegistryTest.one.two"));
     }
 
     @Test
@@ -357,31 +371,35 @@ public class MetricRegistryTest {
         };
 
         assertThat(name(g.getClass(), "one", "two"))
-                .isEqualTo("com.codahale.metrics.MetricRegistryTest$5.one.two");
+                .isEqualTo(MetricName.build(g.getClass().getName() + ".one.two"));
     }
 
     @Test
     public void removesMetricsMatchingAFilter() throws Exception {
-        registry.timer("timer-1");
-        registry.timer("timer-2");
-        registry.histogram("histogram-1");
+        final MetricName timer1 = MetricName.build("timer-1");
+        final MetricName timer2 = MetricName.build("timer-2");
+        final MetricName histogram1 = MetricName.build("histogram-1");
+
+        registry.timer(timer1);
+        registry.timer(timer2);
+        registry.histogram(histogram1);
 
         assertThat(registry.getNames())
-                .contains("timer-1", "timer-2", "histogram-1");
+                .contains(timer1, timer2, histogram1);
 
         registry.removeMatching(new MetricFilter() {
             @Override
-            public boolean matches(String name, Metric metric) {
-                return name.endsWith("1");
+            public boolean matches(MetricName name, Metric metric) {
+                return name.getKey().endsWith("1");
             }
         });
 
         assertThat(registry.getNames())
-                .doesNotContain("timer-1", "histogram-1");
+                .doesNotContain(timer1, histogram1);
         assertThat(registry.getNames())
-                .contains("timer-2");
+                .contains(timer2);
 
-        verify(listener).onTimerRemoved("timer-1");
-        verify(listener).onHistogramRemoved("histogram-1");
+        verify(listener).onTimerRemoved(timer1);
+        verify(listener).onHistogramRemoved(histogram1);
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
@@ -25,11 +25,11 @@ public class ScheduledReporterTest {
                                   TimeUnit.SECONDS,
                                   TimeUnit.MILLISECONDS) {
                 @Override
-                public void report(SortedMap<String, Gauge> gauges,
-                                   SortedMap<String, Counter> counters,
-                                   SortedMap<String, Histogram> histograms,
-                                   SortedMap<String, Meter> meters,
-                                   SortedMap<String, Timer> timers) {
+                public void report(SortedMap<MetricName, Gauge> gauges,
+                                   SortedMap<MetricName, Counter> counters,
+                                   SortedMap<MetricName, Histogram> histograms,
+                                   SortedMap<MetricName, Meter> meters,
+                                   SortedMap<MetricName, Timer> timers) {
                     // nothing doing!
                 }
             }
@@ -63,9 +63,9 @@ public class ScheduledReporterTest {
         );
     }
 
-    private <T> SortedMap<String, T> map(String name, T value) {
-        final SortedMap<String, T> map = new TreeMap<String, T>();
-        map.put(name, value);
+    private <T> SortedMap<MetricName, T> map(String name, T value) {
+        final SortedMap<MetricName, T> map = new TreeMap<MetricName, T>();
+        map.put(MetricName.build(name), value);
         return map;
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/Slf4jReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/Slf4jReporterTest.java
@@ -32,7 +32,7 @@ public class Slf4jReporterTest {
                         this.<Meter>map(),
                         this.<Timer>map());
 
-        verify(logger).info(marker, "type=GAUGE, name={}, value={}", "gauge", "value");
+        verify(logger).info(marker, "type=GAUGE, name={}, value={}", MetricName.build("gauge"), "value");
     }
 
     @Test
@@ -46,7 +46,7 @@ public class Slf4jReporterTest {
                         this.<Meter>map(),
                         this.<Timer>map());
 
-        verify(logger).info(marker, "type=COUNTER, name={}, count={}", "test.counter", 100L);
+        verify(logger).info(marker, "type=COUNTER, name={}, count={}", MetricName.build("test.counter"), 100L);
     }
 
     @Test
@@ -76,7 +76,7 @@ public class Slf4jReporterTest {
 
         verify(logger).info(marker,
                             "type=HISTOGRAM, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}",
-                            "test.histogram",
+                            MetricName.build("test.histogram"),
                             1L,
                             4L,
                             2L,
@@ -107,7 +107,7 @@ public class Slf4jReporterTest {
 
         verify(logger).info(marker,
                             "type=METER, name={}, count={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}",
-                            "test.meter",
+                            MetricName.build("test.meter"),
                             1L,
                             2.0,
                             3.0,
@@ -149,7 +149,7 @@ public class Slf4jReporterTest {
 
         verify(logger).info(marker,
                             "type=TIMER, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}, duration_unit={}",
-                            "test.another.timer",
+                            MetricName.build("test.another.timer"),
                             1L,
                             300.0,
                             100.0,
@@ -169,13 +169,13 @@ public class Slf4jReporterTest {
                             "milliseconds");
     }
 
-    private <T> SortedMap<String, T> map() {
-        return new TreeMap<String, T>();
+    private <T> SortedMap<MetricName, T> map() {
+        return new TreeMap<MetricName, T>();
     }
 
-    private <T> SortedMap<String, T> map(String name, T metric) {
-        final TreeMap<String, T> map = new TreeMap<String, T>();
-        map.put(name, metric);
+    private <T> SortedMap<MetricName, T> map(String name, T metric) {
+        final TreeMap<MetricName, T> map = new TreeMap<MetricName, T>();
+        map.put(MetricName.build(name), metric);
         return map;
     }
 

--- a/metrics-ehcache/src/main/java/com/codahale/metrics/ehcache/InstrumentedEhcache.java
+++ b/metrics-ehcache/src/main/java/com/codahale/metrics/ehcache/InstrumentedEhcache.java
@@ -1,8 +1,10 @@
 package com.codahale.metrics.ehcache;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+
 import net.sf.ehcache.CacheException;
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
@@ -118,8 +120,8 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
         cache.setSampledStatisticsEnabled(true);
         cache.setStatisticsAccuracy(Statistics.STATISTICS_ACCURACY_NONE);
 
-        final String prefix = name(cache.getClass(), cache.getName());
-        registry.register(name(prefix, "hits"),
+        final MetricName prefix = name(cache.getClass(), cache.getName());
+        registry.register(prefix.resolve("hits"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -127,7 +129,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "in-memory-hits"),
+        registry.register(prefix.resolve("in-memory-hits"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -135,7 +137,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "off-heap-hits"),
+        registry.register(prefix.resolve("off-heap-hits"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -143,7 +145,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "on-disk-hits"),
+        registry.register(prefix.resolve("on-disk-hits"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -151,7 +153,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "misses"),
+        registry.register(prefix.resolve("misses"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -159,7 +161,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "in-memory-misses"),
+        registry.register(prefix.resolve("in-memory-misses"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -167,7 +169,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "off-heap-misses"),
+        registry.register(prefix.resolve("off-heap-misses"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -175,7 +177,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "on-disk-misses"),
+        registry.register(prefix.resolve("on-disk-misses"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -183,7 +185,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "objects"),
+        registry.register(prefix.resolve("objects"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -191,7 +193,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "in-memory-objects"),
+        registry.register(prefix.resolve("in-memory-objects"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -199,7 +201,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "off-heap-objects"),
+        registry.register(prefix.resolve("off-heap-objects"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -207,7 +209,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "on-disk-objects"),
+        registry.register(prefix.resolve("on-disk-objects"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -215,7 +217,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "mean-get-time"),
+        registry.register(prefix.resolve("mean-get-time"),
                           new Gauge<Float>() {
                               @Override
                               public Float getValue() {
@@ -223,7 +225,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "mean-search-time"),
+        registry.register(prefix.resolve("mean-search-time"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -231,7 +233,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "eviction-count"),
+        registry.register(prefix.resolve("eviction-count"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -239,7 +241,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "searches-per-second"),
+        registry.register(prefix.resolve("searches-per-second"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -247,7 +249,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "writer-queue-size"),
+        registry.register(prefix.resolve("writer-queue-size"),
                           new Gauge<Long>() {
                               @Override
                               public Long getValue() {
@@ -255,7 +257,7 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
                               }
                           });
 
-        registry.register(name(prefix, "accuracy"),
+        registry.register(prefix.resolve("accuracy"),
                           new Gauge<String>() {
                               @Override
                               public String getValue() {

--- a/metrics-ganglia/src/test/java/com/codahale/metrics/ganglia/GangliaReporterTest.java
+++ b/metrics-ganglia/src/test/java/com/codahale/metrics/ganglia/GangliaReporterTest.java
@@ -247,13 +247,13 @@ public class GangliaReporterTest {
         verifyNoMoreInteractions(ganglia);
     }
 
-    private <T> SortedMap<String, T> map() {
-        return new TreeMap<String, T>();
+    private <T> SortedMap<MetricName, T> map() {
+        return new TreeMap<MetricName, T>();
     }
 
-    private <T> SortedMap<String, T> map(String name, T metric) {
-        final TreeMap<String, T> map = new TreeMap<String, T>();
-        map.put(name, metric);
+    private <T> SortedMap<MetricName, T> map(String name, T metric) {
+        final TreeMap<MetricName, T> map = new TreeMap<MetricName, T>();
+        map.put(MetricName.build(name), metric);
         return map;
     }
 

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -299,13 +299,13 @@ public class GraphiteReporterTest {
         verifyNoMoreInteractions(graphite);
     }
 
-    private <T> SortedMap<String, T> map() {
-        return new TreeMap<String, T>();
+    private <T> SortedMap<MetricName, T> map() {
+        return new TreeMap<MetricName, T>();
     }
 
-    private <T> SortedMap<String, T> map(String name, T metric) {
-        final TreeMap<String, T> map = new TreeMap<String, T>();
-        map.put(name, metric);
+    private <T> SortedMap<MetricName, T> map(String name, T metric) {
+        final TreeMap<MetricName, T> map = new TreeMap<MetricName, T>();
+        map.put(MetricName.build(name), metric);
         return map;
     }
 

--- a/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategies.java
+++ b/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategies.java
@@ -5,6 +5,8 @@ import org.apache.http.RequestLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.utils.URIBuilder;
 
+import com.codahale.metrics.MetricName;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -15,7 +17,7 @@ public class HttpClientMetricNameStrategies {
     public static final HttpClientMetricNameStrategy METHOD_ONLY =
             new HttpClientMetricNameStrategy() {
                 @Override
-                public String getNameFor(String name, HttpRequest request) {
+                public MetricName getNameFor(String name, HttpRequest request) {
                     return name(HttpClient.class,
                                 name,
                                 methodNameString(request));
@@ -25,7 +27,7 @@ public class HttpClientMetricNameStrategies {
     public static final HttpClientMetricNameStrategy HOST_AND_METHOD =
             new HttpClientMetricNameStrategy() {
                 @Override
-                public String getNameFor(String name, HttpRequest request) {
+                public MetricName getNameFor(String name, HttpRequest request) {
                     final RequestLine requestLine = request.getRequestLine();
                     final URI uri = URI.create(requestLine.getUri());
                     return name(HttpClient.class,
@@ -38,7 +40,7 @@ public class HttpClientMetricNameStrategies {
     public static final HttpClientMetricNameStrategy QUERYLESS_URL_AND_METHOD =
             new HttpClientMetricNameStrategy() {
                 @Override
-                public String getNameFor(String name, HttpRequest request) {
+                public MetricName getNameFor(String name, HttpRequest request) {
                     try {
                         final RequestLine requestLine = request.getRequestLine();
                         final URIBuilder url = new URIBuilder(requestLine.getUri());

--- a/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategy.java
+++ b/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategy.java
@@ -2,6 +2,8 @@ package com.codahale.metrics.httpclient;
 
 import org.apache.http.HttpRequest;
 
+import com.codahale.metrics.MetricName;
+
 public interface HttpClientMetricNameStrategy {
-    String getNameFor(String name, HttpRequest request);
+    MetricName getNameFor(String name, HttpRequest request);
 }

--- a/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategiesTest.java
+++ b/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategiesTest.java
@@ -5,6 +5,8 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.junit.Test;
 
+import com.codahale.metrics.MetricName;
+
 import static com.codahale.metrics.httpclient.HttpClientMetricNameStrategies.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -14,25 +16,25 @@ public class HttpClientMetricNameStrategiesTest {
     @Test
     public void methodOnlyWithName() {
         assertThat(METHOD_ONLY.getNameFor("some-service", new HttpGet("/whatever")),
-                   is("org.apache.http.client.HttpClient.some-service.get-requests"));
+                   is(MetricName.build("org.apache.http.client.HttpClient.some-service.get-requests")));
     }
 
     @Test
     public void methodOnlyWithoutName() {
         assertThat(METHOD_ONLY.getNameFor(null, new HttpGet("/whatever")),
-                is("org.apache.http.client.HttpClient.get-requests"));
+                is(MetricName.build("org.apache.http.client.HttpClient.get-requests")));
     }
 
     @Test
     public void hostAndMethodWithName() {
         assertThat(HOST_AND_METHOD.getNameFor("some-service", new HttpPost("http://my.host.com/whatever")),
-                   is("org.apache.http.client.HttpClient.some-service.my.host.com.post-requests"));
+                   is(MetricName.build("org.apache.http.client.HttpClient.some-service.my.host.com.post-requests")));
     }
 
     @Test
     public void hostAndMethodWithoutName() {
         assertThat(HOST_AND_METHOD.getNameFor(null, new HttpPost("http://my.host.com/whatever")),
-                is("org.apache.http.client.HttpClient.my.host.com.post-requests"));
+                is(MetricName.build("org.apache.http.client.HttpClient.my.host.com.post-requests")));
     }
 
     @Test
@@ -40,6 +42,6 @@ public class HttpClientMetricNameStrategiesTest {
         assertThat(QUERYLESS_URL_AND_METHOD.getNameFor(
                 "some-service",
                 new HttpPut("https://thing.com:8090/my/path?ignore=this&and=this")),
-                is("org.apache.http.client.HttpClient.some-service.https://thing.com:8090/my/path.put-requests"));
+                is(MetricName.build("org.apache.http.client.HttpClient.some-service.https://thing.com:8090/my/path.put-requests")));
     }
 }

--- a/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/InstrumentedHttpClientsTest.java
+++ b/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/InstrumentedHttpClientsTest.java
@@ -1,8 +1,10 @@
 package com.codahale.metrics.httpclient;
 
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricRegistryListener;
 import com.codahale.metrics.Timer;
+
 import org.apache.http.HttpRequest;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -31,7 +33,7 @@ public class InstrumentedHttpClientsTest {
     @Test
     public void registersExpectedMetricsGivenNameStrategy() throws Exception {
         final HttpGet get = new HttpGet("http://example.com?q=anything");
-        final String metricName = "some.made.up.metric.name";
+        final MetricName metricName = MetricName.build("some.made.up.metric.name");
 
         when(metricNameStrategy.getNameFor(anyString(), any(HttpRequest.class)))
                 .thenReturn(metricName);

--- a/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/DelegatingStatementNameStrategy.java
+++ b/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/DelegatingStatementNameStrategy.java
@@ -2,6 +2,8 @@ package com.codahale.metrics.jdbi.strategies;
 
 import org.skife.jdbi.v2.StatementContext;
 
+import com.codahale.metrics.MetricName;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -18,9 +20,9 @@ public abstract class DelegatingStatementNameStrategy implements StatementNameSt
     }
 
     @Override
-    public String getStatementName(StatementContext statementContext) {
+    public MetricName getStatementName(StatementContext statementContext) {
         for (StatementNameStrategy strategy : strategies) {
-            final String statementName = strategy.getStatementName(statementContext);
+            final MetricName statementName = strategy.getStatementName(statementContext);
             if (statementName != null) {
                 return statementName;
             }

--- a/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/NameStrategies.java
+++ b/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/NameStrategies.java
@@ -3,6 +3,8 @@ package com.codahale.metrics.jdbi.strategies;
 import org.skife.jdbi.v2.ClasspathStatementLocator;
 import org.skife.jdbi.v2.StatementContext;
 
+import com.codahale.metrics.MetricName;
+
 import java.lang.reflect.Method;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -20,12 +22,12 @@ public final class NameStrategies {
     /**
      * An empty SQL statement.
      */
-    private static final String EMPTY_SQL = "sql.empty";
+    private static final MetricName EMPTY_SQL = MetricName.build("sql.empty");
 
     /**
      * Unknown SQL.
      */
-    static final String UNKNOWN_SQL = "sql.unknown";
+    static final MetricName UNKNOWN_SQL = MetricName.build("sql.unknown");
 
     /**
      * Context attribute name for the metric class.
@@ -47,7 +49,7 @@ public final class NameStrategies {
      */
     public static final String STATEMENT_NAME = "_metric_name";
 
-    private static String forRawSql(String rawSql) {
+    private static MetricName forRawSql(String rawSql) {
         return name("sql", "raw", rawSql);
     }
 
@@ -56,7 +58,7 @@ public final class NameStrategies {
         }
 
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final String rawSql = statementContext.getRawSql();
 
             if (rawSql == null || rawSql.length() == 0) {
@@ -71,7 +73,7 @@ public final class NameStrategies {
         }
 
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final String rawSql = statementContext.getRawSql();
 
             if (ClasspathStatementLocator.looksLikeSql(rawSql)) {
@@ -86,7 +88,7 @@ public final class NameStrategies {
         }
 
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final String rawSql = statementContext.getRawSql();
 
             // Is it using the template loader?
@@ -108,7 +110,7 @@ public final class NameStrategies {
         }
 
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final Class<?> clazz = statementContext.getSqlObjectType();
             final Method method = statementContext.getSqlObjectMethod();
             if (clazz != null) {
@@ -128,7 +130,7 @@ public final class NameStrategies {
         }
 
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final Object classObj = statementContext.getAttribute(STATEMENT_CLASS);
             final Object nameObj = statementContext.getAttribute(STATEMENT_NAME);
 
@@ -160,7 +162,7 @@ public final class NameStrategies {
         }
 
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final Object groupObj = statementContext.getAttribute(STATEMENT_GROUP);
             final Object typeObj = statementContext.getAttribute(STATEMENT_TYPE);
             final Object nameObj = statementContext.getAttribute(STATEMENT_NAME);

--- a/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/ShortNameStrategy.java
+++ b/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/ShortNameStrategy.java
@@ -2,6 +2,8 @@ package com.codahale.metrics.jdbi.strategies;
 
 import org.skife.jdbi.v2.StatementContext;
 
+import com.codahale.metrics.MetricName;
+
 import java.lang.reflect.Method;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -31,7 +33,7 @@ public final class ShortNameStrategy extends DelegatingStatementNameStrategy {
 
     private final class ShortContextClassStrategy implements StatementNameStrategy {
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final Object classObj = statementContext.getAttribute(NameStrategies.STATEMENT_CLASS);
             final Object nameObj = statementContext.getAttribute(NameStrategies.STATEMENT_NAME);
 
@@ -60,7 +62,7 @@ public final class ShortNameStrategy extends DelegatingStatementNameStrategy {
 
     private final class ShortSqlObjectStrategy implements StatementNameStrategy {
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final Class<?> clazz = statementContext.getSqlObjectType();
             final Method method = statementContext.getSqlObjectMethod();
             if (clazz != null && method != null) {

--- a/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/StatementNameStrategy.java
+++ b/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/StatementNameStrategy.java
@@ -2,9 +2,11 @@ package com.codahale.metrics.jdbi.strategies;
 
 import org.skife.jdbi.v2.StatementContext;
 
+import com.codahale.metrics.MetricName;
+
 /**
  * Interface for strategies to statement contexts to metric names.
  */
 public interface StatementNameStrategy {
-    String getStatementName(StatementContext statementContext);
+    MetricName getStatementName(StatementContext statementContext);
 }

--- a/metrics-jdbi/src/test/java/com/codahale/metrics/jdbi/InstrumentedTimingCollectorTest.java
+++ b/metrics-jdbi/src/test/java/com/codahale/metrics/jdbi/InstrumentedTimingCollectorTest.java
@@ -1,11 +1,13 @@
 package com.codahale.metrics.jdbi;
 
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.jdbi.strategies.NameStrategies;
 import com.codahale.metrics.jdbi.strategies.ShortNameStrategy;
 import com.codahale.metrics.jdbi.strategies.SmartNameStrategy;
 import com.codahale.metrics.jdbi.strategies.StatementNameStrategy;
+
 import org.junit.Test;
 import org.skife.jdbi.v2.StatementContext;
 
@@ -31,7 +33,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(1), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -51,7 +53,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(1), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -70,7 +72,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(2), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -88,7 +90,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(2), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -107,7 +109,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(3), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -129,7 +131,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(3), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -151,7 +153,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(4), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -173,7 +175,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(4), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -196,7 +198,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(5), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -218,7 +220,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(1), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -242,7 +244,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(3), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)

--- a/metrics-jetty8/src/main/java/com/codahale/metrics/jetty8/InstrumentedHandler.java
+++ b/metrics-jetty8/src/main/java/com/codahale/metrics/jetty8/InstrumentedHandler.java
@@ -60,28 +60,27 @@ public class InstrumentedHandler extends HandlerWrapper {
      * @param underlying the handler about which metrics will be collected
      * @param prefix     the prefix to use for the metrics names
      */
-    public InstrumentedHandler(MetricRegistry registry, Handler underlying, String prefix) {
+    public InstrumentedHandler(MetricRegistry registry, Handler underlying, MetricName prefix) {
         super();
-        this.dispatches = registry.timer(name(prefix, "dispatches"));
-        this.requests = registry.meter(name(prefix, "requests"));
-        this.resumes = registry.meter(name(prefix, "resumes"));
-        this.suspends = registry.meter(name(prefix, "suspends"));
-        this.expires = registry.meter(name(prefix, "expires"));
+        this.dispatches = registry.timer(prefix.resolve("dispatches"));
+        this.requests = registry.meter(prefix.resolve("requests"));
+        this.resumes = registry.meter(prefix.resolve("resumes"));
+        this.suspends = registry.meter(prefix.resolve("suspends"));
+        this.expires = registry.meter(prefix.resolve("expires"));
 
-        this.activeRequests = registry.counter(name(prefix, "active-requests"));
-        this.activeSuspendedRequests = registry.counter(name(prefix,
-                                                             "active-suspended-requests"));
-        this.activeDispatches = registry.counter(name(prefix, "active-dispatches"));
+        this.activeRequests = registry.counter(prefix.resolve("active-requests"));
+        this.activeSuspendedRequests = registry.counter(prefix.resolve("active-suspended-requests"));
+        this.activeDispatches = registry.counter(prefix.resolve("active-dispatches"));
 
         this.responses = new Meter[]{
-                registry.meter(name(prefix, "1xx-responses")), // 1xx
-                registry.meter(name(prefix, "2xx-responses")), // 2xx
-                registry.meter(name(prefix, "3xx-responses")), // 3xx
-                registry.meter(name(prefix, "4xx-responses")), // 4xx
-                registry.meter(name(prefix, "5xx-responses"))  // 5xx
+                registry.meter(prefix.resolve("1xx-responses")), // 1xx
+                registry.meter(prefix.resolve("2xx-responses")), // 2xx
+                registry.meter(prefix.resolve("3xx-responses")), // 3xx
+                registry.meter(prefix.resolve("4xx-responses")), // 4xx
+                registry.meter(prefix.resolve("5xx-responses"))  // 5xx
         };
 
-        registry.register(name(prefix, "percent-4xx-1m"), new RatioGauge() {
+        registry.register(prefix.resolve("percent-4xx-1m"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[3].getOneMinuteRate(),
@@ -89,7 +88,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             }
         });
 
-        registry.register(name(prefix, "percent-4xx-5m"), new RatioGauge() {
+        registry.register(prefix.resolve("percent-4xx-5m"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[3].getFiveMinuteRate(),
@@ -97,7 +96,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             }
         });
 
-        registry.register(name(prefix, "percent-4xx-15m"), new RatioGauge() {
+        registry.register(prefix.resolve("percent-4xx-15m"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[3].getFifteenMinuteRate(),
@@ -105,7 +104,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             }
         });
 
-        registry.register(name(prefix, "percent-5xx-1m"), new RatioGauge() {
+        registry.register(prefix.resolve("percent-5xx-1m"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[4].getOneMinuteRate(),
@@ -113,7 +112,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             }
         });
 
-        registry.register(name(prefix, "percent-5xx-5m"), new RatioGauge() {
+        registry.register(prefix.resolve("percent-5xx-5m"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[4].getFiveMinuteRate(),
@@ -121,7 +120,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             }
         });
 
-        registry.register(name(prefix, "percent-5xx-15m"), new RatioGauge() {
+        registry.register(prefix.resolve("percent-5xx-15m"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[4].getFifteenMinuteRate(),
@@ -150,16 +149,16 @@ public class InstrumentedHandler extends HandlerWrapper {
             }
         };
 
-        this.getRequests = registry.timer(name(prefix, "get-requests"));
-        this.postRequests = registry.timer(name(prefix, "post-requests"));
-        this.headRequests = registry.timer(name(prefix, "head-requests"));
-        this.putRequests = registry.timer(name(prefix, "put-requests"));
-        this.deleteRequests = registry.timer(name(prefix, "delete-requests"));
-        this.optionsRequests = registry.timer(name(prefix, "options-requests"));
-        this.traceRequests = registry.timer(name(prefix, "trace-requests"));
-        this.connectRequests = registry.timer(name(prefix, "connect-requests"));
-        this.patchRequests = registry.timer(name(prefix, "patch-requests"));
-        this.otherRequests = registry.timer(name(prefix, "other-requests"));
+        this.getRequests = registry.timer(prefix.resolve("get-requests"));
+        this.postRequests = registry.timer(prefix.resolve("post-requests"));
+        this.headRequests = registry.timer(prefix.resolve("head-requests"));
+        this.putRequests = registry.timer(prefix.resolve("put-requests"));
+        this.deleteRequests = registry.timer(prefix.resolve("delete-requests"));
+        this.optionsRequests = registry.timer(prefix.resolve("options-requests"));
+        this.traceRequests = registry.timer(prefix.resolve("trace-requests"));
+        this.connectRequests = registry.timer(prefix.resolve("connect-requests"));
+        this.patchRequests = registry.timer(prefix.resolve("patch-requests"));
+        this.otherRequests = registry.timer(prefix.resolve("other-requests"));
 
         setHandler(underlying);
     }

--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -2,8 +2,10 @@ package com.codahale.metrics.jetty9;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.server.AsyncContextState;
 import org.eclipse.jetty.server.Handler;
@@ -16,6 +18,7 @@ import javax.servlet.AsyncListener;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
@@ -101,36 +104,36 @@ public class InstrumentedHandler extends HandlerWrapper {
     protected void doStart() throws Exception {
         super.doStart();
 
-        final String prefix = this.prefix == null ? name(getHandler().getClass(), name) : name(this.prefix, name);
+        final MetricName prefix = this.prefix == null ? name(getHandler().getClass(), name) : name(this.prefix, name);
 
-        this.requests = metricRegistry.timer(name(prefix, "requests"));
-        this.dispatches = metricRegistry.timer(name(prefix, "dispatches"));
+        this.requests = metricRegistry.timer(prefix.resolve("requests"));
+        this.dispatches = metricRegistry.timer(prefix.resolve("dispatches"));
 
-        this.activeRequests = metricRegistry.counter(name(prefix, "active-requests"));
-        this.activeDispatches = metricRegistry.counter(name(prefix, "active-dispatches"));
-        this.activeSuspended = metricRegistry.counter(name(prefix, "active-suspended"));
+        this.activeRequests = metricRegistry.counter(prefix.resolve("active-requests"));
+        this.activeDispatches = metricRegistry.counter(prefix.resolve("active-dispatches"));
+        this.activeSuspended = metricRegistry.counter(prefix.resolve("active-suspended"));
 
-        this.asyncDispatches = metricRegistry.meter(name(prefix, "async-dispatches"));
-        this.asyncTimeouts = metricRegistry.meter(name(prefix, "async-timeouts"));
+        this.asyncDispatches = metricRegistry.meter(prefix.resolve("async-dispatches"));
+        this.asyncTimeouts = metricRegistry.meter(prefix.resolve("async-timeouts"));
 
         this.responses = new Meter[]{
-                metricRegistry.meter(name(prefix, "1xx-responses")), // 1xx
-                metricRegistry.meter(name(prefix, "2xx-responses")), // 2xx
-                metricRegistry.meter(name(prefix, "3xx-responses")), // 3xx
-                metricRegistry.meter(name(prefix, "4xx-responses")), // 4xx
-                metricRegistry.meter(name(prefix, "5xx-responses"))  // 5xx
+                metricRegistry.meter(prefix.resolve("1xx-responses")), // 1xx
+                metricRegistry.meter(prefix.resolve("2xx-responses")), // 2xx
+                metricRegistry.meter(prefix.resolve("3xx-responses")), // 3xx
+                metricRegistry.meter(prefix.resolve("4xx-responses")), // 4xx
+                metricRegistry.meter(prefix.resolve("5xx-responses"))  // 5xx
         };
 
-        this.getRequests = metricRegistry.timer(name(prefix, "get-requests"));
-        this.postRequests = metricRegistry.timer(name(prefix, "post-requests"));
-        this.headRequests = metricRegistry.timer(name(prefix, "head-requests"));
-        this.putRequests = metricRegistry.timer(name(prefix, "put-requests"));
-        this.deleteRequests = metricRegistry.timer(name(prefix, "delete-requests"));
-        this.optionsRequests = metricRegistry.timer(name(prefix, "options-requests"));
-        this.traceRequests = metricRegistry.timer(name(prefix, "trace-requests"));
-        this.connectRequests = metricRegistry.timer(name(prefix, "connect-requests"));
-        this.moveRequests = metricRegistry.timer(name(prefix, "move-requests"));
-        this.otherRequests = metricRegistry.timer(name(prefix, "other-requests"));
+        this.getRequests = metricRegistry.timer(prefix.resolve("get-requests"));
+        this.postRequests = metricRegistry.timer(prefix.resolve("post-requests"));
+        this.headRequests = metricRegistry.timer(prefix.resolve("head-requests"));
+        this.putRequests = metricRegistry.timer(prefix.resolve("put-requests"));
+        this.deleteRequests = metricRegistry.timer(prefix.resolve("delete-requests"));
+        this.optionsRequests = metricRegistry.timer(prefix.resolve("options-requests"));
+        this.traceRequests = metricRegistry.timer(prefix.resolve("trace-requests"));
+        this.connectRequests = metricRegistry.timer(prefix.resolve("connect-requests"));
+        this.moveRequests = metricRegistry.timer(prefix.resolve("move-requests"));
+        this.otherRequests = metricRegistry.timer(prefix.resolve("other-requests"));
 
         this.listener = new AsyncListener() {
             @Override

--- a/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHandlerTest.java
+++ b/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHandlerTest.java
@@ -1,6 +1,8 @@
 package com.codahale.metrics.jetty9;
 
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
+
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.server.Server;
@@ -48,30 +50,32 @@ public class InstrumentedHandlerTest {
         assertThat(response.getStatus())
                 .isEqualTo(404);
 
+        final MetricName prefix = MetricName.build("org.eclipse.jetty.server.handler.DefaultHandler.handler");
+        
         assertThat(registry.getNames())
                 .containsOnly(
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.1xx-responses",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.2xx-responses",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.3xx-responses",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.4xx-responses",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.5xx-responses",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.active-suspended",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.async-dispatches",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.async-timeouts",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.get-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.put-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.active-dispatches",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.trace-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.other-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.connect-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.dispatches",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.head-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.post-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.options-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.active-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.delete-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.move-requests"
+                        prefix.resolve("1xx-responses"),
+                        prefix.resolve("2xx-responses"),
+                        prefix.resolve("3xx-responses"),
+                        prefix.resolve("4xx-responses"),
+                        prefix.resolve("5xx-responses"),
+                        prefix.resolve("requests"),
+                        prefix.resolve("active-suspended"),
+                        prefix.resolve("async-dispatches"),
+                        prefix.resolve("async-timeouts"),
+                        prefix.resolve("get-requests"),
+                        prefix.resolve("put-requests"),
+                        prefix.resolve("active-dispatches"),
+                        prefix.resolve("trace-requests"),
+                        prefix.resolve("other-requests"),
+                        prefix.resolve("connect-requests"),
+                        prefix.resolve("dispatches"),
+                        prefix.resolve("head-requests"),
+                        prefix.resolve("post-requests"),
+                        prefix.resolve("options-requests"),
+                        prefix.resolve("active-requests"),
+                        prefix.resolve("delete-requests"),
+                        prefix.resolve("move-requests")
                 );
     }
 }

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/BufferPoolMetricSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/BufferPoolMetricSet.java
@@ -2,13 +2,16 @@ package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.JmxAttributeGauge;
 import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricSet;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.management.JMException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,12 +36,13 @@ public class BufferPoolMetricSet implements MetricSet {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        final Map<String, Metric> gauges = new HashMap<String, Metric>();
+    public Map<MetricName, Metric> getMetrics() {
+        final Map<MetricName, Metric> gauges = new HashMap<MetricName, Metric>();
         for (String pool : POOLS) {
             for (int i = 0; i < ATTRIBUTES.length; i++) {
                 final String attribute = ATTRIBUTES[i];
                 final String name = NAMES[i];
+
                 try {
                     final ObjectName on = new ObjectName("java.nio:type=BufferPool,name=" + pool);
                     mBeanServer.getMBeanInfo(on);

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ClassLoadingGaugeSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ClassLoadingGaugeSet.java
@@ -2,6 +2,7 @@ package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricSet;
 
 import java.lang.management.ClassLoadingMXBean;
@@ -25,17 +26,17 @@ public class ClassLoadingGaugeSet implements MetricSet {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        final Map<String, Metric> gauges = new HashMap<String, Metric>();
+    public Map<MetricName, Metric> getMetrics() {
+        final Map<MetricName, Metric> gauges = new HashMap<MetricName, Metric>();
 
-        gauges.put("loaded", new Gauge<Long>() {
+        gauges.put(MetricName.build("loaded"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getTotalLoadedClassCount();
             }
         });
 
-        gauges.put("unloaded", new Gauge<Long>() {
+        gauges.put(MetricName.build("unloaded"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getUnloadedClassCount();

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/GarbageCollectorMetricSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/GarbageCollectorMetricSet.java
@@ -2,6 +2,7 @@ package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricSet;
 
 import java.lang.management.GarbageCollectorMXBean;
@@ -36,8 +37,8 @@ public class GarbageCollectorMetricSet implements MetricSet {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        final Map<String, Metric> gauges = new HashMap<String, Metric>();
+    public Map<MetricName, Metric> getMetrics() {
+        final Map<MetricName, Metric> gauges = new HashMap<MetricName, Metric>();
         for (final GarbageCollectorMXBean gc : garbageCollectors) {
             final String name = WHITESPACE.matcher(gc.getName()).replaceAll("-");
             gauges.put(name(name, "count"), new Gauge<Long>() {

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/MemoryUsageGaugeSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/MemoryUsageGaugeSet.java
@@ -2,6 +2,7 @@ package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricSet;
 import com.codahale.metrics.RatioGauge;
 
@@ -36,10 +37,10 @@ public class MemoryUsageGaugeSet implements MetricSet {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        final Map<String, Metric> gauges = new HashMap<String, Metric>();
+    public Map<MetricName, Metric> getMetrics() {
+        final Map<MetricName, Metric> gauges = new HashMap<MetricName, Metric>();
 
-        gauges.put("total.init", new Gauge<Long>() {
+        gauges.put(MetricName.build("total.init"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getInit() +
@@ -47,7 +48,7 @@ public class MemoryUsageGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("total.used", new Gauge<Long>() {
+        gauges.put(MetricName.build("total.used"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getUsed() +
@@ -55,7 +56,7 @@ public class MemoryUsageGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("total.max", new Gauge<Long>() {
+        gauges.put(MetricName.build("total.max"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getMax() +
@@ -63,7 +64,7 @@ public class MemoryUsageGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("total.committed", new Gauge<Long>() {
+        gauges.put(MetricName.build("total.committed"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getCommitted() +
@@ -72,35 +73,35 @@ public class MemoryUsageGaugeSet implements MetricSet {
         });
 
 
-        gauges.put("heap.init", new Gauge<Long>() {
+        gauges.put(MetricName.build("heap.init"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getInit();
             }
         });
 
-        gauges.put("heap.used", new Gauge<Long>() {
+        gauges.put(MetricName.build("heap.used"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getUsed();
             }
         });
 
-        gauges.put("heap.max", new Gauge<Long>() {
+        gauges.put(MetricName.build("heap.max"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getMax();
             }
         });
 
-        gauges.put("heap.committed", new Gauge<Long>() {
+        gauges.put(MetricName.build("heap.committed"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getHeapMemoryUsage().getCommitted();
             }
         });
 
-        gauges.put("heap.usage", new RatioGauge() {
+        gauges.put(MetricName.build("heap.usage"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 final MemoryUsage usage = mxBean.getHeapMemoryUsage();
@@ -108,35 +109,35 @@ public class MemoryUsageGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("non-heap.init", new Gauge<Long>() {
+        gauges.put(MetricName.build("non-heap.init"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getNonHeapMemoryUsage().getInit();
             }
         });
 
-        gauges.put("non-heap.used", new Gauge<Long>() {
+        gauges.put(MetricName.build("non-heap.used"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getNonHeapMemoryUsage().getUsed();
             }
         });
 
-        gauges.put("non-heap.max", new Gauge<Long>() {
+        gauges.put(MetricName.build("non-heap.max"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getNonHeapMemoryUsage().getMax();
             }
         });
 
-        gauges.put("non-heap.committed", new Gauge<Long>() {
+        gauges.put(MetricName.build("non-heap.committed"), new Gauge<Long>() {
             @Override
             public Long getValue() {
                 return mxBean.getNonHeapMemoryUsage().getCommitted();
             }
         });
 
-        gauges.put("non-heap.usage", new RatioGauge() {
+        gauges.put(MetricName.build("non-heap.usage"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 final MemoryUsage usage = mxBean.getNonHeapMemoryUsage();

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ThreadStatesGaugeSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ThreadStatesGaugeSet.java
@@ -2,6 +2,7 @@ package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricSet;
 
 import java.lang.management.ManagementFactory;
@@ -45,8 +46,8 @@ public class ThreadStatesGaugeSet implements MetricSet {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        final Map<String, Metric> gauges = new HashMap<String, Metric>();
+    public Map<MetricName, Metric> getMetrics() {
+        final Map<MetricName, Metric> gauges = new HashMap<MetricName, Metric>();
 
         for (final Thread.State state : Thread.State.values()) {
             gauges.put(name(state.toString().toLowerCase(), "count"),
@@ -58,28 +59,28 @@ public class ThreadStatesGaugeSet implements MetricSet {
                        });
         }
 
-        gauges.put("count", new Gauge<Integer>() {
+        gauges.put(MetricName.build("count"), new Gauge<Integer>() {
             @Override
             public Integer getValue() {
                 return threads.getThreadCount();
             }
         });
 
-        gauges.put("daemon.count", new Gauge<Integer>() {
+        gauges.put(MetricName.build("daemon.count"), new Gauge<Integer>() {
             @Override
             public Integer getValue() {
                 return threads.getDaemonThreadCount();
             }
         });
 
-        gauges.put("deadlock.count", new Gauge<Integer>() {
+        gauges.put(MetricName.build("deadlock.count"), new Gauge<Integer>() {
             @Override
             public Integer getValue() {
                 return deadlockDetector.getDeadlockedThreads().size();
             }
         });
 
-        gauges.put("deadlocks", new Gauge<Set<String>>() {
+        gauges.put(MetricName.build("deadlocks"), new Gauge<Set<String>>() {
             @Override
             public Set<String> getValue() {
                 return deadlockDetector.getDeadlockedThreads();

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/BufferPoolMetricSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/BufferPoolMetricSetTest.java
@@ -1,6 +1,8 @@
 package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricName;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -19,6 +21,15 @@ public class BufferPoolMetricSetTest {
     private ObjectName mapped;
     private ObjectName direct;
 
+    private final MetricName DIRECT = MetricName.build("direct");
+    private final MetricName MAPPED = MetricName.build("mapped");
+    private final MetricName DIRECT_COUNT = DIRECT.resolve("count");
+    private final MetricName DIRECT_CAPACITY = DIRECT.resolve("capacity");
+    private final MetricName DIRECT_USED = DIRECT.resolve("used");
+    private final MetricName MAPPED_COUNT = MAPPED.resolve("count");
+    private final MetricName MAPPED_CAPACITY = MAPPED.resolve("capacity");
+    private final MetricName MAPPED_USED = MAPPED.resolve("used");
+
     @Before
     public void setUp() throws Exception {
         this.mapped = new ObjectName("java.nio:type=BufferPool,name=mapped");
@@ -29,12 +40,12 @@ public class BufferPoolMetricSetTest {
     @Test
     public void includesGaugesForDirectAndMappedPools() throws Exception {
         assertThat(buffers.getMetrics().keySet())
-                .containsOnly("direct.count",
-                              "mapped.used",
-                              "mapped.capacity",
-                              "direct.capacity",
-                              "mapped.count",
-                              "direct.used");
+                .containsOnly(DIRECT_COUNT,
+                              DIRECT_USED,
+                              DIRECT_CAPACITY,
+                              MAPPED_COUNT,
+                              MAPPED_USED,
+                              MAPPED_CAPACITY);
     }
 
     @Test
@@ -42,14 +53,14 @@ public class BufferPoolMetricSetTest {
         when(mBeanServer.getMBeanInfo(mapped)).thenThrow(new InstanceNotFoundException());
 
         assertThat(buffers.getMetrics().keySet())
-                .containsOnly("direct.count",
-                              "direct.capacity",
-                              "direct.used");
+                .containsOnly(DIRECT_COUNT,
+                              DIRECT_USED,
+                              DIRECT_CAPACITY);
     }
 
     @Test
     public void includesAGaugeForDirectCount() throws Exception {
-        final Gauge gauge = (Gauge) buffers.getMetrics().get("direct.count");
+        final Gauge gauge = (Gauge) buffers.getMetrics().get(DIRECT_COUNT);
 
         when(mBeanServer.getAttribute(direct, "Count")).thenReturn(100);
 
@@ -59,7 +70,7 @@ public class BufferPoolMetricSetTest {
 
     @Test
     public void includesAGaugeForDirectMemoryUsed() throws Exception {
-        final Gauge gauge = (Gauge) buffers.getMetrics().get("direct.used");
+        final Gauge gauge = (Gauge) buffers.getMetrics().get(DIRECT_USED);
 
         when(mBeanServer.getAttribute(direct, "MemoryUsed")).thenReturn(100);
 
@@ -69,7 +80,7 @@ public class BufferPoolMetricSetTest {
 
     @Test
     public void includesAGaugeForDirectCapacity() throws Exception {
-        final Gauge gauge = (Gauge) buffers.getMetrics().get("direct.capacity");
+        final Gauge gauge = (Gauge) buffers.getMetrics().get(DIRECT_CAPACITY);
 
         when(mBeanServer.getAttribute(direct, "TotalCapacity")).thenReturn(100);
 
@@ -79,7 +90,7 @@ public class BufferPoolMetricSetTest {
     
     @Test
     public void includesAGaugeForMappedCount() throws Exception {
-        final Gauge gauge = (Gauge) buffers.getMetrics().get("mapped.count");
+        final Gauge gauge = (Gauge) buffers.getMetrics().get(MAPPED_COUNT);
 
         when(mBeanServer.getAttribute(mapped, "Count")).thenReturn(100);
 
@@ -89,7 +100,7 @@ public class BufferPoolMetricSetTest {
 
     @Test
     public void includesAGaugeForMappedMemoryUsed() throws Exception {
-        final Gauge gauge = (Gauge) buffers.getMetrics().get("mapped.used");
+        final Gauge gauge = (Gauge) buffers.getMetrics().get(MAPPED_USED);
 
         when(mBeanServer.getAttribute(mapped, "MemoryUsed")).thenReturn(100);
 
@@ -99,7 +110,7 @@ public class BufferPoolMetricSetTest {
 
     @Test
     public void includesAGaugeForMappedCapacity() throws Exception {
-        final Gauge gauge = (Gauge) buffers.getMetrics().get("mapped.capacity");
+        final Gauge gauge = (Gauge) buffers.getMetrics().get(MAPPED_CAPACITY);
 
         when(mBeanServer.getAttribute(mapped, "TotalCapacity")).thenReturn(100);
 

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ClassLoadingGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ClassLoadingGaugeSetTest.java
@@ -1,6 +1,8 @@
 package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricName;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -23,13 +25,13 @@ public class ClassLoadingGaugeSetTest {
 
     @Test
     public void loadedGauge() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("loaded");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(MetricName.build("loaded"));
         assertThat(gauge.getValue()).isEqualTo(2L);
     }
 
     @Test
     public void unLoadedGauge() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("unloaded");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(MetricName.build("unloaded"));
         assertThat(gauge.getValue()).isEqualTo(1L);
     }
 

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/GarbageCollectorMetricSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/GarbageCollectorMetricSetTest.java
@@ -1,6 +1,8 @@
 package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricName;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -15,6 +17,9 @@ public class GarbageCollectorMetricSetTest {
     private final GarbageCollectorMXBean gc = mock(GarbageCollectorMXBean.class);
     private final GarbageCollectorMetricSet metrics = new GarbageCollectorMetricSet(Arrays.asList(gc));
 
+    private static final MetricName PS_OLDGEN_TIME = MetricName.build("PS-OldGen.time");
+    private static final MetricName PS_OLDGEN_COUNT = MetricName.build("PS-OldGen.count");
+    
     @Before
     public void setUp() throws Exception {
         when(gc.getName()).thenReturn("PS OldGen");
@@ -25,19 +30,19 @@ public class GarbageCollectorMetricSetTest {
     @Test
     public void hasGaugesForGcCountsAndElapsedTimes() throws Exception {
         assertThat(metrics.getMetrics().keySet())
-                .containsOnly("PS-OldGen.time", "PS-OldGen.count");
+                .containsOnly(PS_OLDGEN_TIME, PS_OLDGEN_COUNT);
     }
 
     @Test
     public void hasAGaugeForGcCounts() throws Exception {
-        final Gauge gauge = (Gauge) metrics.getMetrics().get("PS-OldGen.count");
+        final Gauge gauge = (Gauge) metrics.getMetrics().get(PS_OLDGEN_COUNT);
         assertThat(gauge.getValue())
                 .isEqualTo(1L);
     }
 
     @Test
     public void hasAGaugeForGcTimes() throws Exception {
-        final Gauge gauge = (Gauge) metrics.getMetrics().get("PS-OldGen.time");
+        final Gauge gauge = (Gauge) metrics.getMetrics().get(PS_OLDGEN_TIME);
         assertThat(gauge.getValue())
                 .isEqualTo(2L);
     }

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/MemoryUsageGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/MemoryUsageGaugeSetTest.java
@@ -1,6 +1,8 @@
 package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricName;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,6 +27,28 @@ public class MemoryUsageGaugeSetTest {
     private final MemoryUsageGaugeSet gauges = new MemoryUsageGaugeSet(mxBean,
                                                                        Arrays.asList(memoryPool,
                                                                                      weirdMemoryPool));
+
+    private static final MetricName TOTAL = MetricName.build("total");
+    private static final MetricName HEAP = MetricName.build("heap");
+    private static final MetricName NON_HEAP = MetricName.build("non-heap");
+    private static final MetricName POOLS = MetricName.build("pools");
+
+    private static final MetricName TOTAL_MAX = TOTAL.resolve("max");
+    private static final MetricName TOTAL_INIT = TOTAL.resolve("init");
+    private static final MetricName TOTAL_USED = TOTAL.resolve("used");
+    private static final MetricName TOTAL_COMMITTED = TOTAL.resolve("committed");
+    private static final MetricName POOLS_BIG_POOL_USAGE = POOLS.resolve("Big-Pool.usage");
+    private static final MetricName POOLS_WEIRD_POOL_USAGE = POOLS.resolve("Weird-Pool.usage");
+    private static final MetricName HEAP_INIT = HEAP.resolve("init");
+    private static final MetricName HEAP_COMMITTED = HEAP.resolve("committed");
+    private static final MetricName HEAP_USAGE = HEAP.resolve("usage");
+    private static final MetricName HEAP_USED = HEAP.resolve("used");
+    private static final MetricName HEAP_MAX = HEAP.resolve("max");
+    private static final MetricName NON_HEAP_USAGE = NON_HEAP.resolve("usage");
+    private static final MetricName NON_HEAP_MAX = NON_HEAP.resolve("max");
+    private static final MetricName NON_HEAP_USED = NON_HEAP.resolve("used");
+    private static final MetricName NON_HEAP_INIT = NON_HEAP.resolve("init");
+    private static final MetricName NON_HEAP_COMMITTED = NON_HEAP.resolve("committed");
 
     @Before
     public void setUp() throws Exception {
@@ -61,27 +85,28 @@ public class MemoryUsageGaugeSetTest {
     @Test
     public void hasASetOfGauges() throws Exception {
         assertThat(gauges.getMetrics().keySet())
-                .containsOnly("heap.init",
-                              "non-heap.usage",
-                              "total.max",
-                              "total.init",
-                              "heap.committed",
-                              "non-heap.max",
-                              "heap.usage",
-                              "pools.Big-Pool.usage",
-                              "pools.Weird-Pool.usage",
-                              "heap.used",
-                              "non-heap.used",
-                              "non-heap.init",
-                              "total.used",
-                              "total.committed",
-                              "non-heap.committed",
-                              "heap.max");
+                .containsOnly(
+                        TOTAL_MAX,
+                        TOTAL_INIT,
+                        TOTAL_USED,
+                        TOTAL_COMMITTED,
+                        POOLS_BIG_POOL_USAGE,
+                        POOLS_WEIRD_POOL_USAGE,
+                        HEAP_INIT,
+                        HEAP_COMMITTED,
+                        HEAP_USAGE,
+                        HEAP_USED,
+                        HEAP_MAX,
+                        NON_HEAP_USAGE,
+                        NON_HEAP_MAX,
+                        NON_HEAP_USED,
+                        NON_HEAP_INIT,
+                        NON_HEAP_COMMITTED);
     }
 
     @Test
     public void hasAGaugeForTotalCommitted() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("total.committed");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(TOTAL_COMMITTED);
 
         assertThat(gauge.getValue())
                 .isEqualTo(11L);
@@ -89,7 +114,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForTotalInit() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("total.init");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(TOTAL_INIT);
 
         assertThat(gauge.getValue())
                 .isEqualTo(22L);
@@ -97,7 +122,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForTotalUsed() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("total.used");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(TOTAL_USED);
 
         assertThat(gauge.getValue())
                 .isEqualTo(33L);
@@ -105,7 +130,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForTotalMax() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("total.max");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(TOTAL_MAX);
 
         assertThat(gauge.getValue())
                 .isEqualTo(44L);
@@ -113,7 +138,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForHeapCommitted() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.committed");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(HEAP_COMMITTED);
 
         assertThat(gauge.getValue())
                 .isEqualTo(10L);
@@ -121,7 +146,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForHeapInit() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.init");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(HEAP_INIT);
 
         assertThat(gauge.getValue())
                 .isEqualTo(20L);
@@ -129,7 +154,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForHeapUsed() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.used");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(HEAP_USED);
 
         assertThat(gauge.getValue())
                 .isEqualTo(30L);
@@ -137,7 +162,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForHeapMax() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.max");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(HEAP_MAX);
 
         assertThat(gauge.getValue())
                 .isEqualTo(40L);
@@ -145,7 +170,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForHeapUsage() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.usage");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(HEAP_USAGE);
 
         assertThat(gauge.getValue())
                 .isEqualTo(0.75);
@@ -153,7 +178,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForNonHeapCommitted() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.committed");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(NON_HEAP_COMMITTED);
 
         assertThat(gauge.getValue())
                 .isEqualTo(1L);
@@ -161,7 +186,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForNonHeapInit() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.init");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(NON_HEAP_INIT);
 
         assertThat(gauge.getValue())
                 .isEqualTo(2L);
@@ -169,7 +194,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForNonHeapUsed() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.used");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(NON_HEAP_USED);
 
         assertThat(gauge.getValue())
                 .isEqualTo(3L);
@@ -177,7 +202,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForNonHeapMax() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.max");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(NON_HEAP_MAX);
 
         assertThat(gauge.getValue())
                 .isEqualTo(4L);
@@ -185,7 +210,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForNonHeapUsage() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.usage");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(NON_HEAP_USAGE);
 
         assertThat(gauge.getValue())
                 .isEqualTo(0.75);
@@ -193,7 +218,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForMemoryPoolUsage() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Big-Pool.usage");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(POOLS_BIG_POOL_USAGE);
 
         assertThat(gauge.getValue())
                 .isEqualTo(0.75);
@@ -201,7 +226,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForWeirdMemoryPoolUsage() throws Exception {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Weird-Pool.usage");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(POOLS_WEIRD_POOL_USAGE);
 
         assertThat(gauge.getValue())
                 .isEqualTo(3.0);

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadStatesGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadStatesGaugeSetTest.java
@@ -1,6 +1,8 @@
 package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricName;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,6 +30,17 @@ public class ThreadStatesGaugeSetTest {
 
     private final Set<String> deadlocks = new HashSet<String>();
 
+    private static final MetricName TERMINATED_COUNT = MetricName.build("terminated.count");
+    private static final MetricName NEW_COUNT = MetricName.build("new.count");
+    private static final MetricName COUNT = MetricName.build("count");
+    private static final MetricName TIMED_WAITING_COUNT = MetricName.build("timed_waiting.count");
+    private static final MetricName DEADLOCKS = MetricName.build("deadlocks");
+    private static final MetricName BLOCKED_COUNT = MetricName.build("blocked.count");
+    private static final MetricName WAITING_COUNT = MetricName.build("waiting.count");
+    private static final MetricName DAEMON_COUNT = MetricName.build("daemon.count");
+    private static final MetricName RUNNABLE_COUNT = MetricName.build("runnable.count");
+    private static final MetricName DEADLOCK_COUNT = MetricName.build("deadlock.count");
+
     @Before
     public void setUp() throws Exception {
         deadlocks.add("yay");
@@ -54,69 +67,69 @@ public class ThreadStatesGaugeSetTest {
     @Test
     public void hasASetOfGauges() throws Exception {
         assertThat(gauges.getMetrics().keySet())
-                .containsOnly("terminated.count",
-                              "new.count",
-                              "count",
-                              "timed_waiting.count",
-                              "deadlocks",
-                              "blocked.count",
-                              "waiting.count",
-                              "daemon.count",
-                              "runnable.count",
-                              "deadlock.count");
+                .containsOnly(TERMINATED_COUNT,
+                              NEW_COUNT,
+                              COUNT,
+                              TIMED_WAITING_COUNT,
+                              DEADLOCKS,
+                              BLOCKED_COUNT,
+                              WAITING_COUNT,
+                              DAEMON_COUNT,
+                              RUNNABLE_COUNT,
+                              DEADLOCK_COUNT);
     }
 
     @Test
     public void hasAGaugeForEachThreadState() throws Exception {
-        assertThat(((Gauge) gauges.getMetrics().get("new.count")).getValue())
+        assertThat(((Gauge) gauges.getMetrics().get(NEW_COUNT)).getValue())
                 .isEqualTo(1);
 
-        assertThat(((Gauge) gauges.getMetrics().get("runnable.count")).getValue())
+        assertThat(((Gauge) gauges.getMetrics().get(RUNNABLE_COUNT)).getValue())
                 .isEqualTo(1);
 
-        assertThat(((Gauge) gauges.getMetrics().get("blocked.count")).getValue())
+        assertThat(((Gauge) gauges.getMetrics().get(BLOCKED_COUNT)).getValue())
                 .isEqualTo(1);
 
-        assertThat(((Gauge) gauges.getMetrics().get("waiting.count")).getValue())
+        assertThat(((Gauge) gauges.getMetrics().get(WAITING_COUNT)).getValue())
                 .isEqualTo(1);
 
-        assertThat(((Gauge) gauges.getMetrics().get("timed_waiting.count")).getValue())
+        assertThat(((Gauge) gauges.getMetrics().get(TIMED_WAITING_COUNT)).getValue())
                 .isEqualTo(1);
 
-        assertThat(((Gauge) gauges.getMetrics().get("terminated.count")).getValue())
+        assertThat(((Gauge) gauges.getMetrics().get(TERMINATED_COUNT)).getValue())
                 .isEqualTo(1);
     }
 
     @Test
     public void hasAGaugeForTheNumberOfThreads() throws Exception {
-        assertThat(((Gauge) gauges.getMetrics().get("count")).getValue())
+        assertThat(((Gauge) gauges.getMetrics().get(COUNT)).getValue())
                 .isEqualTo(12);
     }
 
     @Test
     public void hasAGaugeForTheNumberOfDaemonThreads() throws Exception {
-        assertThat(((Gauge) gauges.getMetrics().get("daemon.count")).getValue())
+        assertThat(((Gauge) gauges.getMetrics().get(DAEMON_COUNT)).getValue())
                 .isEqualTo(13);
     }
 
     @Test
     public void hasAGaugeForAnyDeadlocks() throws Exception {
-        assertThat(((Gauge) gauges.getMetrics().get("deadlocks")).getValue())
+        assertThat(((Gauge) gauges.getMetrics().get(DEADLOCKS)).getValue())
                 .isEqualTo(deadlocks);
     }
 
     @Test
     public void hasAGaugeForAnyDeadlockCount() throws Exception {
-        assertThat(((Gauge) gauges.getMetrics().get("deadlock.count")).getValue())
+        assertThat(((Gauge) gauges.getMetrics().get(DEADLOCK_COUNT)).getValue())
                 .isEqualTo(1);
     }
 
     @Test
     public void autoDiscoversTheMXBeans() throws Exception {
         final ThreadStatesGaugeSet set = new ThreadStatesGaugeSet();
-        assertThat(((Gauge) set.getMetrics().get("count")).getValue())
+        assertThat(((Gauge) set.getMetrics().get(COUNT)).getValue())
                 .isNotNull();
-        assertThat(((Gauge) set.getMetrics().get("deadlocks")).getValue())
+        assertThat(((Gauge) set.getMetrics().get(DEADLOCKS)).getValue())
                 .isNotNull();
     }
 }

--- a/metrics-log4j/src/main/java/com/codahale/metrics/log4j/InstrumentedAppender.java
+++ b/metrics-log4j/src/main/java/com/codahale/metrics/log4j/InstrumentedAppender.java
@@ -42,7 +42,7 @@ public class InstrumentedAppender extends AppenderSkeleton {
      */
     public InstrumentedAppender(MetricRegistry registry) {
         this.registry = registry;
-        setName(name(Appender.class));
+        setName(name(Appender.class).getKey());
     }
 
     @Override

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletTest.java
@@ -64,16 +64,18 @@ public class MetricsServletTest extends AbstractServletTest {
                 .isEqualTo("{" +
                                    "\"version\":\"3.0.0\"," +
                                    "\"gauges\":{" +
-                                       "\"g1\":{\"value\":100}" +
+                                       "\"g1{}\":{\"value\":100}" +
                                    "}," +
                                    "\"counters\":{" +
-                                       "\"c\":{\"count\":1}" +
+                                       "\"c{}\":{\"count\":1}" +
                                    "}," +
                                    "\"histograms\":{" +
-                                       "\"h\":{\"count\":1,\"max\":1,\"mean\":1.0,\"min\":1,\"p50\":1.0,\"p75\":1.0,\"p95\":1.0,\"p98\":1.0,\"p99\":1.0,\"p999\":1.0,\"stddev\":0.0}" +
+                                       "\"h{}\":{\"count\":1,\"max\":1,\"mean\":1.0,\"min\":1,\"p50\":1.0,\"p75\":1.0,\"p95\":1.0,\"p98\":1.0,\"p99\":1.0,\"p999\":1.0,\"stddev\":0.0}" +
                                    "}," +
                                    "\"meters\":{" +
-                                       "\"m\":{\"count\":1,\"m15_rate\":0.0,\"m1_rate\":0.0,\"m5_rate\":0.0,\"mean_rate\":3333333.3333333335,\"units\":\"events/second\"}},\"timers\":{\"t\":{\"count\":1,\"max\":1.0,\"mean\":1.0,\"min\":1.0,\"p50\":1.0,\"p75\":1.0,\"p95\":1.0,\"p98\":1.0,\"p99\":1.0,\"p999\":1.0,\"stddev\":0.0,\"m15_rate\":0.0,\"m1_rate\":0.0,\"m5_rate\":0.0,\"mean_rate\":1.0E7,\"duration_units\":\"seconds\",\"rate_units\":\"calls/second\"}" +
+                                       "\"m{}\":{\"count\":1,\"m15_rate\":0.0,\"m1_rate\":0.0,\"m5_rate\":0.0,\"mean_rate\":3333333.3333333335,\"units\":\"events/second\"}},"+
+                                   "\"timers\":{"+
+                                       "\"t{}\":{\"count\":1,\"max\":1.0,\"mean\":1.0,\"min\":1.0,\"p50\":1.0,\"p75\":1.0,\"p95\":1.0,\"p98\":1.0,\"p99\":1.0,\"p999\":1.0,\"stddev\":0.0,\"m15_rate\":0.0,\"m1_rate\":0.0,\"m5_rate\":0.0,\"mean_rate\":1.0E7,\"duration_units\":\"seconds\",\"rate_units\":\"calls/second\"}" +
                                    "}" +
                                "}");
         assertThat(response.get(HttpHeader.CONTENT_TYPE))
@@ -94,17 +96,17 @@ public class MetricsServletTest extends AbstractServletTest {
                 .isEqualTo(String.format("{%n" +
                                                  "  \"version\" : \"3.0.0\",%n" +
                                                  "  \"gauges\" : {%n" +
-                                                 "    \"g1\" : {%n" +
+                                                 "    \"g1{}\" : {%n" +
                                                  "      \"value\" : 100%n" +
                                                  "    }%n" +
                                                  "  },%n" +
                                                  "  \"counters\" : {%n" +
-                                                 "    \"c\" : {%n" +
+                                                 "    \"c{}\" : {%n" +
                                                  "      \"count\" : 1%n" +
                                                  "    }%n" +
                                                  "  },%n" +
                                                  "  \"histograms\" : {%n" +
-                                                 "    \"h\" : {%n" +
+                                                 "    \"h{}\" : {%n" +
                                                  "      \"count\" : 1,%n" +
                                                  "      \"max\" : 1,%n" +
                                                  "      \"mean\" : 1.0,%n" +
@@ -119,7 +121,7 @@ public class MetricsServletTest extends AbstractServletTest {
                                                  "    }%n" +
                                                  "  },%n" +
                                                  "  \"meters\" : {%n" +
-                                                 "    \"m\" : {%n" +
+                                                 "    \"m{}\" : {%n" +
                                                  "      \"count\" : 1,%n" +
                                                  "      \"m15_rate\" : 0.0,%n" +
                                                  "      \"m1_rate\" : 0.0,%n" +
@@ -129,7 +131,7 @@ public class MetricsServletTest extends AbstractServletTest {
                                                  "    }%n" +
                                                  "  },%n" +
                                                  "  \"timers\" : {%n" +
-                                                 "    \"t\" : {%n" +
+                                                 "    \"t{}\" : {%n" +
                                                  "      \"count\" : 1,%n" +
                                                  "      \"max\" : 1.0,%n" +
                                                  "      \"mean\" : 1.0,%n" +


### PR DESCRIPTION
**The point of this pull request** is not to have it merged. I appreciate the fact that it is a big undertaking to incorporate something like this (third party libraries especially will be a blast).

I am hoping to start the discussion, and I see no better way of doing it that through code.

##### Commit message
This is a large refactoring meant to change the way metric names are
represented to better suit a wide variety of backends.

Quite a few metric backend systems are starting to use a general concept of
'tags' which is a step back from having too encode information in the (string)
names of the metrics*.

\* KairosDB (http://code.google.com/p/kairosdb/), OpenTSDB
(http://opentsdb.net/overview.html)

Tags are meant to allow for natural grouping of similar timeseries allowing for
the ability to easily correlate freely between the timeseries that incorporate
them.

For example, take the following two timeseries.

* example.com.**interface.traffic**.eth0.in
* example.com.**interface.traffic**.eth0.out

Using tags, these would be represented as;

* **interface.traffic** {host=example.com, interface=eth0, direction=in}
* **interface.traffic** {host=example.com, interface=eth0, direction=out}