### PR TITLE
#577 Lazy fetch of PlatformMBeanServer

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
@@ -33,7 +33,7 @@ public class JmxReporter implements Reporter, Closeable {
      */
     public static class Builder {
         private final MetricRegistry registry;
-        private MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+        private MBeanServer mBeanServer;
         private TimeUnit rateUnit;
         private TimeUnit durationUnit;
         private MetricFilter filter = MetricFilter.ALL;
@@ -129,6 +129,9 @@ public class JmxReporter implements Reporter, Closeable {
          */
         public JmxReporter build() {
             final MetricTimeUnits timeUnits = new MetricTimeUnits(rateUnit, durationUnit, specificRateUnits, specificDurationUnits);
+            if (mBeanServer==null) {
+            	mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            }
             return new JmxReporter(mBeanServer, domain, registry, filter, timeUnits);
         }
     }


### PR DESCRIPTION
In environments with a java security policy enabled, the metrics codebase needs to be granted specific permissions to fetch the PlatformMBeanServer.
The JmxReporter class does this fetch always at initialisation, and as such always needs the permission grant. It should not, since the builder pattern allows it to be configured with a specific mBeanServer, originating from a granted code base, hence avoiding the need for the permission for the metrics library.

Lazy fetch of mBeanServer, only call ManagementFactory.getPlatformMBeanServer() when none is set in the builder pattern
