### PR TITLE
Added ElementType.PARAMETER as a Target to Metrics

### DIFF
--- a/metrics-annotation/src/main/java/com/codahale/metrics/annotation/Metric.java
+++ b/metrics-annotation/src/main/java/com/codahale/metrics/annotation/Metric.java
@@ -46,7 +46,7 @@ import java.lang.annotation.Target;
  * @since 4.0.0
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
 public @interface Metric {
 
     /**


### PR DESCRIPTION
Fix for #586 to allow the Metric annotation to be used on method and constructor parameters.
