### PR TITLE
Added support for filtering metric values out of GraphiteReporter

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/MetricValueFilter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricValueFilter.java
@@ -1,0 +1,26 @@
+package com.codahale.metrics;
+
+/**
+ * A filter used to determine if a value should be reported or not
+ *
+ * See {@link Value}
+ */
+public interface MetricValueFilter {
+    /**
+     * Matches all values, regardless of type or name.
+     */
+    MetricValueFilter ALL = new MetricValueFilter() {
+        @Override
+        public boolean isReportingOn(Value value) {
+            return true;
+        }
+    };
+
+    /**
+     * Returns {@code true} if the value matches the filter; {@code false} otherwise.
+     *
+     * @param value the {@link Value} to match
+     * @return {@code true} if the value matches the filter
+     */
+    boolean isReportingOn(Value value);
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/Value.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Value.java
@@ -1,0 +1,38 @@
+package com.codahale.metrics;
+
+/**
+ * Metric values of timer, histogram and meter
+ */
+public enum Value {
+    TIMER_COUNT,
+    TIMER_MAX,
+    TIMER_MEAN,
+    TIMER_MIN,
+    TIMER_STDDEV,
+    TIMER_P50,
+    TIMER_P75,
+    TIMER_P95,
+    TIMER_P98,
+    TIMER_P99,
+    TIMER_P999,
+    TIMER_M1_RATE,
+    TIMER_M5_RATE,
+    TIMER_M15_RATE,
+    TIMER_MEAN_RATE,
+    HISTOGRAM_COUNT,
+    HISTOGRAM_MAX,
+    HISTOGRAM_MEAN,
+    HISTOGRAM_MIN,
+    HISTOGRAM_STDDEV,
+    HISTOGRAM_P50,
+    HISTOGRAM_P75,
+    HISTOGRAM_P95,
+    HISTOGRAM_P98,
+    HISTOGRAM_P99,
+    HISTOGRAM_P999,
+    METER_COUNT,
+    METER_M1_RATE,
+    METER_M5_RATE,
+    METER_M15_RATE,
+    METER_MEAN_RATE;
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/ValueFilter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ValueFilter.java
@@ -1,0 +1,51 @@
+package com.codahale.metrics;
+
+import java.util.EnumSet;
+
+/**
+ * Implementation of MetricValueFilter.
+ */
+public class ValueFilter implements MetricValueFilter {
+
+
+    private EnumSet<Value> reportedValues;
+
+    /**
+     * Construct a ValueFilter with reporting on for all values
+     */
+    public ValueFilter() {
+        reportedValues = EnumSet.allOf(Value.class);
+    }
+
+    /**
+     * Turns reporting off for the given value
+     * @return this
+     */
+    public ValueFilter excludeValue(Value value) {
+        reportedValues.remove(value);
+        return this;
+    }
+
+    /**
+     * Turns reporting on for the given value
+     * @return this
+     */
+    public ValueFilter includeValue(Value value) {
+        reportedValues.add(value);
+        return this;
+    }
+
+    /**
+     * Turns reporting off for all timer, meter and histogram values
+     * @return this
+     */
+    public ValueFilter excludeAllValues() {
+        reportedValues.clear();
+        return this;
+    }
+
+    @Override
+    public boolean isReportingOn(Value value) {
+        return reportedValues.contains(value);
+    }
+}


### PR DESCRIPTION
I implemented these changes to avoid flooding our graphite server with too many data points.

The other reporters could use the MetricValueFilter as well, if they want to reduce the volume of data published.