### PR TITLE
Intercept HttpServletResponseWrapper#setStatus(int, String) to fix response status tracking

### DIFF
--- a/metrics-servlet/src/main/java/com/codahale/metrics/servlet/AbstractInstrumentedFilter.java
+++ b/metrics-servlet/src/main/java/com/codahale/metrics/servlet/AbstractInstrumentedFilter.java
@@ -144,6 +144,12 @@ public abstract class AbstractInstrumentedFilter implements Filter {
             super.setStatus(sc);
         }
 
+        @Override
+        public void setStatus(int sc, String sm) {
+            httpStatus = sc;
+            super.setStatus(sc, sm);
+        }
+
         public int getStatus() {
             return httpStatus;
         }


### PR DESCRIPTION
We are using version 2.2.0 of the metrics library and noticed that the WebappMetricsFilter (renamed in v3 to AbstractInstrumentedFilter) was recording a high number of 'responseCodes.other' responses for our services, and 0 for most other response types, include 'responseCodes.ok'. After a little debugging, found that this was due to HttpServletResponseWrapper#setStatus(int, String) being called to set the response status, and this method not getting intercepted in the WebappMetricFilter's StatusExposingServletResponse. In metrics-web 2.2.0 the StatusExposingServletResponse's httpStatus variable is not initialized (that was changed in v3 to default to 200), so the response status appears to the filter to be 0, associating it to the 'other' meter.

For what it's worth, here are a few examples of how we are setting the status in our service code.
- return Response.ok(builder.toString()).build();
- return Response.status(Status.NOT_FOUND).build();
- return Response.status(Status.SERVICE_UNAVAILABLE.getStatusCode()).entity(builder.toString()).build();
