### PR TITLE
Opt-in default shared registry

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/SharedMetricRegistries.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SharedMetricRegistries.java
@@ -11,6 +11,8 @@ public class SharedMetricRegistries {
     private static final ConcurrentMap<String, MetricRegistry> REGISTRIES =
             new ConcurrentHashMap<String, MetricRegistry>();
 
+    private static volatile String defaultRegistryName = null;
+
     private SharedMetricRegistries() { /* singleton */ }
 
     public static void clear() {
@@ -40,5 +42,21 @@ public class SharedMetricRegistries {
             return raced;
         }
         return existing;
+    }
+
+    public synchronized static MetricRegistry setDefault(String name) {
+        if (defaultRegistryName == null) {
+            final MetricRegistry registry = getOrCreate(name);
+            defaultRegistryName = name;
+            return registry;
+        }
+        throw new IllegalStateException("Default metric registry name is already set.");
+    }
+
+    public static MetricRegistry getDefault() {
+        if (defaultRegistryName != null) {
+            return getOrCreate(defaultRegistryName);
+        }
+        throw new IllegalStateException("Default registry name has not been set.");
     }
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/SharedMetricRegistries.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SharedMetricRegistries.java
@@ -45,10 +45,15 @@ public class SharedMetricRegistries {
     }
 
     public synchronized static MetricRegistry setDefault(String name) {
+        final MetricRegistry registry = getOrCreate(name);
+        return setDefault(name, registry);
+    }
+
+    public static MetricRegistry setDefault(String name, MetricRegistry metricRegistry) {
         if (defaultRegistryName == null) {
-            final MetricRegistry registry = getOrCreate(name);
             defaultRegistryName = name;
-            return registry;
+            add(name, metricRegistry);
+            return metricRegistry;
         }
         throw new IllegalStateException("Default metric registry name is already set.");
     }

--- a/metrics-core/src/test/java/com/codahale/metrics/SharedMetricRegistriesTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SharedMetricRegistriesTest.java
@@ -22,7 +22,7 @@ public class SharedMetricRegistriesTest {
     }
 
     @Test
-    public void memoizesRegistriesByName() throws Exception {
+    public void memorizesRegistriesByName() throws Exception {
         final MetricRegistry one = SharedMetricRegistries.getOrCreate("one");
         final MetricRegistry two = SharedMetricRegistries.getOrCreate("one");
 
@@ -90,5 +90,14 @@ public class SharedMetricRegistriesTest {
             assertThat(e).isInstanceOf(IllegalStateException.class);
             assertThat(e.getMessage()).isEqualTo("Default metric registry name is already set.");
         }
+    }
+
+    @Test
+    public void setsDefaultExistingRegistries() throws Exception {
+        final String defaultName = "default";
+        final MetricRegistry registry = new MetricRegistry();
+        assertThat(SharedMetricRegistries.setDefault(defaultName, registry)).isEqualTo(registry);
+        assertThat(SharedMetricRegistries.getDefault()).isEqualTo(registry);
+        assertThat(SharedMetricRegistries.getOrCreate(defaultName)).isEqualTo(registry);
     }
 }


### PR DESCRIPTION
In https://github.com/dropwizard/metrics/issues/334, it was mentioned that the default metric registry has disappeared. While it makes sense to disallow a "default" default registry to prevent having a dumping ground for all metrics, this unfortunately creates a bit more complexity for multilayered services. If there's a shared registry of metrics between them, for instance, each of the pieces that make up a service would need to be cognisant of this default registry's name, even if the name has no semantic meaning. 

In order to reduce complexity, we are aiming to expose a method to set a default registry name and allow consumers to call into SharedMetricRegistries to access this default registry. This enables a single orchestrator (such as a service container) to initialize the default registry with whatever name is suitable, leaving other pieces to just call SharedMetricRegistries.getDefault() in order to access this default registry.

This comes with a couple of caveats obviously:
1. This method should only be called once (hence the IllegalStateException). It should be recommended somewhere in the contract, but as this class has no Javadoc on the methods, I have not included that recommendation yet.
2. The name **must** be set before calling getDefault(). This is akin to the above in which we are trying to guard against consumers making bad assumptions about the state of their metrics registries. The server container, for instance, should set up the default metric registry before spinning up any workers that would access the default registry.
3. Currently, clear() still clears the default registry. To me this is dubious, since this functionality gives the caller power to blow away the shared default registry that might be needed by other threads, etc. Comments on this are more than welcome as we need to decide what to do in this situation.

Tests are written. I'll add them to the pull request once this implementation code is reviewed. 