### PR TITLE
Add client request timing for Jersey 2.x

### DIFF
--- a/metrics-jersey2/pom.xml
+++ b/metrics-jersey2/pom.xml
@@ -17,7 +17,7 @@
     </description>
 
     <properties>
-	<jersey.version>2.11</jersey.version>
+	<jersey.version>2.13</jersey.version>
     </properties>
 
     <dependencies>

--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedClientFilter.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedClientFilter.java
@@ -1,0 +1,50 @@
+package com.codahale.metrics.jersey2;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import java.io.IOException;
+
+public class InstrumentedClientFilter implements ClientRequestFilter, ClientResponseFilter {
+
+    private final MetricRegistry registry;
+    private final Jersey2MetricNameStrategy metricNameStrategy;
+    private final String name;
+
+    private static final String CONTEXT_PROPERTY_NAME = "InstrumentedClientFilter.timerContext";
+
+    public InstrumentedClientFilter(MetricRegistry registry, Jersey2MetricNameStrategy metricNameStrategy) {
+        this(registry, metricNameStrategy, null);
+    }
+
+    public InstrumentedClientFilter(MetricRegistry registry, Jersey2MetricNameStrategy metricNameStrategy, String name) {
+        this.registry = registry;
+        this.metricNameStrategy = metricNameStrategy;
+        this.name = name;
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext) throws IOException {
+        final Timer.Context timerContext = timer(requestContext).time();
+        requestContext.setProperty(CONTEXT_PROPERTY_NAME, timerContext);
+    }
+
+    @Override
+    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
+        Object timer = requestContext.getProperty(CONTEXT_PROPERTY_NAME);
+        if (timer != null) {
+            final Timer.Context timerContext = (Timer.Context)timer;
+            timerContext.stop();
+            requestContext.removeProperty(CONTEXT_PROPERTY_NAME);
+        }
+    }
+
+    private Timer timer(ClientRequestContext context) {
+        return registry.timer(metricNameStrategy.getNameFor(name, context));
+    }
+
+}

--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/Jersey2MetricNameStrategies.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/Jersey2MetricNameStrategies.java
@@ -1,0 +1,52 @@
+package com.codahale.metrics.jersey2;
+
+
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.core.UriBuilder;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+public class Jersey2MetricNameStrategies {
+
+    public static final Jersey2MetricNameStrategy METHOD_ONLY =
+            new Jersey2MetricNameStrategy() {
+                @Override
+                public String getNameFor(String name, ClientRequestContext context) {
+                    return name(Client.class,
+                            name,
+                            methodNameString(context));
+                }
+            };
+
+    public static final Jersey2MetricNameStrategy HOST_AND_METHOD =
+            new Jersey2MetricNameStrategy() {
+                @Override
+                public String getNameFor(String name, ClientRequestContext context) {
+                    final URI uri = context.getUri();
+                    return name(Client.class,
+                            name,
+                            uri.getHost(),
+                            methodNameString(context));
+                }
+            };
+
+    public static final Jersey2MetricNameStrategy QUERYLESS_URL_AND_METHOD =
+            new Jersey2MetricNameStrategy() {
+                @Override
+                public String getNameFor(String name, ClientRequestContext context) {
+                    final UriBuilder url = UriBuilder.fromUri(context.getUri());
+                    return name(Client.class,
+                            name,
+                            url.replaceQuery("").build().toString(),
+                            methodNameString(context));
+                }
+            };
+
+    private static String methodNameString(ClientRequestContext context) {
+        return context.getMethod().toLowerCase() + "-requests";
+    }
+}

--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/Jersey2MetricNameStrategy.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/Jersey2MetricNameStrategy.java
@@ -1,0 +1,7 @@
+package com.codahale.metrics.jersey2;
+
+import javax.ws.rs.client.ClientRequestContext;
+
+public interface Jersey2MetricNameStrategy {
+    String getNameFor(String name, ClientRequestContext context);
+}


### PR DESCRIPTION
This PR adds Jersey 2.x client request timing.  This replaces the functionality of **InstrumentedHttpRequestExecutor** from **metrics-jersey** which no longer works in Jersey 2.x
