### PR TITLE
Simplify slf4j reporting when logging is disabled

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
@@ -182,24 +182,26 @@ public class Slf4jReporter extends ScheduledReporter {
                        SortedMap<String, Histogram> histograms,
                        SortedMap<String, Meter> meters,
                        SortedMap<String, Timer> timers) {
-        for (Entry<String, Gauge> entry : gauges.entrySet()) {
-            logGauge(entry.getKey(), entry.getValue());
-        }
+        if (loggerProxy.isEnabled(marker)) {
+            for (Entry<String, Gauge> entry : gauges.entrySet()) {
+                logGauge(entry.getKey(), entry.getValue());
+            }
 
-        for (Entry<String, Counter> entry : counters.entrySet()) {
-            logCounter(entry.getKey(), entry.getValue());
-        }
+            for (Entry<String, Counter> entry : counters.entrySet()) {
+                logCounter(entry.getKey(), entry.getValue());
+            }
 
-        for (Entry<String, Histogram> entry : histograms.entrySet()) {
-            logHistogram(entry.getKey(), entry.getValue());
-        }
+            for (Entry<String, Histogram> entry : histograms.entrySet()) {
+                logHistogram(entry.getKey(), entry.getValue());
+            }
 
-        for (Entry<String, Meter> entry : meters.entrySet()) {
-            logMeter(entry.getKey(), entry.getValue());
-        }
+            for (Entry<String, Meter> entry : meters.entrySet()) {
+                logMeter(entry.getKey(), entry.getValue());
+            }
 
-        for (Entry<String, Timer> entry : timers.entrySet()) {
-            logTimer(entry.getKey(), entry.getValue());
+            for (Entry<String, Timer> entry : timers.entrySet()) {
+                logTimer(entry.getKey(), entry.getValue());
+            }
         }
     }
 
@@ -286,6 +288,8 @@ public class Slf4jReporter extends ScheduledReporter {
         }
 
         abstract void log(Marker marker, String format, Object... arguments);
+
+        abstract boolean isEnabled(Marker marker);
     }
 
     /* private class to allow logger configuration */
@@ -297,6 +301,11 @@ public class Slf4jReporter extends ScheduledReporter {
         @Override
         public void log(Marker marker, String format, Object... arguments) {
             logger.debug(marker, format, arguments);
+        }
+
+        @Override
+        public boolean isEnabled(Marker marker) {
+            return logger.isDebugEnabled(marker);
         }
     }
 
@@ -311,6 +320,10 @@ public class Slf4jReporter extends ScheduledReporter {
             logger.trace(marker, format, arguments);
         }
 
+        @Override
+        public boolean isEnabled(Marker marker) {
+            return logger.isTraceEnabled(marker);
+        }
     }
 
     /* private class to allow logger configuration */
@@ -322,6 +335,11 @@ public class Slf4jReporter extends ScheduledReporter {
         @Override
         public void log(Marker marker, String format, Object... arguments) {
             logger.info(marker, format, arguments);
+        }
+
+        @Override
+        public boolean isEnabled(Marker marker) {
+            return logger.isInfoEnabled(marker);
         }
     }
 
@@ -335,6 +353,11 @@ public class Slf4jReporter extends ScheduledReporter {
         public void log(Marker marker, String format, Object... arguments) {
             logger.warn(marker, format, arguments);
         }
+
+        @Override
+        public boolean isEnabled(Marker marker) {
+            return logger.isWarnEnabled(marker);
+        }
     }
 
     /* private class to allow logger configuration */
@@ -346,6 +369,11 @@ public class Slf4jReporter extends ScheduledReporter {
         @Override
         public void log(Marker marker, String format, Object... arguments) {
             logger.error(marker, format, arguments);
+        }
+
+        @Override
+        public boolean isEnabled(Marker marker) {
+            return logger.isErrorEnabled(marker);
         }
     }
 

--- a/metrics-core/src/test/java/com/codahale/metrics/Slf4jReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/Slf4jReporterTest.java
@@ -35,6 +35,7 @@ public class Slf4jReporterTest {
 
     @Test
     public void reportsGaugeValuesAtError() throws Exception {
+        when(logger.isErrorEnabled(marker)).thenReturn(true);
         errorReporter.report(map("gauge", gauge("value")),
                 this.<Counter>map(),
                 this.<Histogram>map(),
@@ -48,6 +49,7 @@ public class Slf4jReporterTest {
     public void reportsCounterValuesAtError() throws Exception {
         final Counter counter = mock(Counter.class);
         when(counter.getCount()).thenReturn(100L);
+        when(logger.isErrorEnabled(marker)).thenReturn(true);
 
         errorReporter.report(this.<Gauge>map(),
                 map("test.counter", counter),
@@ -76,6 +78,7 @@ public class Slf4jReporterTest {
         when(snapshot.get999thPercentile()).thenReturn(11.0);
 
         when(histogram.getSnapshot()).thenReturn(snapshot);
+        when(logger.isErrorEnabled(marker)).thenReturn(true);
 
         errorReporter.report(this.<Gauge>map(),
                 this.<Counter>map(),
@@ -107,6 +110,7 @@ public class Slf4jReporterTest {
         when(meter.getOneMinuteRate()).thenReturn(3.0);
         when(meter.getFiveMinuteRate()).thenReturn(4.0);
         when(meter.getFifteenMinuteRate()).thenReturn(5.0);
+        when(logger.isErrorEnabled(marker)).thenReturn(true);
 
         errorReporter.report(this.<Gauge>map(),
                 this.<Counter>map(),
@@ -150,6 +154,8 @@ public class Slf4jReporterTest {
 
         when(timer.getSnapshot()).thenReturn(snapshot);
 
+        when(logger.isErrorEnabled(marker)).thenReturn(true);
+
         errorReporter.report(this.<Gauge>map(),
                 this.<Counter>map(),
                 this.<Histogram>map(),
@@ -180,6 +186,7 @@ public class Slf4jReporterTest {
 
     @Test
     public void reportsGaugeValues() throws Exception {
+        when(logger.isInfoEnabled(marker)).thenReturn(true);
         infoReporter.report(map("gauge", gauge("value")),
                 this.<Counter>map(),
                 this.<Histogram>map(),
@@ -193,6 +200,7 @@ public class Slf4jReporterTest {
     public void reportsCounterValues() throws Exception {
         final Counter counter = mock(Counter.class);
         when(counter.getCount()).thenReturn(100L);
+        when(logger.isInfoEnabled(marker)).thenReturn(true);
 
         infoReporter.report(this.<Gauge>map(),
                 map("test.counter", counter),
@@ -221,6 +229,7 @@ public class Slf4jReporterTest {
         when(snapshot.get999thPercentile()).thenReturn(11.0);
 
         when(histogram.getSnapshot()).thenReturn(snapshot);
+        when(logger.isInfoEnabled(marker)).thenReturn(true);
 
         infoReporter.report(this.<Gauge>map(),
                 this.<Counter>map(),
@@ -252,6 +261,7 @@ public class Slf4jReporterTest {
         when(meter.getOneMinuteRate()).thenReturn(3.0);
         when(meter.getFiveMinuteRate()).thenReturn(4.0);
         when(meter.getFifteenMinuteRate()).thenReturn(5.0);
+        when(logger.isInfoEnabled(marker)).thenReturn(true);
 
         infoReporter.report(this.<Gauge>map(),
                 this.<Counter>map(),
@@ -294,6 +304,7 @@ public class Slf4jReporterTest {
                 .toNanos(1000));
 
         when(timer.getSnapshot()).thenReturn(snapshot);
+        when(logger.isInfoEnabled(marker)).thenReturn(true);
 
         infoReporter.report(this.<Gauge>map(),
                 this.<Counter>map(),


### PR DESCRIPTION
Avoid overhead when logging is disabled for the specified reporting log level or marker.