### PR TITLE
adds enable/disable feature to MetricRegistry

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/Counter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Counter.java
@@ -3,8 +3,9 @@ package com.codahale.metrics;
 /**
  * An incrementing and decrementing counter metric.
  */
-public class Counter implements Metric, Counting {
+public class Counter implements Metric, Counting, Toggleable {
     private final LongAdder count;
+    private boolean enabled = true;
 
     public Counter() {
         this.count = new LongAdder();
@@ -23,7 +24,9 @@ public class Counter implements Metric, Counting {
      * @param n the amount by which the counter will be increased
      */
     public void inc(long n) {
-        count.add(n);
+        if (enabled) {
+            count.add(n);
+        }
     }
 
     /**
@@ -39,7 +42,9 @@ public class Counter implements Metric, Counting {
      * @param n the amount by which the counter will be decreased
      */
     public void dec(long n) {
-        count.add(-n);
+        if (enabled) {
+            count.add(-n);
+        }
     }
 
     /**
@@ -50,5 +55,17 @@ public class Counter implements Metric, Counting {
     @Override
     public long getCount() {
         return count.sum();
+    }
+
+    /**
+     * Enable and disable this metric
+     * @param enabled new value for enabled
+     */
+    @Override
+    public void setEnabled(boolean enabled) {
+        if (!enabled) {
+            count.reset();
+        }
+        this.enabled = enabled;
     }
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/EWMA.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/EWMA.java
@@ -103,4 +103,11 @@ public class EWMA {
     public double getRate(TimeUnit rateUnit) {
         return rate * (double) rateUnit.toNanos(1);
     }
+
+    /**
+     * Reset the EWMA
+     */
+    public void reset() {
+        uncounted.reset();
+    }
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
@@ -74,6 +74,17 @@ public class ExponentiallyDecayingReservoir implements Reservoir {
         this.nextScaleTime = new AtomicLong(clock.getTick() + RESCALE_THRESHOLD);
     }
 
+    /**
+     * Reset the values
+     */
+    @Override
+    public void reset() {
+        values.clear();
+        count.set(0L);
+        startTime = currentTimeInSeconds();
+        nextScaleTime.set(clock.getTick() + RESCALE_THRESHOLD);
+    }
+
     @Override
     public int size() {
         return (int) min(size, count.get());

--- a/metrics-core/src/main/java/com/codahale/metrics/Histogram.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Histogram.java
@@ -6,9 +6,10 @@ package com.codahale.metrics;
  * @see <a href="http://www.johndcook.com/standard_deviation.html">Accurately computing running
  *      variance</a>
  */
-public class Histogram implements Metric, Sampling, Counting {
+public class Histogram implements Metric, Sampling, Counting, Toggleable {
     private final Reservoir reservoir;
     private final LongAdder count;
+    private boolean enabled = true;
 
     /**
      * Creates a new {@link Histogram} with the given reservoir.
@@ -35,8 +36,10 @@ public class Histogram implements Metric, Sampling, Counting {
      * @param value the length of the value
      */
     public void update(long value) {
-        count.increment();
-        reservoir.update(value);
+        if (enabled) {
+            count.increment();
+            reservoir.update(value);
+        }
     }
 
     /**
@@ -52,5 +55,18 @@ public class Histogram implements Metric, Sampling, Counting {
     @Override
     public Snapshot getSnapshot() {
         return reservoir.getSnapshot();
+    }
+
+    /**
+     * Enable and disable this metric
+     * @param enabled new value for enabled
+     */
+    @Override
+    public void setEnabled(boolean enabled) {
+        if (!enabled) {
+            count.reset();
+            reservoir.reset();
+        }
+        this.enabled = enabled;
     }
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -52,6 +52,20 @@ public class MetricRegistry implements MetricSet {
     private final List<MetricRegistryListener> listeners;
 
     /**
+     * Enable and disable all metrics in this registry
+     * @param enabled new value for enabled
+     */
+    public void setEnable(boolean enabled) {
+        Set<String> keys = metrics.keySet();
+        for (String key : keys) {
+            Metric metric = metrics.get(key);
+            if (metric instanceof Toggleable) {
+                ((Toggleable) metric).setEnabled(enabled);
+            }
+        }
+    }
+
+    /**
      * Creates a new {@link MetricRegistry}.
      */
     public MetricRegistry() {

--- a/metrics-core/src/main/java/com/codahale/metrics/Reservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Reservoir.java
@@ -24,4 +24,9 @@ public interface Reservoir {
      * @return a snapshot of the reservoir's values
      */
     Snapshot getSnapshot();
+
+    /**
+     * Reset the current reservoir
+     */
+    void reset();
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/SlidingTimeWindowReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SlidingTimeWindowReservoir.java
@@ -65,6 +65,13 @@ public class SlidingTimeWindowReservoir implements Reservoir {
         return new UniformSnapshot(measurements.values());
     }
 
+    @Override
+    public void reset() {
+        measurements.clear();
+        lastTick.set(clock.getTick() * COLLISION_BUFFER);
+        count.set(0L);
+    }
+
     private long getTick() {
         for (; ; ) {
             final long oldTick = lastTick.get();

--- a/metrics-core/src/main/java/com/codahale/metrics/SlidingWindowReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SlidingWindowReservoir.java
@@ -1,5 +1,7 @@
 package com.codahale.metrics;
 
+import java.util.Arrays;
+
 import static java.lang.Math.min;
 
 /**
@@ -39,5 +41,11 @@ public class SlidingWindowReservoir implements Reservoir {
             }
         }
         return new UniformSnapshot(values);
+    }
+
+    @Override
+    public synchronized void reset() {
+        this.count = 0;
+        Arrays.fill(measurements, 0L);
     }
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/Timer.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Timer.java
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit;
  * A timer metric which aggregates timing durations and provides duration statistics, plus
  * throughput statistics via {@link Meter}.
  */
-public class Timer implements Metered, Sampling {
+public class Timer implements Metered, Sampling, Toggleable {
     /**
      * A timing context.
      *
@@ -46,6 +46,7 @@ public class Timer implements Metered, Sampling {
     private final Meter meter;
     private final Histogram histogram;
     private final Clock clock;
+    private boolean enabled = true;
 
     /**
      * Creates a new {@link Timer} using an {@link ExponentiallyDecayingReservoir} and the default
@@ -160,9 +161,18 @@ public class Timer implements Metered, Sampling {
     }
 
     private void update(long duration) {
-        if (duration >= 0) {
-            histogram.update(duration);
-            meter.mark();
+        if (enabled) {
+            if (duration >= 0) {
+                histogram.update(duration);
+                meter.mark();
+            }
         }
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        meter.setEnabled(enabled);
+        histogram.setEnabled(enabled);
+        this.enabled = enabled;
     }
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/Toggleable.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Toggleable.java
@@ -1,0 +1,13 @@
+package com.codahale.metrics;
+
+/**
+ * An interface for metric types which have enable/disable feature.
+ */
+public interface Toggleable {
+
+    /**
+     * Enable and disable this metric
+     * @param enabled new value for enabled
+     */
+    void setEnabled(boolean enabled);
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/UniformReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/UniformReservoir.java
@@ -86,4 +86,12 @@ public class UniformReservoir implements Reservoir {
         }
         return new UniformSnapshot(copy);
     }
+
+    @Override
+    public void reset() {
+        for (int i = 0; i < values.length(); i++) {
+            values.set(i, 0);
+        }
+        count.set(0);
+    }
 }


### PR DESCRIPTION
Toggleable interface is implemented by the metrics which support
enable/disable feature. when metric is disabled, all values
collected so far are reset and any calls to update the metrics
do nothing.