### PR TITLE
Changing access modifier for getMetrics method in class MetricRegistry to protected final instead of private

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -322,7 +322,7 @@ public class MetricRegistry implements MetricSet {
     }
 
     @SuppressWarnings("unchecked")
-    private <T extends Metric> SortedMap<String, T> getMetrics(Class<T> klass, MetricFilter filter) {
+    protected final <T extends Metric> SortedMap<String, T> getMetrics(Class<T> klass, MetricFilter filter) {
         final TreeMap<String, T> timers = new TreeMap<String, T>();
         for (Map.Entry<String, Metric> entry : metrics.entrySet()) {
             if (klass.isInstance(entry.getValue()) && filter.matches(entry.getKey(),


### PR DESCRIPTION
Changing access modifier for getMetrics method in class MetricRegistry to protected final instead of private. 
This will allow subclasses of MetricRegistry to use this method. final modifier will ensure subclasses wont change the behavior of this method. 
I currently created a subclass of MetricRegistry that had a few new types of metrics. I wanted to get a list of my custom metrics and was unable to do so since the getMetrics method was private. So thought of changing it to protected final.
