### PR TITLE
Add CollectionUsage.getUsed() to MemoryPool gauges

### DIFF
--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/MemoryUsageGaugeSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/MemoryUsageGaugeSet.java
@@ -178,6 +178,13 @@ public class MemoryUsageGaugeSet implements MetricSet {
                 }
             });
 
+            gauges.put(name(poolName, "used-after-gc"),new Gauge<Long>() {
+                @Override
+                public Long getValue() {
+                    return pool.getCollectionUsage().getUsed();
+                }
+            });
+
             gauges.put(name(poolName, "init"),new Gauge<Long>() {
                 @Override
                 public Long getValue() {

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/MemoryUsageGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/MemoryUsageGaugeSetTest.java
@@ -18,6 +18,7 @@ public class MemoryUsageGaugeSetTest {
     private final MemoryUsage nonHeap = mock(MemoryUsage.class);
     private final MemoryUsage pool = mock(MemoryUsage.class);
     private final MemoryUsage weirdPool = mock(MemoryUsage.class);
+    private final MemoryUsage weirdCollection = mock(MemoryUsage.class);
     private final MemoryMXBean mxBean = mock(MemoryMXBean.class);
     private final MemoryPoolMXBean memoryPool = mock(MemoryPoolMXBean.class);
     private final MemoryPoolMXBean weirdMemoryPool = mock(MemoryPoolMXBean.class);
@@ -48,6 +49,8 @@ public class MemoryUsageGaugeSetTest {
         when(weirdPool.getUsed()).thenReturn(300L);
         when(weirdPool.getMax()).thenReturn(-1L);
 
+        when(weirdCollection.getUsed()).thenReturn(290L);
+
         when(mxBean.getHeapMemoryUsage()).thenReturn(heap);
         when(mxBean.getNonHeapMemoryUsage()).thenReturn(nonHeap);
 
@@ -55,6 +58,7 @@ public class MemoryUsageGaugeSetTest {
         when(memoryPool.getName()).thenReturn("Big Pool");
 
         when(weirdMemoryPool.getUsage()).thenReturn(weirdPool);
+        when(weirdMemoryPool.getCollectionUsage()).thenReturn(weirdCollection);
         when(weirdMemoryPool.getName()).thenReturn("Weird Pool");
     }
 
@@ -81,9 +85,11 @@ public class MemoryUsageGaugeSetTest {
                         "pools.Big-Pool.used",
                         "pools.Big-Pool.usage",
                         "pools.Big-Pool.max",
+                        "pools.Big-Pool.used-after-gc",
                         "pools.Weird-Pool.init",
                         "pools.Weird-Pool.committed",
                         "pools.Weird-Pool.used",
+                        "pools.Weird-Pool.used-after-gc",
                         "pools.Weird-Pool.usage",
                         "pools.Weird-Pool.max");
     }
@@ -246,6 +252,14 @@ public class MemoryUsageGaugeSetTest {
 
         assertThat(gauge.getValue())
                 .isEqualTo(-1L);
+    }
+
+    @Test
+    public void hasAGaugeForWeirdCollectionPoolUsed() throws Exception {
+        final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Weird-Pool.used-after-gc");
+
+        assertThat(gauge.getValue())
+                .isEqualTo(290L);
     }
 
     @Test


### PR DESCRIPTION
For monitoring memory usage, the memory used gauge is not very suitable to put automated analysis on, because it can be varying wildly. A better choice for these situations would be the JMX metric of the memory that's still in use after the last garbage collection. This gives a more accurate indication of retained memory, without varying short lived object allocation.

This pull requests adds it as a gauge to the memory pool gauge set with postfix "used-after-gc".

The rest of the CollectionUsage methods (init, committed, max) are of no value, since they're basically identical to the normal MemoryUsage of the same pool,  and are therefore not included.