### PR TITLE
Fixed an issue that not all memory pools support collection usage sta…

### DIFF
--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/MemoryUsageGaugeSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/MemoryUsageGaugeSet.java
@@ -178,12 +178,15 @@ public class MemoryUsageGaugeSet implements MetricSet {
                 }
             });
 
-            gauges.put(name(poolName, "used-after-gc"),new Gauge<Long>() {
-                @Override
-                public Long getValue() {
-                    return pool.getCollectionUsage().getUsed();
-                }
-            });
+            // Only register GC usage metrics if the memory pool supports usage statistics.
+            if (pool.getCollectionUsage() != null) {
+            	gauges.put(name(poolName, "used-after-gc"),new Gauge<Long>() {
+                    @Override
+                    public Long getValue() {
+                        return pool.getCollectionUsage().getUsed();
+                    }
+                });
+            }
 
             gauges.put(name(poolName, "init"),new Gauge<Long>() {
                 @Override

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/MemoryUsageGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/MemoryUsageGaugeSetTest.java
@@ -55,6 +55,9 @@ public class MemoryUsageGaugeSetTest {
         when(mxBean.getNonHeapMemoryUsage()).thenReturn(nonHeap);
 
         when(memoryPool.getUsage()).thenReturn(pool);
+        // Mock that "Big Pool" is a non-collected pool therefore doesn't
+        // have collection usage statistics.
+        when(memoryPool.getCollectionUsage()).thenReturn(null);
         when(memoryPool.getName()).thenReturn("Big Pool");
 
         when(weirdMemoryPool.getUsage()).thenReturn(weirdPool);
@@ -85,7 +88,7 @@ public class MemoryUsageGaugeSetTest {
                         "pools.Big-Pool.used",
                         "pools.Big-Pool.usage",
                         "pools.Big-Pool.max",
-                        "pools.Big-Pool.used-after-gc",
+                        // skip in non-collected pools - "pools.Big-Pool.used-after-gc",
                         "pools.Weird-Pool.init",
                         "pools.Weird-Pool.committed",
                         "pools.Weird-Pool.used",


### PR DESCRIPTION
…tistics e.g. Code Cache, Meta Space in Java 8, this was resulting a NullPointerException when trying to access the used-after-gc gauge. Pools that don't support collection usage statistics will skip this metric.