### PR TITLE
Revert "Changing access modifier for getMetrics method in class MetricRe...

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -322,7 +322,7 @@ public class MetricRegistry implements MetricSet {
     }
 
     @SuppressWarnings("unchecked")
-    protected final <T extends Metric> SortedMap<String, T> getMetrics(Class<T> klass, MetricFilter filter) {
+    private <T extends Metric> SortedMap<String, T> getMetrics(Class<T> klass, MetricFilter filter) {
         final TreeMap<String, T> timers = new TreeMap<String, T>();
         for (Map.Entry<String, Metric> entry : metrics.entrySet()) {
             if (klass.isInstance(entry.getValue()) && filter.matches(entry.getKey(),


### PR DESCRIPTION
Reverts dropwizard/metrics#585

In #628 @astefanutti raises an issue with proxying MetricRegistry due to it containing a non-private final method. We'll figure out extensibility for v4.
