### PR TITLE
Override toString in Metric implementations

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics/CachedGauge.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/CachedGauge.java
@@ -1,5 +1,6 @@
 package io.dropwizard.metrics;
 
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -64,5 +65,10 @@ public abstract class CachedGauge<T> implements Gauge<T> {
                 return true;
             }
         }
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(this.getValue());
     }
 }

--- a/metrics-core/src/main/java/io/dropwizard/metrics/Clock.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/Clock.java
@@ -23,6 +23,11 @@ public abstract class Clock {
         return System.currentTimeMillis();
     }
 
+    @Override
+    public String toString() {
+        return Long.toString(this.getTime());
+    }
+
     private static final Clock DEFAULT = new UserTimeClock();
 
     /**

--- a/metrics-core/src/main/java/io/dropwizard/metrics/Counter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/Counter.java
@@ -51,4 +51,9 @@ public class Counter implements Metric, Counting {
     public long getCount() {
         return count.sum();
     }
+
+    @Override
+    public String toString() {
+        return String.valueOf(this.count);
+    }
 }

--- a/metrics-core/src/main/java/io/dropwizard/metrics/Histogram.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/Histogram.java
@@ -1,5 +1,10 @@
 package io.dropwizard.metrics;
 
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 /**
  * A metric which calculates the distribution of a value.
  *
@@ -7,6 +12,7 @@ package io.dropwizard.metrics;
  *      variance</a>
  */
 public class Histogram implements Metric, Sampling, Counting {
+
     private final Reservoir reservoir;
     private final LongAdder count;
 
@@ -52,5 +58,16 @@ public class Histogram implements Metric, Sampling, Counting {
     @Override
     public Snapshot getSnapshot() {
         return reservoir.getSnapshot();
+    }
+
+    @Override
+    public String toString() {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        this.getSnapshot().dump(out);
+        try {
+            return out.toString(StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException e) {
+            return super.toString();
+        }
     }
 }

--- a/metrics-core/src/main/java/io/dropwizard/metrics/Meter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/Meter.java
@@ -108,4 +108,12 @@ public class Meter implements Metered {
         tickIfNecessary();
         return m1Rate.getRate(TimeUnit.SECONDS);
     }
+
+    @Override
+    public String toString() {
+        return "Meter[mean=" + this.getMeanRate() +
+               ", 1m=" + this.m1Rate.getRate(TimeUnit.SECONDS) +
+               ", 5m=" + this.m5Rate.getRate(TimeUnit.SECONDS) +
+               ", 15m=" + this.m15Rate.getRate(TimeUnit.SECONDS) + "]";
+    }
 }

--- a/metrics-core/src/main/java/io/dropwizard/metrics/Timer.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/Timer.java
@@ -40,6 +40,12 @@ public class Timer implements Metered, Sampling {
         public void close() {
             stop();
         }
+
+        @Override
+        public String toString() {
+            return "Timer.Context[start_time=" + this.startTime +
+                   ", " + this.timer + ", " +  this.clock + "]";
+        }
     }
 
     private final Meter meter;
@@ -163,5 +169,14 @@ public class Timer implements Metered, Sampling {
             histogram.update(duration);
             meter.mark();
         }
+    }
+
+    @Override
+    public String toString() {
+        return "Timer[count=" + this.getCount() +
+               ", mean=" + this.getMeanRate() +
+               ", 1m=" + this.getOneMinuteRate() +
+               ", 5m=" + this.getFiveMinuteRate() +
+               ", 15m=" + this.getFifteenMinuteRate() + " ]";
     }
 }


### PR DESCRIPTION
Keeping the basic output for Counter and Clock in the same line as the existing RatioGauge::toString, but for Histogram etc. tries a human friendly yet parseable output. Happy to amend to better formats anyway.

Fixes #566