### PR TITLE
Introduce a backend for Instrumental

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -381,7 +381,7 @@ public class MetricRegistry implements MetricSet {
         }
     }
 
-    private void registerAll(String prefix, MetricSet metrics) throws IllegalArgumentException {
+    public void registerAll(String prefix, MetricSet metrics) throws IllegalArgumentException {
         for (Map.Entry<String, Metric> entry : metrics.getMetrics().entrySet()) {
             if (entry.getValue() instanceof MetricSet) {
                 registerAll(name(prefix, entry.getKey()), (MetricSet) entry.getValue());

--- a/metrics-instrumental/pom.xml
+++ b/metrics-instrumental/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>metrics-parent</artifactId>
+        <groupId>io.dropwizard.metrics</groupId>
+        <version>3.1.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>metrics-instrumental</artifactId>
+    <name>Instrumental Integration for Metrics</name>
+    <packaging>bundle</packaging>
+    <description>
+        A reporter for Metrics which announces measurements to an Instrumental instance.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/metrics-instrumental/src/main/java/com/codahale/metrics/instrumental/Instrumental.java
+++ b/metrics-instrumental/src/main/java/com/codahale/metrics/instrumental/Instrumental.java
@@ -1,0 +1,169 @@
+package com.codahale.metrics.instrumental;
+
+import javax.net.SocketFactory;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.nio.charset.Charset;
+import java.util.regex.Pattern;
+
+/**
+ * Created by bvarner on 1/6/15.
+ */
+public class Instrumental implements InstrumentalSender {
+
+	private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
+	private static final Charset ASCII = Charset.forName("ASCII");
+	private static byte[] LF = "\n".getBytes(ASCII);
+
+	private String hostname;
+	private int port;
+	private String apiKey;
+	private InetSocketAddress address;
+	private SocketFactory socketFactory;
+
+	public Socket socket = null;
+	private int failures;
+
+
+	public Instrumental(String apiKey, String hostname, int port) {
+		this(apiKey, hostname, port, SocketFactory.getDefault());
+	}
+
+	public Instrumental(String apiKey, String hostname, int port, SocketFactory socketFactory) {
+		this.hostname = hostname;
+		this.port = port;
+		this.apiKey = apiKey;
+		this.address = null;
+		this.socketFactory = socketFactory;
+	}
+
+	public Instrumental(String apiKey, InetSocketAddress address) {
+		this(apiKey, address, SocketFactory.getDefault());
+	}
+
+	public Instrumental(String apiKey, InetSocketAddress address, SocketFactory socketFactory) {
+		this.hostname = null;
+		this.port = -1;
+		this.apiKey = apiKey;
+		this.address = address;
+		this.socketFactory = socketFactory;
+	}
+
+	@Override
+	public void connect() throws IllegalStateException, IOException {
+		if (isConnected()) {
+			throw new IllegalStateException("Already connected");
+		}
+
+		if (socket != null) {
+			socket.close();
+		}
+
+		if (hostname != null) {
+			address = new InetSocketAddress(hostname, port);
+		}
+
+		socket = socketFactory.createSocket();
+		socket.setTcpNoDelay(true);
+		socket.setKeepAlive(true);
+		socket.setTrafficClass(0x04 | 0x10); // Reliability, low-delay
+		socket.setPerformancePreferences(0, 2, 1); // latency more important than bandwidth and connection time.
+		if (address.isUnresolved()) {
+			throw new UnknownHostException(address.getHostName());
+		}
+		socket.connect(address);
+
+		String hello = "hello version java/metrics_instrumental/3.1.1 hostname " + socket.getLocalAddress().getHostName() + " pid " + getProcessId("?") + " runtime " + getRuntimeInfo() + " platform " + getPlatformInfo();
+		socket.getOutputStream().write(hello.getBytes(ASCII));
+		socket.getOutputStream().write(LF);
+		socket.getOutputStream().flush();
+		socket.getOutputStream().write(("authenticate " + apiKey).getBytes(ASCII));
+		socket.getOutputStream().write(LF);
+		socket.getOutputStream().flush();
+	}
+
+	@Override
+	public boolean isConnected() {
+		return socket != null && !socket.isClosed() && !socket.isOutputShutdown();
+	}
+
+	@Override
+	public void send(String name, String value, long timestamp) throws IOException {
+		if (!isConnected()) {
+			connect();
+		}
+
+		try {
+			StringBuilder buf = new StringBuilder("gauge ");
+			buf.append(sanitize(name));
+			buf.append(' ');
+			buf.append(sanitize(value));
+			buf.append(' ');
+			buf.append(Long.toString(timestamp));
+			buf.append('\n');
+			socket.getOutputStream().write(buf.toString().getBytes(ASCII));
+			this.failures = 0;
+		} catch (IOException ioe) {
+			failures++;
+			throw ioe;
+		}
+	}
+
+	@Override
+	public int getFailures() {
+		return failures;
+	}
+
+	@Override
+	public void flush() throws IOException {
+		if (isConnected()) {
+			socket.getOutputStream().flush();
+		}
+	}
+
+	@Override
+	public void close() throws IOException {
+		if (isConnected()) {
+			socket.shutdownOutput();
+			socket.close();
+		}
+	}
+
+	private static String getProcessId(final String fallback) {
+		// Note: may fail in some JVM implementations
+		// therefore fallback has to be provided
+
+		// something like '<pid>@<hostname>', at least in SUN / Oracle JVMs
+		final String jvmName = ManagementFactory.getRuntimeMXBean().getName();
+		final int index = jvmName.indexOf('@');
+
+		if (index < 1) {
+			// part before '@' empty (index = 0) / '@' not found (index = -1)
+			return fallback;
+		}
+
+		try {
+			return Long.toString(Long.parseLong(jvmName.substring(0, index)));
+		} catch (NumberFormatException e) {
+			// ignore
+		}
+		return fallback;
+	}
+
+	private static String getPlatformInfo() {
+		return System.getProperty("os.arch", "unknown").replaceAll(" ", "_") + "-" + System.getProperty("os.name", "unknown").replaceAll(" ", "_") + System.getProperty("os.version", "").replaceAll(" ", "_");
+	}
+
+	private static String getRuntimeInfo() {
+		return System.getProperty("java.vendor", "java").replaceAll(" ", "_") + "/" + System.getProperty("java.version", "?").replaceAll(" ", "_");
+	}
+
+	protected String sanitize(String s) {
+		return WHITESPACE.matcher(s).replaceAll(".");
+	}
+
+
+}

--- a/metrics-instrumental/src/main/java/com/codahale/metrics/instrumental/InstrumentalReporter.java
+++ b/metrics-instrumental/src/main/java/com/codahale/metrics/instrumental/InstrumentalReporter.java
@@ -1,0 +1,297 @@
+package com.codahale.metrics.instrumental;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metered;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by bvarner on 1/6/15.
+ */
+public class InstrumentalReporter extends ScheduledReporter {
+
+	/**
+	 * Returns a new {@link Builder} for {@link com.codahale.metrics.instrumental.InstrumentalReporter}
+	 *
+	 * @param registry the registry to report
+	 * @return a {@link Builder} instance for a {@link com.codahale.metrics.instrumental.InstrumentalReporter}
+	 */
+	public static Builder forRegistry(MetricRegistry registry) {
+		return new Builder(registry);
+	}
+
+	/**
+	 * A builder for a {@link InstrumentalReporter} instances. Defaults to not using a prefix, using the default clock,
+	 * converting rates to events/second, converting durations to milliseconds, and not filtering metrics.
+	 */
+	public static class Builder {
+		private final MetricRegistry registry;
+		private Clock clock;
+		private String prefix;
+		private TimeUnit rateUnit;
+		private TimeUnit durationUnit;
+		private MetricFilter filter;
+
+		private Builder(MetricRegistry registry) {
+			this.registry = registry;
+			this.clock = Clock.defaultClock();
+			this.prefix = null;
+			this.rateUnit = TimeUnit.SECONDS;
+			this.durationUnit = TimeUnit.MILLISECONDS;
+			this.filter = MetricFilter.ALL;
+		}
+
+		/**
+		 * Use the given {@link Clock} instance for the time.
+		 *
+		 * @param clock a {@link Clock} instance
+		 * @return {@code this}
+		 */
+		public Builder withClock(Clock clock) {
+			this.clock = clock;
+			return this;
+		}
+
+		/**
+		 * Prefix all metric names with the given string.
+		 *
+		 * @param prefix the prefix for all metric names
+		 * @return {@code this}
+		 */
+		public Builder prefixedWith(String prefix) {
+			this.prefix = prefix;
+			return this;
+		}
+
+		/**
+		 * Convert rates to the given time unit.
+		 *
+		 * @param rateUnit a unit of time
+		 * @return {@code this}
+		 */
+		public Builder convertRatesTo(TimeUnit rateUnit) {
+			this.rateUnit = rateUnit;
+			return this;
+		}
+
+		/**
+		 * Convert durations to the given time unit.
+		 *
+		 * @param durationUnit a unit of time
+		 * @return {@code this}
+		 */
+		public Builder convertDurationsTo(TimeUnit durationUnit) {
+			this.durationUnit = durationUnit;
+			return this;
+		}
+
+		/**
+		 * Only report metrics which match the given filter.
+		 *
+		 * @param filter a {@link MetricFilter}
+		 * @return {@code this}
+		 */
+		public Builder filter(MetricFilter filter) {
+			this.filter = filter;
+			return this;
+		}
+
+		/**
+		 * Builds a {@link com.codahale.metrics.instrumental.InstrumentalReporter} with the given properties, sending metrics
+		 * using the given {@link InstrumentalSender}
+		 */
+		public InstrumentalReporter build(InstrumentalSender instrumental) {
+			return new InstrumentalReporter(registry, instrumental, clock, prefix, rateUnit, durationUnit, filter);
+		}
+	}
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(InstrumentalReporter.class);
+
+	private final InstrumentalSender instrumental;
+	private final Clock clock;
+	private final String prefix;
+
+	private InstrumentalReporter(MetricRegistry registry,
+	                             InstrumentalSender instrumental,
+	                             Clock clock,
+	                             String prefix,
+	                             TimeUnit rateUnit,
+	                             TimeUnit durationUnit,
+	                             MetricFilter filter) {
+		super(registry, "instrumental-reporter", filter, rateUnit, durationUnit);
+		this.instrumental = instrumental;
+		this.clock = clock;
+		this.prefix = prefix;
+	}
+
+	@Override
+	public void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters, SortedMap<String, Histogram> histograms, SortedMap<String, Meter> meters, SortedMap<String, Timer> timers) {
+		final long timestamp = clock.getTime() / 1000;
+
+		// oh it'd be lovely to use Java 7 here
+		try {
+			if (!instrumental.isConnected()) {
+				instrumental.connect();
+			}
+
+			for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+				reportGauge(entry.getKey(), entry.getValue(), timestamp);
+			}
+
+			for (Map.Entry<String, Counter> entry : counters.entrySet()) {
+				reportCounter(entry.getKey(), entry.getValue(), timestamp);
+			}
+
+			for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
+				reportHistogram(entry.getKey(), entry.getValue(), timestamp);
+			}
+
+			for (Map.Entry<String, Meter> entry : meters.entrySet()) {
+				reportMetered(entry.getKey(), entry.getValue(), timestamp);
+			}
+
+			for (Map.Entry<String, Timer> entry : timers.entrySet()) {
+				reportTimer(entry.getKey(), entry.getValue(), timestamp);
+			}
+
+			instrumental.flush();
+		} catch (IOException e) {
+			LOGGER.warn("Unable to report to Instrumental", instrumental, e);
+			try {
+				instrumental.close();
+			} catch (IOException e1) {
+				LOGGER.warn("Error closing Instrumental", instrumental, e1);
+			}
+		}
+	}
+
+	@Override
+	public void stop() {
+		try {
+			super.stop();
+		} finally {
+			try {
+				instrumental.close();
+			} catch (IOException e) {
+				LOGGER.debug("Error disconnecting from Instrumental", instrumental, e);
+			}
+		}
+	}
+
+	private void reportTimer(String name, Timer timer, long timestamp) throws IOException {
+		final Snapshot snapshot = timer.getSnapshot();
+
+		instrumental.send(prefix(name, "max"), format(convertDuration(snapshot.getMax())), timestamp);
+		instrumental.send(prefix(name, "mean"), format(convertDuration(snapshot.getMean())), timestamp);
+		instrumental.send(prefix(name, "min"), format(convertDuration(snapshot.getMin())), timestamp);
+		instrumental.send(prefix(name, "stddev"),
+				             format(convertDuration(snapshot.getStdDev())),
+				             timestamp);
+		instrumental.send(prefix(name, "p50"),
+				             format(convertDuration(snapshot.getMedian())),
+				             timestamp);
+		instrumental.send(prefix(name, "p75"),
+				             format(convertDuration(snapshot.get75thPercentile())),
+				             timestamp);
+		instrumental.send(prefix(name, "p95"),
+				             format(convertDuration(snapshot.get95thPercentile())),
+				             timestamp);
+		instrumental.send(prefix(name, "p98"),
+				             format(convertDuration(snapshot.get98thPercentile())),
+				             timestamp);
+		instrumental.send(prefix(name, "p99"),
+				             format(convertDuration(snapshot.get99thPercentile())),
+				             timestamp);
+		instrumental.send(prefix(name, "p999"),
+				             format(convertDuration(snapshot.get999thPercentile())),
+				             timestamp);
+
+		reportMetered(name, timer, timestamp);
+	}
+
+	private void reportMetered(String name, Metered meter, long timestamp) throws IOException {
+		instrumental.send(prefix(name, "count"), format(meter.getCount()), timestamp);
+		instrumental.send(prefix(name, "m1_rate"),
+				             format(convertRate(meter.getOneMinuteRate())),
+				             timestamp);
+		instrumental.send(prefix(name, "m5_rate"),
+				             format(convertRate(meter.getFiveMinuteRate())),
+				             timestamp);
+		instrumental.send(prefix(name, "m15_rate"),
+				             format(convertRate(meter.getFifteenMinuteRate())),
+				             timestamp);
+		instrumental.send(prefix(name, "mean_rate"),
+				             format(convertRate(meter.getMeanRate())),
+				             timestamp);
+	}
+
+	private void reportHistogram(String name, Histogram histogram, long timestamp) throws IOException {
+		final Snapshot snapshot = histogram.getSnapshot();
+		instrumental.send(prefix(name, "count"), format(histogram.getCount()), timestamp);
+		instrumental.send(prefix(name, "max"), format(snapshot.getMax()), timestamp);
+		instrumental.send(prefix(name, "mean"), format(snapshot.getMean()), timestamp);
+		instrumental.send(prefix(name, "min"), format(snapshot.getMin()), timestamp);
+		instrumental.send(prefix(name, "stddev"), format(snapshot.getStdDev()), timestamp);
+		instrumental.send(prefix(name, "p50"), format(snapshot.getMedian()), timestamp);
+		instrumental.send(prefix(name, "p75"), format(snapshot.get75thPercentile()), timestamp);
+		instrumental.send(prefix(name, "p95"), format(snapshot.get95thPercentile()), timestamp);
+		instrumental.send(prefix(name, "p98"), format(snapshot.get98thPercentile()), timestamp);
+		instrumental.send(prefix(name, "p99"), format(snapshot.get99thPercentile()), timestamp);
+		instrumental.send(prefix(name, "p999"), format(snapshot.get999thPercentile()), timestamp);
+	}
+
+	private void reportCounter(String name, Counter counter, long timestamp) throws IOException {
+		instrumental.send(prefix(name, "count"), format(counter.getCount()), timestamp);
+	}
+
+	private void reportGauge(String name, Gauge gauge, long timestamp) throws IOException {
+		final String value = format(gauge.getValue());
+		if (value != null) {
+			instrumental.send(prefix(name), value, timestamp);
+		}
+	}
+
+	private String prefix(String... components) {
+		return MetricRegistry.name(prefix, components);
+	}
+
+	private String format(long n) {
+		return Long.toString(n);
+	}
+
+	private String format(double v) {
+		return String.format(Locale.US, "%2.2f", v);
+	}
+
+	private String format(Object o) {
+		if (o instanceof Float) {
+			return format(((Float) o).floatValue());
+		} else if (o instanceof Double) {
+			return format(((Double) o).floatValue());
+		} else if (o instanceof Byte) {
+			return format(((Byte) o).floatValue());
+		} else if (o instanceof Short) {
+			return format(((Short) o).floatValue());
+		} else if (o instanceof Integer) {
+			return format(((Integer) o).floatValue());
+		} else if (o instanceof Long) {
+			return format(((Long) o).floatValue());
+		}
+		return null;
+	}
+}

--- a/metrics-instrumental/src/main/java/com/codahale/metrics/instrumental/InstrumentalSender.java
+++ b/metrics-instrumental/src/main/java/com/codahale/metrics/instrumental/InstrumentalSender.java
@@ -1,0 +1,19 @@
+package com.codahale.metrics.instrumental;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Created by bvarner on 1/6/15.
+ */
+public interface InstrumentalSender extends Closeable {
+	public void connect() throws IllegalStateException, IOException;
+
+	public void send(String name, String value, long timestamp) throws IOException;
+
+	void flush() throws IOException;
+
+	boolean isConnected();
+
+	public int getFailures();
+}

--- a/metrics-instrumental/src/test/java/com/codahale/metrics/instrumental/InstrumentalReporterTest.java
+++ b/metrics-instrumental/src/test/java/com/codahale/metrics/instrumental/InstrumentalReporterTest.java
@@ -1,0 +1,352 @@
+package com.codahale.metrics.instrumental;
+
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import java.net.UnknownHostException;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class InstrumentalReporterTest {
+    private final long timestamp = 1000198;
+    private final Clock clock = mock(Clock.class);
+    private final Instrumental instrumental = mock(Instrumental.class);
+    private final MetricRegistry registry = mock(MetricRegistry.class);
+    private final InstrumentalReporter reporter = InstrumentalReporter.forRegistry(registry)
+                                                              .withClock(clock)
+                                                              .prefixedWith("prefix")
+                                                              .convertRatesTo(TimeUnit.SECONDS)
+                                                              .convertDurationsTo(TimeUnit.MILLISECONDS)
+                                                              .filter(MetricFilter.ALL)
+                                                              .build(instrumental);
+
+    @Before
+    public void setUp() throws Exception {
+        when(clock.getTime()).thenReturn(timestamp * 1000);
+    }
+
+    @Test
+    public void doesNotReportStringGaugeValues() throws Exception {
+        reporter.report(map("gauge", gauge("value")),
+                        this.<Counter>map(),
+                        this.<Histogram>map(),
+                        this.<Meter>map(),
+                        this.<Timer>map());
+
+        final InOrder inOrder = inOrder(instrumental);
+        inOrder.verify(instrumental).isConnected();
+        inOrder.verify(instrumental).connect();
+        inOrder.verify(instrumental, never()).send("prefix.gauge", "value", timestamp);
+        inOrder.verify(instrumental).flush();
+
+        verifyNoMoreInteractions(instrumental);
+    }
+
+    @Test
+    public void reportsByteGaugeValues() throws Exception {
+        reporter.report(map("gauge", gauge((byte) 1)),
+                        this.<Counter>map(),
+                        this.<Histogram>map(),
+                        this.<Meter>map(),
+                        this.<Timer>map());
+
+        final InOrder inOrder = inOrder(instrumental);
+        inOrder.verify(instrumental).isConnected();
+        inOrder.verify(instrumental).connect();
+        inOrder.verify(instrumental).send("prefix.gauge", "1.00", timestamp);
+        inOrder.verify(instrumental).flush();
+
+        verifyNoMoreInteractions(instrumental);
+    }
+
+    @Test
+    public void reportsShortGaugeValues() throws Exception {
+        reporter.report(map("gauge", gauge((short) 1)),
+                        this.<Counter>map(),
+                        this.<Histogram>map(),
+                        this.<Meter>map(),
+                        this.<Timer>map());
+
+        final InOrder inOrder = inOrder(instrumental);
+        inOrder.verify(instrumental).isConnected();
+        inOrder.verify(instrumental).connect();
+        inOrder.verify(instrumental).send("prefix.gauge", "1.00", timestamp);
+        inOrder.verify(instrumental).flush();
+
+        verifyNoMoreInteractions(instrumental);
+    }
+
+    @Test
+    public void reportsIntegerGaugeValues() throws Exception {
+        reporter.report(map("gauge", gauge(1)),
+                        this.<Counter>map(),
+                        this.<Histogram>map(),
+                        this.<Meter>map(),
+                        this.<Timer>map());
+
+        final InOrder inOrder = inOrder(instrumental);
+        inOrder.verify(instrumental).isConnected();
+        inOrder.verify(instrumental).connect();
+        inOrder.verify(instrumental).send("prefix.gauge", "1.00", timestamp);
+        inOrder.verify(instrumental).flush();
+
+        verifyNoMoreInteractions(instrumental);
+    }
+
+    @Test
+    public void reportsLongGaugeValues() throws Exception {
+        reporter.report(map("gauge", gauge(1L)),
+                        this.<Counter>map(),
+                        this.<Histogram>map(),
+                        this.<Meter>map(),
+                        this.<Timer>map());
+
+        final InOrder inOrder = inOrder(instrumental);
+        inOrder.verify(instrumental).isConnected();
+        inOrder.verify(instrumental).connect();
+        inOrder.verify(instrumental).send("prefix.gauge", "1.00", timestamp);
+        inOrder.verify(instrumental).flush();
+
+        verifyNoMoreInteractions(instrumental);
+    }
+
+    @Test
+    public void reportsFloatGaugeValues() throws Exception {
+        reporter.report(map("gauge", gauge(1.1f)),
+                        this.<Counter>map(),
+                        this.<Histogram>map(),
+                        this.<Meter>map(),
+                        this.<Timer>map());
+
+        final InOrder inOrder = inOrder(instrumental);
+        inOrder.verify(instrumental).isConnected();
+        inOrder.verify(instrumental).connect();
+        inOrder.verify(instrumental).send("prefix.gauge", "1.10", timestamp);
+        inOrder.verify(instrumental).flush();
+
+        verifyNoMoreInteractions(instrumental);
+    }
+
+    @Test
+    public void reportsDoubleGaugeValues() throws Exception {
+        reporter.report(map("gauge", gauge(1.1)),
+                        this.<Counter>map(),
+                        this.<Histogram>map(),
+                        this.<Meter>map(),
+                        this.<Timer>map());
+
+        final InOrder inOrder = inOrder(instrumental);
+        inOrder.verify(instrumental).isConnected();
+        inOrder.verify(instrumental).connect();
+        inOrder.verify(instrumental).send("prefix.gauge", "1.10", timestamp);
+        inOrder.verify(instrumental).flush();
+
+        verifyNoMoreInteractions(instrumental);
+    }
+
+    @Test
+    public void reportsCounters() throws Exception {
+        final Counter counter = mock(Counter.class);
+        when(counter.getCount()).thenReturn(100L);
+
+        reporter.report(this.<Gauge>map(),
+                        this.<Counter>map("counter", counter),
+                        this.<Histogram>map(),
+                        this.<Meter>map(),
+                        this.<Timer>map());
+
+        final InOrder inOrder = inOrder(instrumental);
+        inOrder.verify(instrumental).isConnected();
+        inOrder.verify(instrumental).connect();
+        inOrder.verify(instrumental).send("prefix.counter.count", "100", timestamp);
+        inOrder.verify(instrumental).flush();
+
+        verifyNoMoreInteractions(instrumental);
+    }
+
+    @Test
+    public void reportsHistograms() throws Exception {
+        final Histogram histogram = mock(Histogram.class);
+        when(histogram.getCount()).thenReturn(1L);
+
+        final Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.getMax()).thenReturn(2L);
+        when(snapshot.getMean()).thenReturn(3.0);
+        when(snapshot.getMin()).thenReturn(4L);
+        when(snapshot.getStdDev()).thenReturn(5.0);
+        when(snapshot.getMedian()).thenReturn(6.0);
+        when(snapshot.get75thPercentile()).thenReturn(7.0);
+        when(snapshot.get95thPercentile()).thenReturn(8.0);
+        when(snapshot.get98thPercentile()).thenReturn(9.0);
+        when(snapshot.get99thPercentile()).thenReturn(10.0);
+        when(snapshot.get999thPercentile()).thenReturn(11.0);
+
+        when(histogram.getSnapshot()).thenReturn(snapshot);
+
+        reporter.report(this.<Gauge>map(),
+                        this.<Counter>map(),
+                        this.<Histogram>map("histogram", histogram),
+                        this.<Meter>map(),
+                        this.<Timer>map());
+
+        final InOrder inOrder = inOrder(instrumental);
+        inOrder.verify(instrumental).isConnected();
+        inOrder.verify(instrumental).connect();
+        inOrder.verify(instrumental).send("prefix.histogram.count", "1", timestamp);
+        inOrder.verify(instrumental).send("prefix.histogram.max", "2", timestamp);
+        inOrder.verify(instrumental).send("prefix.histogram.mean", "3.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.histogram.min", "4", timestamp);
+        inOrder.verify(instrumental).send("prefix.histogram.stddev", "5.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.histogram.p50", "6.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.histogram.p75", "7.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.histogram.p95", "8.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.histogram.p98", "9.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.histogram.p99", "10.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.histogram.p999", "11.00", timestamp);
+        inOrder.verify(instrumental).flush();
+
+        verifyNoMoreInteractions(instrumental);
+    }
+
+    @Test
+    public void reportsMeters() throws Exception {
+        final Meter meter = mock(Meter.class);
+        when(meter.getCount()).thenReturn(1L);
+        when(meter.getOneMinuteRate()).thenReturn(2.0);
+        when(meter.getFiveMinuteRate()).thenReturn(3.0);
+        when(meter.getFifteenMinuteRate()).thenReturn(4.0);
+        when(meter.getMeanRate()).thenReturn(5.0);
+
+        reporter.report(this.<Gauge>map(),
+                        this.<Counter>map(),
+                        this.<Histogram>map(),
+                        this.<Meter>map("meter", meter),
+                        this.<Timer>map());
+
+        final InOrder inOrder = inOrder(instrumental);
+        inOrder.verify(instrumental).isConnected();
+        inOrder.verify(instrumental).connect();
+        inOrder.verify(instrumental).send("prefix.meter.count", "1", timestamp);
+        inOrder.verify(instrumental).send("prefix.meter.m1_rate", "2.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.meter.m5_rate", "3.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.meter.m15_rate", "4.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.meter.mean_rate", "5.00", timestamp);
+        inOrder.verify(instrumental).flush();
+
+        verifyNoMoreInteractions(instrumental);
+    }
+
+    @Test
+    public void reportsTimers() throws Exception {
+        final Timer timer = mock(Timer.class);
+        when(timer.getCount()).thenReturn(1L);
+        when(timer.getMeanRate()).thenReturn(2.0);
+        when(timer.getOneMinuteRate()).thenReturn(3.0);
+        when(timer.getFiveMinuteRate()).thenReturn(4.0);
+        when(timer.getFifteenMinuteRate()).thenReturn(5.0);
+
+        final Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.getMax()).thenReturn(TimeUnit.MILLISECONDS.toNanos(100));
+        when(snapshot.getMean()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(200));
+        when(snapshot.getMin()).thenReturn(TimeUnit.MILLISECONDS.toNanos(300));
+        when(snapshot.getStdDev()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(400));
+        when(snapshot.getMedian()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(500));
+        when(snapshot.get75thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(600));
+        when(snapshot.get95thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(700));
+        when(snapshot.get98thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(800));
+        when(snapshot.get99thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(900));
+        when(snapshot.get999thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS
+                                                                        .toNanos(1000));
+
+        when(timer.getSnapshot()).thenReturn(snapshot);
+
+        reporter.report(this.<Gauge>map(),
+                        this.<Counter>map(),
+                        this.<Histogram>map(),
+                        this.<Meter>map(),
+                        map("timer", timer));
+
+        final InOrder inOrder = inOrder(instrumental);
+        inOrder.verify(instrumental).isConnected();
+        inOrder.verify(instrumental).connect();
+        inOrder.verify(instrumental).send("prefix.timer.max", "100.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.timer.mean", "200.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.timer.min", "300.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.timer.stddev", "400.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.timer.p50", "500.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.timer.p75", "600.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.timer.p95", "700.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.timer.p98", "800.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.timer.p99", "900.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.timer.p999", "1000.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.timer.count", "1", timestamp);
+        inOrder.verify(instrumental).send("prefix.timer.m1_rate", "3.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.timer.m5_rate", "4.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.timer.m15_rate", "5.00", timestamp);
+        inOrder.verify(instrumental).send("prefix.timer.mean_rate", "2.00", timestamp);
+        inOrder.verify(instrumental).flush();
+
+        verifyNoMoreInteractions(instrumental);
+    }
+
+    @Test
+    public void closesConnectionIfInstrumentalIsUnavailable() throws Exception {
+        doThrow(new UnknownHostException("UNKNOWN-HOST")).when(instrumental).connect();
+        reporter.report(map("gauge", gauge(1)),
+            this.<Counter>map(),
+            this.<Histogram>map(),
+            this.<Meter>map(),
+            this.<Timer>map());
+
+        final InOrder inOrder = inOrder(instrumental);
+        inOrder.verify(instrumental).isConnected();
+        inOrder.verify(instrumental).connect();
+        inOrder.verify(instrumental).close();
+
+        verifyNoMoreInteractions(instrumental);
+    }
+
+    @Test
+    public void closesConnectionOnReporterStop() throws Exception {
+        reporter.stop();
+
+        verify(instrumental).close();
+
+        verifyNoMoreInteractions(instrumental);
+    }
+
+    private <T> SortedMap<String, T> map() {
+        return new TreeMap<String, T>();
+    }
+
+    private <T> SortedMap<String, T> map(String name, T metric) {
+        final TreeMap<String, T> map = new TreeMap<String, T>();
+        map.put(name, metric);
+        return map;
+    }
+
+    private <T> Gauge gauge(T value) {
+        final Gauge gauge = mock(Gauge.class);
+        when(gauge.getValue()).thenReturn(value);
+        return gauge;
+    }
+}

--- a/metrics-instrumental/src/test/java/com/codahale/metrics/instrumental/InstrumentalTest.java
+++ b/metrics-instrumental/src/test/java/com/codahale/metrics/instrumental/InstrumentalTest.java
@@ -1,0 +1,175 @@
+package com.codahale.metrics.instrumental;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import javax.net.SocketFactory;
+import java.io.ByteArrayOutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class InstrumentalTest {
+    private final String host = "example.com";
+    private final int port = 1234;
+    private final String apiKey = "Th3Ap1K3y";
+    private final SocketFactory socketFactory = mock(SocketFactory.class);
+    private final InetSocketAddress address = new InetSocketAddress(host, port);
+
+    private final Socket socket = mock(Socket.class);
+    private final ByteArrayOutputStream output = spy(new ByteArrayOutputStream());
+
+    private Instrumental instrumental;
+
+    @Before
+    public void setUp() throws Exception {
+        when(socket.getOutputStream()).thenReturn(output);
+
+        // Mock behavior of socket.getOutputStream().close() calling socket.close();
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                invocation.callRealMethod();
+                socket.close();
+                return null;
+            }
+        }).when(output).close();
+
+        doAnswer(new Answer<InetAddress>() {
+            @Override
+            public InetAddress answer(InvocationOnMock invocation) throws Throwable {
+                return InetAddress.getLocalHost();
+            }
+        }).when(socket).getLocalAddress();
+
+        when(socketFactory.createSocket()).thenReturn(socket);
+    }
+
+    @Test
+    public void connectsToInstrumentalWithInetSocketAddress() throws Exception {
+        instrumental = new Instrumental(apiKey, address, socketFactory);
+        instrumental.connect();
+
+        verify(socketFactory).createSocket();
+        verify(socket).setTcpNoDelay(true);
+        verify(socket).setKeepAlive(true);
+        verify(socket).setTrafficClass(0x04 | 0x10);
+        verify(socket).setPerformancePreferences(0, 2, 1);
+        verify(socket).connect(address);
+    }
+
+    @Test
+    public void connectsToInstrumentalWithHostAndPort() throws Exception {
+        instrumental = new Instrumental(apiKey, host, port, socketFactory);
+        instrumental.connect();
+
+        verify(socketFactory).createSocket();
+        verify(socket).setTcpNoDelay(true);
+        verify(socket).setKeepAlive(true);
+        verify(socket).setTrafficClass(0x04 | 0x10);
+        verify(socket).setPerformancePreferences(0, 2, 1);
+        verify(socket).connect(address);
+    }
+
+    @Test
+    public void measuresFailures() throws Exception {
+        instrumental = new Instrumental(apiKey, address, socketFactory);
+        assertThat(instrumental.getFailures())
+                .isZero();
+    }
+
+    @Test
+    public void disconnectsFromInstrumental() throws Exception {
+        instrumental = new Instrumental(apiKey, address, socketFactory);
+        instrumental.connect();
+        instrumental.close();
+
+        verify(socket).close();
+    }
+
+    @Test
+    public void doesNotAllowDoubleConnections() throws Exception {
+        instrumental = new Instrumental(apiKey, address, socketFactory);
+        instrumental.connect();
+        try {
+            instrumental.connect();
+            failBecauseExceptionWasNotThrown(IllegalStateException.class);
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage())
+                    .isEqualTo("Already connected");
+        }
+    }
+
+    @Test
+    public void handshakesProperly() throws Exception {
+        instrumental = new Instrumental(apiKey, address, socketFactory);
+        instrumental.connect();
+        instrumental.close();
+
+        assertThat(output.toString()).matches("hello version .* hostname .* pid .* runtime .* platform .*\\n.*\\n");
+        assertThat(output.toString()).contains("authenticate " + apiKey);
+    }
+
+
+    @Test
+    public void writesValuesToInstrumental() throws Exception {
+        instrumental = new Instrumental(apiKey, address, socketFactory);
+        instrumental.connect();
+        output.reset();
+        instrumental.send("name", "value", 100);
+        instrumental.close();
+
+        assertThat(output.toString())
+                .isEqualTo("gauge name value 100\n");
+    }
+
+    @Test
+    public void sanitizesNames() throws Exception {
+        instrumental = new Instrumental(apiKey, address, socketFactory);
+        instrumental.connect();
+        output.reset();
+        instrumental.send("name woo", "value", 100);
+        instrumental.close();
+
+        assertThat(output.toString())
+                .isEqualTo("gauge name.woo value 100\n");
+    }
+
+    @Test
+    public void sanitizesValues() throws Exception {
+        instrumental = new Instrumental(apiKey, address, socketFactory);
+        instrumental.connect();
+        output.reset();
+        instrumental.send("name", "value woo", 100);
+        instrumental.close();
+
+        assertThat(output.toString())
+                .isEqualTo("gauge name value.woo 100\n");
+    }
+
+    @Test
+    public void notifiesIfInstrumentalIsUnavailable() throws Exception {
+        final String unavailableHost = "unknown-host-10el6m7yg56ge7dm.com";
+        InetSocketAddress unavailableAddress = new InetSocketAddress(unavailableHost, 1234);
+        Instrumental unavailableInstrumental = new Instrumental(apiKey, unavailableAddress, socketFactory);
+
+        try {
+            unavailableInstrumental.connect();
+            failBecauseExceptionWasNotThrown(UnknownHostException.class);
+        } catch (Exception e) {
+            assertThat(e.getMessage())
+                .isEqualTo(unavailableHost);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <module>metrics-ehcache</module>
         <module>metrics-ganglia</module>
         <module>metrics-graphite</module>
+        <module>metrics-instrumental</module>
         <module>metrics-httpclient</module>
         <module>metrics-httpasyncclient</module>
         <module>metrics-jdbi</module>


### PR DESCRIPTION
[Instrumental](http://instrumentalapp.com) is a cloud-based metric graphing / dashboard type service that uses a protocol similar to graphite, but with a few changes (handshake, gauge semantics, etc.)

This PR includes full tests cases to make sure the handshake works, and the core function is largely based (but different from) the graphite reporter.

I've also included a change exposing a private method as public for registering MetricSets with string prefixes... this seemed like a really natrual thing to do, especially since not having MetricSets with prefixes was getting very unwieldy in the Instrumental front-end.