### PR TITLE
Add size field to the histogram json representation

### DIFF
--- a/metrics-json/src/main/java/com/codahale/metrics/json/MetricsModule.java
+++ b/metrics-json/src/main/java/com/codahale/metrics/json/MetricsModule.java
@@ -71,6 +71,7 @@ public class MetricsModule extends Module {
             json.writeNumberField("max", snapshot.getMax());
             json.writeNumberField("mean", snapshot.getMean());
             json.writeNumberField("min", snapshot.getMin());
+            json.writeNumberField("size", snapshot.size());
             json.writeNumberField("p50", snapshot.getMedian());
             json.writeNumberField("p75", snapshot.get75thPercentile());
             json.writeNumberField("p95", snapshot.get95thPercentile());

--- a/metrics-json/src/test/java/com/codahale/metrics/json/MetricsModuleTest.java
+++ b/metrics-json/src/test/java/com/codahale/metrics/json/MetricsModuleTest.java
@@ -58,6 +58,7 @@ public class MetricsModuleTest {
         when(snapshot.getMax()).thenReturn(2L);
         when(snapshot.getMean()).thenReturn(3.0);
         when(snapshot.getMin()).thenReturn(4L);
+        when(snapshot.size()).thenReturn(5);
         when(snapshot.getStdDev()).thenReturn(5.0);
         when(snapshot.getMedian()).thenReturn(6.0);
         when(snapshot.get75thPercentile()).thenReturn(7.0);
@@ -75,6 +76,7 @@ public class MetricsModuleTest {
                                    "\"max\":2," +
                                    "\"mean\":3.0," +
                                    "\"min\":4," +
+                                   "\"size\":5," +
                                    "\"p50\":6.0," +
                                    "\"p75\":7.0," +
                                    "\"p95\":8.0," +
@@ -92,6 +94,7 @@ public class MetricsModuleTest {
                                    "\"max\":2," +
                                    "\"mean\":3.0," +
                                    "\"min\":4," +
+                                   "\"size\":5," +
                                    "\"p50\":6.0," +
                                    "\"p75\":7.0," +
                                    "\"p95\":8.0," +

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletContextListenerTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletContextListenerTest.java
@@ -84,7 +84,7 @@ public class MetricsServletContextListenerTest extends AbstractServletTest {
                         "\"c\":{\"count\":1}" +
                         "}," +
                         "\"histograms\":{" +
-                        "\"h\":{\"count\":1,\"max\":1,\"mean\":1.0,\"min\":1,\"p50\":1.0,\"p75\":1.0,\"p95\":1.0,\"p98\":1.0,\"p99\":1.0,\"p999\":1.0,\"stddev\":0.0}" +
+                        "\"h\":{\"count\":1,\"max\":1,\"mean\":1.0,\"min\":1,\"size\":1,\"p50\":1.0,\"p75\":1.0,\"p95\":1.0,\"p98\":1.0,\"p99\":1.0,\"p999\":1.0,\"stddev\":0.0}" +
                         "}," +
                         "\"meters\":{" +
                         "\"m\":{\"count\":1,\"m15_rate\":0.0,\"m1_rate\":0.0,\"m5_rate\":0.0,\"mean_rate\":2.0E8,\"units\":\"events/minute\"}},\"timers\":{\"t\":{\"count\":1,\"max\":1000.0,\"mean\":1000.0,\"min\":1000.0,\"p50\":1000.0,\"p75\":1000.0,\"p95\":1000.0,\"p98\":1000.0,\"p99\":1000.0,\"p999\":1000.0,\"stddev\":0.0,\"m15_rate\":0.0,\"m1_rate\":0.0,\"m5_rate\":0.0,\"mean_rate\":6.0E8,\"duration_units\":\"milliseconds\",\"rate_units\":\"calls/minute\"}" +
@@ -123,6 +123,7 @@ public class MetricsServletContextListenerTest extends AbstractServletTest {
                         "      \"max\" : 1,%n" +
                         "      \"mean\" : 1.0,%n" +
                         "      \"min\" : 1,%n" +
+                        "      \"size\" : 1,%n" +
                         "      \"p50\" : 1.0,%n" +
                         "      \"p75\" : 1.0,%n" +
                         "      \"p95\" : 1.0,%n" +

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletTest.java
@@ -73,7 +73,7 @@ public class MetricsServletTest extends AbstractServletTest {
                                        "\"c\":{\"count\":1}" +
                                    "}," +
                                    "\"histograms\":{" +
-                                       "\"h\":{\"count\":1,\"max\":1,\"mean\":1.0,\"min\":1,\"p50\":1.0,\"p75\":1.0,\"p95\":1.0,\"p98\":1.0,\"p99\":1.0,\"p999\":1.0,\"stddev\":0.0}" +
+                                       "\"h\":{\"count\":1,\"max\":1,\"mean\":1.0,\"min\":1,\"size\":1,\"p50\":1.0,\"p75\":1.0,\"p95\":1.0,\"p98\":1.0,\"p99\":1.0,\"p999\":1.0,\"stddev\":0.0}" +
                                    "}," +
                                    "\"meters\":{" +
                                        "\"m\":{\"count\":1,\"m15_rate\":0.0,\"m1_rate\":0.0,\"m5_rate\":0.0,\"mean_rate\":3333333.3333333335,\"units\":\"events/second\"}},\"timers\":{\"t\":{\"count\":1,\"max\":1.0,\"mean\":1.0,\"min\":1.0,\"p50\":1.0,\"p75\":1.0,\"p95\":1.0,\"p98\":1.0,\"p99\":1.0,\"p999\":1.0,\"stddev\":0.0,\"m15_rate\":0.0,\"m1_rate\":0.0,\"m5_rate\":0.0,\"mean_rate\":1.0E7,\"duration_units\":\"seconds\",\"rate_units\":\"calls/second\"}" +
@@ -104,7 +104,7 @@ public class MetricsServletTest extends AbstractServletTest {
                                        "\"c\":{\"count\":1}" +
                                    "}," +
                                    "\"histograms\":{" +
-                                       "\"h\":{\"count\":1,\"max\":1,\"mean\":1.0,\"min\":1,\"p50\":1.0,\"p75\":1.0,\"p95\":1.0,\"p98\":1.0,\"p99\":1.0,\"p999\":1.0,\"stddev\":0.0}" +
+                                       "\"h\":{\"count\":1,\"max\":1,\"mean\":1.0,\"min\":1,\"size\":1,\"p50\":1.0,\"p75\":1.0,\"p95\":1.0,\"p98\":1.0,\"p99\":1.0,\"p999\":1.0,\"stddev\":0.0}" +
                                    "}," +
                                    "\"meters\":{" +
                                        "\"m\":{\"count\":1,\"m15_rate\":0.0,\"m1_rate\":0.0,\"m5_rate\":0.0,\"mean_rate\":3333333.3333333335,\"units\":\"events/second\"}},\"timers\":{\"t\":{\"count\":1,\"max\":1.0,\"mean\":1.0,\"min\":1.0,\"p50\":1.0,\"p75\":1.0,\"p95\":1.0,\"p98\":1.0,\"p99\":1.0,\"p999\":1.0,\"stddev\":0.0,\"m15_rate\":0.0,\"m1_rate\":0.0,\"m5_rate\":0.0,\"mean_rate\":1.0E7,\"duration_units\":\"seconds\",\"rate_units\":\"calls/second\"}" +
@@ -135,7 +135,7 @@ public class MetricsServletTest extends AbstractServletTest {
                                        "\"c\":{\"count\":1}" +
                                    "}," +
                                    "\"histograms\":{" +
-                                       "\"h\":{\"count\":1,\"max\":1,\"mean\":1.0,\"min\":1,\"p50\":1.0,\"p75\":1.0,\"p95\":1.0,\"p98\":1.0,\"p99\":1.0,\"p999\":1.0,\"stddev\":0.0}" +
+                                       "\"h\":{\"count\":1,\"max\":1,\"mean\":1.0,\"min\":1,\"size\":1,\"p50\":1.0,\"p75\":1.0,\"p95\":1.0,\"p98\":1.0,\"p99\":1.0,\"p999\":1.0,\"stddev\":0.0}" +
                                    "}," +
                                    "\"meters\":{" +
                                        "\"m\":{\"count\":1,\"m15_rate\":0.0,\"m1_rate\":0.0,\"m5_rate\":0.0,\"mean_rate\":3333333.3333333335,\"units\":\"events/second\"}},\"timers\":{\"t\":{\"count\":1,\"max\":1.0,\"mean\":1.0,\"min\":1.0,\"p50\":1.0,\"p75\":1.0,\"p95\":1.0,\"p98\":1.0,\"p99\":1.0,\"p999\":1.0,\"stddev\":0.0,\"m15_rate\":0.0,\"m1_rate\":0.0,\"m5_rate\":0.0,\"mean_rate\":1.0E7,\"duration_units\":\"seconds\",\"rate_units\":\"calls/second\"}" +
@@ -174,6 +174,7 @@ public class MetricsServletTest extends AbstractServletTest {
                                                  "      \"max\" : 1,%n" +
                                                  "      \"mean\" : 1.0,%n" +
                                                  "      \"min\" : 1,%n" +
+                                                 "      \"size\" : 1,%n" +
                                                  "      \"p50\" : 1.0,%n" +
                                                  "      \"p75\" : 1.0,%n" +
                                                  "      \"p95\" : 1.0,%n" +


### PR DESCRIPTION
Having the size field included in the json is interesting for some use cases. Not sure if it would be interesting for Timers. Thanks for your comments.