### PR TITLE
Change Graphite client to use isConnected()

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/Graphite.java
@@ -104,7 +104,7 @@ public class Graphite implements GraphiteSender {
 
     @Override
     public void connect() throws IllegalStateException, IOException {
-        if (socket != null) {
+        if (isConnected()) {
             throw new IllegalStateException("Already connected");
         }
         InetSocketAddress address = this.address;


### PR DESCRIPTION
Resolves #767

On disconnect from carbon server the Graphite client doesn't reconnect. This appears to be due to the way connect() does it s checks. Instead of checking isConnected() it checks for socket != null. However on disconnected socket is not set to null. 

This does not effect the PickelGraphite client as it uses the isConnected() function instead.