### PR TITLE
Add Timer.time method that accepts Runnable.

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/Timer.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Timer.java
@@ -87,7 +87,7 @@ public class Timer implements Metered, Sampling {
     }
 
     /**
-     * Times and records the duration of event.
+     * Times and records the duration of an event.
      *
      * @param event a {@link Callable} whose {@link Callable#call()} method implements a process
      *              whose duration should be timed
@@ -101,6 +101,21 @@ public class Timer implements Metered, Sampling {
             return event.call();
         } finally {
             update(clock.getTick() - startTime);
+        }
+    }
+
+    /**
+     * Times and records the duration of an event.
+     *
+     * @param event a {@link Runnable} whose {@link Runnable#run()} method implements a process
+     *              whose duration should be timed
+     */
+    public void time(Runnable event) {
+        long startTime = this.clock.getTick();
+        try {
+            event.run();
+        } finally {
+            update(this.clock.getTick() - startTime);
         }
     }
 

--- a/metrics-core/src/test/java/com/codahale/metrics/TimerTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/TimerTest.java
@@ -70,6 +70,25 @@ public class TimerTest {
     }
 
     @Test
+    public void timesRunnableInstances() throws Exception {
+        final boolean[] called = {false};
+        timer.time(new Runnable() {
+            @Override
+            public void run() {
+                called[0] = true;
+            }
+        });
+
+        assertThat(timer.getCount())
+                .isEqualTo(1);
+
+        assertThat(called[0])
+                .isTrue();
+
+        verify(reservoir).update(50000000);
+    }
+
+    @Test
     public void timesContexts() throws Exception {
         timer.time().stop();
 


### PR DESCRIPTION
Makes it easier to use Timer with Java 8.
See issue #807 