### PR TITLE
Updated javadoc in Timer.Context.

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/Timer.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Timer.java
@@ -26,7 +26,8 @@ public class Timer implements Metered, Sampling {
         }
 
         /**
-         * Stops recording the elapsed time and updates the timer.
+         * Updates the timer with the difference between current and start time. Call to this method will
+         * not reset the start time. Multiple calls result in multiple updates.
          * @return the elapsed time in nanoseconds
          */
         public long stop() {
@@ -35,6 +36,7 @@ public class Timer implements Metered, Sampling {
             return elapsed;
         }
 
+        /** Equivalent to calling {@link #stop()}. */
         @Override
         public void close() {
             stop();


### PR DESCRIPTION
Existing comment is a bit misleading, because the time "recording" is not "stopped" after calling the method, so multiple calls result in multiple updates from the same start time. At this point I don't consider that last part as a bug, but I think this behavior might be surprising if the user doesn't check actual implementation.

Please let me know what you think. 
