### PR TITLE
Use same string instance for rateUnit across all instances

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
@@ -8,6 +8,7 @@ import javax.management.*;
 import java.io.Closeable;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -333,6 +334,9 @@ public class JmxReporter implements Reporter, Closeable {
     //CHECKSTYLE:ON
 
     private static class JmxMeter extends AbstractBean implements JmxMeterMBean {
+
+        private static final Map<TimeUnit, String> RATE_UNITS = new HashMap<TimeUnit, String>();
+
         private final Metered metric;
         private final double rateFactor;
         private final String rateUnit;
@@ -341,7 +345,11 @@ public class JmxReporter implements Reporter, Closeable {
             super(objectName);
             this.metric = metric;
             this.rateFactor = rateUnit.toSeconds(1);
-            this.rateUnit = "events/" + calculateRateUnit(rateUnit);
+            if (!RATE_UNITS.containsKey(rateUnit))
+            {
+              RATE_UNITS.put(rateUnit, "events/" + calculateRateUnit(rateUnit));
+            }
+            this.rateUnit = RATE_UNITS.get(rateUnit);
         }
 
         @Override

--- a/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
@@ -333,7 +333,6 @@ public class JmxReporter implements Reporter, Closeable {
     //CHECKSTYLE:ON
 
     private static class JmxMeter extends AbstractBean implements JmxMeterMBean {
-
         private final Metered metric;
         private final double rateFactor;
         private final String rateUnit;

--- a/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JmxReporter.java
@@ -8,7 +8,6 @@ import javax.management.*;
 import java.io.Closeable;
 import java.lang.management.ManagementFactory;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -335,8 +334,6 @@ public class JmxReporter implements Reporter, Closeable {
 
     private static class JmxMeter extends AbstractBean implements JmxMeterMBean {
 
-        private static final Map<TimeUnit, String> RATE_UNITS = new HashMap<TimeUnit, String>();
-
         private final Metered metric;
         private final double rateFactor;
         private final String rateUnit;
@@ -345,11 +342,7 @@ public class JmxReporter implements Reporter, Closeable {
             super(objectName);
             this.metric = metric;
             this.rateFactor = rateUnit.toSeconds(1);
-            if (!RATE_UNITS.containsKey(rateUnit))
-            {
-              RATE_UNITS.put(rateUnit, "events/" + calculateRateUnit(rateUnit));
-            }
-            this.rateUnit = RATE_UNITS.get(rateUnit);
+            this.rateUnit = ("events/" + calculateRateUnit(rateUnit)).intern();
         }
 
         @Override


### PR DESCRIPTION
Use same string instance for rateUnit across all instances that have the same TimeUnit.

Fixes https://github.com/dropwizard/metrics/issues/802