### PR TITLE
Update for Jetty 9.3.0

### DIFF
--- a/metrics-jetty9/src/main/java/io/dropwizard/metrics/jetty9/InstrumentedConnectionFactory.java
+++ b/metrics-jetty9/src/main/java/io/dropwizard/metrics/jetty9/InstrumentedConnectionFactory.java
@@ -8,19 +8,41 @@ import org.eclipse.jetty.util.component.ContainerLifeCycle;
 
 import io.dropwizard.metrics.Timer;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+
 public class InstrumentedConnectionFactory extends ContainerLifeCycle implements ConnectionFactory {
     private final ConnectionFactory connectionFactory;
     private final Timer timer;
+    private Method getProtocols;
 
     public InstrumentedConnectionFactory(ConnectionFactory connectionFactory, Timer timer) {
         this.connectionFactory = connectionFactory;
         this.timer = timer;
         addBean(connectionFactory);
+        try {
+            getProtocols = connectionFactory.getClass().getMethod("getProtocols");
+        } catch (NoSuchMethodException ignore) {
+            getProtocols = null;
+        }
     }
 
     @Override
     public String getProtocol() {
         return connectionFactory.getProtocol();
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<String> getProtocols() {
+        try {
+            return getProtocols != null ?
+                    (List<String>) getProtocols.invoke(connectionFactory) :
+                    Collections.<String>emptyList();
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalStateException("Unable to invoke `connectionFactory#getProtocols`", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
Jetty 9.3.0 is the latest update of Jetty with some API changes.

* Update `InstrumentedConnectionFactory` to support instrumentation for Jetty 9.3. 
The update should be backward-compatible with Jetty 9.1 and 9.2, because we only implement a new method.