### PR TITLE
Replaced fest-assert-core with assertj-core

### DIFF
--- a/metrics-core/src/test/java/com/codahale/metrics/CachedGaugeTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/CachedGaugeTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CachedGaugeTest {
     private final AtomicInteger value = new AtomicInteger(0);

--- a/metrics-core/src/test/java/com/codahale/metrics/ClockTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ClockTest.java
@@ -4,8 +4,8 @@ import org.junit.Test;
 
 import java.lang.management.ManagementFactory;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.data.Offset.offset;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
 
 public class ClockTest {
     @Test

--- a/metrics-core/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
@@ -12,7 +12,7 @@ import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-core/src/test/java/com/codahale/metrics/CounterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/CounterTest.java
@@ -2,7 +2,7 @@ package com.codahale.metrics;
 
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CounterTest {
     private final Counter counter = new Counter();

--- a/metrics-core/src/test/java/com/codahale/metrics/CsvReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/CsvReporterTest.java
@@ -12,7 +12,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-core/src/test/java/com/codahale/metrics/DefaultObjectNameFactoryTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/DefaultObjectNameFactoryTest.java
@@ -1,6 +1,6 @@
 package com.codahale.metrics;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.management.ObjectName;
 

--- a/metrics-core/src/test/java/com/codahale/metrics/DerivativeGaugeTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/DerivativeGaugeTest.java
@@ -2,7 +2,7 @@ package com.codahale.metrics;
 
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class DerivativeGaugeTest {
     private final Gauge<String> gauge1 = new Gauge<String>() {

--- a/metrics-core/src/test/java/com/codahale/metrics/EWMATest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/EWMATest.java
@@ -4,8 +4,8 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.data.Offset.offset;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
 
 public class EWMATest {
     @Test

--- a/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
@@ -3,7 +3,7 @@ package com.codahale.metrics;
 import org.junit.Test;
 import java.util.concurrent.TimeUnit;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExponentiallyDecayingReservoirTest {
     @Test

--- a/metrics-core/src/test/java/com/codahale/metrics/HistogramTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/HistogramTest.java
@@ -2,7 +2,7 @@ package com.codahale.metrics;
 
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 public class HistogramTest {

--- a/metrics-core/src/test/java/com/codahale/metrics/InstrumentedExecutorServiceTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/InstrumentedExecutorServiceTest.java
@@ -8,7 +8,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class InstrumentedExecutorServiceTest {
     private final ExecutorService executor = Executors.newCachedThreadPool();

--- a/metrics-core/src/test/java/com/codahale/metrics/InstrumentedScheduledExecutorServiceTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/InstrumentedScheduledExecutorServiceTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 import java.util.concurrent.*;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class InstrumentedScheduledExecutorServiceTest {
     private final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();

--- a/metrics-core/src/test/java/com/codahale/metrics/InstrumentedThreadFactoryTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/InstrumentedThreadFactoryTest.java
@@ -1,6 +1,6 @@
 package com.codahale.metrics;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;

--- a/metrics-core/src/test/java/com/codahale/metrics/JmxAttributeGaugeTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/JmxAttributeGaugeTest.java
@@ -6,7 +6,7 @@ import javax.management.AttributeNotFoundException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-core/src/test/java/com/codahale/metrics/JmxReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/JmxReporterTest.java
@@ -11,7 +11,7 @@ import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import static org.fest.assertions.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 public class JmxReporterTest {

--- a/metrics-core/src/test/java/com/codahale/metrics/JvmAttributeGaugeSetTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/JvmAttributeGaugeSetTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 import java.lang.management.RuntimeMXBean;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-core/src/test/java/com/codahale/metrics/MeterApproximationTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MeterApproximationTest.java
@@ -9,8 +9,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.offset;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
 
 @RunWith(value = Parameterized.class)
 public class MeterApproximationTest {

--- a/metrics-core/src/test/java/com/codahale/metrics/MeterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MeterTest.java
@@ -5,8 +5,8 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.offset;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricFilterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricFilterTest.java
@@ -2,7 +2,7 @@ package com.codahale.metrics;
 
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 public class MetricFilterTest {

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
@@ -7,8 +7,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.data.MapEntry.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.*;
 
 public class MetricRegistryTest {

--- a/metrics-core/src/test/java/com/codahale/metrics/RatioGaugeTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/RatioGaugeTest.java
@@ -2,7 +2,7 @@ package com.codahale.metrics;
 
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class RatioGaugeTest {
     @Test

--- a/metrics-core/src/test/java/com/codahale/metrics/SharedMetricRegistriesTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SharedMetricRegistriesTest.java
@@ -3,7 +3,7 @@ package com.codahale.metrics;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SharedMetricRegistriesTest {
     @Before

--- a/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowReservoirTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-core/src/test/java/com/codahale/metrics/SlidingWindowReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SlidingWindowReservoirTest.java
@@ -2,7 +2,7 @@ package com.codahale.metrics;
 
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SlidingWindowReservoirTest {
     private final SlidingWindowReservoir reservoir = new SlidingWindowReservoir(3);

--- a/metrics-core/src/test/java/com/codahale/metrics/TimerTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/TimerTest.java
@@ -5,8 +5,8 @@ import org.junit.Test;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.offset;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
 import static org.mockito.Mockito.*;
 
 public class TimerTest {

--- a/metrics-core/src/test/java/com/codahale/metrics/UniformReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/UniformReservoirTest.java
@@ -2,7 +2,7 @@ package com.codahale.metrics;
 
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class UniformReservoirTest {
     @Test

--- a/metrics-core/src/test/java/com/codahale/metrics/UniformSnapshotTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/UniformSnapshotTest.java
@@ -7,8 +7,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.offset;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 

--- a/metrics-core/src/test/java/com/codahale/metrics/WeightedSnapshotTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/WeightedSnapshotTest.java
@@ -8,8 +8,8 @@ import java.util.List;
 
 import com.codahale.metrics.WeightedSnapshot.WeightedSample;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.offset;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 

--- a/metrics-ehcache/src/test/java/com/codahale/metrics/ehcache/InstrumentedCacheDecoratorFactoryTest.java
+++ b/metrics-ehcache/src/test/java/com/codahale/metrics/ehcache/InstrumentedCacheDecoratorFactoryTest.java
@@ -11,7 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assume.assumeThat;
 

--- a/metrics-ehcache/src/test/java/com/codahale/metrics/ehcache/InstrumentedEhcacheTest.java
+++ b/metrics-ehcache/src/test/java/com/codahale/metrics/ehcache/InstrumentedEhcacheTest.java
@@ -11,7 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class InstrumentedEhcacheTest {
     private static final CacheManager MANAGER = CacheManager.create();

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteRabbitMQTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteRabbitMQTest.java
@@ -11,8 +11,8 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Fail.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
 
 
 import static org.mockito.Mockito.*;

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteTest.java
@@ -10,8 +10,8 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Fail.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.*;

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/PickledGraphiteTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/PickledGraphiteTest.java
@@ -1,6 +1,6 @@
 package com.codahale.metrics.graphite;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.*;

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckRegistryTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckRegistryTest.java
@@ -9,7 +9,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import static org.fest.assertions.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
@@ -2,7 +2,7 @@ package com.codahale.metrics.health;
 
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/SharedMetricRegistriesTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/SharedMetricRegistriesTest.java
@@ -3,7 +3,7 @@ package com.codahale.metrics.health;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SharedMetricRegistriesTest {
     @Before

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/jvm/ThreadDeadlockHealthCheckTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/jvm/ThreadDeadlockHealthCheckTest.java
@@ -8,7 +8,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-jdbi/src/test/java/com/codahale/metrics/jdbi/InstrumentedTimingCollectorTest.java
+++ b/metrics-jdbi/src/test/java/com/codahale/metrics/jdbi/InstrumentedTimingCollectorTest.java
@@ -12,7 +12,7 @@ import org.skife.jdbi.v2.StatementContext;
 import java.util.concurrent.TimeUnit;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 

--- a/metrics-jersey/src/test/java/com/codahale/metrics/jersey/SingletonMetricsJerseyTest.java
+++ b/metrics-jersey/src/test/java/com/codahale/metrics/jersey/SingletonMetricsJerseyTest.java
@@ -16,8 +16,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 /**
  * Tests importing {@link InstrumentedResourceMethodDispatchAdapter} as a singleton

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
@@ -18,8 +18,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static org.fest.assertions.api.Assertions.assertThat;
-import static org.fest.assertions.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 /**
  * Tests registering {@link InstrumentedResourceMethodApplicationListener} as a singleton

--- a/metrics-jetty9-legacy/src/test/java/com/codahale/metrics/jetty9/InstrumentedConnectionFactoryTest.java
+++ b/metrics-jetty9-legacy/src/test/java/com/codahale/metrics/jetty9/InstrumentedConnectionFactoryTest.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class InstrumentedConnectionFactoryTest {
     private final MetricRegistry registry = new MetricRegistry();

--- a/metrics-jetty9-legacy/src/test/java/com/codahale/metrics/jetty9/InstrumentedHandlerTest.java
+++ b/metrics-jetty9-legacy/src/test/java/com/codahale/metrics/jetty9/InstrumentedHandlerTest.java
@@ -10,7 +10,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class InstrumentedHandlerTest {
     private final HttpClient client = new HttpClient();

--- a/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedConnectionFactoryTest.java
+++ b/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedConnectionFactoryTest.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class InstrumentedConnectionFactoryTest {
     private final MetricRegistry registry = new MetricRegistry();

--- a/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHandlerTest.java
+++ b/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHandlerTest.java
@@ -10,7 +10,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class InstrumentedHandlerTest {
     private final HttpClient client = new HttpClient();

--- a/metrics-json/src/test/java/com/codahale/metrics/json/HealthCheckModuleTest.java
+++ b/metrics-json/src/test/java/com/codahale/metrics/json/HealthCheckModuleTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.codahale.metrics.health.HealthCheck;
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-json/src/test/java/com/codahale/metrics/json/MetricsModuleTest.java
+++ b/metrics-json/src/test/java/com/codahale/metrics/json/MetricsModuleTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/BufferPoolMetricSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/BufferPoolMetricSetTest.java
@@ -8,7 +8,7 @@ import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ClassLoadingGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ClassLoadingGaugeSetTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 import java.lang.management.ClassLoadingMXBean;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/FileDescriptorRatioGaugeTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/FileDescriptorRatioGaugeTest.java
@@ -6,7 +6,7 @@ import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
 

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/GarbageCollectorMetricSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/GarbageCollectorMetricSetTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import java.lang.management.GarbageCollectorMXBean;
 import java.util.Arrays;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/MemoryUsageGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/MemoryUsageGaugeSetTest.java
@@ -9,7 +9,7 @@ import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
 import java.util.Arrays;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadDeadlockDetectorTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadDeadlockDetectorTest.java
@@ -6,7 +6,7 @@ import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.Locale;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadDumpTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadDumpTest.java
@@ -9,7 +9,7 @@ import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadStatesGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadStatesGaugeSetTest.java
@@ -9,7 +9,7 @@ import java.lang.management.ThreadMXBean;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-log4j/src/test/java/com/codahale/metrics/log4j/InstrumentedAppenderTest.java
+++ b/metrics-log4j/src/test/java/com/codahale/metrics/log4j/InstrumentedAppenderTest.java
@@ -8,7 +8,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-log4j2/src/test/java/com/codahale/metrics/log4j2/InstrumentedAppenderTest.java
+++ b/metrics-log4j2/src/test/java/com/codahale/metrics/log4j2/InstrumentedAppenderTest.java
@@ -10,7 +10,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-logback/src/test/java/com/codahale/metrics/logback/InstrumentedAppenderTest.java
+++ b/metrics-logback/src/test/java/com/codahale/metrics/logback/InstrumentedAppenderTest.java
@@ -9,7 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/AdminServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/AdminServletTest.java
@@ -7,7 +7,7 @@ import org.eclipse.jetty.servlet.ServletTester;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AdminServletTest extends AbstractServletTest {
     private final MetricRegistry registry = new MetricRegistry();

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
@@ -17,7 +17,7 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HealthCheckServletTest extends AbstractServletTest {
     private final HealthCheckRegistry registry = new HealthCheckRegistry();

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletContextListenerTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletContextListenerTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletTest.java
@@ -13,7 +13,7 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/PingServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/PingServletTest.java
@@ -5,7 +5,7 @@ import org.eclipse.jetty.servlet.ServletTester;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PingServletTest extends AbstractServletTest {
     @Override

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/ThreadDumpServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/ThreadDumpServletTest.java
@@ -5,7 +5,7 @@ import org.eclipse.jetty.servlet.ServletTester;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ThreadDumpServletTest extends AbstractServletTest {
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -120,9 +120,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert-core</artifactId>
-            <version>2.0M10</version>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>1.6.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
[AssertJ](http://joel-costigliola.github.io/assertj/) is a fork of FEST, which itself doesn't seem to be maintained anymore.

(see http://joel-costigliola.github.io/assertj/assertj-core.html#fork)
