### PR TITLE
Invalid JDK range in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <profile>
             <id>doclint-java8-disable</id>
             <activation>
-                <jdk>[1.8,</jdk>
+                <jdk>[1.8,)</jdk>
             </activation>
 
             <build>


### PR DESCRIPTION
Very small change, but the JDK range in the root pom is invalid (missing the closing tag). This doesn't cause problems with Maven from what I can tell, but it causes issues with IntelliJ.

Without the closing tag, IntelliJ doesn't recognise dependencies correctly, which leads to compilation issues in the IDE. Not sure whether Eclipse has the same issue.
