### PR TITLE
Added possibility to define a custom size of snapshot

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
@@ -47,6 +47,15 @@ public class ExponentiallyDecayingReservoir implements Reservoir {
      * Creates a new {@link ExponentiallyDecayingReservoir}.
      *
      * @param size  the number of samples to keep in the sampling reservoir
+     */
+    public ExponentiallyDecayingReservoir(int size) {
+        this(size, DEFAULT_ALPHA);
+    }
+
+    /**
+     * Creates a new {@link ExponentiallyDecayingReservoir}.
+     *
+     * @param size  the number of samples to keep in the sampling reservoir
      * @param alpha the exponential decay factor; the higher this is, the more biased the reservoir
      *              will be towards newer values
      */


### PR DESCRIPTION
In our project we need a bit more precise quantiles (like p9999) but this is not possible without increasing size of snaphot.
This PR introduces a possibility to create MetricRegistry object with custom size of created metrics.