### PR TITLE
Updating jackson dependencies to match the project

### DIFF
--- a/metrics-influxdb/pom.xml
+++ b/metrics-influxdb/pom.xml
@@ -23,9 +23,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.13</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/metrics-influxdb/src/main/java/com/codehale/metrics/influxdb/utils/InfluxDbWriteObjectSerializer.java
+++ b/metrics-influxdb/src/main/java/com/codehale/metrics/influxdb/utils/InfluxDbWriteObjectSerializer.java
@@ -3,15 +3,14 @@ package com.codehale.metrics.influxdb.utils;
 import java.io.IOException;
 import java.util.Map;
 
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.Version;
-import org.codehaus.jackson.map.JsonSerializer;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializerProvider;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.module.SimpleModule;
-
 import com.codehale.metrics.influxdb.data.InfluxDbWriteObject;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
 
 public class InfluxDbWriteObjectSerializer {
 
@@ -34,9 +33,9 @@ public class InfluxDbWriteObjectSerializer {
 
     public InfluxDbWriteObjectSerializer() {
         objectMapper = new ObjectMapper();
-        objectMapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_EMPTY);
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
 
-        final SimpleModule module = new SimpleModule("SimpleModule", new Version(1, 0, 0, null));
+        final SimpleModule module = new SimpleModule("SimpleModule", new Version(1, 0, 0, null, null, null));
         module.addSerializer(Map.class, new MapSerializer());
         objectMapper.registerModule(module);
     }

--- a/metrics-influxdb/src/test/java/com/codehale/metrics/influxdb/utils/InfluxDbWriteObjectSerializerTest.java
+++ b/metrics-influxdb/src/test/java/com/codehale/metrics/influxdb/utils/InfluxDbWriteObjectSerializerTest.java
@@ -6,10 +6,11 @@ import static org.assertj.core.api.Assertions.*;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.codehaus.jackson.Version;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.annotate.JsonSerialize;
-import org.codehaus.jackson.map.module.SimpleModule;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -18,8 +19,8 @@ public class InfluxDbWriteObjectSerializerTest {
 
     @Before
     public void init() {
-        objectMapper.setSerializationInclusion(JsonSerialize.Inclusion.NON_EMPTY);
-        final SimpleModule module = new SimpleModule("SimpleModule", new Version(1, 0, 0, null));
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+        final SimpleModule module = new SimpleModule("SimpleModule", new Version(1, 0, 0, null, null, null));
         module.addSerializer(Map.class, new MapSerializer());
         objectMapper.registerModule(module);
     }


### PR DESCRIPTION
Getting rid of org.codehaus.jackson dependency and using the same jackson dependencies as the metrics-json module. 