### PR TITLE
added reconnect flag

### DIFF
--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
@@ -29,6 +29,9 @@ import java.util.concurrent.TimeUnit;
  * @see <a href="http://graphite.wikidot.com/">Graphite - Scalable Realtime Graphing</a>
  */
 public class GraphiteReporter extends ScheduledReporter {
+	
+	private boolean reconnect;
+	
     /**
      * Returns a new {@link Builder} for {@link GraphiteReporter}.
      *
@@ -186,10 +189,13 @@ public class GraphiteReporter extends ScheduledReporter {
             for (Map.Entry<MetricName, Timer> entry : timers.entrySet()) {
                 reportTimer(entry.getKey(), entry.getValue(), timestamp);
             }
-
             graphite.flush();
         } catch (Throwable t) {
             LOGGER.warn("Unable to report to Graphite", graphite, t);
+            if(!reconnect) {
+                LOGGER.warn("Not trying to reconnect, stopping scheduler", graphite, t);
+            	stop();
+            }
             closeGraphiteConnection();
         }
     }
@@ -318,4 +324,12 @@ public class GraphiteReporter extends ScheduledReporter {
         // US-formatted digits
         return String.format(Locale.US, "%2.2f", v);
     }
+
+	public boolean isReconnect() {
+		return reconnect;
+	}
+
+	public void setReconnect(boolean reconnect) {
+		this.reconnect = reconnect;
+	}
 }

--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class GraphiteReporter extends ScheduledReporter {
 	
-	private boolean reconnect;
+	private boolean reconnect = true;
 	
     /**
      * Returns a new {@link Builder} for {@link GraphiteReporter}.


### PR DESCRIPTION
we have the situation that in some places, we might not have graphite available at all. so i would like to be able to tell the graphite reporter to stop reconnecting. 

for this, i added a configuration flag, and if there is an error connecting and this flag is off, i stop the executor. 

the default setting is "true", so it behaves like before.
