### PR TITLE
Added null check to prevent NullPointerException when connecting to rabb...

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteRabbitMQ.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteRabbitMQ.java
@@ -111,11 +111,12 @@ public class GraphiteRabbitMQ implements GraphiteSender {
 
     @Override
     public void connect() throws IllegalStateException, IOException {
-        if (isConnected()) {
+        if (connection != null && connection.isOpen()) {
             throw new IllegalStateException("Already connected");
         }
 
         connection = connectionFactory.newConnection();
+
         channel = connection.createChannel();
     }
 


### PR DESCRIPTION
I have added a null check in the connect() method of com.codahale.metrics.graphite.GraphiteRabbitMQ.java which prevents the method to fail with NullPointerException