### PR TITLE
Add Graphite UDP sender

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
@@ -9,9 +9,9 @@ import java.nio.charset.Charset;
 import java.util.regex.Pattern;
 
 /**
- * A client to a Carbon server.
+ * A client to a Carbon server via TCP.
  */
-public class Graphite implements Closeable {
+public class Graphite implements GraphiteSender {
     private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
     // this may be optimistic about Carbon/Graphite
     private static final Charset UTF_8 = Charset.forName("UTF-8");
@@ -58,12 +58,7 @@ public class Graphite implements Closeable {
         this.charset = charset;
     }
 
-    /**
-     * Connects to the server.
-     *
-     * @throws IllegalStateException if the client is already connected
-     * @throws IOException           if there is an error connecting
-     */
+    @Override
     public void connect() throws IllegalStateException, IOException {
         if (socket != null) {
             throw new IllegalStateException("Already connected");
@@ -76,14 +71,7 @@ public class Graphite implements Closeable {
         this.writer = new BufferedWriter(new OutputStreamWriter(socket.getOutputStream(), charset));
     }
 
-    /**
-     * Sends the given measurement to the server.
-     *
-     * @param name      the name of the metric
-     * @param value     the value of the metric
-     * @param timestamp the timestamp of the metric
-     * @throws IOException if there was an error sending the metric
-     */
+    @Override
     public void send(String name, String value, long timestamp) throws IOException {
         try {
             writer.write(sanitize(name));
@@ -100,11 +88,7 @@ public class Graphite implements Closeable {
         }
     }
 
-    /**
-     * Returns the number of failed writes to the server.
-     *
-     * @return the number of failed writes to the server
-     */
+    @Override
     public int getFailures() {
         return failures;
     }

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -105,12 +105,12 @@ public class GraphiteReporter extends ScheduledReporter {
 
         /**
          * Builds a {@link GraphiteReporter} with the given properties, sending metrics using the
-         * given {@link Graphite} client.
+         * given {@link GraphiteSender}.
          *
-         * @param graphite a {@link Graphite} client
+         * @param graphite a {@link GraphiteSender}
          * @return a {@link GraphiteReporter}
          */
-        public GraphiteReporter build(Graphite graphite) {
+        public GraphiteReporter build(GraphiteSender graphite) {
             return new GraphiteReporter(registry,
                                         graphite,
                                         clock,
@@ -123,12 +123,12 @@ public class GraphiteReporter extends ScheduledReporter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GraphiteReporter.class);
 
-    private final Graphite graphite;
+    private final GraphiteSender graphite;
     private final Clock clock;
     private final String prefix;
 
     private GraphiteReporter(MetricRegistry registry,
-                             Graphite graphite,
+                             GraphiteSender graphite,
                              Clock clock,
                              String prefix,
                              TimeUnit rateUnit,

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteSender.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteSender.java
@@ -1,0 +1,34 @@
+package com.codahale.metrics.graphite;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public interface GraphiteSender extends Closeable{
+
+	/**
+	 * Connects to the server.
+	 *
+	 * @throws IllegalStateException if the client is already connected
+	 * @throws IOException if there is an error connecting
+	 */
+	public void connect() throws IllegalStateException, IOException;
+
+	/**
+	 * Sends the given measurement to the server.
+	 *
+	 * @param name         the name of the metric
+	 * @param value        the value of the metric
+	 * @param timestamp    the timestamp of the metric
+	 * @throws IOException if there was an error sending the metric
+	 */
+	public void send(String name, String value, long timestamp)
+			throws IOException;
+
+	/**
+	 * Returns the number of failed writes to the server.
+	 *
+	 * @return the number of failed writes to the server
+	 */
+	public int getFailures();
+
+}

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteUDP.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteUDP.java
@@ -1,0 +1,76 @@
+package com.codahale.metrics.graphite;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.util.regex.Pattern;
+
+/**
+ * A client to a Carbon server using unconnected UDP
+ */
+public class GraphiteUDP implements GraphiteSender {
+    private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
+
+    private final InetSocketAddress address;
+
+    private DatagramChannel datagramChannel = null;
+    private int failures;
+
+    /**
+     * Creates a new client which sends data to given address using UDP
+     *
+     * @param address the address of the Carbon server
+     */
+    public GraphiteUDP(InetSocketAddress address) {
+    	this.address = address;
+    }
+
+    @Override
+    public void connect() throws IllegalStateException, IOException {
+    	// Only open the channel the first time...
+    	if (datagramChannel == null){
+        	datagramChannel = DatagramChannel.open();
+    	}
+    }
+
+    @Override
+    public void send(String name, String value, long timestamp) throws IOException {
+    	// Underlying socket can be closed by ICMP
+    	if (datagramChannel.socket().isClosed()){
+    		datagramChannel.close();
+        	datagramChannel = DatagramChannel.open();
+    	}
+
+        try {
+        	StringBuilder buf = new StringBuilder();
+            buf.append(sanitize(name));
+            buf.append(' ');
+            buf.append(sanitize(value));
+            buf.append(' ');
+            buf.append(Long.toString(timestamp));
+            buf.append('\n');
+            String str = buf.toString();
+            ByteBuffer byteBuffer = ByteBuffer.wrap(str.getBytes());
+            datagramChannel.send(byteBuffer, address);
+            this.failures = 0;
+        } catch (IOException e) {
+            failures++;
+            throw e;
+        }
+    }
+
+    @Override
+    public int getFailures() {
+        return failures;
+    }
+
+    @Override
+    public void close() throws IOException {
+    	// Leave channel & socket open for next metrics
+    }
+
+    protected String sanitize(String s) {
+        return WHITESPACE.matcher(s).replaceAll("-");
+    }
+}


### PR DESCRIPTION
Basically I pulled out an interface from the existing Graphite.java and then made the TCP and UDP classes implement it.  That left the reporting side generic and able to use either impl.

Feel free to rename the classes/interface to your tastes.  I left them like this so as not to break existing code.
