### PR TITLE
Log Level enhancement for Slf4jReporter

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
@@ -114,23 +114,22 @@ public class Slf4jReporter extends ScheduledReporter {
         public Slf4jReporter build() {
             LoggerHelper loggerHelper;
             switch (loggingLevel) {
-                case TRACE:
-                    loggerHelper = new TraceLoggerHelper(logger);
-                    break;
-                case DEBUG:
-                    loggerHelper = new DebugLoggerHelper(logger);
-                    break;
-                case INFO:
-                    loggerHelper = new InfoLoggerHelper(logger);
+                case ERROR:
+                    loggerHelper = new ErrorLoggerHelper(logger);
                     break;
                 case WARN:
                     loggerHelper = new WarnLoggerHelper(logger);
                     break;
-                case ERROR:
-                    loggerHelper = new ErrorLoggerHelper(logger);
+                case INFO:
+                    loggerHelper = new InfoLoggerHelper(logger);
                     break;
+                case TRACE:
+                    loggerHelper = new TraceLoggerHelper(logger);
+                    break;
+                default:
+                    loggerHelper = new DebugLoggerHelper(logger);
+                	break;                	
             }
-            loggerHelper = new DebugLoggerHelper(logger);
             return new Slf4jReporter(registry, loggerHelper, marker, rateUnit, durationUnit, filter);
         }
 


### PR DESCRIPTION
We use this custom reporter already.  It lets you specify alternative logging levels for Slf4jReporters.  (I wanted them to be debug, so I needed a way to configure)

Thought others might find it useful.
