### PR TITLE
Improve GraphiteReporter robustness

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -153,23 +153,43 @@ public class GraphiteReporter extends ScheduledReporter {
             graphite.connect();
 
             for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
-                reportGauge(entry.getKey(), entry.getValue(), timestamp);
+                try {
+                    reportGauge(entry.getKey(), entry.getValue(), timestamp);
+                } catch (RuntimeException e) {
+                    LOGGER.warn("Cannot get data from the metric '{}'", entry.getKey(), e);
+                }
             }
 
             for (Map.Entry<String, Counter> entry : counters.entrySet()) {
-                reportCounter(entry.getKey(), entry.getValue(), timestamp);
+                try {
+                    reportCounter(entry.getKey(), entry.getValue(), timestamp);
+                } catch (RuntimeException e) {
+                    LOGGER.warn("Cannot get data from the metric '{}'", entry.getKey(), e);
+                }
             }
 
             for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
-                reportHistogram(entry.getKey(), entry.getValue(), timestamp);
+                try {
+                    reportHistogram(entry.getKey(), entry.getValue(), timestamp);
+                } catch (RuntimeException e) {
+                    LOGGER.warn("Cannot get data from the metric '{}'", entry.getKey(), e);
+                }
             }
 
             for (Map.Entry<String, Meter> entry : meters.entrySet()) {
-                reportMetered(entry.getKey(), entry.getValue(), timestamp);
+                try {
+                    reportMetered(entry.getKey(), entry.getValue(), timestamp);
+                } catch (RuntimeException e) {
+                    LOGGER.warn("Cannot get data from the metric '{}'", entry.getKey(), e);
+                }
             }
 
             for (Map.Entry<String, Timer> entry : timers.entrySet()) {
-                reportTimer(entry.getKey(), entry.getValue(), timestamp);
+                try {
+                    reportTimer(entry.getKey(), entry.getValue(), timestamp);
+                } catch (RuntimeException e) {
+                    LOGGER.warn("Cannot get data from the metric '{}'", entry.getKey(), e);
+                }
             }
         } catch (IOException e) {
             LOGGER.warn("Unable to report to Graphite", graphite, e);


### PR DESCRIPTION
An exception thrown from a metric must be catched otherwise it would 
break/interrupt the scheduler thread responsible for reporting data to
Graphite
(please seef ScheduledExecutorService.scheduleAtFixedRate).

This patch ensures that an exception is isolated and properly logged. There
are neither interferences among metrics nor with the scheduler thread.
