### PR TITLE
Provide a common method to stop a reporter

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.management.*;
 
-import java.io.Closeable;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
 import java.util.Locale;
@@ -16,7 +15,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * A reporter which listens for new metrics and exposes them as namespaced MBeans.
  */
-public class JmxReporter implements Reporter, Closeable {
+public class JmxReporter implements Reporter {
     /**
      * Returns a new {@link Builder} for {@link JmxReporter}.
      *

--- a/metrics-core/src/main/java/com/codahale/metrics/Reporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Reporter.java
@@ -1,8 +1,14 @@
 package com.codahale.metrics;
 
-/*
- * A tag interface to indicate that a class is a Reporter.
- */
-public interface Reporter {
+import java.io.Closeable;
 
+/**
+ * Base interface for all reporter implementations.
+ */
+public interface Reporter extends Closeable {
+
+    /**
+     * Stops the reporter.
+     */
+    void stop();
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -1,6 +1,5 @@
 package com.codahale.metrics;
 
-import java.io.Closeable;
 import java.util.Locale;
 import java.util.SortedMap;
 import java.util.concurrent.Executors;
@@ -20,7 +19,7 @@ import org.slf4j.LoggerFactory;
  * @see CsvReporter
  * @see Slf4jReporter
  */
-public abstract class ScheduledReporter implements Closeable, Reporter {
+public abstract class ScheduledReporter implements Reporter {
 
     private static final Logger LOG = LoggerFactory.getLogger(ScheduledReporter.class);
 


### PR DESCRIPTION
We use multiple reporter and it would be helpfull to have a common method to stop a reporter. This change only changes the `Reporter` interface. All `Reporter` implementations provide already a `stop` method and also implement the `Closeable` interface.