### PR TITLE
Log and ignore Exceptions from Meters in GraphiteReporter

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -175,7 +175,7 @@ public class GraphiteReporter extends ScheduledReporter {
             }
 
             graphite.flush();
-        } catch (IOException e) {
+        } catch (Exception e) {
             LOGGER.warn("Unable to report to Graphite", graphite, e);
             try {
                 graphite.close();

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -312,6 +312,25 @@ public class GraphiteReporterTest {
     }
 
     @Test
+    public void ignoresExceptionsFromGauges() throws Exception {
+        final Gauge brokenGauge = mock(Gauge.class);
+        when(brokenGauge.getValue()).thenThrow(new RuntimeException("I'm broken"));
+
+        reporter.report(map("brokenGauge", brokenGauge),
+                this.<Counter>map(),
+                this.<Histogram>map(),
+                this.<Meter>map(),
+                this.<Timer>map());
+
+        final InOrder inOrder = inOrder(graphite);
+        inOrder.verify(graphite).isConnected();
+        inOrder.verify(graphite).connect();
+        inOrder.verify(graphite).close();
+
+        verifyNoMoreInteractions(graphite);
+    }
+
+    @Test
     public void closesConnectionOnReporterStop() throws Exception {
         reporter.stop();
 


### PR DESCRIPTION
`GraphiteReporter` stops sending metrics to Graphite in case of any non-`IOException` thrown.