### PR TITLE
adapted ehcache integration to latest ehcache version 2.8.3. Fixes #615

### DIFF
--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -23,8 +23,8 @@
         </dependency>
         <dependency>
             <groupId>net.sf.ehcache</groupId>
-            <artifactId>ehcache-core</artifactId>
-            <version>2.6.6</version>
+            <artifactId>ehcache</artifactId>
+            <version>2.8.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Changed dependency from ehcache-core 2.6.x to ehcache 2.8.x;
ehcache core is now in the artifact group net.sf.ehcache.internal,
so I guess it shouldn't be used as a direct dependency

changed the InstrumentedEhcache to use the new statistics API of ehcache.
Unfortunately I couldn't find any documentation, so I basically had to
guess the correct methods to use.

Many where straight forward, or at least reasonably close.

Except the following:

getSearchesPerSecond -> .cacheSearchOperation().rate().value() // no idea if rate is actually in #/s

I couldn't find any replacement for anything related to Accuracy or Sampling, so I just removed it.
see http://stackoverflow.com/questions/25226062/documentation-of-the-ehcache-statistics-api-in-2-8-x

Note that some Gauges changed their type parameter.
