### PR TITLE
Handle unexpected exceptions when reporting to graphite

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -175,13 +175,17 @@ public class GraphiteReporter extends ScheduledReporter {
             }
 
             graphite.flush();
+        } catch (Throwable t) {
+            LOGGER.warn("Unable to report to Graphite", graphite, t);
+            closeGraphiteConnection();
+        }
+    }
+
+    private void closeGraphiteConnection() {
+        try {
+            graphite.close();
         } catch (IOException e) {
-            LOGGER.warn("Unable to report to Graphite", graphite, e);
-            try {
-                graphite.close();
-            } catch (IOException e1) {
-                LOGGER.warn("Error closing Graphite", graphite, e1);
-            }
+            LOGGER.warn("Error closing Graphite", graphite, e);
         }
     }
 

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -312,6 +312,25 @@ public class GraphiteReporterTest {
     }
 
     @Test
+    public void closesConnectionIfAnUnexpectedExceptionOccurs() throws Exception {
+        final Gauge gauge = mock(Gauge.class);
+        when(gauge.getValue()).thenThrow(new RuntimeException("kaboom"));
+
+        reporter.report(map("gauge", gauge),
+                        this.<Counter>map(),
+                        this.<Histogram>map(),
+                        this.<Meter>map(),
+                        this.<Timer>map());
+
+        final InOrder inOrder = inOrder(graphite);
+        inOrder.verify(graphite).isConnected();
+        inOrder.verify(graphite).connect();
+        inOrder.verify(graphite).close();
+
+        verifyNoMoreInteractions(graphite);
+    }
+
+    @Test
     public void closesConnectionOnReporterStop() throws Exception {
         reporter.stop();
 


### PR DESCRIPTION
This prevents an unexpected exception from killing the reporter thread
silently. Instead log the exception and close the connection gracefully.

We observed this problem a few times with hystrix (for instance, hystrix 1.4.7 implements its own metrics which have had various bugs - in one case we saw an ArrayOutOfBoundsException when calling #getValue on a gauage). It was difficult to debug as the reporter thread silently dies since the exception is unhandled. In general I think we should be careful to avoid killing the scheduler thread.