### PR TITLE
Add non-accumulating garbage collector metric set

### DIFF
--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -22,5 +22,10 @@
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.3.2</version>
+        </dependency>
     </dependencies>
 </project>

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/NonAccumulatingGarbageCollectorMetricSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/NonAccumulatingGarbageCollectorMetricSet.java
@@ -1,0 +1,193 @@
+package com.codahale.metrics.jvm;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricSet;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This metric set class alters the behavior of the {@link GarbageCollectorMetricSet},
+ * which takes readings of GC counts and times that are cumulative over the life of the JVM.
+ * This metric set uses gauges that represent data for a specific time interval, rather than all time.
+ * It also adds an extra gauge for GC throughput, which is a convenient summary metric for JVM's.
+ *
+ * To calculate readings for a specific time interval, this metric set needs to maintain state
+ * for previous values and non-accumulated values. To do it in a thread safe way, this metric set
+ * runs a background process in a scheduled thread that updates and stores gauge readings at
+ * user-specified time intervals. When clients call {@link com.codahale.metrics.Gauge#getValue()},
+ * the stored readings are read (not modified), rather than calling the underlying gauges directly.
+ */
+public class NonAccumulatingGarbageCollectorMetricSet implements MetricSet {
+    private static final Logger LOG = LoggerFactory.getLogger(NonAccumulatingGarbageCollectorMetricSet.class);
+    public static final String GC_THROUGHPUT_METRIC_NAME = "GC-throughput.percent";
+
+    private Map<String, Long> previousValues;
+    private Map<String, Long> nonAccumulatingValues;
+    private GarbageCollectorMetricSet garbageCollectorMetricSet;
+    private ScheduledExecutorService scheduledExecutorService;
+    private long interval;
+
+    /**
+     * Constructor does not take an executor service, instead deferring
+     * to the default scheduled executor service provided by this class.
+     *
+     * @param garbageCollectorMetricSet a metric set that collects counts and times of garbage collections
+     * @param interval the time interval over which to calculate non-accumulating gauge readings
+     *                 for all the gauges in {@code garbageCollectorMetricSet}
+     */
+    public NonAccumulatingGarbageCollectorMetricSet(
+            GarbageCollectorMetricSet garbageCollectorMetricSet, long interval) {
+        this(garbageCollectorMetricSet, interval, null);
+    }
+
+    /**
+     * Constructor sets up the scheduled executor service that runs a background task to
+     * calculate non-accumulating gauge readings at periodic intervals.
+     *
+     * @param garbageCollectorMetricSet a metric set that collects counts and times of garbage collections
+     * @param interval the time interval over which to calculate non-accumulating gauge readings
+     *                 for all the gauges in {@code garbageCollectorMetricSet}
+     * @param scheduledExecutorService scheduled executor service that runs the task to calculate
+     *                                 non-accumulating gauge readings at a frequency determined by
+     *                                 {@code interval}.
+     */
+    public NonAccumulatingGarbageCollectorMetricSet(
+            GarbageCollectorMetricSet garbageCollectorMetricSet, long interval,
+            ScheduledExecutorService scheduledExecutorService) {
+        this.garbageCollectorMetricSet = garbageCollectorMetricSet;
+        this.interval = interval;
+        previousValues = new HashMap<String, Long>();
+        nonAccumulatingValues = new ConcurrentHashMap<String, Long>();
+        if (scheduledExecutorService == null) {
+            BasicThreadFactory basicThreadFactory = new BasicThreadFactory.Builder()
+                    .namingPattern("metrics-gc-stats-update-%d")
+                    .daemon(false)
+                    .priority(Thread.NORM_PRIORITY)
+                    .build();
+            this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(basicThreadFactory);
+        } else {
+            this.scheduledExecutorService = scheduledExecutorService;
+        }
+        scheduleBackgroundCollectionOfNonAccumulatingValues();
+    }
+
+    /**
+     * Initialize the scheduled executor service that runs the task to calculate
+     * non-accumulating gauge readings.
+     */
+    protected void scheduleBackgroundCollectionOfNonAccumulatingValues() {
+        scheduledExecutorService.scheduleAtFixedRate(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    getMetricsOnSchedule();
+                } catch (RuntimeException ex) {
+                    LOG.error("RuntimeException thrown in NonAccumulatingGarbageCollectorMetricSet. Exception was suppressed.");
+                }
+            }
+        }, 0, interval, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Background process to harvest readings from the {@code garbageCollectorMetricSet},
+     * which are cumulative over all time. The process updates two maps: one that stores
+     * the previous values of all gauges, and one that stores the non-accumulating values
+     * for those gauges (the difference between the last reading and the current reading).
+     */
+    private void getMetricsOnSchedule() {
+        Map<String, Metric> metricMap = garbageCollectorMetricSet.getMetrics();
+        for (Map.Entry<String, Metric> metricEntry : metricMap.entrySet()) {
+            Gauge currentGauge = (Gauge) metricEntry.getValue();
+            String currentKey = metricEntry.getKey();
+            Long currentValue = (Long) currentGauge.getValue();
+
+            // first reading of gauges will have no previous value. Simply store the current readings.
+            if (previousValues.get(currentKey) == null) {
+                previousValues.put(currentKey, currentValue);
+                nonAccumulatingValues.put(currentKey, currentValue);
+            } else {
+                // subtract the previous gauge readings from the current readings, and store result
+                Long difference = currentValue - previousValues.get(currentKey);
+                nonAccumulatingValues.put(currentKey, difference);
+                previousValues.put(currentKey, currentValue);
+            }
+        }
+    }
+
+    /**
+     * Creates a map of non-accumulating gauges for the underlying gauges in {@code garbageCollectorMetricSet}
+     * Also, add an additional gauge for GC throughput.
+     *
+     * @return the map of metrics that contains non-cumulative gauges
+     */
+    @Override
+    public Map<String, Metric> getMetrics() {
+        Map<String, Metric> metricMap = garbageCollectorMetricSet.getMetrics();
+        Map<String, Metric> nonAccumulatingMetricMap = new HashMap<String, Metric>();
+
+        for (final Map.Entry<String, Metric> metricEntry : metricMap.entrySet()) {
+            Gauge nonAccumulatingGauge = new Gauge<Long>() {
+                /**
+                 * Instead of reading from the accumulating gauges in {@code garbageCollectorMetricSet},
+                 * we read from the map of non-accumulating values (which is updated by the background
+                 * task running in {@code scheduledExecutorService}).
+                 *
+                 * For reporters that call this method, it makes sense to align the frequency of
+                 * those calls with the frequency of the background updates of non-accumulating
+                 * gauges. For example, if a reporter calls this method every minute, then the
+                 * {@code interval} setting of this metric-set should also be 1 minute. Calling
+                 * this method more or less frequently does not impact the operation of this
+                 * class--but the caller will either get repeated values (for more frequent calls),
+                 * or will miss some values (for less frequent calls).
+                 *
+                 * @return the gauge value representing only the current reporting interval
+                 */
+                @Override
+                public Long getValue() {
+                    Long value = nonAccumulatingValues.get(metricEntry.getKey());
+                    return value != null ? value : 0L;
+                }
+            };
+            nonAccumulatingMetricMap.put(metricEntry.getKey(), nonAccumulatingGauge);
+        }
+
+        Gauge gcThroughputGauge = new Gauge<Double>() {
+            /**
+             * This gauge returns readings for garbage collector throughput. GC throughput
+             * is derived from the readings of time spent by all garbage collectors in
+             * the current {@code interval} of time.
+             *
+             * Example: for an interval of 1 minute, we have 60,000 ms of total time.
+             * If we spent 200 ms on minor GC's and 100 ms on major GC's, then
+             * 59,700 ms were available to the application. 59,700 / 60,000 = 99.5% GC throughput.
+             *
+             * @return a value between 0.0 and 100.0 that represents the garbage collector
+             * throughput for the current interval (as defined by {@code interval}
+             */
+            @Override
+            public Double getValue() {
+                Double totalGCTime = 0.0;
+
+                for (Map.Entry<String, Long> metricEntry : nonAccumulatingValues.entrySet()) {
+                    if (metricEntry.getKey().endsWith("time")) {
+                        totalGCTime += metricEntry.getValue();
+                    }
+                }
+
+                return 100 - ((totalGCTime / interval) * 100);
+            }
+        };
+        nonAccumulatingMetricMap.put(GC_THROUGHPUT_METRIC_NAME, gcThroughputGauge);
+
+        return Collections.unmodifiableMap(nonAccumulatingMetricMap);
+    }
+}

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/NonAccumulatingGarbageCollectorMetricSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/NonAccumulatingGarbageCollectorMetricSetTest.java
@@ -1,0 +1,295 @@
+package com.codahale.metrics.jvm;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Delayed;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NonAccumulatingGarbageCollectorMetricSetTest {
+    GarbageCollectorMetricSet garbageCollectorMetricSet;
+    NonAccumulatingGarbageCollectorMetricSet nonAccumulatingGarbageCollectorMetricSet;
+    long interval;
+    ScheduledExecutorService deterministicScheduledExecutorService;
+
+    @Before
+    public void setUp() throws Exception {
+        garbageCollectorMetricSet = mock(GarbageCollectorMetricSet.class);
+        interval = 60000L; //1 minute in milliseconds
+        deterministicScheduledExecutorService = new MockScheduledExecutorService();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        nonAccumulatingGarbageCollectorMetricSet = null;
+    }
+
+    @Test
+    public void testGetMetrics() throws Exception {
+        Map<String, Metric> mockMetricMap = getStringMetricMap(4L, 800L);
+        when(garbageCollectorMetricSet.getMetrics()).thenReturn(mockMetricMap);
+        nonAccumulatingGarbageCollectorMetricSet = new NonAccumulatingGarbageCollectorMetricSet(
+                garbageCollectorMetricSet, interval, deterministicScheduledExecutorService);
+
+        // on first call, there is no previous data, so it should just return the unaltered mock data
+        Map<String, Metric> actualMetricMap = nonAccumulatingGarbageCollectorMetricSet.getMetrics();
+        assertEquals(4L, ((Gauge) actualMetricMap.get("count")).getValue());
+        assertEquals(800L, ((Gauge) actualMetricMap.get("time")).getValue());
+        assertEquals(98.666, (Double) ((Gauge) actualMetricMap.get(
+                NonAccumulatingGarbageCollectorMetricSet.GC_THROUGHPUT_METRIC_NAME)).getValue(), 0.001);
+        assertEquals(3, actualMetricMap.size());
+
+        // on second call, we still have not run the background process that updates the
+        // non-accumulating values, so we expect to get the same readings again
+        assertEquals(4L, ((Gauge) actualMetricMap.get("count")).getValue());
+        assertEquals(800L, ((Gauge) actualMetricMap.get("time")).getValue());
+        assertEquals(98.666, (Double) ((Gauge) actualMetricMap.get(
+                NonAccumulatingGarbageCollectorMetricSet.GC_THROUGHPUT_METRIC_NAME)).getValue(), 0.001);
+        assertEquals(3, actualMetricMap.size());
+
+        // trigger an update of the the background process that updates non-accumulating values
+        // normally this will be scheduled, but we invoke it deterministically for the unit test.
+        nonAccumulatingGarbageCollectorMetricSet.scheduleBackgroundCollectionOfNonAccumulatingValues();
+
+        // now previous data should be subtracted from current gauge readings.
+        // Since the readings were the same in both cases, the difference should be 0.
+        // Since there were no increases in the GC time, we expect GC throughput to be 100
+        assertEquals(0L, ((Gauge) actualMetricMap.get("count")).getValue());
+        assertEquals(0L, ((Gauge) actualMetricMap.get("time")).getValue());
+        assertEquals(100.000, (Double) ((Gauge) actualMetricMap.get(
+                NonAccumulatingGarbageCollectorMetricSet.GC_THROUGHPUT_METRIC_NAME)).getValue(), 0.001);
+        assertEquals(3, actualMetricMap.size());
+
+        // Now we change the mock data for the underlying garbage collectors. They now report an
+        // increase in the total GC count and time. We trigger the background update process again.
+        // We should see the non-accumulating values (6-4=2) and (1100-800=300)
+        mockMetricMap = getStringMetricMap(6L, 1100L);
+        when(garbageCollectorMetricSet.getMetrics()).thenReturn(mockMetricMap);
+        nonAccumulatingGarbageCollectorMetricSet.scheduleBackgroundCollectionOfNonAccumulatingValues();
+        assertEquals(2L, ((Gauge) actualMetricMap.get("count")).getValue());
+        assertEquals(300L, ((Gauge) actualMetricMap.get("time")).getValue());
+        assertEquals(99.5, (Double) ((Gauge) actualMetricMap.get(
+                NonAccumulatingGarbageCollectorMetricSet.GC_THROUGHPUT_METRIC_NAME)).getValue(), 0.001);
+        assertEquals(3, actualMetricMap.size());
+
+    }
+
+    @Test
+    public void testNameOfBackgroundUpdateThread() throws Exception {
+        Map<String, Metric> mockMetricMap = getStringMetricMap(4L, 800L);
+        when(garbageCollectorMetricSet.getMetrics()).thenReturn(mockMetricMap);
+        nonAccumulatingGarbageCollectorMetricSet = new NonAccumulatingGarbageCollectorMetricSet(
+                garbageCollectorMetricSet, interval);
+
+        assertTrue(foundBackgroundUpdateThread());
+    }
+
+    private Boolean foundBackgroundUpdateThread() {
+        Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
+        Boolean foundName = false;
+        for(Thread thread : threadSet) {
+            if ("metrics-gc-stats-update-1".equals(thread.getName())) {
+                foundName = true;
+            }
+        }
+        return foundName;
+    }
+
+    private Map<String, Metric> getStringMetricMap(final Long gcCount, final Long gcTime) {
+        Gauge gcCountGauge = new Gauge<Long>() {
+            @Override
+            public Long getValue() {
+                return gcCount;
+            }
+        };
+        Gauge gcTimeGauge = new Gauge<Long>() {
+            @Override
+            public Long getValue() {
+                return gcTime;
+            }
+        };
+        Map<String, Metric> metricStringMap = new HashMap<String, Metric>();
+        metricStringMap.put("count", gcCountGauge);
+        metricStringMap.put("time", gcTimeGauge);
+        return metricStringMap;
+    }
+
+    /**
+     * This is a very simple mock implementation of a scheduled executor service that executes
+     * the task synchronously in the main thread, rather than at a non-deterministic time
+     * in another thread. Use this to make unit tests behave deterministically while still
+     * exercising all the logic in the scheduled task.
+     */
+    private static class MockScheduledExecutorService implements ScheduledExecutorService {
+        private boolean shutdown;
+
+        private MockScheduledExecutorService() {
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+            throw new UnsupportedOperationException("No mock implementation available");
+        }
+
+        @Override
+        public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+            throw new UnsupportedOperationException("No mock implementation available");
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+            //run the task synchronously
+            command.run();
+            // return a dummy implementation of the scheduled future, since we are running the task synchronously.
+            return new ScheduledFuture<Object>() {
+                @Override
+                public long getDelay(TimeUnit unit) {
+                    throw new UnsupportedOperationException("No mock implementation available");
+                }
+
+                @Override
+                public int compareTo(Delayed o) {
+                    throw new UnsupportedOperationException("No mock implementation available");
+                }
+
+                @Override
+                public boolean cancel(boolean mayInterruptIfRunning) {
+                    throw new UnsupportedOperationException("No mock implementation available");
+                }
+
+                @Override
+                public boolean isCancelled() {
+                    throw new UnsupportedOperationException("No mock implementation available");
+                }
+
+                @Override
+                public boolean isDone() {
+                    throw new UnsupportedOperationException("No mock implementation available");
+                }
+
+                @Override
+                public Object get() throws InterruptedException, ExecutionException {
+                    throw new UnsupportedOperationException("No mock implementation available");
+                }
+
+                @Override
+                public Object get(long timeout,
+                                  TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+                    throw new UnsupportedOperationException("No mock implementation available");
+                }
+            };
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay,
+                                                         TimeUnit unit) {
+            throw new UnsupportedOperationException("No mock implementation available");
+        }
+
+        @Override
+        public void shutdown() {
+            shutdown = true;
+        }
+
+        @Override
+        public List<Runnable> shutdownNow() {
+            shutdown = true;
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean isShutdown() {
+            shutdown = true;
+            return shutdown;
+        }
+
+        @Override
+        public boolean isTerminated() {
+            return shutdown;
+        }
+
+        @Override
+        public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+            return true;
+        }
+
+        @Override
+        public <T> Future<T> submit(Callable<T> task) {
+            {
+                throw new UnsupportedOperationException("No mock implementation available");
+            }
+        }
+
+        @Override
+        public <T> Future<T> submit(Runnable task, T result) {
+            {
+                throw new UnsupportedOperationException("No mock implementation available");
+            }
+        }
+
+        @Override
+        public Future<?> submit(Runnable task) {
+            {
+                throw new UnsupportedOperationException("No mock implementation available");
+            }
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+            {
+                throw new UnsupportedOperationException("No mock implementation available");
+            }
+        }
+
+        @Override
+        public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout,
+                                             TimeUnit unit) throws InterruptedException {
+            {
+                throw new UnsupportedOperationException("No mock implementation available");
+            }
+        }
+
+        @Override
+        public <T> T invokeAny(
+                Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+            {
+                throw new UnsupportedOperationException("No mock implementation available");
+            }
+        }
+
+        @Override
+        public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout,
+                               TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            {
+                throw new UnsupportedOperationException("No mock implementation available");
+            }
+        }
+
+        @Override
+        public void execute(Runnable command) {
+            {
+                throw new UnsupportedOperationException("No mock implementation available");
+            }
+        }
+    }
+}


### PR DESCRIPTION
The existing GarbageCollectorMetricSet is not ideal for metrics that are reported to graphite because it keeps cumulative counts and times for each garbage collector over the life of the JVM process. It is more interesting to see the counts/times for the elapsed time since the last data point was reported. This NonAccumulatingGarbageCollectorMetricSet wraps the GarbageCollectorMetricSet to provide this functionality. In addition, it provides a GC throughput gauge that is often useful as a summary measurement of application health and capacity.