### PR TITLE
Allow Java 1.7 source level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,8 +205,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Is there any reason to still keep compatibility with Java 1.6? If not, it would be nice to be able to use all the neat Java 1.7 language features.