### PR TITLE
Use JSR305 annotations.

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/InstrumentedExecutorService.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/InstrumentedExecutorService.java
@@ -194,8 +194,8 @@ public class InstrumentedExecutorService implements ExecutorService {
     }
 
     @Override
-    public boolean awaitTermination(long l, TimeUnit timeUnit) throws InterruptedException {
-        return delegate.awaitTermination(l, timeUnit);
+    public boolean awaitTermination(long duration, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(duration, unit);
     }
 
     private class InstrumentedRunnable implements Runnable {

--- a/metrics-core/src/main/java/com/codahale/metrics/InstrumentedScheduledExecutorService.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/InstrumentedScheduledExecutorService.java
@@ -206,7 +206,7 @@ public class InstrumentedScheduledExecutorService implements ScheduledExecutorSe
     private <T> Collection<? extends Callable<T>> instrument(Collection<? extends Callable<T>> tasks) {
         final List<InstrumentedCallable<T>> instrumented = new ArrayList<InstrumentedCallable<T>>(tasks.size());
         for (Callable<T> task : tasks) {
-            instrumented.add(new InstrumentedCallable(task));
+            instrumented.add(new InstrumentedCallable<T>(task));
         }
         return instrumented;
     }

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -1,5 +1,7 @@
 package com.codahale.metrics;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -16,7 +18,7 @@ public class MetricRegistry implements MetricSet {
      * @param names    the remaining elements of the name
      * @return {@code name} and {@code names} concatenated by periods
      */
-    public static String name(String name, String... names) {
+    public static String name(@Nullable String name, @Nullable String... names) {
         final StringBuilder builder = new StringBuilder();
         append(builder, name);
         if (names != null) {
@@ -35,11 +37,11 @@ public class MetricRegistry implements MetricSet {
      * @param names    the remaining elements of the name
      * @return {@code klass} and {@code names} concatenated by periods
      */
-    public static String name(Class<?> klass, String... names) {
+    public static String name(Class<?> klass, @Nullable String... names) {
         return name(klass.getName(), names);
     }
 
-    private static void append(StringBuilder builder, String part) {
+    private static void append(StringBuilder builder, @Nullable String part) {
         if (part != null && !part.isEmpty()) {
             if (builder.length() > 0) {
                 builder.append('.');
@@ -381,7 +383,7 @@ public class MetricRegistry implements MetricSet {
         }
     }
 
-    private void registerAll(String prefix, MetricSet metrics) throws IllegalArgumentException {
+    private void registerAll(@Nullable String prefix, MetricSet metrics) throws IllegalArgumentException {
         for (Map.Entry<String, Metric> entry : metrics.getMetrics().entrySet()) {
             if (entry.getValue() instanceof MetricSet) {
                 registerAll(name(prefix, entry.getKey()), (MetricSet) entry.getValue());

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -452,6 +452,6 @@ public class MetricRegistry implements MetricSet {
 
         T newMetric();
 
-        boolean isInstance(Metric metric);
+        boolean isInstance(@Nullable Metric metric);
     }
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/WeightedSnapshot.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/WeightedSnapshot.java
@@ -99,7 +99,7 @@ public class WeightedSnapshot extends Snapshot {
             return values[values.length - 1];
         }
 
-        return values[(int) posx];
+        return values[posx];
     }
 
     /**

--- a/metrics-core/src/main/java/com/codahale/metrics/package-info.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-ehcache/src/main/java/com/codahale/metrics/ehcache/package-info.java
+++ b/metrics-ehcache/src/main/java/com/codahale/metrics/ehcache/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.ehcache;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-ganglia/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java
+++ b/metrics-ganglia/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java
@@ -10,6 +10,8 @@ import info.ganglia.gmetric4j.gmetric.GangliaException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
@@ -150,15 +152,18 @@ public class GangliaReporter extends ScheduledReporter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(GangliaReporter.class);
 
+    @CheckForNull
     private final GMetric gmetric;
+
+    @CheckForNull
     private final GMetric[] gmetrics;
     private final String prefix;
     private final int tMax;
     private final int dMax;
 
     private GangliaReporter(MetricRegistry registry,
-                            GMetric gmetric,
-                            GMetric[] gmetrics,
+                            @Nullable GMetric gmetric,
+                            @Nullable GMetric[] gmetrics,
                             String prefix,
                             int tMax,
                             int dMax,
@@ -316,7 +321,7 @@ public class GangliaReporter extends ScheduledReporter {
     private void announce(String name, String group, String value, GMetricType type, String units) throws GangliaException {
         if (gmetric != null) {
             gmetric.announce(name, value, type, units, GMetricSlope.BOTH, tMax, dMax, group);
-        } else {
+        } else if (gmetrics != null) {
             for (GMetric gmetric : gmetrics) {
                 gmetric.announce(name, value, type, units, GMetricSlope.BOTH, tMax, dMax, group);
             }

--- a/metrics-ganglia/src/main/java/com/codahale/metrics/ganglia/package-info.java
+++ b/metrics-ganglia/src/main/java/com/codahale/metrics/ganglia/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.ganglia;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
@@ -129,18 +129,24 @@ public class Graphite implements GraphiteSender {
 
     @Override
     public boolean isConnected() {
-    		return socket != null && socket.isConnected() && !socket.isClosed();
+    	return socket != null && socket.isConnected() && !socket.isClosed();
     }
 
     @Override
     public void send(String name, String value, long timestamp) throws IOException {
+        final Writer localWriter = this.writer;
+
+        if (localWriter == null) {
+            throw new IllegalStateException( "Unable to acquire writer. Call connect() first." );
+        }
+
         try {
-            writer.write(sanitize(name));
-            writer.write(' ');
-            writer.write(sanitize(value));
-            writer.write(' ');
-            writer.write(Long.toString(timestamp));
-            writer.write('\n');
+            localWriter.write( sanitize( name ) );
+            localWriter.write( ' ' );
+            localWriter.write( sanitize( value ) );
+            localWriter.write( ' ' );
+            localWriter.write( Long.toString( timestamp ) );
+            localWriter.write( '\n' );
             this.failures = 0;
         } catch (IOException e) {
             failures++;

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
@@ -1,5 +1,7 @@
 package com.codahale.metrics.graphite;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.concurrent.NotThreadSafe;
 import javax.net.SocketFactory;
 
 import java.io.*;
@@ -12,6 +14,7 @@ import java.util.regex.Pattern;
 /**
  * A client to a Carbon server via TCP.
  */
+@NotThreadSafe
 public class Graphite implements GraphiteSender {
     private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
     // this may be optimistic about Carbon/Graphite
@@ -19,11 +22,16 @@ public class Graphite implements GraphiteSender {
 
     private final String hostname;
     private final int port;
-    private final InetSocketAddress address;
     private final SocketFactory socketFactory;
     private final Charset charset;
 
+    @CheckForNull
+    private final InetSocketAddress address;
+
+    @CheckForNull
     private Socket socket;
+
+    @CheckForNull
     private Writer writer;
     private int failures;
 

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteRabbitMQ.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteRabbitMQ.java
@@ -5,14 +5,17 @@ import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.DefaultSocketConfigurator;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.charset.Charset;
 import java.util.regex.Pattern;
 
 /**
- * A rabbit-mq client to a Carbon server.
+ * A rabbit-mq client to a Carbon server. Assumes payload is in UTF-8.
  */
+@NotThreadSafe
 public class GraphiteRabbitMQ implements GraphiteSender {
 
     private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
@@ -24,7 +27,11 @@ public class GraphiteRabbitMQ implements GraphiteSender {
     private static final Integer DEFAULT_RABBIT_REQUESTED_HEARTBEAT_SEC = 10;
 
     private ConnectionFactory connectionFactory;
+
+    @CheckForNull
     private Connection connection;
+
+    @CheckForNull
     private Channel channel;
     private String exchange;
 

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteRabbitMQ.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteRabbitMQ.java
@@ -19,7 +19,6 @@ import java.util.regex.Pattern;
 public class GraphiteRabbitMQ implements GraphiteSender {
 
     private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
-
     private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     private static final Integer DEFAULT_RABBIT_CONNECTION_TIMEOUT_MS = 500;
@@ -65,13 +64,13 @@ public class GraphiteRabbitMQ implements GraphiteSender {
             final String exchange) {
 
         this(rabbitHost,
-                rabbitPort,
-                rabbitUsername,
-                rabbitPassword,
-                exchange,
-                DEFAULT_RABBIT_CONNECTION_TIMEOUT_MS,
-                DEFAULT_RABBIT_SOCKET_TIMEOUT_MS,
-                DEFAULT_RABBIT_REQUESTED_HEARTBEAT_SEC);
+             rabbitPort,
+             rabbitUsername,
+             rabbitPassword,
+             exchange,
+             DEFAULT_RABBIT_CONNECTION_TIMEOUT_MS,
+             DEFAULT_RABBIT_SOCKET_TIMEOUT_MS,
+             DEFAULT_RABBIT_REQUESTED_HEARTBEAT_SEC);
     }
 
     /**
@@ -133,6 +132,12 @@ public class GraphiteRabbitMQ implements GraphiteSender {
 
     @Override
     public void send(String name, String value, long timestamp) throws IOException {
+        final Channel localChannel = this.channel;
+
+        if (localChannel == null) {
+            throw new IllegalStateException( "Unable to acquire channel. Call connect() first." );
+        }
+
         try {
             final String sanitizedName = sanitize(name);
             final String sanitizedValue = sanitize(value);
@@ -143,7 +148,7 @@ public class GraphiteRabbitMQ implements GraphiteSender {
                             .append(sanitizedValue).append(' ')
                             .append(Long.toString(timestamp)).append('\n').toString();
 
-            channel.basicPublish(exchange, sanitizedName, null, message.getBytes(UTF_8));
+            localChannel.basicPublish(exchange, sanitizedName, null, message.getBytes(UTF_8));
         } catch (IOException e) {
             failures++;
             throw e;

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.CheckForNull;
 import java.io.IOException;
 import java.util.Locale;
 import java.util.Map;
@@ -148,7 +149,7 @@ public class GraphiteReporter extends ScheduledReporter {
                        SortedMap<String, Timer> timers) {
         final long timestamp = clock.getTime() / 1000;
 
-        // oh it'd be lovely to use Java 7 here
+        // oh it'd be lovely to use Java 8 here
         try {
             if (!graphite.isConnected()) {
     	          graphite.connect();
@@ -271,6 +272,7 @@ public class GraphiteReporter extends ScheduledReporter {
         }
     }
 
+    @CheckForNull
     private String format(Object o) {
         if (o instanceof Float) {
             return format(((Float) o).doubleValue());

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteUDP.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteUDP.java
@@ -1,5 +1,7 @@
 package com.codahale.metrics.graphite;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.concurrent.NotThreadSafe;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
@@ -8,19 +10,24 @@ import java.nio.charset.Charset;
 import java.util.regex.Pattern;
 
 /**
- * A client to a Carbon server using unconnected UDP
+ * A client to a Carbon server using unconnected UDP. Assumes payload is in UTF-8.
  */
+@NotThreadSafe
 public class GraphiteUDP implements GraphiteSender {
 
     private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
-
     private static final Charset UTF_8 = Charset.forName("UTF-8");
 
+    @CheckForNull
     private final String hostname;
     private final int port;
+
+    @CheckForNull
     private InetSocketAddress address;
 
+    @CheckForNull
     private DatagramChannel datagramChannel = null;
+
     private int failures;
 
     /**

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/PickledGraphite.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/PickledGraphite.java
@@ -262,11 +262,16 @@ public class PickledGraphite implements GraphiteSender {
     private void writeMetrics() throws IOException {
         if (metrics.size() > 0) {
             try {
+                final Socket localSocket = this.socket;
+                if (localSocket == null) {
+                    throw new IllegalStateException( "Unable to acquire the socket. Call connect() first." );
+                }
+
                 byte[] payload = pickleMetrics(metrics);
                 byte[] header = ByteBuffer.allocate(4).putInt(payload.length).array();
 
                 @SuppressWarnings("resource")
-                OutputStream outputStream = socket.getOutputStream();
+                OutputStream outputStream = localSocket.getOutputStream();
                 outputStream.write(header);
                 outputStream.write(payload);
                 outputStream.flush();

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/PickledGraphite.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/PickledGraphite.java
@@ -3,6 +3,8 @@ package com.codahale.metrics.graphite;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.concurrent.NotThreadSafe;
 import javax.net.SocketFactory;
 
 import java.io.BufferedWriter;
@@ -23,6 +25,7 @@ import java.util.regex.Pattern;
 /**
  * A client to a Carbon server that sends all metrics after they have been pickled in configurable sized batches
  */
+@NotThreadSafe
 public class PickledGraphite implements GraphiteSender {
 
     private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
@@ -37,11 +40,16 @@ public class PickledGraphite implements GraphiteSender {
 
     private final String hostname;
     private final int port;
+
+    @CheckForNull
     private final InetSocketAddress address;
     private final SocketFactory socketFactory;
     private final Charset charset;
 
+    @CheckForNull
     private Socket socket;
+
+    @CheckForNull
     private Writer writer;
     private int failures;
 

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/package-info.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.graphite;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
@@ -1,5 +1,8 @@
 package com.codahale.metrics.health;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+
 /**
  * A health check for a component of your application.
  */
@@ -80,10 +83,14 @@ public abstract class HealthCheck {
         }
 
         private final boolean healthy;
+
+        @CheckForNull
         private final String message;
+
+        @CheckForNull
         private final Throwable error;
 
-        private Result(boolean isHealthy, String message, Throwable error) {
+        private Result(boolean isHealthy, @Nullable String message, @Nullable Throwable error) {
             this.healthy = isHealthy;
             this.message = message;
             this.error = error;
@@ -105,6 +112,7 @@ public abstract class HealthCheck {
          *
          * @return any additional message for the result, or {@code null}
          */
+        @CheckForNull
         public String getMessage() {
             return message;
         }
@@ -114,6 +122,7 @@ public abstract class HealthCheck {
          *
          * @return any exception for the result, or {@code null}
          */
+        @CheckForNull
         public Throwable getError() {
             return error;
         }

--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/jvm/package-info.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/jvm/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.health.jvm;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/package-info.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.health;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-httpasyncclient/src/main/java/com/codahale/metrics/httpasyncclient/InstrumentedNHttpClientBuilder.java
+++ b/metrics-httpasyncclient/src/main/java/com/codahale/metrics/httpasyncclient/InstrumentedNHttpClientBuilder.java
@@ -15,12 +15,17 @@ import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
 import org.apache.http.nio.protocol.HttpAsyncResponseConsumer;
 import org.apache.http.protocol.HttpContext;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+
 public class InstrumentedNHttpClientBuilder extends HttpAsyncClientBuilder {
     private final MetricRegistry metricRegistry;
-    private final String name;
     private final HttpClientMetricNameStrategy metricNameStrategy;
 
-    public InstrumentedNHttpClientBuilder(MetricRegistry metricRegistry, HttpClientMetricNameStrategy metricNameStrategy, String name) {
+    @CheckForNull
+    private final String name;
+
+    public InstrumentedNHttpClientBuilder(MetricRegistry metricRegistry, HttpClientMetricNameStrategy metricNameStrategy, @Nullable String name) {
         super();
         this.metricRegistry = metricRegistry;
         this.metricNameStrategy = metricNameStrategy;

--- a/metrics-httpasyncclient/src/main/java/com/codahale/metrics/httpasyncclient/package-info.java
+++ b/metrics-httpasyncclient/src/main/java/com/codahale/metrics/httpasyncclient/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.httpasyncclient;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategy.java
+++ b/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategy.java
@@ -2,6 +2,8 @@ package com.codahale.metrics.httpclient;
 
 import org.apache.http.HttpRequest;
 
+import javax.annotation.Nullable;
+
 public interface HttpClientMetricNameStrategy {
-    String getNameFor(String name, HttpRequest request);
+    String getNameFor(@Nullable String name, HttpRequest request);
 }

--- a/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/InstrumentedHttpClientConnectionManager.java
+++ b/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/InstrumentedHttpClientConnectionManager.java
@@ -12,6 +12,8 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -30,6 +32,8 @@ public class InstrumentedHttpClientConnectionManager extends PoolingHttpClientCo
     }
 
     private final MetricRegistry metricsRegistry;
+
+    @CheckForNull
     private final String name;
 
     public InstrumentedHttpClientConnectionManager(MetricRegistry metricRegistry) {
@@ -51,12 +55,12 @@ public class InstrumentedHttpClientConnectionManager extends PoolingHttpClientCo
 
     public InstrumentedHttpClientConnectionManager(MetricRegistry metricsRegistry,
                                                    Registry<ConnectionSocketFactory> socketFactoryRegistry,
-                                                   HttpConnectionFactory<HttpRoute,ManagedHttpClientConnection> connFactory,
-                                                   SchemePortResolver schemePortResolver,
+                                                   @Nullable HttpConnectionFactory<HttpRoute,ManagedHttpClientConnection> connFactory,
+                                                   @Nullable SchemePortResolver schemePortResolver,
                                                    DnsResolver dnsResolver,
                                                    long connTTL,
                                                    TimeUnit connTTLTimeUnit,
-                                                   String name) {
+                                                   @Nullable String name) {
         super(socketFactoryRegistry, connFactory, schemePortResolver, dnsResolver, connTTL, connTTLTimeUnit);
         this.metricsRegistry = metricsRegistry;
         this.name = name;

--- a/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/InstrumentedHttpRequestExecutor.java
+++ b/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/InstrumentedHttpRequestExecutor.java
@@ -9,11 +9,15 @@ import org.apache.http.HttpResponse;
 import org.apache.http.protocol.HttpContext;
 import org.apache.http.protocol.HttpRequestExecutor;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 
 public class InstrumentedHttpRequestExecutor extends HttpRequestExecutor {
     private final MetricRegistry registry;
     private final HttpClientMetricNameStrategy metricNameStrategy;
+
+    @CheckForNull
     private final String name;
 
     public InstrumentedHttpRequestExecutor(MetricRegistry registry,
@@ -23,13 +27,13 @@ public class InstrumentedHttpRequestExecutor extends HttpRequestExecutor {
 
     public InstrumentedHttpRequestExecutor(MetricRegistry registry,
                                            HttpClientMetricNameStrategy metricNameStrategy,
-                                           String name) {
+                                           @Nullable String name) {
         this(registry, metricNameStrategy, name, HttpRequestExecutor.DEFAULT_WAIT_FOR_CONTINUE);
     }
 
     public InstrumentedHttpRequestExecutor(MetricRegistry registry,
                                            HttpClientMetricNameStrategy metricNameStrategy,
-                                           String name,
+                                           @Nullable String name,
                                            int waitForContinue) {
         super(waitForContinue);
         this.registry = registry;

--- a/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/package-info.java
+++ b/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.httpclient;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/package-info.java
+++ b/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.jdbi;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/package-info.java
+++ b/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.jdbi.strategies;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-jersey/src/main/java/com/codahale/metrics/jersey/package-info.java
+++ b/metrics-jersey/src/main/java/com/codahale/metrics/jersey/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.jersey;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/package-info.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.jersey2;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-jetty8/src/main/java/com/codahale/metrics/jetty8/package-info.java
+++ b/metrics-jetty8/src/main/java/com/codahale/metrics/jetty8/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.jetty8;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-jetty9-legacy/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9-legacy/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -12,6 +12,8 @@ import org.eclipse.jetty.server.HttpChannelState;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 import javax.servlet.AsyncEvent;
 import javax.servlet.AsyncListener;
 import javax.servlet.ServletException;
@@ -30,6 +32,8 @@ public class InstrumentedHandler extends HandlerWrapper {
     private final MetricRegistry metricRegistry;
 
     private String name;
+
+    @CheckForNull
     private final String prefix;
 
     // the requests handled by this handler, excluding active
@@ -85,7 +89,7 @@ public class InstrumentedHandler extends HandlerWrapper {
 	 * @param prefix     the prefix to use for the metrics names
 	 *
 	 */
-	public InstrumentedHandler(MetricRegistry registry, String prefix) {
+	public InstrumentedHandler(MetricRegistry registry, @Nullable String prefix) {
 		this.metricRegistry = registry;
 		this.prefix = prefix;
 	}

--- a/metrics-jetty9-legacy/src/main/java/com/codahale/metrics/jetty9/InstrumentedQueuedThreadPool.java
+++ b/metrics-jetty9-legacy/src/main/java/com/codahale/metrics/jetty9/InstrumentedQueuedThreadPool.java
@@ -6,6 +6,7 @@ import com.codahale.metrics.RatioGauge;
 import org.eclipse.jetty.util.annotation.Name;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
+import javax.annotation.Nullable;
 import java.util.concurrent.BlockingQueue;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -39,7 +40,7 @@ public class InstrumentedQueuedThreadPool extends QueuedThreadPool {
                                         @Name("maxThreads") int maxThreads,
                                         @Name("minThreads") int minThreads,
                                         @Name("idleTimeout") int idleTimeout,
-                                        @Name("queue") BlockingQueue<Runnable> queue) {
+                                        @Name("queue") @Nullable BlockingQueue<Runnable> queue) {
         super(maxThreads, minThreads, idleTimeout, queue);
         this.metricRegistry = registry;
     }

--- a/metrics-jetty9-legacy/src/main/java/com/codahale/metrics/jetty9/package-info.java
+++ b/metrics-jetty9-legacy/src/main/java/com/codahale/metrics/jetty9/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.jetty9;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -12,6 +12,8 @@ import org.eclipse.jetty.server.HttpChannelState;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
 
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 import javax.servlet.AsyncEvent;
 import javax.servlet.AsyncListener;
 import javax.servlet.ServletException;
@@ -30,6 +32,8 @@ public class InstrumentedHandler extends HandlerWrapper {
     private final MetricRegistry metricRegistry;
 
     private String name;
+
+    @CheckForNull
     private final String prefix;
 
     // the requests handled by this handler, excluding active
@@ -85,7 +89,7 @@ public class InstrumentedHandler extends HandlerWrapper {
 	 * @param prefix     the prefix to use for the metrics names
 	 *
 	 */
-	public InstrumentedHandler(MetricRegistry registry, String prefix) {
+	public InstrumentedHandler(MetricRegistry registry, @Nullable String prefix) {
 		this.metricRegistry = registry;
 		this.prefix = prefix;
 	}

--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedQueuedThreadPool.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedQueuedThreadPool.java
@@ -6,6 +6,7 @@ import com.codahale.metrics.RatioGauge;
 import org.eclipse.jetty.util.annotation.Name;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
+import javax.annotation.Nullable;
 import java.util.concurrent.BlockingQueue;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -39,7 +40,7 @@ public class InstrumentedQueuedThreadPool extends QueuedThreadPool {
                                         @Name("maxThreads") int maxThreads,
                                         @Name("minThreads") int minThreads,
                                         @Name("idleTimeout") int idleTimeout,
-                                        @Name("queue") BlockingQueue<Runnable> queue) {
+                                        @Name("queue") @Nullable BlockingQueue<Runnable> queue) {
         super(maxThreads, minThreads, idleTimeout, queue);
         this.metricRegistry = registry;
     }

--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/package-info.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.jetty9;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-json/src/main/java/com/codahale/metrics/json/package-info.java
+++ b/metrics-json/src/main/java/com/codahale/metrics/json/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.json;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/package-info.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.jvm;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-log4j/src/main/java/com/codahale/metrics/log4j/package-info.java
+++ b/metrics-log4j/src/main/java/com/codahale/metrics/log4j/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.log4j;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-log4j2/src/main/java/com/codahale/metrics/log4j2/InstrumentedAppender.java
+++ b/metrics-log4j2/src/main/java/com/codahale/metrics/log4j2/InstrumentedAppender.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
 
+import javax.annotation.Nullable;
 import java.io.Serializable;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -70,7 +71,7 @@ public class InstrumentedAppender extends AbstractAppender {
      * @param ignoreExceptions If true, exceptions will be logged and suppressed. If false errors will be
      * logged and then passed to the application.
      */
-    public InstrumentedAppender(MetricRegistry registry, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions) {
+    public InstrumentedAppender(MetricRegistry registry, @Nullable Filter filter, @Nullable Layout<? extends Serializable> layout, boolean ignoreExceptions) {
         super(name(Appender.class), filter, layout, ignoreExceptions);
         this.registry = registry;
     }

--- a/metrics-log4j2/src/main/java/com/codahale/metrics/log4j2/package-info.java
+++ b/metrics-log4j2/src/main/java/com/codahale/metrics/log4j2/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.log4j2;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-logback/src/main/java/com/codahale/metrics/logback/package-info.java
+++ b/metrics-logback/src/main/java/com/codahale/metrics/logback/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.logback;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-servlet/src/main/java/com/codahale/metrics/servlet/package-info.java
+++ b/metrics-servlet/src/main/java/com/codahale/metrics/servlet/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.servlet;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/AdminServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/AdminServlet.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.servlets;
 
+import javax.annotation.Nullable;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -110,7 +111,8 @@ public class AdminServlet extends HttpServlet {
         }
     }
 
-    private static String getParam(String initParam, String defaultValue) {
+    @Nullable
+    private static String getParam(@Nullable String initParam, @Nullable String defaultValue) {
         return initParam == null ? defaultValue : initParam;
     }
 }

--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
@@ -6,6 +6,7 @@ import com.codahale.metrics.health.HealthCheck;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.codahale.metrics.json.HealthCheckModule;
 
+import javax.annotation.Nullable;
 import javax.servlet.*;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -27,6 +28,7 @@ public class HealthCheckServlet extends HttpServlet {
          * @return the {@link ExecutorService} to inject into the servlet context, or {@code null}
          * if the health checks should be run in the servlet worker thread.
          */
+        @Nullable
         protected ExecutorService getExecutorService() {
             // don't use a thread pool by default
             return null;

--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/package-info.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/package-info.java
@@ -1,0 +1,4 @@
+@ParametersAreNonnullByDefault
+package com.codahale.metrics.servlets;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,11 @@
                 <artifactId>slf4j-api</artifactId>
                 <version>${slf4j.version}</version>
             </dependency>
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>3.0.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -118,6 +123,10 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -297,6 +306,7 @@
                     <effort>Max</effort>
                     <threshold>Default</threshold>
                     <xmlOutput>true</xmlOutput>
+                    <nested>true</nested>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Use JSR305 annotations.

These help FindBugs (and other similar static analysis tools) to find
possible null dereferences. These also provide some help for other
developers (other as in 'not you' and 'you in six months') to avoid
null-related pitfalls.

`@ParametersAreNonnullByDefault` annotation was used mostly on
`package-info.java` classes to avoid editing quite literally every
possible class. `@CheckForNull` and `@Nullable` were added where the
code seemed to reasonably expect null values (for example, one of the
constructors passed a null value).

Also added few `@NotThreadSafe` where it was painfully obvious that the
class does not support concurrent access.

The additional dependency (jar file with annotations) contains the
annotations only (no frameworks or any other funny business) and
should not impact users negatively.

Note: I understand that these might be controversial to some. If this pull request gets merged - it'd be fine, if it doesn't - it'd be fine too.
