### PR TITLE
Adding a module to write metrics to InfluxDb

### DIFF
--- a/metrics-influxdb/pom.xml
+++ b/metrics-influxdb/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>metrics-parent</artifactId>
+        <groupId>io.dropwizard.metrics</groupId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>metrics-influxdb</artifactId>
+    <name>InfluxDb Integration for Metrics</name>
+    <packaging>bundle</packaging>
+    <description>
+        A reporter for Metrics which announces measurements to a InfluxDb server.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+            <version>1.9.13</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.10</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/metrics-influxdb/src/main/java/com/codehale/metrics/influxdb/InfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/com/codehale/metrics/influxdb/InfluxDbHttpSender.java
@@ -1,0 +1,117 @@
+package com.codehale.metrics.influxdb;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.codec.binary.Base64;
+
+import com.codehale.metrics.influxdb.data.InfluxDbPoint;
+import com.codehale.metrics.influxdb.data.InfluxDbWriteObject;
+import com.codehale.metrics.influxdb.utils.InfluxDbWriteObjectSerializer;
+
+/**
+ * An implementation of InfluxDbSender that writes to InfluxDb via http.
+ */
+public class InfluxDbHttpSender implements InfluxDbSender {
+    private static final Charset UTF_8 = StandardCharsets.UTF_8;
+    private final URL url;
+    // The base64 encoded authString.
+    private final String authStringEncoded;
+    private final InfluxDbWriteObject influxDbWriteObject;
+    private final InfluxDbWriteObjectSerializer influxDbWriteObjectSerializer;
+
+    /**
+     * Creates a new http sender given connection details.
+     *
+     * @param hostname   the influxDb hostname
+     * @param port       the influxDb http port
+     * @param database   the influxDb database to write to
+     * @param authString the authorization string to be used to connect to InfluxDb, of format username:password
+     * @throws Exception exception while creating the influxDb sender(MalformedURLException)
+     */
+    public InfluxDbHttpSender(final String hostname, final int port, final String database, final String authString) throws Exception {
+        this(hostname, port, database, authString, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Creates a new http sender given connection details.
+     *
+     * @param hostname      the influxDb hostname
+     * @param port          the influxDb http port
+     * @param database      the influxDb database to write to
+     * @param authString    the authorization string to be used to connect to InfluxDb, of format username:password
+     * @param timePrecision the time precision of the metrics
+     * @throws Exception exception while creating the influxDb sender(MalformedURLException)
+     */
+    public InfluxDbHttpSender(final String hostname, final int port, final String database, final String authString,
+                              final TimeUnit timePrecision) throws Exception {
+        this.url = new URL("http", hostname, port, "/write");
+
+        if (authString != null && !authString.isEmpty()) {
+            this.authStringEncoded = Base64.encodeBase64String(authString.getBytes(UTF_8));
+        } else {
+            this.authStringEncoded = "";
+        }
+
+        this.influxDbWriteObject = new InfluxDbWriteObject(database, timePrecision);
+        this.influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer();
+    }
+
+    @Override
+    public void flush() {
+        influxDbWriteObject.setPoints(new HashSet<InfluxDbPoint>());
+    }
+
+    @Override
+    public boolean hasSeriesData() {
+        return influxDbWriteObject.getPoints() != null && !influxDbWriteObject.getPoints().isEmpty();
+    }
+
+    @Override
+    public void appendPoints(final InfluxDbPoint point) {
+        if (point != null) {
+            influxDbWriteObject.getPoints().add(point);
+        }
+    }
+
+    @Override
+    public int writeData() throws Exception {
+        final String json = influxDbWriteObjectSerializer.getJsonString(influxDbWriteObject);
+        final HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        con.setRequestMethod("POST");
+        if (authStringEncoded != null && !authStringEncoded.isEmpty()) {
+            con.setRequestProperty("Authorization", "Basic " + authStringEncoded);
+        }
+        con.setDoOutput(true);
+        con.setConnectTimeout(1000);
+        con.setReadTimeout(1000);
+
+        try (final OutputStream out = con.getOutputStream()) {
+            out.write(json.getBytes(UTF_8));
+            out.flush();
+        }
+
+        int responseCode = con.getResponseCode();
+
+        // Check if non 2XX response code.
+        if (responseCode / 100 != 2) {
+            throw new IOException("Server returned HTTP response code: " + responseCode + "for URL: " + url + " with content :'"
+                    + con.getResponseMessage() + "'");
+        }
+        return responseCode;
+    }
+
+    @Override
+    public void setTags(final Map<String, String> tags) {
+        if (tags != null) {
+            influxDbWriteObject.setTags(tags);
+        }
+    }
+}

--- a/metrics-influxdb/src/main/java/com/codehale/metrics/influxdb/InfluxDbReporter.java
+++ b/metrics-influxdb/src/main/java/com/codehale/metrics/influxdb/InfluxDbReporter.java
@@ -1,0 +1,280 @@
+package com.codehale.metrics.influxdb;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Counting;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metered;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+import com.codehale.metrics.influxdb.data.InfluxDbPoint;
+
+public final class InfluxDbReporter extends ScheduledReporter {
+    public static final class Builder {
+        private final MetricRegistry registry;
+        private Map<String, String> tags;
+        private TimeUnit rateUnit;
+        private TimeUnit durationUnit;
+        private MetricFilter filter;
+        private boolean skipIdleMetrics;
+
+        private Builder(MetricRegistry registry) {
+            this.registry = registry;
+            this.tags = null;
+            this.rateUnit = TimeUnit.SECONDS;
+            this.durationUnit = TimeUnit.MILLISECONDS;
+            this.filter = MetricFilter.ALL;
+        }
+
+        /**
+         * Add these tags to all metrics.
+         *
+         * @param tags a map containing tags common to all metrics
+         * @return {@code this}
+         */
+        public Builder withTags(Map<String, String> tags) {
+            this.tags = Collections.unmodifiableMap(tags);
+            return this;
+        }
+
+        /**
+         * Convert rates to the given time unit.
+         *
+         * @param rateUnit a unit of time
+         * @return {@code this}
+         */
+        public Builder convertRatesTo(TimeUnit rateUnit) {
+            this.rateUnit = rateUnit;
+            return this;
+        }
+
+        /**
+         * Convert durations to the given time unit.
+         *
+         * @param durationUnit a unit of time
+         * @return {@code this}
+         */
+        public Builder convertDurationsTo(TimeUnit durationUnit) {
+            this.durationUnit = durationUnit;
+            return this;
+        }
+
+        /**
+         * Only report metrics which match the given filter.
+         *
+         * @param filter a {@link MetricFilter}
+         * @return {@code this}
+         */
+        public Builder filter(MetricFilter filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        /**
+         * Only report metrics that have changed.
+         *
+         * @param skipIdleMetrics true/false for skipping metrics not reported
+         * @return {@code this}
+         */
+        public Builder skipIdleMetrics(boolean skipIdleMetrics) {
+            this.skipIdleMetrics = skipIdleMetrics;
+            return this;
+        }
+
+        public InfluxDbReporter build(final InfluxDbSender influxDb) {
+            return new InfluxDbReporter(registry, influxDb, tags, rateUnit, durationUnit, filter, skipIdleMetrics);
+        }
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InfluxDbReporter.class);
+    private final InfluxDbSender influxDb;
+    private final boolean skipIdleMetrics;
+    private final Map<String, Long> previousValues;
+    private Map<String, Map<String, String>> metricTags = new HashMap<>();
+
+    private InfluxDbReporter(final MetricRegistry registry, final InfluxDbSender influxDb, final Map<String, String> tags,
+                             final TimeUnit rateUnit, final TimeUnit durationUnit, final MetricFilter filter, final boolean skipIdleMetrics) {
+        super(registry, "influxDb-reporter", filter, rateUnit, durationUnit);
+        this.influxDb = influxDb;
+        influxDb.setTags(tags);
+        this.skipIdleMetrics = skipIdleMetrics;
+        this.previousValues = new TreeMap<>();
+    }
+
+    public static Builder forRegistry(MetricRegistry registry) {
+        return new Builder(registry);
+    }
+
+    @Override
+    public void report(final SortedMap<String, Gauge> gauges, final SortedMap<String, Counter> counters,
+                       final SortedMap<String, Histogram> histograms, final SortedMap<String, Meter> meters, final SortedMap<String, Timer> timers) {
+        final long now = System.currentTimeMillis();
+
+        try {
+            influxDb.flush();
+
+            for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+                reportGauge(entry.getKey(), entry.getValue(), now);
+            }
+
+            for (Map.Entry<String, Counter> entry : counters.entrySet()) {
+                reportCounter(entry.getKey(), entry.getValue(), now);
+            }
+
+            for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
+                reportHistogram(entry.getKey(), entry.getValue(), now);
+            }
+
+            for (Map.Entry<String, Meter> entry : meters.entrySet()) {
+                reportMeter(entry.getKey(), entry.getValue(), now);
+            }
+
+            for (Map.Entry<String, Timer> entry : timers.entrySet()) {
+                reportTimer(entry.getKey(), entry.getValue(), now);
+            }
+
+            if (influxDb.hasSeriesData()) {
+                influxDb.writeData();
+            }
+        } catch (Exception e) {
+            LOGGER.warn("Unable to report to InfluxDB. Discarding data.", e);
+        }
+    }
+
+    private void reportTimer(String name, Timer timer, long now) {
+        if (canSkipMetric(name, timer)) {
+            return;
+        }
+        final Snapshot snapshot = timer.getSnapshot();
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("count", timer.getCount());
+        fields.put("min", convertDuration(snapshot.getMin()));
+        fields.put("max", convertDuration(snapshot.getMax()));
+        fields.put("mean", convertDuration(snapshot.getMean()));
+        fields.put("std-dev", convertDuration(snapshot.getStdDev()));
+        fields.put("median", convertDuration(snapshot.getMedian()));
+        fields.put("50-percentile", convertDuration(snapshot.getMedian()));
+        fields.put("75-percentile", convertDuration(snapshot.get75thPercentile()));
+        fields.put("95-percentile", convertDuration(snapshot.get95thPercentile()));
+        fields.put("98-percentile", convertDuration(snapshot.get98thPercentile()));
+        fields.put("99-percentile", convertDuration(snapshot.get99thPercentile()));
+        fields.put("999-percentile", convertDuration(snapshot.get999thPercentile()));
+        fields.put("one-minute", convertRate(timer.getOneMinuteRate()));
+        fields.put("five-minute", convertRate(timer.getFiveMinuteRate()));
+        fields.put("fifteen-minute", convertRate(timer.getFifteenMinuteRate()));
+        fields.put("mean-rate", convertRate(timer.getMeanRate()));
+        fields.put("run-count", timer.getCount());
+        influxDb.appendPoints(new InfluxDbPoint(
+                name,
+                metricTags.containsKey(name) ? metricTags.get(name) : Collections.<String, String>emptyMap(),
+                String.valueOf(now),
+                fields));
+    }
+
+    private void reportHistogram(String name, Histogram histogram, long now) {
+        if (canSkipMetric(name, histogram)) {
+            return;
+        }
+        final Snapshot snapshot = histogram.getSnapshot();
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("count", histogram.getCount());
+        fields.put("min", snapshot.getMin());
+        fields.put("max", snapshot.getMax());
+        fields.put("mean", snapshot.getMean());
+        fields.put("median", snapshot.getMedian());
+        fields.put("std-dev", snapshot.getStdDev());
+        fields.put("50-percentile", snapshot.getMedian());
+        fields.put("75-percentile", snapshot.get75thPercentile());
+        fields.put("95-percentile", snapshot.get95thPercentile());
+        fields.put("98-percentile", snapshot.get98thPercentile());
+        fields.put("99-percentile", snapshot.get99thPercentile());
+        fields.put("999-percentile", snapshot.get999thPercentile());
+        fields.put("run-count", histogram.getCount());
+        influxDb.appendPoints(new InfluxDbPoint(
+                name,
+                metricTags.containsKey(name) ? metricTags.get(name) : Collections.<String, String>emptyMap(),
+                String.valueOf(now),
+                fields));
+    }
+
+    private void reportCounter(String name, Counter counter, long now) {
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("count", counter.getCount());
+        influxDb.appendPoints(new InfluxDbPoint(
+                name,
+                metricTags.containsKey(name) ? metricTags.get(name) : Collections.<String, String>emptyMap(),
+                String.valueOf(now),
+                fields));
+    }
+
+    private void reportGauge(String name, Gauge<?> gauge, long now) {
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("value", gauge.getValue());
+        influxDb.appendPoints(new InfluxDbPoint(
+                name,
+                metricTags.containsKey(name) ? metricTags.get(name) : Collections.<String, String>emptyMap(),
+                String.valueOf(now),
+                fields));
+    }
+
+    private void reportMeter(String name, Metered meter, long now) {
+        if (canSkipMetric(name, meter)) {
+            return;
+        }
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("count", meter.getCount());
+        fields.put("one-minute", convertRate(meter.getOneMinuteRate()));
+        fields.put("five-minute", convertRate(meter.getFiveMinuteRate()));
+        fields.put("fifteen-minute", convertRate(meter.getFifteenMinuteRate()));
+        fields.put("mean-rate", convertRate(meter.getMeanRate()));
+        influxDb.appendPoints(new InfluxDbPoint(
+                name,
+                metricTags.containsKey(name) ? metricTags.get(name) : Collections.<String, String>emptyMap(),
+                String.valueOf(now),
+                fields));
+    }
+
+    private boolean canSkipMetric(String name, Counting counting) {
+        boolean isIdle = (calculateDelta(name, counting.getCount()) == 0);
+        if (skipIdleMetrics && !isIdle) {
+            previousValues.put(name, counting.getCount());
+        }
+        return skipIdleMetrics && isIdle;
+    }
+
+    private long calculateDelta(String name, long count) {
+        Long previous = previousValues.get(name);
+        if (previous == null) {
+            return -1;
+        }
+        if (count < previous) {
+            LOGGER.warn("Saw a non-monotonically increasing value for metric '{}'", name);
+            return 0;
+        }
+        return count - previous;
+    }
+
+    /**
+     * Adds tags for the Metric with name.
+     *
+     * @param metricName the name of the metric
+     * @param tags       map containing the tag name and value
+     */
+    public void putTagsForMetric(final String metricName, final Map<String, String> tags) {
+        metricTags.put(metricName, tags);
+    }
+}

--- a/metrics-influxdb/src/main/java/com/codehale/metrics/influxdb/InfluxDbSender.java
+++ b/metrics-influxdb/src/main/java/com/codehale/metrics/influxdb/InfluxDbSender.java
@@ -1,0 +1,40 @@
+package com.codehale.metrics.influxdb;
+
+import java.util.Map;
+
+import com.codehale.metrics.influxdb.data.InfluxDbPoint;
+
+public interface InfluxDbSender {
+    /**
+     * Flushes buffer, if applicable.
+     */
+    void flush();
+
+    /**
+     * @return true if there is data available to send.
+     */
+    boolean hasSeriesData();
+
+    /**
+     * Adds this metric point to the buffer.
+     *
+     * @param point metric point with tags and fields
+     */
+    void appendPoints(final InfluxDbPoint point);
+
+    /**
+     * Writes buffer data to InfluxDb.
+     *
+     * @return the response code for the request sent to InfluxDb.
+     *
+     * @throws Exception exception while writing to InfluxDb api
+     */
+    int writeData() throws Exception;
+
+    /**
+     * Set tags applicable for all the points.
+     *
+     * @param tags map containing tags common to all metrics
+     */
+    void setTags(final Map<String, String> tags);
+}

--- a/metrics-influxdb/src/main/java/com/codehale/metrics/influxdb/data/InfluxDbPoint.java
+++ b/metrics-influxdb/src/main/java/com/codehale/metrics/influxdb/data/InfluxDbPoint.java
@@ -1,0 +1,70 @@
+package com.codehale.metrics.influxdb.data;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * This class is a bean that holds time series data of a point. A point co relates to a metric.
+ */
+public class InfluxDbPoint {
+    private String measurement;
+    private Map<String, String> tags = Collections.emptyMap();
+    private String timestamp;
+    private Map<String, Object> fields = Collections.emptyMap();
+
+    public InfluxDbPoint(final String measurement, final String timestamp, final Map<String, Object> fields) {
+        this.measurement = measurement;
+        this.timestamp = timestamp;
+        if (fields != null) {
+            this.fields = Collections.unmodifiableMap(fields);
+        }
+
+    }
+
+    public InfluxDbPoint(String measurement, Map<String, String> tags, String timestamp, Map<String, Object> fields) {
+        this.measurement = measurement;
+        if (tags != null) {
+            this.tags = Collections.unmodifiableMap(tags);
+        }
+        this.timestamp = timestamp;
+        if (fields != null) {
+            this.fields = Collections.unmodifiableMap(fields);
+        }
+    }
+
+    public String getMeasurement() {
+        return measurement;
+    }
+
+    public void setMeasurement(String measurement) {
+        this.measurement = measurement;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    public void setTags(Map<String, String> tags) {
+        if (tags != null) {
+            this.tags = Collections.unmodifiableMap(tags);
+        }
+    }
+
+    public String getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Map<String, Object> getFields() {
+        return fields;
+    }
+
+    public void setFields(Map<String, Object> fields) {
+        if (fields != null) {
+            this.fields = Collections.unmodifiableMap(fields);
+        }
+    }
+}

--- a/metrics-influxdb/src/main/java/com/codehale/metrics/influxdb/data/InfluxDbWriteObject.java
+++ b/metrics-influxdb/src/main/java/com/codehale/metrics/influxdb/data/InfluxDbWriteObject.java
@@ -1,0 +1,79 @@
+package com.codehale.metrics.influxdb.data;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This class contains the request object to be sent to InfluxDb for writing. It contains a collection of points.
+ */
+public class InfluxDbWriteObject {
+
+    private String database;
+
+    private String precision;
+
+    private Set<InfluxDbPoint> points;
+
+    private Map<String, String> tags = Collections.emptyMap();
+
+    public InfluxDbWriteObject(final String database, final TimeUnit timeUnit) {
+        this.points = new HashSet<>();
+        this.database = database;
+        this.precision = toTimePrecision(timeUnit);
+    }
+
+    private static String toTimePrecision(TimeUnit t) {
+        switch (t) {
+            case HOURS:
+                return "h";
+            case MINUTES:
+                return "m";
+            case SECONDS:
+                return "s";
+            case MILLISECONDS:
+                return "ms";
+            case MICROSECONDS:
+                return "u";
+            case NANOSECONDS:
+                return "n";
+            default:
+                throw new IllegalArgumentException(
+                        "time precision should be HOURS OR MINUTES OR SECONDS or MILLISECONDS or MICROSECONDS OR NANOSECONDS");
+        }
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(String database) {
+        this.database = database;
+    }
+
+    public String getPrecision() {
+        return precision;
+    }
+
+    public void setPrecision(String precision) {
+        this.precision = precision;
+    }
+
+    public Set<InfluxDbPoint> getPoints() {
+        return points;
+    }
+
+    public void setPoints(Set<InfluxDbPoint> points) {
+        this.points = points;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    public void setTags(Map<String, String> tags) {
+        this.tags = Collections.unmodifiableMap(tags);
+    }
+}

--- a/metrics-influxdb/src/main/java/com/codehale/metrics/influxdb/utils/InfluxDbWriteObjectSerializer.java
+++ b/metrics-influxdb/src/main/java/com/codehale/metrics/influxdb/utils/InfluxDbWriteObjectSerializer.java
@@ -1,0 +1,47 @@
+package com.codehale.metrics.influxdb.utils;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.Version;
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializerProvider;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+import org.codehaus.jackson.map.module.SimpleModule;
+
+import com.codehale.metrics.influxdb.data.InfluxDbWriteObject;
+
+public class InfluxDbWriteObjectSerializer {
+
+    protected static class MapSerializer<P, Q> extends JsonSerializer<Map<P, Q>> {
+        @Override
+        public void serialize(final Map<P, Q> influxDbMap, final JsonGenerator jsonGenerator, final SerializerProvider provider)
+                throws IOException {
+            if (influxDbMap != null) {
+                jsonGenerator.writeStartObject();
+                for (Map.Entry<P, Q> entry : influxDbMap.entrySet()) {
+                    jsonGenerator.writeFieldName(entry.getKey().toString());
+                    jsonGenerator.writeObject(entry.getValue());
+                }
+                jsonGenerator.writeEndObject();
+            }
+        }
+    }
+
+    private final ObjectMapper objectMapper;
+
+    public InfluxDbWriteObjectSerializer() {
+        objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_EMPTY);
+
+        final SimpleModule module = new SimpleModule("SimpleModule", new Version(1, 0, 0, null));
+        module.addSerializer(Map.class, new MapSerializer());
+        objectMapper.registerModule(module);
+    }
+
+    public String getJsonString(InfluxDbWriteObject influxDbWriteObject) throws Exception {
+        return objectMapper.writeValueAsString(influxDbWriteObject);
+    }
+}

--- a/metrics-influxdb/src/test/java/com/codehale/metrics/influxdb/InfluxDbReporterTest.java
+++ b/metrics-influxdb/src/test/java/com/codehale/metrics/influxdb/InfluxDbReporterTest.java
@@ -1,0 +1,264 @@
+package com.codehale.metrics.influxdb;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+import com.codehale.metrics.influxdb.data.InfluxDbPoint;
+import com.codehale.metrics.influxdb.data.InfluxDbWriteObject;
+
+public class InfluxDbReporterTest {
+    @Mock
+    private InfluxDbSender influxDb;
+    @Mock
+    private InfluxDbWriteObject writeObject;
+    @Mock
+    private MetricRegistry registry;
+    private InfluxDbReporter reporter;
+
+    @Before
+    public void init() {
+        MockitoAnnotations.initMocks(this);
+        reporter = InfluxDbReporter
+                .forRegistry(registry)
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .filter(MetricFilter.ALL)
+                .build(influxDb);
+
+    }
+
+    @Test
+    public void reportsCounters() throws Exception {
+        final Counter counter = mock(Counter.class);
+        Mockito.when(counter.getCount()).thenReturn(100L);
+
+        reporter.report(this.<Gauge>map(), this.map("counter", counter), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
+        final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
+        Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
+        InfluxDbPoint point = influxDbPointCaptor.getValue();
+        assertThat(point.getMeasurement()).isEqualTo("counter");
+        assertThat(point.getFields()).isNotEmpty();
+        assertThat(point.getFields()).hasSize(1);
+        assertThat(point.getFields()).contains(entry("count", 100L));
+    }
+
+    @Test
+    public void reportsHistograms() throws Exception {
+        final Histogram histogram = mock(Histogram.class);
+        when(histogram.getCount()).thenReturn(1L);
+
+        final Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.getMax()).thenReturn(2L);
+        when(snapshot.getMean()).thenReturn(3.0);
+        when(snapshot.getMin()).thenReturn(4L);
+        when(snapshot.getStdDev()).thenReturn(5.0);
+        when(snapshot.getMedian()).thenReturn(6.0);
+        when(snapshot.get75thPercentile()).thenReturn(7.0);
+        when(snapshot.get95thPercentile()).thenReturn(8.0);
+        when(snapshot.get98thPercentile()).thenReturn(9.0);
+        when(snapshot.get99thPercentile()).thenReturn(10.0);
+        when(snapshot.get999thPercentile()).thenReturn(11.0);
+
+        when(histogram.getSnapshot()).thenReturn(snapshot);
+
+        reporter.report(this.<Gauge>map(), this.<Counter>map(), this.map("histogram", histogram), this.<Meter>map(), this.<Timer>map());
+
+        final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
+        Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
+        InfluxDbPoint point = influxDbPointCaptor.getValue();
+
+        assertThat(point.getMeasurement()).isEqualTo("histogram");
+        assertThat(point.getFields()).isNotEmpty();
+        assertThat(point.getFields()).hasSize(13);
+        assertThat(point.getFields()).contains(entry("max", 2L));
+        assertThat(point.getFields()).contains(entry("mean", 3.0));
+        assertThat(point.getFields()).contains(entry("min", 4L));
+        assertThat(point.getFields()).contains(entry("std-dev", 5.0));
+        assertThat(point.getFields()).contains(entry("median", 6.0));
+        assertThat(point.getFields()).contains(entry("75-percentile", 7.0));
+        assertThat(point.getFields()).contains(entry("95-percentile", 8.0));
+        assertThat(point.getFields()).contains(entry("98-percentile", 9.0));
+        assertThat(point.getFields()).contains(entry("99-percentile", 10.0));
+        assertThat(point.getFields()).contains(entry("999-percentile", 11.0));
+    }
+
+    @Test
+    public void reportsMeters() throws Exception {
+        final Meter meter = mock(Meter.class);
+        when(meter.getCount()).thenReturn(1L);
+        when(meter.getOneMinuteRate()).thenReturn(2.0);
+        when(meter.getFiveMinuteRate()).thenReturn(3.0);
+        when(meter.getFifteenMinuteRate()).thenReturn(4.0);
+        when(meter.getMeanRate()).thenReturn(5.0);
+
+        reporter.report(this.<Gauge>map(), this.<Counter>map(), this.<Histogram>map(), this.map("meter", meter), this.<Timer>map());
+
+        final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
+        Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
+        InfluxDbPoint point = influxDbPointCaptor.getValue();
+
+        assertThat(point.getMeasurement()).isEqualTo("meter");
+        assertThat(point.getFields()).isNotEmpty();
+        assertThat(point.getFields()).hasSize(5);
+        assertThat(point.getFields()).contains(entry("count", 1L));
+        assertThat(point.getFields()).contains(entry("one-minute", 2.0));
+        assertThat(point.getFields()).contains(entry("five-minute", 3.0));
+        assertThat(point.getFields()).contains(entry("fifteen-minute", 4.0));
+        assertThat(point.getFields()).contains(entry("mean-rate", 5.0));
+    }
+
+    @Test
+    public void reportsTimers() throws Exception {
+        final Timer timer = mock(Timer.class);
+        when(timer.getCount()).thenReturn(1L);
+        when(timer.getMeanRate()).thenReturn(2.0);
+        when(timer.getOneMinuteRate()).thenReturn(3.0);
+        when(timer.getFiveMinuteRate()).thenReturn(4.0);
+        when(timer.getFifteenMinuteRate()).thenReturn(5.0);
+
+        final Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.getMin()).thenReturn(TimeUnit.MILLISECONDS.toNanos(100));
+        when(snapshot.getMean()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(200));
+        when(snapshot.getMax()).thenReturn(TimeUnit.MILLISECONDS.toNanos(300));
+        when(snapshot.getStdDev()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(400));
+        when(snapshot.getMedian()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(500));
+        when(snapshot.get75thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(600));
+        when(snapshot.get95thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(700));
+        when(snapshot.get98thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(800));
+        when(snapshot.get99thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(900));
+        when(snapshot.get999thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(1000));
+
+        when(timer.getSnapshot()).thenReturn(snapshot);
+
+        reporter.report(this.<Gauge>map(), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), map("timer", timer));
+
+        final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
+        Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
+        InfluxDbPoint point = influxDbPointCaptor.getValue();
+
+        assertThat(point.getMeasurement()).isEqualTo("timer");
+        assertThat(point.getFields()).isNotEmpty();
+        assertThat(point.getFields()).hasSize(17);
+        assertThat(point.getFields()).contains(entry("count", 1L));
+        assertThat(point.getFields()).contains(entry("mean-rate", 2.0));
+        assertThat(point.getFields()).contains(entry("one-minute", 3.0));
+        assertThat(point.getFields()).contains(entry("five-minute", 4.0));
+        assertThat(point.getFields()).contains(entry("fifteen-minute", 5.0));
+        assertThat(point.getFields()).contains(entry("min", 100.0));
+        assertThat(point.getFields()).contains(entry("mean", 200.0));
+        assertThat(point.getFields()).contains(entry("max", 300.0));
+        assertThat(point.getFields()).contains(entry("std-dev", 400.0));
+        assertThat(point.getFields()).contains(entry("median", 500.0));
+        assertThat(point.getFields()).contains(entry("75-percentile", 600.0));
+        assertThat(point.getFields()).contains(entry("95-percentile", 700.0));
+        assertThat(point.getFields()).contains(entry("98-percentile", 800.0));
+        assertThat(point.getFields()).contains(entry("99-percentile", 900.0));
+        assertThat(point.getFields()).contains(entry("999-percentile", 1000.0));
+    }
+
+    @Test
+    public void reportsIntegerGaugeValues() throws Exception {
+        reporter.report(map("gauge", gauge(1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
+
+        final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
+        Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
+        InfluxDbPoint point = influxDbPointCaptor.getValue();
+
+        assertThat(point.getMeasurement()).isEqualTo("gauge");
+        assertThat(point.getFields()).isNotEmpty();
+        assertThat(point.getFields()).hasSize(1);
+        assertThat(point.getFields()).contains(entry("value", 1));
+    }
+
+    @Test
+    public void reportsLongGaugeValues() throws Exception {
+        reporter.report(map("gauge", gauge(1L)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
+
+        final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
+        Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
+        InfluxDbPoint point = influxDbPointCaptor.getValue();
+
+        assertThat(point.getMeasurement()).isEqualTo("gauge");
+        assertThat(point.getFields()).isNotEmpty();
+        assertThat(point.getFields()).hasSize(1);
+        assertThat(point.getFields()).contains(entry("value", 1L));
+    }
+
+    @Test
+    public void reportsFloatGaugeValues() throws Exception {
+        reporter.report(map("gauge", gauge(1.1f)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
+
+        final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
+        Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
+        InfluxDbPoint point = influxDbPointCaptor.getValue();
+
+        assertThat(point.getMeasurement()).isEqualTo("gauge");
+        assertThat(point.getFields()).isNotEmpty();
+        assertThat(point.getFields()).hasSize(1);
+        assertThat(point.getFields()).contains(entry("value", 1.1f));
+    }
+
+    @Test
+    public void reportsDoubleGaugeValues() throws Exception {
+        reporter.report(map("gauge", gauge(1.1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
+
+        final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
+        Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
+        InfluxDbPoint point = influxDbPointCaptor.getValue();
+
+        assertThat(point.getMeasurement()).isEqualTo("gauge");
+        assertThat(point.getFields()).isNotEmpty();
+        assertThat(point.getFields()).hasSize(1);
+        assertThat(point.getFields()).contains(entry("value", 1.1));
+    }
+
+    @Test
+    public void reportsByteGaugeValues() throws Exception {
+        reporter
+                .report(map("gauge", gauge((byte) 1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
+
+        final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
+        Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
+        InfluxDbPoint point = influxDbPointCaptor.getValue();
+
+        assertThat(point.getMeasurement()).isEqualTo("gauge");
+        assertThat(point.getFields()).isNotEmpty();
+        assertThat(point.getFields()).hasSize(1);
+        assertThat(point.getFields()).contains(entry("value", (byte) 1));
+    }
+
+    private <T> SortedMap<String, T> map() {
+        return new TreeMap<>();
+    }
+
+    private <T> SortedMap<String, T> map(String name, T metric) {
+        final TreeMap<String, T> map = new TreeMap<>();
+        map.put(name, metric);
+        return map;
+    }
+
+    private <T> Gauge gauge(T value) {
+        final Gauge gauge = mock(Gauge.class);
+        when(gauge.getValue()).thenReturn(value);
+        return gauge;
+    }
+}

--- a/metrics-influxdb/src/test/java/com/codehale/metrics/influxdb/utils/InfluxDbWriteObjectSerializerTest.java
+++ b/metrics-influxdb/src/test/java/com/codehale/metrics/influxdb/utils/InfluxDbWriteObjectSerializerTest.java
@@ -1,0 +1,46 @@
+package com.codehale.metrics.influxdb.utils;
+
+import static com.codehale.metrics.influxdb.utils.InfluxDbWriteObjectSerializer.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.codehaus.jackson.Version;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.annotate.JsonSerialize;
+import org.codehaus.jackson.map.module.SimpleModule;
+import org.junit.Before;
+import org.junit.Test;
+
+public class InfluxDbWriteObjectSerializerTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Before
+    public void init() {
+        objectMapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_EMPTY);
+        final SimpleModule module = new SimpleModule("SimpleModule", new Version(1, 0, 0, null));
+        module.addSerializer(Map.class, new MapSerializer());
+        objectMapper.registerModule(module);
+    }
+
+    @Test
+    public void serializeStringMap() throws Exception {
+        Map<String, String> testMap = new HashMap<>();
+        testMap.put("key", "value");
+        final String json = objectMapper.writeValueAsString(testMap);
+
+        assertThat(json).isNotEmpty();
+        assertThat(json).isEqualTo("{\"key\":\"value\"}");
+    }
+
+    @Test
+    public void serializeStringObjectMap() throws Exception {
+        Map<String, Integer> testMap = new HashMap<>();
+        testMap.put("intObject", 10);
+        final String json = objectMapper.writeValueAsString(testMap);
+
+        assertThat(json).isNotEmpty();
+        assertThat(json).isEqualTo("{\"intObject\":10}");
+    }
+}

--- a/metrics-influxdb/src/test/java/sandbox/SendToLocalInfluxDB.java
+++ b/metrics-influxdb/src/test/java/sandbox/SendToLocalInfluxDB.java
@@ -1,0 +1,86 @@
+package sandbox;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import com.codahale.metrics.ConsoleReporter;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.Timer;
+import com.codehale.metrics.influxdb.InfluxDbHttpSender;
+import com.codehale.metrics.influxdb.InfluxDbReporter;
+
+public final class SendToLocalInfluxDB {
+    private SendToLocalInfluxDB() {
+
+    }
+
+    public static void main(String[] args) {
+        InfluxDbReporter influxDbReporter = null;
+        ScheduledReporter consoleReporter = null;
+        Timer.Context context = null;
+        try {
+            final MetricRegistry registry = new MetricRegistry();
+            consoleReporter = startConsoleReporter(registry);
+            influxDbReporter = startInfluxDbReporter(registry);
+
+            final Meter myMeter = registry.meter("testMetric");
+            final Map<String, String> tags = new HashMap<>();
+            tags.put("env", "test");
+            influxDbReporter.putTagsForMetric("testMetric", tags);
+
+            final Timer myTimer = registry.timer("testTimer");
+            context = myTimer.time();
+            for (int i = 0; i < 5; i++) {
+                myMeter.mark();
+                myMeter.mark(Math.round(Math.random() * 100.0));
+                Thread.sleep(2000);
+            }
+        } catch (Exception exc) {
+            exc.printStackTrace();
+            System.exit(1);
+        } finally {
+            if (context != null) {
+                context.stop();
+            }
+            if (influxDbReporter != null) {
+                influxDbReporter.report();
+                influxDbReporter.stop();
+            }
+            if (consoleReporter != null) {
+                consoleReporter.report();
+                consoleReporter.stop();
+            }
+            System.out.println("Finished");
+        }
+    }
+
+    private static InfluxDbReporter startInfluxDbReporter(MetricRegistry registry) throws Exception {
+        final InfluxDbHttpSender influxDb = new InfluxDbHttpSender("127.0.0.1", 8086, "dropwizard", "root:root");
+        final Map<String, String> tags = new HashMap<>();
+        tags.put("host", "localhost");
+        final InfluxDbReporter reporter = InfluxDbReporter
+                .forRegistry(registry)
+                .withTags(tags)
+                .skipIdleMetrics(true)
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .filter(MetricFilter.ALL)
+                .build(influxDb);
+        reporter.start(10, TimeUnit.SECONDS);
+        return reporter;
+    }
+
+    private static ConsoleReporter startConsoleReporter(MetricRegistry registry) throws Exception {
+        final ConsoleReporter reporter = ConsoleReporter
+                .forRegistry(registry)
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .build();
+        reporter.start(1, TimeUnit.MINUTES);
+        return reporter;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <module>metrics-graphite</module>
         <module>metrics-httpclient</module>
         <module>metrics-httpasyncclient</module>
+        <module>metrics-influxdb</module>
         <module>metrics-jdbi</module>
         <module>metrics-jersey</module>
         <module>metrics-jersey2</module>


### PR DESCRIPTION
Adding metrics-influxdb module to enable writing application metrics to [influxdb] (https://influxdb.com/docs/v0.9/introduction/overview.html). 
The latest v0.9 influxdb release was announced recently and it will be great to have metrics report to influxdb as well, similar to graphite.