### PR TITLE
Fixed graphite server DNS lookup after disconnection

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
@@ -1,8 +1,10 @@
 package com.codahale.metrics.graphite;
 
 import javax.net.SocketFactory;
-
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
@@ -19,10 +21,10 @@ public class Graphite implements GraphiteSender {
 
     private final String hostname;
     private final int port;
-    private final InetSocketAddress address;
     private final SocketFactory socketFactory;
     private final Charset charset;
 
+    private InetSocketAddress address;
     private Socket socket;
     private Writer writer;
     private int failures;
@@ -95,8 +97,8 @@ public class Graphite implements GraphiteSender {
      * @param charset       the character set used by the server
      */
     public Graphite(InetSocketAddress address, SocketFactory socketFactory, Charset charset) {
-        this.hostname = null;
-        this.port = -1;
+        this.hostname = address.getHostString();
+        this.port = address.getPort();
         this.address = address;
         this.socketFactory = socketFactory;
         this.charset = charset;
@@ -107,7 +109,6 @@ public class Graphite implements GraphiteSender {
         if (socket != null) {
             throw new IllegalStateException("Already connected");
         }
-        InetSocketAddress address = this.address;
         if (address == null) {
             address = new InetSocketAddress(hostname, port);
         }
@@ -121,7 +122,7 @@ public class Graphite implements GraphiteSender {
 
     @Override
     public boolean isConnected() {
-    		return socket != null && socket.isConnected() && !socket.isClosed();
+        return socket != null && socket.isConnected() && !socket.isClosed();
     }
 
     @Override
@@ -165,6 +166,7 @@ public class Graphite implements GraphiteSender {
         } finally {
             this.socket = null;
             this.writer = null;
+            this.address = null;
         }
     }
 

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteUDP.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteUDP.java
@@ -41,8 +41,8 @@ public class GraphiteUDP implements GraphiteSender {
      * @param address the address of the Carbon server
      */
     public GraphiteUDP(InetSocketAddress address) {
-        this.hostname = null;
-        this.port = -1;
+        this.hostname = address.getHostString();
+        this.port = address.getPort();
         this.address = address;
     }
 
@@ -58,7 +58,7 @@ public class GraphiteUDP implements GraphiteSender {
         }
 
         // Resolve hostname
-        if (hostname != null) {
+        if (address == null) {
             address = new InetSocketAddress(hostname, port);
         }
 
@@ -107,6 +107,7 @@ public class GraphiteUDP implements GraphiteSender {
 
     @Override
     public void close() throws IOException {
+        address = null;
         // Leave channel & socket open for next metrics
     }
 

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/PickledGraphite.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/PickledGraphite.java
@@ -37,10 +37,10 @@ public class PickledGraphite implements GraphiteSender {
 
     private final String hostname;
     private final int port;
-    private final InetSocketAddress address;
     private final SocketFactory socketFactory;
     private final Charset charset;
 
+    private InetSocketAddress address;
     private Socket socket;
     private Writer writer;
     private int failures;
@@ -96,8 +96,8 @@ public class PickledGraphite implements GraphiteSender {
      */
     public PickledGraphite(InetSocketAddress address, SocketFactory socketFactory, Charset charset, int batchSize) {
         this.address = address;
-        this.hostname = null;
-        this.port = -1;
+        this.hostname = address.getHostString();
+        this.port = address.getPort();
         this.socketFactory = socketFactory;
         this.charset = charset;
         this.batchSize = batchSize;
@@ -174,7 +174,6 @@ public class PickledGraphite implements GraphiteSender {
         if (isConnected()) {
             throw new IllegalStateException("Already connected");
         }
-        InetSocketAddress address = this.address;
         if (address == null) {
             address = new InetSocketAddress(hostname, port);
         }
@@ -238,6 +237,7 @@ public class PickledGraphite implements GraphiteSender {
         } finally {
             this.socket = null;
             this.writer = null;
+            this.address = null;
         }
     }
 


### PR DESCRIPTION
Hello.
Right now graphite clients cache the DNS location of a graphite server (in the `InetSocketAddress` object). The problem is that the network setup of the graphite host may change, and it would be impossible for the client to successfully renew the connection after loosing it. My PR should fix the issue.
