### PR TITLE
Ping response without new line

### DIFF
--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/PingServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/PingServlet.java
@@ -25,7 +25,7 @@ public class PingServlet extends HttpServlet {
         resp.setContentType(CONTENT_TYPE);
         final PrintWriter writer = resp.getWriter();
         try {
-            writer.println(CONTENT);
+            writer.print(CONTENT);
         } finally {
             writer.close();
         }

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/PingServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/PingServletTest.java
@@ -31,7 +31,7 @@ public class PingServletTest extends AbstractServletTest {
     @Test
     public void returnsPong() throws Exception {
         assertThat(response.getContent())
-                .isEqualTo(String.format("pong%n"));
+                .isEqualTo(String.format("pong"));
     }
 
     @Test


### PR DESCRIPTION
When testing it is easier to test for ping only.
It is not obvious that there is an newline in the response when testing in the browser before setting up the surveillance using the ping.
Removed the new line from the ping response.