### PR TITLE
Correct comparison of System.nanoTime in SlidingTimeWindowReservoir

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/SlidingTimeWindowReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SlidingTimeWindowReservoir.java
@@ -41,7 +41,7 @@ public class SlidingTimeWindowReservoir implements Reservoir {
         this.clock = clock;
         this.measurements = new ConcurrentSkipListMap<Long, Long>();
         this.window = windowUnit.toNanos(window) * COLLISION_BUFFER;
-        this.lastTick = new AtomicLong();
+        this.lastTick = new AtomicLong(clock.getTick() * COLLISION_BUFFER);
         this.count = new AtomicLong();
     }
 
@@ -70,7 +70,7 @@ public class SlidingTimeWindowReservoir implements Reservoir {
             final long oldTick = lastTick.get();
             final long tick = clock.getTick() * COLLISION_BUFFER;
             // ensure the tick is strictly incrementing even if there are duplicate ticks
-            final long newTick = tick > oldTick ? tick : oldTick + 1;
+            final long newTick = tick - oldTick > 0 ? tick : oldTick + 1;
             if (lastTick.compareAndSet(oldTick, newTick)) {
                 return newTick;
             }


### PR DESCRIPTION
The currently used comparison between oldTick and Tick (tick > oldTick) is bound to break because System.nanoTime can easily overflow (more easily if multiplied with COLLISION_BUFFER). Therefore, one should compare tick - oldTick > 0, according to System.nanoTime documentation. This fixes an odd behaviour I have experienced where values wouldn't degrade after "leaving" the window.

Please contact me if you need anything else.

Thanks,
Volker
