### PR TITLE
Add support for patterns in MBean object names

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/JmxAttributeGauge.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/JmxAttributeGauge.java
@@ -5,6 +5,7 @@ import javax.management.JMException;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
+import java.util.Set;
 
 /**
  * A {@link Gauge} implementation which queries an {@link MBeanServerConnection} for an attribute of an object.
@@ -40,11 +41,21 @@ public class JmxAttributeGauge implements Gauge<Object> {
     @Override
     public Object getValue() {
         try {
-            return mBeanServerConn.getAttribute(objectName, attributeName);
+            return mBeanServerConn.getAttribute(getObjectName(), attributeName);
         } catch (IOException e) {
             return null;
         } catch (JMException e) {
             return null;
         }
+    }
+
+    private ObjectName getObjectName() throws IOException {
+        if (objectName.isPattern()) {
+            Set<ObjectName> foundNames = mBeanServerConn.queryNames(objectName, null);
+            if (foundNames.size() == 1) {
+                return foundNames.iterator().next();
+            }
+        }
+        return objectName;
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/JmxAttributeGaugeTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/JmxAttributeGaugeTest.java
@@ -1,34 +1,99 @@
 package com.codahale.metrics;
 
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.management.AttributeNotFoundException;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.management.JMException;
 import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
 import javax.management.ObjectName;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 public class JmxAttributeGaugeTest {
-    private final MBeanServer mBeanServer = mock(MBeanServer.class);
-    private final ObjectName objectName = mock(ObjectName.class);
-    private final JmxAttributeGauge gauge = new JmxAttributeGauge(mBeanServer, objectName, "attr");
-    private final Object value = mock(Object.class);
 
-    @Test
-    public void returnsAJmxAttribute() throws Exception {
-        when(mBeanServer.getAttribute(objectName, "attr")).thenReturn(value);
+    private static MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
 
-        assertThat(gauge.getValue())
-                .isEqualTo(value);
+    private static List<ObjectName> registeredMBeans = new ArrayList<ObjectName>();
+
+    public interface JmxTestMBean {
+        Long getValue();
+    }
+
+    private static class JmxTest implements JmxTestMBean {
+        @Override
+        public Long getValue() {
+            return Long.MAX_VALUE;
+        }
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        registerMBean(new ObjectName("JmxAttributeGaugeTest:type=test,name=test1"));
+        registerMBean(new ObjectName("JmxAttributeGaugeTest:type=test,name=test2"));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        for (ObjectName objectName : registeredMBeans) {
+            try {
+                mBeanServer.unregisterMBean(objectName);
+            } catch (Exception e) {
+                // ignore
+            }
+        }
     }
 
     @Test
-    public void returnsNullIfThereIsAnException() throws Exception {
-        when(mBeanServer.getAttribute(objectName, "attr")).thenThrow(new AttributeNotFoundException());
+    public void returnsJmxAttribute() throws Exception {
+        ObjectName objectName = new ObjectName("java.lang:type=ClassLoading");
+        JmxAttributeGauge gauge = new JmxAttributeGauge(mBeanServer, objectName, "LoadedClassCount");
 
-        assertThat(gauge.getValue())
-                .isNull();
+        assertThat(gauge.getValue()).isInstanceOf(Integer.class);
+        assertThat((Integer) gauge.getValue()).isGreaterThan(0);
     }
+
+    @Test
+    public void returnsNullIfAttributeDoesNotExist() throws Exception {
+        ObjectName objectName = new ObjectName("java.lang:type=ClassLoading");
+        JmxAttributeGauge gauge = new JmxAttributeGauge(mBeanServer, objectName, "DoesNotExist");
+
+        assertThat(gauge.getValue()).isNull();
+    }
+
+    @Test
+    public void returnsNullIfMBeanNotFound() throws Exception {
+        ObjectName objectName = new ObjectName("foo.bar:type=NoSuchMBean");
+        JmxAttributeGauge gauge = new JmxAttributeGauge(mBeanServer, objectName, "LoadedClassCount");
+
+        assertThat(gauge.getValue()).isNull();
+    }
+
+    @Test
+    public void returnsAttributeForObjectNamePattern() throws Exception {
+        ObjectName objectName = new ObjectName("JmxAttributeGaugeTest:name=test1,*");
+        JmxAttributeGauge gauge = new JmxAttributeGauge(mBeanServer, objectName, "Value");
+
+        assertThat(gauge.getValue()).isInstanceOf(Long.class);
+        assertThat((Long) gauge.getValue()).isEqualTo(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void returnsNullIfObjectNamePatternAmbiguous() throws Exception {
+        ObjectName objectName = new ObjectName("JmxAttributeGaugeTest:type=test,*");
+        JmxAttributeGauge gauge = new JmxAttributeGauge(mBeanServer, objectName, "Value");
+
+        assertThat(gauge.getValue()).isNull();
+    }
+
+    private static void registerMBean(ObjectName objectName) throws JMException {
+        ObjectInstance objectInstance = mBeanServer.registerMBean(new JmxTest(), objectName);
+        registeredMBeans.add(objectInstance.getObjectName());
+    }
+
 }


### PR DESCRIPTION
If the object name is a pattern, perform a query for matching object
names and return the value of the given attribute if the pattern yields
a unique match. If the match is ambiguous, return null to avoid
returning the value from a wrong match.

The object name of an MBean consists of a domain part and a list of
key/value pairs that together form a unique identifier. The values,
however, often depend on current configuration parameters (i.e. the
hostname). By using an object name pattern it is possible to avoid the
need of considering configuration parameters when passing the object
name to the JmxAttributeGauge.