### PR TITLE
Fixed graphite server address resolving for TCP clients

### DIFF
--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/Graphite.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/Graphite.java
@@ -1,8 +1,10 @@
 package io.dropwizard.metrics.graphite;
 
 import javax.net.SocketFactory;
-
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
@@ -19,10 +21,10 @@ public class Graphite implements GraphiteSender {
 
     private final String hostname;
     private final int port;
-    private final InetSocketAddress address;
     private final SocketFactory socketFactory;
     private final Charset charset;
 
+    private InetSocketAddress address;
     private Socket socket;
     private Writer writer;
     private int failures;
@@ -95,8 +97,8 @@ public class Graphite implements GraphiteSender {
      * @param charset       the character set used by the server
      */
     public Graphite(InetSocketAddress address, SocketFactory socketFactory, Charset charset) {
-        this.hostname = null;
-        this.port = -1;
+        this.hostname = address.getHostString();
+        this.port = address.getPort();
         this.address = address;
         this.socketFactory = socketFactory;
         this.charset = charset;
@@ -107,7 +109,6 @@ public class Graphite implements GraphiteSender {
         if (isConnected()) {
             throw new IllegalStateException("Already connected");
         }
-        InetSocketAddress address = this.address;
         if (address == null) {
             address = new InetSocketAddress(hostname, port);
         }
@@ -126,7 +127,7 @@ public class Graphite implements GraphiteSender {
 
     @Override
     public boolean isConnected() {
-    		return socket != null && socket.isConnected() && !socket.isClosed();
+        return socket != null && socket.isConnected() && !socket.isClosed();
     }
 
     @Override
@@ -170,6 +171,7 @@ public class Graphite implements GraphiteSender {
         } finally {
             this.socket = null;
             this.writer = null;
+            this.address = null;
         }
     }
 

--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/PickledGraphite.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/PickledGraphite.java
@@ -35,10 +35,10 @@ public class PickledGraphite implements GraphiteSender {
 
     private final String hostname;
     private final int port;
-    private final InetSocketAddress address;
     private final SocketFactory socketFactory;
     private final Charset charset;
 
+    private InetSocketAddress address;
     private Socket socket;
     private Writer writer;
     private int failures;
@@ -94,8 +94,8 @@ public class PickledGraphite implements GraphiteSender {
      */
     public PickledGraphite(InetSocketAddress address, SocketFactory socketFactory, Charset charset, int batchSize) {
         this.address = address;
-        this.hostname = null;
-        this.port = -1;
+        this.hostname = address.getHostString();
+        this.port = address.getPort();
         this.socketFactory = socketFactory;
         this.charset = charset;
         this.batchSize = batchSize;
@@ -172,7 +172,6 @@ public class PickledGraphite implements GraphiteSender {
         if (isConnected()) {
             throw new IllegalStateException("Already connected");
         }
-        InetSocketAddress address = this.address;
         if (address == null) {
             address = new InetSocketAddress(hostname, port);
         }
@@ -236,6 +235,7 @@ public class PickledGraphite implements GraphiteSender {
         } finally {
             this.socket = null;
             this.writer = null;
+            this.address = null;
         }
     }
 


### PR DESCRIPTION
Hello.
Right now graphite TCP clients cache the DNS location of graphite server forever (the `InetSocketAddress` object). The problem is that the network setup of the graphite host may change, and it would be impossible for the client to successfully renew the connection after loosing it. 
My PR should fix the issue.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dropwizard/metrics/719)

<!-- Reviewable:end -->
