### PR TITLE
Add support for async servlet to metrics-servlet

### DIFF
--- a/metrics-servlet/src/main/java/com/codahale/metrics/servlet/AbstractInstrumentedFilter.java
+++ b/metrics-servlet/src/main/java/com/codahale/metrics/servlet/AbstractInstrumentedFilter.java
@@ -30,6 +30,8 @@ public abstract class AbstractInstrumentedFilter implements Filter {
     // initialized after call of init method
     private ConcurrentMap<Integer, Meter> metersByStatusCode;
     private Meter otherMeter;
+    private Meter timeoutsMeter;
+    private Meter errorsMeter;
     private Counter activeRequests;
     private Timer requestTimer;
 
@@ -68,6 +70,10 @@ public abstract class AbstractInstrumentedFilter implements Filter {
         }
         this.otherMeter = metricsRegistry.meter(name(metricName,
                                                      otherMetricName));
+        this.timeoutsMeter = metricsRegistry.meter(name(metricName,
+                                                        "timeouts"));
+        this.errorsMeter = metricsRegistry.meter(name(metricName,
+                                                      "errors"));
         this.activeRequests = metricsRegistry.counter(name(metricName,
                                                            "activeRequests"));
         this.requestTimer = metricsRegistry.timer(name(metricName,
@@ -100,12 +106,30 @@ public abstract class AbstractInstrumentedFilter implements Filter {
                 new StatusExposingServletResponse((HttpServletResponse) response);
         activeRequests.inc();
         final Timer.Context context = requestTimer.time();
+        boolean error = false;
         try {
             chain.doFilter(request, wrappedResponse);
+        } catch (IOException e) {
+            error = true;
+            throw e;
+        } catch (ServletException e) {
+            error = true;
+            throw e;
+        } catch (RuntimeException e) {
+            error = true;
+            throw e;
         } finally {
-            context.stop();
-            activeRequests.dec();
-            markMeterForStatusCode(wrappedResponse.getStatus());
+            if (!error && request.isAsyncStarted()) {
+                request.getAsyncContext().addListener(new AsyncResultListener(context));
+            } else {
+                context.stop();
+                activeRequests.dec();
+                if (error) {
+                    errorsMeter.mark();
+                } else {
+                    markMeterForStatusCode(wrappedResponse.getStatus());
+                }
+            }
         }
     }
 
@@ -152,6 +176,46 @@ public abstract class AbstractInstrumentedFilter implements Filter {
 
         public int getStatus() {
             return httpStatus;
+        }
+    }
+
+    private class AsyncResultListener implements AsyncListener {
+        private Timer.Context context;
+        private boolean done = false;
+
+        public AsyncResultListener(Timer.Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {
+            if (!done) {
+                HttpServletResponse suppliedResponse = (HttpServletResponse) event.getSuppliedResponse();
+                context.stop();
+                activeRequests.dec();
+                markMeterForStatusCode(suppliedResponse.getStatus());
+            }
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {
+            context.stop();
+            activeRequests.dec();
+            timeoutsMeter.mark();
+            done = true;
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {
+            context.stop();
+            activeRequests.dec();
+            errorsMeter.mark();
+            done = true;
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+
         }
     }
 }


### PR DESCRIPTION
Proposition for issue #795.

The requests timer and the activeRequests counter now properly observe the entire processing time. Use meters separate from the response code meters for timeouts and errors since the code isn't representative (i.e. 200) for these situations.