### PR TITLE
Include type in properties of exposed JMX MBeans

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
@@ -641,11 +641,15 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         private ObjectName createName(String type, String name) {
+            Hashtable<String, String> properties = new Hashtable<String, String>();
+            properties.put("name", name);
+            properties.put("type", type);
             try {
-                return new ObjectName(this.name, "name", name);
+                return new ObjectName(this.name, properties);
             } catch (MalformedObjectNameException e) {
                 try {
-                    return new ObjectName(this.name, "name", ObjectName.quote(name));
+                    properties.put("name", ObjectName.quote(name));
+                    return new ObjectName(this.name, properties);
                 } catch (MalformedObjectNameException e1) {
                     LOGGER.warn("Unable to register {} {}", type, name, e1);
                     throw new RuntimeException(e1);


### PR DESCRIPTION
Previously, the type of Metric (gauge, counter, etc.) was being ignored.  Type
is now included in the properties list of the MBean along with name.  MBeans
will be nicely grouped by type in JVisualVM and equivalent tools.
