### PR TITLE
New URL for documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Metrics [![Build Status](https://secure.travis-ci.org/dropwizard/metrics.png)](h
 
 *Capturing JVM- and application-level metrics. So you know what's going on.*
 
-For more information, please see [the documentation](http://metrics.codahale.com).
+For more information, please see [the documentation](http://dropwizard.github.io/metrics/).
 
 
 License


### PR DESCRIPTION
Since it seems to have moved. metrics.codahale.com now redirects to this github repo (dropwizard/metrics), which puts the user in an infinite loop if they want to find the documentation.
