### PR TITLE
Honour metrics annotation in resources implementing interfaces

### DIFF
--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
@@ -194,7 +194,11 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
     private void registerTimedAnnotations(final ImmutableMap.Builder<Method, Timer> builder,
                                           final ResourceMethod method) {
         final Method definitionMethod = method.getInvocable().getDefinitionMethod();
-        final Timed annotation = definitionMethod.getAnnotation(Timed.class);
+        Timed annotation = definitionMethod.getAnnotation(Timed.class);
+
+        if (annotation == null) {
+            annotation = method.getInvocable().getHandlingMethod().getAnnotation(Timed.class);
+        }
 
         if (annotation != null) {
             builder.put(definitionMethod, timerMetric(this.metrics, method, annotation));
@@ -204,7 +208,11 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
     private void registerMeteredAnnotations(final ImmutableMap.Builder<Method, Meter> builder,
                                             final ResourceMethod method) {
         final Method definitionMethod = method.getInvocable().getDefinitionMethod();
-        final Metered annotation = definitionMethod.getAnnotation(Metered.class);
+        Metered annotation = definitionMethod.getAnnotation(Metered.class);
+
+        if (annotation == null) {
+            annotation = method.getInvocable().getHandlingMethod().getAnnotation(Metered.class);
+        }
 
         if (annotation != null) {
             builder.put(definitionMethod, meterMetric(metrics, method, annotation));
@@ -214,7 +222,11 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
     private void registerExceptionMeteredAnnotations(final ImmutableMap.Builder<Method, ExceptionMeterMetric> builder,
                                                      final ResourceMethod method) {
         final Method definitionMethod = method.getInvocable().getDefinitionMethod();
-        final ExceptionMetered annotation = definitionMethod.getAnnotation(ExceptionMetered.class);
+        ExceptionMetered annotation = definitionMethod.getAnnotation(ExceptionMetered.class);
+
+        if (annotation == null) {
+            annotation = method.getInvocable().getHandlingMethod().getAnnotation(ExceptionMetered.class);
+        }
 
         if (annotation != null) {
             builder.put(definitionMethod, new ExceptionMeterMetric(metrics, method, annotation));

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 
 @Path("/")
 @Produces(MediaType.TEXT_PLAIN)
-public class InstrumentedResource {
+public class InstrumentedResource implements InstrumentedResourceInterface {
     @GET
     @Timed
     @Path("/timed")
@@ -18,11 +18,33 @@ public class InstrumentedResource {
         return "yay";
     }
 
+    @Override
+    public String timedInInterface() {
+        return "yay-interface";
+    }
+
+    @Override
+    @Timed
+    public String timedInImplementation() {
+        return "yay-implementation";
+    }
+
     @GET
     @Metered
     @Path("/metered")
     public String metered() {
         return "woo";
+    }
+
+    @Override
+    public String meteredInInterface() {
+        return "woo-interface";
+    }
+
+    @Override
+    @Metered
+    public String meteredInImplementation() {
+        return "woo-implementation";
     }
 
     @GET
@@ -33,5 +55,22 @@ public class InstrumentedResource {
             throw new IOException("AUGH");
         }
         return "fuh";
+    }
+
+    @Override
+    public String exceptionMeteredInInterface(boolean splode) throws IOException {
+        if (splode) {
+            throw new IOException("AUGH");
+        }
+        return "fuh-interface";
+    }
+
+    @Override
+    @ExceptionMetered(cause = IOException.class)
+    public String exceptionMeteredInImplementation(boolean splode) throws IOException {
+        if (splode) {
+            throw new IOException("AUGH");
+        }
+        return "fuh-implementation";
     }
 }

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResourceInterface.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResourceInterface.java
@@ -1,0 +1,40 @@
+package com.codahale.metrics.jersey2.resources;
+
+import com.codahale.metrics.annotation.ExceptionMetered;
+import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.Timed;
+
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import java.io.IOException;
+
+public interface InstrumentedResourceInterface {
+    @GET
+    @Timed
+    @Path("/timed-in-interface")
+    String timedInInterface();
+
+    @GET
+    @Path("/timed-in-implementation")
+    String timedInImplementation();
+
+    @GET
+    @Metered
+    @Path("/metered-in-interface")
+    String meteredInInterface();
+
+    @GET
+    @Path("/metered-in-implementation")
+    String meteredInImplementation();
+
+    @GET
+    @ExceptionMetered(cause = IOException.class)
+    @Path("/exception-metered-in-interface")
+    String exceptionMeteredInInterface(@QueryParam("splode") @DefaultValue("false") boolean splode) throws IOException;
+
+    @GET
+    @Path("/exception-metered-in-implementation")
+    String exceptionMeteredInImplementation(@QueryParam("splode") @DefaultValue("false") boolean splode) throws IOException;
+}


### PR DESCRIPTION
When a resource implements an interface, the metrics annotations (@Metered, @Timed, @ExceptionMetered) were not picked up when they were applied to the implementing method. They were picked up when they are on the defining method, in the interface.
The fix looks at the annotation on the interface or defining method first, then on the implementation or handling method after. Now the annotations on implementing methods are picked up.

Our use case is a separate library that holds the API contract, using `@GET` and `@Path` etc. The implementation should be responsible for metering, so the implementing method should have the `@Metered` annotation, not the interface.

The fix is quite simple. I've added a set of tests.
