### PR TITLE
Downgrade assertj to 2.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.1.0</version>
+            <version>2.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Assertj was bumped to 3.1.0 on 59e7c4a3dc255e30d3ce925bf4ad80f4c1ef7636 which breaks the build on JDK7.

```
AssertJ 1.x requires Java 6 or higher (suitable for Android)
AssertJ 2.x requires Java 7 or higher (not suitable for Android due to Path assertions)
AssertJ 3.x requires Java 8 or higher (not suitable for Android due to Path assertions)
```