### PR TITLE
Added a reference to the metrics-instrumental 3rd party lib.

### DIFF
--- a/docs/source/manual/third-party.rst
+++ b/docs/source/manual/third-party.rst
@@ -30,4 +30,4 @@ the many third-party libraries which extend Metrics:
 * `jersey-metrics-filter <https://github.com/palominolabs/jersey-metrics-filter>`_ provides integration with Jersey 1.
 * `metrics-new-relic <https://github.com/palominolabs/metrics-new-relic>`_ provides a reporter which sends data to New Relic.
 * `hdrhistogram-metrics-reservoir <https://bitbucket.org/marshallpierce/hdrhistogram-metrics-reservoir>`_ provides a Histogram reservoir backed by `HdrHistogram <http://hdrhistogram.org/>`_.
-* `metrics-instrumental <https://github.com/egineering-llc/metrics-instrumental>'_ provides a reporter to send data to `Instrumental <http://instrumentalapp.com/>`_.
+* `metrics-instrumental <https://github.com/egineering-llc/metrics-instrumental>`_ provides a reporter to send data to `Instrumental <http://instrumentalapp.com/>`_.

--- a/docs/source/manual/third-party.rst
+++ b/docs/source/manual/third-party.rst
@@ -30,3 +30,4 @@ the many third-party libraries which extend Metrics:
 * `jersey-metrics-filter <https://github.com/palominolabs/jersey-metrics-filter>`_ provides integration with Jersey 1.
 * `metrics-new-relic <https://github.com/palominolabs/metrics-new-relic>`_ provides a reporter which sends data to New Relic.
 * `hdrhistogram-metrics-reservoir <https://bitbucket.org/marshallpierce/hdrhistogram-metrics-reservoir>`_ provides a Histogram reservoir backed by `HdrHistogram <http://hdrhistogram.org/>`_.
+* `metrics-instrumental <https://github.com/egineering-llc/metrics-instrumental>'_ provides a reporter to send data to `Instrumental <http://instrumentalapp.com/>`_.


### PR DESCRIPTION
As suggested by ryantenney in https://github.com/dropwizard/metrics/pull/733,

We've pushed our metrics-instrumental project to maven central, and here's a PR regarding an update to the third-party documentation.

Thanks!