### PR TITLE
Add getLong and getDouble to JmxGaugeBean. Add logging of exceptions to ScheduledReporter

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
@@ -160,6 +160,8 @@ public class JmxReporter implements Closeable {
     @SuppressWarnings("UnusedDeclaration")
     public interface JmxGaugeMBean extends MetricMBean {
         Object getValue();
+        long getLong();
+        double getDouble();
     }
     // CHECKSTYLE:ON
 
@@ -174,6 +176,22 @@ public class JmxReporter implements Closeable {
         @Override
         public Object getValue() {
             return metric.getValue();
+        }
+        @Override
+        public long getLong() {
+            Object value = metric.getValue();
+            if(value != null && value instanceof Long) {
+                return (Long) value;
+            }
+            return 0;
+        }
+        @Override
+        public double getDouble() {
+            Object value = metric.getValue();
+            if(value != null && value instanceof Double) {
+                return (Double) value;
+            }
+            return 0.0;
         }
     }
 

--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -1,5 +1,8 @@
 package com.codahale.metrics;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.Closeable;
 import java.util.Locale;
 import java.util.SortedMap;
@@ -18,6 +21,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @see Slf4jReporter
  */
 public abstract class ScheduledReporter implements Closeable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledReporter.class);
+
     /**
      * A simple named thread factory.
      */
@@ -113,11 +118,17 @@ public abstract class ScheduledReporter implements Closeable {
      * Report the current values of all metrics in the registry.
      */
     public void report() {
-        report(registry.getGauges(filter),
-               registry.getCounters(filter),
-               registry.getHistograms(filter),
-               registry.getMeters(filter),
-               registry.getTimers(filter));
+        try {
+            report(registry.getGauges(filter),
+                    registry.getCounters(filter),
+                    registry.getHistograms(filter),
+                    registry.getMeters(filter),
+                    registry.getTimers(filter));
+        }catch (RuntimeException e){
+            LOGGER.warn("A metric threw an exception",e);
+            //if we rethrow this, the scheduledReporter thread dies.
+            //throw e;
+        }
     }
 
     /**

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -172,12 +172,12 @@ public class GraphiteReporter extends ScheduledReporter {
                 reportTimer(entry.getKey(), entry.getValue(), timestamp);
             }
         } catch (IOException e) {
-            LOGGER.warn("Unable to report to Graphite", graphite, e);
+            LOGGER.warn("Unable to report to Graphite", e);
         } finally {
             try {
                 graphite.close();
             } catch (IOException e) {
-                LOGGER.debug("Error disconnecting from Graphite", graphite, e);
+                LOGGER.debug("Error disconnecting from Graphite", e);
             }
         }
     }


### PR DESCRIPTION
Some JMX visualizers(like jmc) will only plot primitives on their
dashboards. This adds 2 primitive fields to the JmxGauge that will unbox
the value if it's a boxed primitive.

For Scheduled reporter, log exceptions and do not propagate.