### PR TITLE
Added a concurrent instances count to Timer and with max concurrent, along with updating Reporters.

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
@@ -272,6 +272,9 @@ public class ConsoleReporter extends ScheduledReporter {
         output.printf(locale, "              98%% <= %2.2f %s%n", convertDuration(snapshot.get98thPercentile()), getDurationUnit());
         output.printf(locale, "              99%% <= %2.2f %s%n", convertDuration(snapshot.get99thPercentile()), getDurationUnit());
         output.printf(locale, "            99.9%% <= %2.2f %s%n", convertDuration(snapshot.get999thPercentile()), getDurationUnit());
+
+        output.printf(locale, "        concurrent = %d%n", timer.getConcurrent());
+        output.printf(locale, "    max concurrent = %d%n", timer.getMaxConcurrent());
     }
 
     private void printWithBanner(String s, char c) {

--- a/metrics-core/src/main/java/com/codahale/metrics/CsvReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/CsvReporter.java
@@ -172,8 +172,8 @@ public class CsvReporter extends ScheduledReporter {
 
         report(timestamp,
                name,
-               "count,max,mean,min,stddev,p50,p75,p95,p98,p99,p999,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit,duration_unit",
-               "%d,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,calls/%s,%s",
+               "count,max,mean,min,stddev,p50,p75,p95,p98,p99,p999,mean_rate,m1_rate,m5_rate,m15_rate,concurrent,max_concurrent,rate_unit,duration_unit",
+               "%d,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%f,%d,%d,calls/%s,%s",
                timer.getCount(),
                convertDuration(snapshot.getMax()),
                convertDuration(snapshot.getMean()),
@@ -189,6 +189,8 @@ public class CsvReporter extends ScheduledReporter {
                convertRate(timer.getOneMinuteRate()),
                convertRate(timer.getFiveMinuteRate()),
                convertRate(timer.getFifteenMinuteRate()),
+               timer.getConcurrent(),
+               timer.getMaxConcurrent(),
                getRateUnit(),
                getDurationUnit());
     }

--- a/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
@@ -402,6 +402,10 @@ public class JmxReporter implements Reporter, Closeable {
         double get99thPercentile();
 
         double get999thPercentile();
+        
+        long getConcurrent();
+        
+        long getMaxConcurrent();
 
         long[] values();
         String getDurationUnit();
@@ -471,6 +475,16 @@ public class JmxReporter implements Reporter, Closeable {
         @Override
         public double get999thPercentile() {
             return metric.getSnapshot().get999thPercentile() * durationFactor;
+        }
+
+        @Override
+        public long getConcurrent() {
+            return metric.getConcurrent();
+        }
+        
+        @Override
+        public long getMaxConcurrent() {
+            return metric.getMaxConcurrent();
         }
 
         @Override

--- a/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
@@ -208,7 +208,7 @@ public class Slf4jReporter extends ScheduledReporter {
         loggerProxy.log(marker,
                 "type=TIMER, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, " +
                         "p75={}, p95={}, p98={}, p99={}, p999={}, mean_rate={}, m1={}, m5={}, " +
-                        "m15={}, rate_unit={}, duration_unit={}",
+                        "m15={}, concurrent={}, max_concurrent={}, rate_unit={}, duration_unit={}",
                 prefix(name),
                 timer.getCount(),
                 convertDuration(snapshot.getMin()),
@@ -225,6 +225,8 @@ public class Slf4jReporter extends ScheduledReporter {
                 convertRate(timer.getOneMinuteRate()),
                 convertRate(timer.getFiveMinuteRate()),
                 convertRate(timer.getFifteenMinuteRate()),
+                timer.getConcurrent(),
+                timer.getMaxConcurrent(),
                 getRateUnit(),
                 getDurationUnit());
     }

--- a/metrics-core/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
@@ -211,6 +211,8 @@ public class ConsoleReporterTest {
                         "              98% <= 800.00 milliseconds",
                         "              99% <= 900.00 milliseconds",
                         "            99.9% <= 1000.00 milliseconds",
+                        "        concurrent = 0",
+                        "    max concurrent = 0",
                         "",
                         ""
                 ));

--- a/metrics-core/src/test/java/com/codahale/metrics/CsvReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/CsvReporterTest.java
@@ -161,8 +161,8 @@ public class CsvReporterTest {
 
         assertThat(fileContents("test.another.timer.csv"))
                 .isEqualTo(csv(
-                        "t,count,max,mean,min,stddev,p50,p75,p95,p98,p99,p999,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit,duration_unit",
-                        "19910191,1,100.000000,200.000000,300.000000,400.000000,500.000000,600.000000,700.000000,800.000000,900.000000,1000.000000,2.000000,3.000000,4.000000,5.000000,calls/second,milliseconds"
+                        "t,count,max,mean,min,stddev,p50,p75,p95,p98,p99,p999,mean_rate,m1_rate,m5_rate,m15_rate,concurrent,max_concurrent,rate_unit,duration_unit",
+                        "19910191,1,100.000000,200.000000,300.000000,400.000000,500.000000,600.000000,700.000000,800.000000,900.000000,1000.000000,2.000000,3.000000,4.000000,5.000000,0,0,calls/second,milliseconds"
                 ));
     }
 

--- a/metrics-core/src/test/java/com/codahale/metrics/Slf4jReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/Slf4jReporterTest.java
@@ -157,7 +157,7 @@ public class Slf4jReporterTest {
                 map("test.another.timer", timer));
 
         verify(logger).error(marker,
-                "type=TIMER, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}, duration_unit={}",
+                "type=TIMER, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}, mean_rate={}, m1={}, m5={}, m15={}, concurrent={}, max_concurrent={}, rate_unit={}, duration_unit={}",
                 "test.another.timer",
                 1L,
                 300.0,
@@ -174,6 +174,8 @@ public class Slf4jReporterTest {
                 3.0,
                 4.0,
                 5.0,
+                0L,
+                0L,
                 "events/second",
                 "milliseconds");
     }
@@ -302,7 +304,7 @@ public class Slf4jReporterTest {
                 map("test.another.timer", timer));
 
         verify(logger).info(marker,
-                "type=TIMER, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}, duration_unit={}",
+                "type=TIMER, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}, mean_rate={}, m1={}, m5={}, m15={}, concurrent={}, max_concurrent={}, rate_unit={}, duration_unit={}",
                 "prefix.test.another.timer",
                 1L,
                 300.0,
@@ -319,6 +321,8 @@ public class Slf4jReporterTest {
                 3.0,
                 4.0,
                 5.0,
+                0L,
+                0L,
                 "events/second",
                 "milliseconds");
     }

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -226,6 +226,13 @@ public class GraphiteReporter extends ScheduledReporter {
                       format(convertDuration(snapshot.get999thPercentile())),
                       timestamp);
 
+        graphite.send(prefix(name, "concurrent"), 
+                      format(timer.getConcurrent()), 
+                      timestamp);
+        graphite.send(prefix(name, "maxconcurrent"), 
+                      format(timer.getMaxConcurrent()), 
+                      timestamp);
+
         reportMetered(name, timer, timestamp);
     }
 

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -284,6 +284,8 @@ public class GraphiteReporterTest {
         inOrder.verify(graphite).send("prefix.timer.p98", "800.00", timestamp);
         inOrder.verify(graphite).send("prefix.timer.p99", "900.00", timestamp);
         inOrder.verify(graphite).send("prefix.timer.p999", "1000.00", timestamp);
+        inOrder.verify(graphite).send("prefix.timer.concurrent", "0", timestamp);
+        inOrder.verify(graphite).send("prefix.timer.maxconcurrent", "0", timestamp);
         inOrder.verify(graphite).send("prefix.timer.count", "1", timestamp);
         inOrder.verify(graphite).send("prefix.timer.m1_rate", "3.00", timestamp);
         inOrder.verify(graphite).send("prefix.timer.m5_rate", "4.00", timestamp);


### PR DESCRIPTION
Timer now collects how many concurrent events of a Timer there are. When collecting metrics on a HTTP call or DB operation, it is often useful to know if calls are being made in parallel/concurrently, along with the rate and latency. For example, knowing the concurrency gives you insight into how thread or connection pools are being using.

Fixed Reporter tests.