### PR TITLE
Simplify usage of InstrumentedAppender (metrics-log4j2)

### DIFF
--- a/metrics-log4j2/src/main/java/com/codahale/metrics/log4j2/InstrumentedAppender.java
+++ b/metrics-log4j2/src/main/java/com/codahale/metrics/log4j2/InstrumentedAppender.java
@@ -44,6 +44,24 @@ public class InstrumentedAppender extends AbstractAppender {
     }
 
     /**
+     * Create a new instrumented appender using the given registry name.
+     *
+     * @param registryName the name of the registry in {@link SharedMetricRegistries}
+     */
+    public InstrumentedAppender(String registryName) {
+        this(SharedMetricRegistries.getOrCreate(registryName));
+    }
+
+    /**
+     * Create a new instrumented appender using the given registry.
+     *
+     * @param registry the metric registry
+     */
+    public InstrumentedAppender(MetricRegistry registry) {
+        this(registry, null, null, true);
+    }
+
+    /**
      * Create a new instrumented appender using the given registry.
      *
      * @param registry the metric registry

--- a/metrics-log4j2/src/test/java/com/codahale/metrics/log4j2/InstrumentedAppenderTest.java
+++ b/metrics-log4j2/src/test/java/com/codahale/metrics/log4j2/InstrumentedAppenderTest.java
@@ -17,7 +17,7 @@ public class InstrumentedAppenderTest {
     public static final String METRIC_NAME_PREFIX = "org.apache.logging.log4j.core.Appender";
 
     private final MetricRegistry registry = new MetricRegistry();
-    private final InstrumentedAppender appender = new InstrumentedAppender(registry, null, null, true);
+    private final InstrumentedAppender appender = new InstrumentedAppender(registry);
     private final LogEvent event = mock(LogEvent.class);
 
     @Before
@@ -115,7 +115,7 @@ public class InstrumentedAppenderTest {
 
         SharedMetricRegistries.add(registryName, registry);
 
-        final InstrumentedAppender shared = new InstrumentedAppender(registryName, null, null, false);
+        final InstrumentedAppender shared = new InstrumentedAppender(registryName);
         shared.start();
 
         when(event.getLevel()).thenReturn(Level.INFO);


### PR DESCRIPTION
Most of the time the `filter` and `layout` arguments of the `InstrumentedAppender` constructors won't be used.

This PR adds two simple versions of the constructors and also fixes #644.
