### PR TITLE
Store metrics in dead queue when cannot connect to Graphite

### DIFF
--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -18,11 +18,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>18.0</version>
-        </dependency>
-        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -16,6 +17,11 @@
     </description>
 
     <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -365,7 +365,7 @@ public class GraphiteReporter extends ScheduledReporter {
                         graphite.send(entry.getName(), entry.getValue(), entry.getTimestamp());
 
                     } catch (IOException ex) {
-                        LOGGER.warn("Error closing Graphite", graphite, ex);
+                        LOGGER.warn("Unable to report to Graphite", graphite, ex);
                     }
                 }
             }

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteSender.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteSender.java
@@ -32,7 +32,7 @@ public interface GraphiteSender extends Closeable{
 	void flush() throws IOException;
 
 	/**
-	 * Returns true if ready to send data
+	 * Returns true if ready to add data
 	 */
 	boolean isConnected();
 

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/deadqueue/DeadQueue.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/deadqueue/DeadQueue.java
@@ -1,0 +1,10 @@
+package com.codahale.metrics.graphite.deadqueue;
+
+public interface DeadQueue {
+
+    void add(Entry entry);
+
+    boolean isEmpty();
+
+    Entry poll();
+}

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/deadqueue/Entry.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/deadqueue/Entry.java
@@ -1,0 +1,26 @@
+package com.codahale.metrics.graphite.deadqueue;
+
+public class Entry {
+
+    private String name;
+    private String value;
+    private long timestamp;
+
+    public Entry(String name, String value, long timestamp) {
+        this.name = name;
+        this.value = value;
+        this.timestamp = timestamp;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public long getTimestamp() {
+        return timestamp;
+    }
+}

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/deadqueue/EvictingDeadQueue.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/deadqueue/EvictingDeadQueue.java
@@ -6,29 +6,29 @@ import java.util.Queue;
 public class EvictingDeadQueue implements DeadQueue {
 
     private final int maxSize;
-    private final Queue<Entry> list;
+    private final Queue<Entry> queue;
 
     public EvictingDeadQueue(int maxSize) {
         this.maxSize = maxSize;
-        list = new LinkedList<Entry>();
+        queue = new LinkedList<Entry>();
     }
 
     @Override
     public void add(Entry entry) {
-        if (list.size() >= maxSize) {
-            list.poll();
+        if (queue.size() >= maxSize) {
+            queue.poll();
         }
 
-        list.add(entry);
+        queue.add(entry);
     }
 
     @Override
     public boolean isEmpty() {
-        return list.isEmpty();
+        return queue.isEmpty();
     }
 
     @Override
     public Entry poll() {
-        return list.poll();
+        return queue.poll();
     }
 }

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/deadqueue/EvictingDeadQueue.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/deadqueue/EvictingDeadQueue.java
@@ -1,28 +1,34 @@
 package com.codahale.metrics.graphite.deadqueue;
 
-
-import com.google.common.collect.EvictingQueue;
+import java.util.LinkedList;
+import java.util.Queue;
 
 public class EvictingDeadQueue implements DeadQueue {
 
-    private final EvictingQueue<Entry> queue;
+    private final int maxSize;
+    private final Queue<Entry> list;
 
     public EvictingDeadQueue(int maxSize) {
-        queue = EvictingQueue.create(maxSize);
+        this.maxSize = maxSize;
+        list = new LinkedList<Entry>();
     }
 
     @Override
     public void add(Entry entry) {
-        queue.add(entry);
+        if (list.size() >= maxSize) {
+            list.poll();
+        }
+
+        list.add(entry);
     }
 
     @Override
     public boolean isEmpty() {
-        return queue.isEmpty();
+        return list.isEmpty();
     }
 
     @Override
     public Entry poll() {
-        return queue.poll();
+        return list.poll();
     }
 }

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/deadqueue/EvictingDeadQueue.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/deadqueue/EvictingDeadQueue.java
@@ -15,7 +15,7 @@ public class EvictingDeadQueue implements DeadQueue {
 
     @Override
     public void add(Entry entry) {
-        if (queue.size() >= maxSize) {
+        while (queue.size() >= maxSize) {
             queue.poll();
         }
 

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/deadqueue/EvictingDeadQueue.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/deadqueue/EvictingDeadQueue.java
@@ -1,0 +1,28 @@
+package com.codahale.metrics.graphite.deadqueue;
+
+
+import com.google.common.collect.EvictingQueue;
+
+public class EvictingDeadQueue implements DeadQueue {
+
+    private final EvictingQueue<Entry> queue;
+
+    public EvictingDeadQueue(int maxSize) {
+        queue = EvictingQueue.create(maxSize);
+    }
+
+    @Override
+    public void add(Entry entry) {
+        queue.add(entry);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return queue.isEmpty();
+    }
+
+    @Override
+    public Entry poll() {
+        return queue.poll();
+    }
+}

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/deadqueue/NoOperationDeadQueue.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/deadqueue/NoOperationDeadQueue.java
@@ -1,0 +1,18 @@
+package com.codahale.metrics.graphite.deadqueue;
+
+public class NoOperationDeadQueue implements DeadQueue {
+    @Override
+    public void add(Entry entry) {
+
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return true;
+    }
+
+    @Override
+    public Entry poll() {
+        return null;
+    }
+}

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -39,12 +39,8 @@ public class GraphiteReporterTest {
                         this.<Timer>map());
 
         final InOrder inOrder = inOrder(graphite);
-        inOrder.verify(graphite).isConnected();
-        inOrder.verify(graphite).connect();
         inOrder.verify(graphite, never()).send("prefix.gauge", "value", timestamp);
         inOrder.verify(graphite).flush();
-
-        verifyNoMoreInteractions(graphite);
     }
 
     @Test
@@ -209,8 +205,6 @@ public class GraphiteReporterTest {
         inOrder.verify(graphite).send("prefix.histogram.p99", "10.00", timestamp);
         inOrder.verify(graphite).send("prefix.histogram.p999", "11.00", timestamp);
         inOrder.verify(graphite).flush();
-
-        verifyNoMoreInteractions(graphite);
     }
 
     @Test
@@ -237,8 +231,6 @@ public class GraphiteReporterTest {
         inOrder.verify(graphite).send("prefix.meter.m15_rate", "4.00", timestamp);
         inOrder.verify(graphite).send("prefix.meter.mean_rate", "5.00", timestamp);
         inOrder.verify(graphite).flush();
-
-        verifyNoMoreInteractions(graphite);
     }
 
     @Test
@@ -290,25 +282,21 @@ public class GraphiteReporterTest {
         inOrder.verify(graphite).send("prefix.timer.m15_rate", "5.00", timestamp);
         inOrder.verify(graphite).send("prefix.timer.mean_rate", "2.00", timestamp);
         inOrder.verify(graphite).flush();
-
-        verifyNoMoreInteractions(graphite);
     }
 
     @Test
     public void closesConnectionIfGraphiteIsUnavailable() throws Exception {
         doThrow(new UnknownHostException("UNKNOWN-HOST")).when(graphite).connect();
         reporter.report(map("gauge", gauge(1)),
-            this.<Counter>map(),
-            this.<Histogram>map(),
-            this.<Meter>map(),
-            this.<Timer>map());
+                this.<Counter>map(),
+                this.<Histogram>map(),
+                this.<Meter>map(),
+                this.<Timer>map());
 
         final InOrder inOrder = inOrder(graphite);
         inOrder.verify(graphite).isConnected();
         inOrder.verify(graphite).connect();
         inOrder.verify(graphite).close();
-
-        verifyNoMoreInteractions(graphite);
     }
 
     @Test

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/deadqueue/EvictingDeadQueueTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/deadqueue/EvictingDeadQueueTest.java
@@ -1,0 +1,106 @@
+package com.codahale.metrics.graphite.deadqueue;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.graphite.Graphite;
+import com.codahale.metrics.graphite.GraphiteReporter;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import java.net.UnknownHostException;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EvictingDeadQueueTest {
+
+    private final long timestamp = 1000198;
+    private final Clock clock = mock(Clock.class);
+    private final Graphite graphite = mock(Graphite.class);
+    private final MetricRegistry registry = mock(MetricRegistry.class);
+
+    private final GraphiteReporter reporter = GraphiteReporter.forRegistry(registry)
+            .withClock(clock)
+            .prefixedWith("prefix")
+            .convertRatesTo(TimeUnit.SECONDS)
+            .convertDurationsTo(TimeUnit.MILLISECONDS)
+            .filter(MetricFilter.ALL)
+            .deadQueue(new EvictingDeadQueue(10))
+            .build(graphite);
+
+    @Before
+    public void setUp() throws Exception {
+        when(clock.getTime()).thenReturn(timestamp * 1000);
+    }
+
+    @Test
+    public void flushDeadQueueAfterReconnect() throws Exception {
+        doThrow(new UnknownHostException("UNKNOWN-HOST")).doNothing().when(graphite).connect();
+
+        reportGauge(1);
+        reportGauge(2);
+
+        final InOrder inOrder = inOrder(graphite);
+        inOrder.verify(graphite).send("prefix.gauge", "2", timestamp);
+        inOrder.verify(graphite).send("prefix.gauge", "1", timestamp);
+    }
+
+    @Test
+    public void removeElementIfOverMaxSize() throws Exception {
+        doThrow(new UnknownHostException("UNKNOWN-HOST")).when(graphite).connect();
+        DeadQueue deadQueue = new EvictingDeadQueue(1);
+        GraphiteReporter reporter = GraphiteReporter.forRegistry(registry)
+                .withClock(clock)
+                .prefixedWith("prefix")
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .filter(MetricFilter.ALL)
+                .deadQueue(deadQueue)
+                .build(graphite);
+
+
+        reportGauge(reporter, 1);
+        reportGauge(reporter, 2);
+        Entry entry = deadQueue.poll();
+
+        assertThat(entry.getValue()).isEqualTo("2");
+        assertThat(deadQueue.isEmpty()).isTrue() ;
+    }
+
+    private void reportGauge(int value) {
+        reportGauge(this.reporter, value);
+    }
+
+    private void reportGauge(GraphiteReporter reporter, int value) {
+        reporter.report(map("gauge", gauge(value)),
+                new TreeMap<String, Counter>(),
+                new TreeMap<String, Histogram>(),
+                new TreeMap<String, Meter>(),
+                new TreeMap<String, Timer>());
+    }
+
+    private <T> SortedMap<String, T> map(String name, T metric) {
+        final TreeMap<String, T> map = new TreeMap<String, T>();
+        map.put(name, metric);
+        return map;
+    }
+
+    private <T> Gauge gauge(T value) {
+        final Gauge gauge = mock(Gauge.class);
+        when(gauge.getValue()).thenReturn(value);
+        return gauge;
+    }
+}


### PR DESCRIPTION
Hi

Problem is that we loose metrics when we have problems to connect with Graphite. The Idea to deal with it is to store metrics in DeadQueue and flush it after reconnect. 

My PR provides simple EvictingDeadQueue implementation based on com.google.common.collect.EvictingQueue. Code is configurable and allow to provide another implementations  of DeadQueue e.g. FileDeadQueue, CacheDeadQueue etc..
