### PR TITLE
Allow specifying a default reservoir for a registry.

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
@@ -21,8 +21,8 @@ import com.codahale.metrics.WeightedSnapshot.WeightedSample;
  *      Proceedings of the 2009 IEEE International Conference on Data Engineering (2009)</a>
  */
 public class ExponentiallyDecayingReservoir implements Reservoir {
-    private static final int DEFAULT_SIZE = 1028;
-    private static final double DEFAULT_ALPHA = 0.015;
+    static final int DEFAULT_SIZE = 1028;
+    static final double DEFAULT_ALPHA = 0.015;
     private static final long RESCALE_THRESHOLD = TimeUnit.HOURS.toNanos(1);
 
     private final ConcurrentSkipListMap<Double, WeightedSample> values;

--- a/metrics-core/src/main/java/com/codahale/metrics/ReservoirBuilder.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ReservoirBuilder.java
@@ -1,0 +1,75 @@
+package com.codahale.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+public abstract class ReservoirBuilder {
+    public static final class ExponentiallyDecayingReservoirBuilder extends ReservoirBuilder {
+        private final double alpha;
+        private final int size;
+        private final Clock clock;
+
+        public ExponentiallyDecayingReservoirBuilder(final int size, final double alpha, final Clock clock) {
+            this.size = size;
+            this.alpha = alpha;
+            this.clock = clock;
+        }
+
+        public ExponentiallyDecayingReservoirBuilder(final int size, final double alpha) {
+            this(size, alpha, Clock.defaultClock());
+        }
+
+        @Override
+        public Reservoir newReservoir() {
+            return new ExponentiallyDecayingReservoir(size, alpha, clock);
+        }
+    }
+
+    public static final class SlidingWindowReservoirBuilder extends ReservoirBuilder {
+        private final int size;
+
+        public SlidingWindowReservoirBuilder(final int size) {
+            this.size = size;
+        }
+
+        @Override
+        public final Reservoir newReservoir() {
+            return new SlidingWindowReservoir(size);
+        }
+    }
+
+    public static final class SlidingTimeWindowReservoirBuilder extends ReservoirBuilder {
+        private final long window;
+        private final TimeUnit windowUnit;
+        private final Clock clock;
+
+        public SlidingTimeWindowReservoirBuilder(final int window, final TimeUnit windowUnit, final Clock clock) {
+            this.window = window;
+            this.windowUnit = windowUnit;
+            this.clock = clock;
+        }
+
+        public SlidingTimeWindowReservoirBuilder(final int window, final TimeUnit windowUnit) {
+            this(window, windowUnit, Clock.defaultClock());
+        }
+
+        @Override
+        public final Reservoir newReservoir() {
+            return new SlidingTimeWindowReservoir(window, windowUnit, clock);
+        }
+    }
+
+    public static final class UniformReservoirBuilder extends ReservoirBuilder {
+        private final int size;
+
+        public UniformReservoirBuilder(final int size) {
+            this.size = size;
+        }
+
+        @Override
+        public final Reservoir newReservoir() {
+            return new UniformReservoir(size);
+        }
+    }
+
+    public abstract Reservoir newReservoir();
+}


### PR DESCRIPTION
Motivation:

 A usage pattern for the metrics library is to create a MetricRegistry
 and use the counter(), histogram(), meter() and timer() methods to
 create metrics for the application.  When these methods are called
 MetricRegistry potentially creates new metrics with their default
 parameters.

 Creating metrics with non-default parameters, in particular a
 non-default reservoir, currently requires explicitly creating the
 metric and then registering it and remembering it for future use.
 This prevents leveraging functionality already provided by
 MetricsRegistry.

Proposed approach:
 Allow specifying a ReservoirBuilder at MetricsRegistry creation
 time.  ReservoirBuilder creates new reservoirs with custom
 parameters.  This allows the creation of histograms and timers
 with custom default reservoirs.

Alternate approaches:
 A potentially more comprehensive approach would be to allow
 passing a custom "MetricsBuilder" to the MetricsRegistry
 constructor.  This approach is definitely worth exploring.

Closes #679