### PR TITLE
Make shield "Maven Central" usable link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Metrics
 =======
 
 [![Build Status](https://img.shields.io/travis/dropwizard/metrics.svg?style=flat-square)](https://travis-ci.org/dropwizard/metrics)
-![Maven Central](https://img.shields.io/maven-central/v/io.dropwizard.metrics/metrics-core.svg?style=flat-square)
+[![Maven Central](https://img.shields.io/maven-central/v/io.dropwizard.metrics/metrics-core.svg?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/io.dropwizard.metrics/metrics-core/)
 ![GitHub license](https://img.shields.io/github/license/dropwizard/metrics.svg?style=flat-square)
 
 *Capturing JVM- and application-level metrics. So you know what's going on.*


### PR DESCRIPTION
Make shield "Maven Central" usable link to last version on maven central repository