### PR TITLE
Error logging in ScheduledReporter for unexpected exceptions

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics;
 
+import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.util.Locale;
 import java.util.SortedMap;
@@ -86,7 +87,12 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
         executor.scheduleAtFixedRate(new Runnable() {
             @Override
             public void run() {
-                report();
+                try {
+                    report();
+                } catch (RuntimeException e) {
+                    LoggerFactory.getLogger(getClass()).error("An unexpected error occurred attempting to report metrics.", e);
+                    throw e;
+                }
             }
         }, period, period, unit);
     }


### PR DESCRIPTION
This would be helpful in the event that any unexpected exceptions occur while attempting to extract values from metrics during publication.
