### PR TITLE
Initial commit of the metrics-collectd plugin.

### DIFF
--- a/metrics-collectd/README.md
+++ b/metrics-collectd/README.md
@@ -1,0 +1,26 @@
+Metrics-collectd
+=======
+
+*A metrics plugin for reporting results using the collectd binary protocol over UDP*
+
+For more information about metrics, please see [the metrics documentation](http://dropwizard.github.io/metrics/).
+For more information about collectd binary protocol, please see [the collectd documentation](https://collectd.org/wiki/index.php/Binary_protocol).
+
+Usage
+-------
+
+This plugin defines 3 custom collectd types. In order for your collectd server instance to recognize these types, you should add the following entries to your types.db or types.db.custom file:
+``` sh
+histogram		count:GAUGE:0:U, max:GAUGE:U:U, mean:GAUGE:U:U, min:GAUGE:U:U, stddev:GAUGE:0:U, p50:GAUGE:U:U, p75:GAUGE:U:U, p95:GAUGE:U:U, p98:GAUGE:U:U, p99:GAUGE:U:U, p999:GAUGE:U:U
+metered		count:GAUGE:0:U, m1_rate:GAUGE:0:U, m5_rate:GAUGE:0:U, m15_rate:GAUGE:0:U, mean_rate:GAUGE:0:U
+timer		max:GAUGE:U:U, mean:GAUGE:U:U, min:GAUGE:U:U, stddev:GAUGE:0:U, p50:GAUGE:U:U, p75:GAUGE:U:U, p95:GAUGE:U:U, p98:GAUGE:U:U, p99:GAUGE:U:U, p999:GAUGE:U:U
+```
+
+These entries are also included in the /src/main/resources/types.db.custom file in this project.
+
+License
+-------
+
+Copyright (c) 2010-2014 Coda Hale, Yammer.com
+
+Published under Apache Software License 2.0, see LICENSE

--- a/metrics-collectd/pom.xml
+++ b/metrics-collectd/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-parent</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>metrics-collectd</artifactId>
+    <name>Collectd Integration for Metrics</name>
+    <packaging>bundle</packaging>
+    <description>
+        A reporter for Metrics which announces measurements to a Collectd server.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/Collectd.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/Collectd.java
@@ -1,0 +1,191 @@
+package io.dropwizard.metrics.collectd;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A client to a collectd server using unconnected UDP
+ */
+public class Collectd implements CollectdSender {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(Collectd.class);
+
+	public static final String DEFAULT_HOST_NAME = "localhost";
+	public static final String NET_DEFAULT_V4_ADDR = "239.192.74.66";
+	public static final String NET_DEFAULT_V6_ADDR = "ff18::efc0:4a42";
+	public static final int NET_DEFAULT_PORT = 25826;
+	public static final int DEFAULT_PACKET_SIZE = 1452;
+
+	private final InetSocketAddress address;
+	private final DatagramChannelFactory datagramChannelFactory;
+	private final AtomicReference<DatagramChannel> datagramChannel = new AtomicReference<>();
+	private final ByteBuffer buf;
+
+	/**
+	 * Creates a new client which connects to the given address using the
+	 * default {@link DatagramChannelFactory}.
+	 *
+	 * @param hostname
+	 *            The hostname of the Collectd server
+	 * @param port
+	 *            The port of the Collectd server
+	 */
+	public Collectd(final String hostname, final int port) {
+		this(hostname, port, DatagramChannelFactory.getDefault());
+	}
+
+	/**
+	 * Creates a new client which connects to the given address and
+	 * DatagramChannel factory.
+	 *
+	 * @param hostname
+	 *            The hostname of the Collectd server
+	 * @param port
+	 *            The port of the Collectd server
+	 * @param datagramChannelFactory
+	 *            the datagramChannelFactory factory
+	 */
+	public Collectd(final String hostname, final int port, final DatagramChannelFactory datagramChannelFactory) {
+		this(hostname, port, datagramChannelFactory, DEFAULT_PACKET_SIZE);
+	}
+
+	/**
+	 * Creates a new client which connects to the given address and datagram
+	 * channel factory using the given character set.
+	 *
+	 * @param hostname
+	 *            The hostname of the Collectd server
+	 * @param port
+	 *            The port of the Collectd server
+	 * @param datagramChannelFactory
+	 *            the datagramChannel factory
+	 * @param packetSize
+	 *            the max size of the collectd udp packet
+	 */
+	public Collectd(final String hostname, final int port, final DatagramChannelFactory datagramChannelFactory,
+			final int packetSize) {
+		this(new InetSocketAddress(hostname, port), datagramChannelFactory, packetSize);
+	}
+
+	/**
+	 * Creates a new client which connects to the given address using the
+	 * default {@link DatagramChannelFactory}.
+	 *
+	 * @param address
+	 *            the address of the Collectd server
+	 */
+	public Collectd(final InetSocketAddress address) {
+		this(address, DatagramChannelFactory.getDefault());
+	}
+
+	/**
+	 * Creates a new client which connects to the given address and
+	 * datagramChannel factory.
+	 *
+	 * @param address
+	 *            the address of the Collectd server
+	 * @param datagramChannel
+	 *            the datagramChannel factory
+	 */
+	public Collectd(final InetSocketAddress address, final DatagramChannelFactory datagramChannelFactory) {
+		this(address, datagramChannelFactory, DEFAULT_PACKET_SIZE);
+	}
+
+	/**
+	 * Creates a new client which connects to the given address and
+	 * datagramChannel factory using the given character set.
+	 *
+	 * @param address
+	 *            the address of the Collectd server
+	 * @param socketFactory
+	 *            the datagramChannel factory
+	 */
+	public Collectd(final InetSocketAddress address, final DatagramChannelFactory datagramChannelFactory,
+			final int packetSize) {
+		this.address = address;
+		this.datagramChannelFactory = datagramChannelFactory;
+		buf = ByteBuffer.allocate(packetSize);
+		buf.clear();
+	}
+
+	/**
+	 * Creates a new client which connects to the Collectd server on localhost
+	 * with port 25826.
+	 */
+	public Collectd() {
+		this(DEFAULT_HOST_NAME, NET_DEFAULT_PORT);
+	}
+
+	@Override
+	public void connect() throws IllegalStateException, IOException {
+		final InetSocketAddress address = this.address;
+		if (address.getAddress() == null) {
+			throw new UnknownHostException(address.getHostName());
+		}
+		final DatagramChannel currentDatagramChannel = datagramChannel.get();
+		if (isConnected(currentDatagramChannel)) {
+			throw new IllegalStateException("Already connected");
+		}
+		final DatagramChannel newDatagramChannel = datagramChannelFactory.openDatagramChannel();
+		if (datagramChannel.compareAndSet(currentDatagramChannel, newDatagramChannel)) {
+			newDatagramChannel.connect(address);
+		} else {
+			newDatagramChannel.close();
+		}
+	}
+
+	private boolean isConnected(final DatagramChannel datagramChannel) {
+		return datagramChannel != null && datagramChannel.isConnected();
+	}
+
+	@Override
+	public boolean isConnected() {
+		return isConnected(datagramChannel.get());
+	}
+
+	@Override
+	public void send(final Packet packet) throws IOException {
+		final int packetLength = packet.getLength();
+
+		if (packetLength > buf.capacity()) {
+			LOGGER.error(String.format("The packet length %d is greater than the capacity %d. Dropping the packet.",
+					packetLength, buf.capacity()));
+			return;
+		}
+		if (packetLength <= buf.remaining()) {
+			buf.put(packet.build());
+		} else {
+			buf.flip();
+			datagramChannel.get().write(buf);
+			buf.compact();
+		}
+	}
+
+	@Override
+	public void flush() throws IOException {
+		if (buf.position() > 0) {
+			buf.flip();
+			datagramChannel.get().write(buf);
+		}
+		buf.clear();
+	}
+
+	@Override
+	public void close() throws IOException {
+		final DatagramChannel channel = datagramChannel.get();
+		if (null != channel) {
+			try {
+				channel.disconnect();
+			} finally {
+				channel.close();
+			}
+		}
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/Collectd.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/Collectd.java
@@ -91,7 +91,7 @@ public class Collectd implements CollectdSender {
 	 *
 	 * @param address
 	 *            the address of the Collectd server
-	 * @param datagramChannel
+	 * @param datagramChannelFactory
 	 *            the datagramChannel factory
 	 */
 	public Collectd(final InetSocketAddress address, final DatagramChannelFactory datagramChannelFactory) {
@@ -104,8 +104,10 @@ public class Collectd implements CollectdSender {
 	 *
 	 * @param address
 	 *            the address of the Collectd server
-	 * @param socketFactory
+	 * @param datagramChannelFactory
 	 *            the datagramChannel factory
+	 * @param packetSize
+	 *            the maximum packet size for the datagram
 	 */
 	public Collectd(final InetSocketAddress address, final DatagramChannelFactory datagramChannelFactory,
 			final int packetSize) {

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/CollectdReporter.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/CollectdReporter.java
@@ -1,0 +1,303 @@
+package io.dropwizard.metrics.collectd;
+
+import static java.util.Arrays.asList;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.dropwizard.metrics.Clock;
+import io.dropwizard.metrics.Counter;
+import io.dropwizard.metrics.Gauge;
+import io.dropwizard.metrics.Histogram;
+import io.dropwizard.metrics.Meter;
+import io.dropwizard.metrics.Metered;
+import io.dropwizard.metrics.MetricFilter;
+import io.dropwizard.metrics.MetricName;
+import io.dropwizard.metrics.MetricRegistry;
+import io.dropwizard.metrics.ScheduledReporter;
+import io.dropwizard.metrics.Snapshot;
+import io.dropwizard.metrics.Timer;
+import io.dropwizard.metrics.collectd.part.Plugin;
+import io.dropwizard.metrics.collectd.part.PluginInstance;
+import io.dropwizard.metrics.collectd.part.Time;
+import io.dropwizard.metrics.collectd.part.Type;
+import io.dropwizard.metrics.collectd.part.TypeInstance;
+import io.dropwizard.metrics.collectd.part.Values;
+
+/**
+ * A reporter which publishes metric values to a Collectd server using the
+ * collectd binary protocol over UDP.
+ *
+ * @see <a href="https://collectd.org/wiki/index.php/Binary_protocol">collectd -
+ *      Binary protocol</a>
+ */
+public class CollectdReporter extends ScheduledReporter {
+	/**
+	 * Returns a new {@link Builder} for {@link CollectdReporter}.
+	 *
+	 * @param registry
+	 *            the registry to report
+	 * @return a {@link Builder} instance for a {@link CollectdReporter}
+	 */
+	public static Builder forRegistry(final MetricRegistry registry) {
+		return new Builder(registry);
+	}
+
+	/**
+	 * A builder for {@link CollectdReporter} instances. Defaults to using a
+	 * plugin instance of "dropwizard", using the default clock, converting
+	 * rates to events/second, converting durations to milliseconds, and not
+	 * filtering metrics.
+	 */
+	public static class Builder {
+		private static final String DEFAULT_PLUGIN_INSTANCE = "dropwizard";
+
+		private final MetricRegistry registry;
+		private Clock clock;
+		private String pluginInstance;
+		private TimeUnit rateUnit;
+		private TimeUnit durationUnit;
+		private MetricFilter filter;
+
+		private Builder(final MetricRegistry registry) {
+			this.registry = registry;
+			clock = Clock.defaultClock();
+			pluginInstance = DEFAULT_PLUGIN_INSTANCE;
+			rateUnit = TimeUnit.SECONDS;
+			durationUnit = TimeUnit.MILLISECONDS;
+			filter = MetricFilter.ALL;
+		}
+
+		/**
+		 * Use the given {@link Clock} instance for the time.
+		 *
+		 * @param clock
+		 *            a {@link Clock} instance
+		 * @return {@code this}
+		 */
+		public Builder withClock(final Clock clock) {
+			this.clock = clock;
+			return this;
+		}
+
+		/**
+		 * Report all metrics as part of this plugin instance.
+		 *
+		 * @param pluginInstance
+		 *            the plugin instance for all metrics
+		 * @return {@code this}
+		 */
+		public Builder withPluginInstance(final String pluginInstance) {
+			this.pluginInstance = pluginInstance;
+			return this;
+		}
+
+		/**
+		 * Convert rates to the given time unit.
+		 *
+		 * @param rateUnit
+		 *            a unit of time
+		 * @return {@code this}
+		 */
+		public Builder convertRatesTo(final TimeUnit rateUnit) {
+			this.rateUnit = rateUnit;
+			return this;
+		}
+
+		/**
+		 * Convert durations to the given time unit.
+		 *
+		 * @param durationUnit
+		 *            a unit of time
+		 * @return {@code this}
+		 */
+		public Builder convertDurationsTo(final TimeUnit durationUnit) {
+			this.durationUnit = durationUnit;
+			return this;
+		}
+
+		/**
+		 * Only report metrics which match the given filter.
+		 *
+		 * @param filter
+		 *            a {@link MetricFilter}
+		 * @return {@code this}
+		 */
+		public Builder filter(final MetricFilter filter) {
+			this.filter = filter;
+			return this;
+		}
+
+		/**
+		 * Builds a {@link CollectdReporter} with the given properties, sending
+		 * metrics using the given {@link CollectdSender}.
+		 *
+		 * @param collectd
+		 *            a {@link CollectdSender}
+		 * @return a {@link CollectdReporter}
+		 */
+		public CollectdReporter build(final CollectdSender collectd) {
+			return new CollectdReporter(registry, collectd, clock, pluginInstance, rateUnit, durationUnit, filter);
+		}
+	}
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(CollectdReporter.class);
+	private static final Charset UTF_8 = Charset.forName("UTF-8");
+	private static final Part METRICS_PLUGIN = new Plugin("metrics", UTF_8);
+
+	private final CollectdSender collectd;
+	private final Clock clock;
+	private final PluginInstance pluginInstance;
+
+	private CollectdReporter(final MetricRegistry registry, final CollectdSender collectd, final Clock clock,
+			final String pluginInstance, final TimeUnit rateUnit, final TimeUnit durationUnit,
+			final MetricFilter filter) {
+		super(registry, "collectd-reporter", filter, rateUnit, durationUnit);
+		this.collectd = collectd;
+		this.clock = clock;
+		this.pluginInstance = new PluginInstance(pluginInstance, UTF_8);
+	}
+
+	@Override
+	public void report(@SuppressWarnings("rawtypes") final SortedMap<MetricName, Gauge> gauges,
+			final SortedMap<MetricName, Counter> counters, final SortedMap<MetricName, Histogram> histograms,
+			final SortedMap<MetricName, Meter> meters, final SortedMap<MetricName, Timer> timers) {
+		final Time time = new Time(clock.getTime() / 1000);
+
+		try {
+			if (!collectd.isConnected()) {
+				collectd.connect();
+			}
+
+			for (@SuppressWarnings("rawtypes")
+			final Map.Entry<MetricName, Gauge> entry : gauges.entrySet()) {
+				reportGauge(entry.getKey(), entry.getValue(), time);
+			}
+
+			for (final Map.Entry<MetricName, Counter> entry : counters.entrySet()) {
+				reportCounter(entry.getKey(), entry.getValue(), time);
+			}
+
+			for (final Map.Entry<MetricName, Histogram> entry : histograms.entrySet()) {
+				reportHistogram(entry.getKey(), entry.getValue(), time);
+			}
+
+			for (final Map.Entry<MetricName, Meter> entry : meters.entrySet()) {
+				reportMetered(entry.getKey(), entry.getValue(), time);
+			}
+
+			for (final Map.Entry<MetricName, Timer> entry : timers.entrySet()) {
+				reportTimer(entry.getKey(), entry.getValue(), time);
+			}
+
+			collectd.flush();
+		} catch (final Exception e) {
+			LOGGER.warn("Unable to report to Collectd", collectd, e);
+			closeCollectdConnection();
+		}
+	}
+
+	private void closeCollectdConnection() {
+		try {
+			collectd.close();
+		} catch (final IOException e) {
+			LOGGER.warn("Error closing Collectd", collectd, e);
+		}
+	}
+
+	@Override
+	public void stop() {
+		try {
+			super.stop();
+		} finally {
+			try {
+				collectd.close();
+			} catch (final IOException e) {
+				LOGGER.debug("Error disconnecting from Collectd", collectd, e);
+			}
+		}
+	}
+
+	private void reportTimer(final MetricName name, final Timer timer, final Time time) throws IOException {
+		send(time, "timer", name, toValues(timer));
+		reportMetered(name, timer, time);
+	}
+
+	private static Value[] toValues(final Timer t) {
+		final Snapshot s = t.getSnapshot();
+		return new Value[] { new io.dropwizard.metrics.collectd.value.Gauge(s.getMax()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.getMean()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.getMin()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.getStdDev()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.getMedian()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.get75thPercentile()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.get95thPercentile()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.get98thPercentile()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.get99thPercentile()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.get999thPercentile()) };
+	}
+
+	private void reportMetered(final MetricName name, final Metered metered, final Time time) throws IOException {
+		send(time, "metered", name, toValues(metered));
+	}
+
+	private static Value[] toValues(final Metered m) {
+		return new Value[] { new io.dropwizard.metrics.collectd.value.Gauge(m.getCount()),
+				new io.dropwizard.metrics.collectd.value.Gauge(m.getOneMinuteRate()),
+				new io.dropwizard.metrics.collectd.value.Gauge(m.getFiveMinuteRate()),
+				new io.dropwizard.metrics.collectd.value.Gauge(m.getFifteenMinuteRate()),
+				new io.dropwizard.metrics.collectd.value.Gauge(m.getMeanRate()) };
+	}
+
+	private void reportHistogram(final MetricName name, final Histogram histogram, final Time time) throws IOException {
+		send(time, "histogram", name, toValues(histogram));
+	}
+
+	private static Value[] toValues(final Histogram h) {
+		final Snapshot s = h.getSnapshot();
+		return new Value[] { new io.dropwizard.metrics.collectd.value.Gauge(h.getCount()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.getMax()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.getMean()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.getMin()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.getStdDev()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.getMedian()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.get75thPercentile()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.get95thPercentile()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.get98thPercentile()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.get99thPercentile()),
+				new io.dropwizard.metrics.collectd.value.Gauge(s.get999thPercentile()) };
+	}
+
+	private void reportCounter(final MetricName name, final Counter counter, final Time time) throws IOException {
+		send(time, "count", name, new io.dropwizard.metrics.collectd.value.Counter(counter.getCount()));
+	}
+
+	private void reportGauge(final MetricName name, final Gauge<?> gauge, final Time time) throws IOException {
+		final Double value = getValue(gauge);
+		if (value != null) {
+			send(time, name, new io.dropwizard.metrics.collectd.value.Gauge(value));
+		}
+	}
+
+	private void send(final Time time, final MetricName typeInstance, final Value value) throws IOException {
+		collectd.send(new Packet(asList(METRICS_PLUGIN, pluginInstance, time,
+				new TypeInstance(typeInstance.toString(), UTF_8), new Values(asList(value)))));
+	}
+
+	private void send(final Time time, final String type, final MetricName typeInstance, final Value... values)
+			throws IOException {
+		collectd.send(new Packet(asList(METRICS_PLUGIN, pluginInstance, time, new Type(type, UTF_8),
+				new TypeInstance(typeInstance.toString(), UTF_8), new Values(asList(values)))));
+	}
+
+	private Double getValue(final Gauge<?> g) {
+		final Object o = g.getValue();
+		return o instanceof Number ? ((Number) o).doubleValue() : null;
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/CollectdSender.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/CollectdSender.java
@@ -29,11 +29,14 @@ public interface CollectdSender extends Closeable {
 	 * Flushes buffer, if applicable
 	 *
 	 * @throws IOException
+	 *             if there was an error flushing the buffer
 	 */
 	void flush() throws IOException;
 
 	/**
 	 * Returns true if ready to send data
+	 *
+	 * @return a flag indicating whether the connection is still open
 	 */
 	boolean isConnected();
 }

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/CollectdSender.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/CollectdSender.java
@@ -1,0 +1,39 @@
+package io.dropwizard.metrics.collectd;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public interface CollectdSender extends Closeable {
+
+	/**
+	 * Connects to the server.
+	 *
+	 * @throws IllegalStateException
+	 *             if the client is already connected
+	 * @throws IOException
+	 *             if there is an error connecting
+	 */
+	public void connect() throws IllegalStateException, IOException;
+
+	/**
+	 * Sends the given packet to the server.
+	 *
+	 * @param packet
+	 *            the packet
+	 * @throws IOException
+	 *             if there was an error sending the metric
+	 */
+	public void send(final Packet packet) throws IOException;
+
+	/**
+	 * Flushes buffer, if applicable
+	 *
+	 * @throws IOException
+	 */
+	void flush() throws IOException;
+
+	/**
+	 * Returns true if ready to send data
+	 */
+	boolean isConnected();
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/DatagramChannelFactory.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/DatagramChannelFactory.java
@@ -1,0 +1,20 @@
+package io.dropwizard.metrics.collectd;
+
+import java.io.IOException;
+import java.nio.channels.DatagramChannel;
+
+public abstract class DatagramChannelFactory {
+	
+	public abstract DatagramChannel openDatagramChannel() throws IOException;
+	
+	public static DatagramChannelFactory getDefault() {
+		return DEFAULT;
+	}
+	
+	private static final DatagramChannelFactory DEFAULT = new DatagramChannelFactory() {
+		@Override
+		public DatagramChannel openDatagramChannel() throws IOException {
+			return DatagramChannel.open();
+		}
+	}; 
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/Packet.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/Packet.java
@@ -1,0 +1,34 @@
+package io.dropwizard.metrics.collectd;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+public class Packet {
+
+	private final List<? extends Part> parts;
+
+	public Packet(final List<? extends Part> parts) {
+		this.parts = parts;
+	}
+
+	public List<? extends Part> getParts() {
+		return parts;
+	}
+
+	public int getLength() {
+		int length = 0;
+		for (final Part part : parts) {
+			length += part.getLength();
+		}
+		return length;
+	}
+
+	public ByteBuffer build() {
+		final ByteBuffer byteBuffer = ByteBuffer.allocate(getLength());
+		for (final Part part : parts) {
+			part.appendTo(byteBuffer);
+		}
+		byteBuffer.flip();
+		return byteBuffer;
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/Part.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/Part.java
@@ -1,0 +1,31 @@
+package io.dropwizard.metrics.collectd;
+
+import java.nio.ByteBuffer;
+
+import io.dropwizard.metrics.collectd.part.PartType;
+
+public abstract class Part {
+
+	private final PartType partType;
+
+	protected Part(final PartType partType) {
+		this.partType = partType;
+	}
+
+	public PartType getType() {
+		return partType;
+	}
+
+	public final short getLength() {
+		return (short) (4 + getValueLength());
+	}
+
+	public final void appendTo(final ByteBuffer buffer) {
+		buffer.putShort(partType.getPartTypeCode()).putShort(getLength());
+		appendValueTo(buffer);
+	}
+
+	protected abstract short getValueLength();
+
+	protected abstract void appendValueTo(final ByteBuffer buffer);
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/Value.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/Value.java
@@ -19,19 +19,19 @@ public abstract class Value {
 	 * ABSOLUTE → network (big endian) unsigned integer
 	 * </pre>
 	 */
-	private final byte[] value;
+	private final ByteBuffer value;
 	private final DataType dataType;
 
 	protected Value(final DataType dataType, final ByteBuffer value) {
 		this.dataType = dataType;
-		this.value = value.array();
+		this.value = value;
 	}
 
 	public DataType getDataType() {
 		return dataType;
 	}
 
-	public byte[] getValue() {
+	public ByteBuffer getValue() {
 		return value;
 	}
 }

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/Value.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/Value.java
@@ -1,0 +1,37 @@
+package io.dropwizard.metrics.collectd;
+
+import java.nio.ByteBuffer;
+
+import io.dropwizard.metrics.collectd.value.DataType;
+
+public abstract class Value {
+	/**
+	 * <pre>
+	 * Data type code (8 bit field)
+	 * COUNTER → 0
+	 * GAUGE → 1
+	 * DERIVE → 2
+	 * ABSOLUTE → 3
+	 * Value (64 bit field)
+	 * COUNTER → network (big endian) unsigned integer
+	 * GAUGE → x86 (little endian) double
+	 * DERIVE → network (big endian) signed integer
+	 * ABSOLUTE → network (big endian) unsigned integer
+	 * </pre>
+	 */
+	private final byte[] value;
+	private final DataType dataType;
+
+	protected Value(final DataType dataType, final ByteBuffer value) {
+		this.dataType = dataType;
+		this.value = value.array();
+	}
+
+	public DataType getDataType() {
+		return dataType;
+	}
+
+	public byte[] getValue() {
+		return value;
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Host.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Host.java
@@ -1,0 +1,9 @@
+package io.dropwizard.metrics.collectd.part;
+
+import java.nio.charset.Charset;
+
+public class Host extends StringPart {
+	public Host(final String value, final Charset charset) {
+		super(PartType.HOST, value, charset);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Interval.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Interval.java
@@ -1,0 +1,7 @@
+package io.dropwizard.metrics.collectd.part;
+
+public class Interval extends NumericPart {
+	public Interval(final long value) {
+		super(PartType.INTERVAL, value);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/IntervalHiRes.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/IntervalHiRes.java
@@ -1,0 +1,7 @@
+package io.dropwizard.metrics.collectd.part;
+
+public class IntervalHiRes extends NumericPart {
+	public IntervalHiRes(final long value) {
+		super(PartType.INTERVAL_HR, value);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Message.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Message.java
@@ -1,0 +1,9 @@
+package io.dropwizard.metrics.collectd.part;
+
+import java.nio.charset.Charset;
+
+public class Message extends StringPart {
+	public Message(final String value, final Charset charset) {
+		super(PartType.MESSAGE, value, charset);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/NumericPart.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/NumericPart.java
@@ -1,0 +1,25 @@
+package io.dropwizard.metrics.collectd.part;
+
+import java.nio.ByteBuffer;
+
+import io.dropwizard.metrics.collectd.Part;
+
+public abstract class NumericPart extends Part {
+
+	private final long value;
+
+	public NumericPart(final PartType partType, final long value) {
+		super(partType);
+		this.value = value;
+	}
+
+	@Override
+	protected final short getValueLength() {
+		return 8;
+	}
+
+	@Override
+	protected final void appendValueTo(final ByteBuffer buffer) {
+		buffer.putLong(value);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/PartType.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/PartType.java
@@ -1,0 +1,29 @@
+package io.dropwizard.metrics.collectd.part;
+
+public enum PartType {
+
+	HOST((short) 0x0000), //
+	TIME((short) 0x0001), //
+	TIME_HR((short) 0x0008), //
+	PLUGIN((short) 0x0002), //
+	PLUGIN_INSTANCE((short) 0x0003), //
+	TYPE((short) 0x0004), //
+	TYPE_INSTANCE((short) 0x0005), //
+	VALUES((short) 0x0006), //
+	INTERVAL((short) 0x0007), //
+	INTERVAL_HR((short) 0x0009), //
+	MESSAGE((short) 0x0100), //
+	SEVERITY((short) 0x0101), //
+	SIGN_SHA256((short) 0x0200), //
+	ENCR_AES256((short) 0x0210);
+
+	private final short partTypeCode;
+
+	PartType(final short partTypeCode) {
+		this.partTypeCode = partTypeCode;
+	}
+
+	public short getPartTypeCode() {
+		return partTypeCode;
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Plugin.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Plugin.java
@@ -1,0 +1,9 @@
+package io.dropwizard.metrics.collectd.part;
+
+import java.nio.charset.Charset;
+
+public class Plugin extends StringPart {
+	public Plugin(final String value, final Charset charset) {
+		super(PartType.PLUGIN, value, charset);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/PluginInstance.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/PluginInstance.java
@@ -1,0 +1,9 @@
+package io.dropwizard.metrics.collectd.part;
+
+import java.nio.charset.Charset;
+
+public class PluginInstance extends StringPart {
+	public PluginInstance(final String value, final Charset charset) {
+		super(PartType.PLUGIN_INSTANCE, value, charset);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Severity.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Severity.java
@@ -1,0 +1,7 @@
+package io.dropwizard.metrics.collectd.part;
+
+public class Severity extends NumericPart {
+	public Severity(final long value) {
+		super(PartType.SEVERITY, value);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/StringPart.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/StringPart.java
@@ -1,0 +1,26 @@
+package io.dropwizard.metrics.collectd.part;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+import io.dropwizard.metrics.collectd.Part;
+
+public abstract class StringPart extends Part {
+
+	private final byte[] value;
+
+	public StringPart(final PartType partType, final String value, final Charset charset) {
+		super(partType);
+		this.value = (value + '\0').getBytes(charset);
+	}
+
+	@Override
+	protected short getValueLength() {
+		return (short) value.length;
+	}
+
+	@Override
+	protected final void appendValueTo(final ByteBuffer buffer) {
+		buffer.put(value);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Time.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Time.java
@@ -1,0 +1,7 @@
+package io.dropwizard.metrics.collectd.part;
+
+public class Time extends NumericPart {
+	public Time(final long value) {
+		super(PartType.TIME, value);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/TimeHiRes.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/TimeHiRes.java
@@ -1,0 +1,7 @@
+package io.dropwizard.metrics.collectd.part;
+
+public class TimeHiRes extends NumericPart {
+	public TimeHiRes(final long value) {
+		super(PartType.TIME_HR, value);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Type.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Type.java
@@ -1,0 +1,9 @@
+package io.dropwizard.metrics.collectd.part;
+
+import java.nio.charset.Charset;
+
+public class Type extends StringPart {
+	public Type(final String value, final Charset charset) {
+		super(PartType.TYPE, value, charset);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/TypeInstance.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/TypeInstance.java
@@ -1,0 +1,9 @@
+package io.dropwizard.metrics.collectd.part;
+
+import java.nio.charset.Charset;
+
+public class TypeInstance extends StringPart {
+	public TypeInstance(final String value, final Charset charset) {
+		super(PartType.TYPE_INSTANCE, value, charset);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Values.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Values.java
@@ -1,0 +1,52 @@
+package io.dropwizard.metrics.collectd.part;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import io.dropwizard.metrics.collectd.Part;
+import io.dropwizard.metrics.collectd.Value;
+
+public class Values extends Part {
+	/**
+	 * <pre>
+	 * Type 0x0006
+	 * Length (16 bit field)
+	 * Number of values (16 bit field)
+	 * Values, for each one:
+	 * Data type code (8 bit field)
+	 * COUNTER → 0
+	 * GAUGE → 1
+	 * DERIVE → 2
+	 * ABSOLUTE → 3
+	 * Value (64 bit field)
+	 * COUNTER → network (big endian) unsigned integer
+	 * GAUGE → x86 (little endian) double
+	 * DERIVE → network (big endian) signed integer
+	 * ABSOLUTE → network (big endian) unsigned integer
+	 * </pre>
+	 */
+	private final List<? extends Value> values;
+
+	public Values(final List<? extends Value> values) {
+		super(PartType.VALUES);
+		this.values = values;
+	}
+
+	@Override
+	protected final short getValueLength() {
+		// Num values + (values.length * (data type +
+		// value))
+		return (short) (2 + values.size() * 9);
+	}
+
+	@Override
+	protected final void appendValueTo(final ByteBuffer buffer) {
+		buffer.putShort((short) values.size());
+		for (final Value value : values) {
+			buffer.put(value.getDataType().getCode());
+		}
+		for (final Value value : values) {
+			buffer.put(value.getValue());
+		}
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Values.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/part/Values.java
@@ -46,7 +46,7 @@ public class Values extends Part {
 			buffer.put(value.getDataType().getCode());
 		}
 		for (final Value value : values) {
-			buffer.put(value.getValue());
+			buffer.put(value.getValue().array());
 		}
 	}
 }

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/value/Absolute.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/value/Absolute.java
@@ -1,0 +1,7 @@
+package io.dropwizard.metrics.collectd.value;
+
+public class Absolute extends LongValue {
+	public Absolute(final long value) {
+		super(DataType.ABSOLUTE, value);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/value/Counter.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/value/Counter.java
@@ -1,0 +1,7 @@
+package io.dropwizard.metrics.collectd.value;
+
+public class Counter extends LongValue {
+	public Counter(final long value) {
+		super(DataType.COUNTER, value);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/value/DataType.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/value/DataType.java
@@ -1,0 +1,18 @@
+package io.dropwizard.metrics.collectd.value;
+
+public enum DataType {
+	COUNTER((byte) 0), //
+	GAUGE((byte) 1), //
+	DERIVE((byte) 2), //
+	ABSOLUTE((byte) 3);
+
+	private final byte code;
+
+	DataType(final byte code) {
+		this.code = code;
+	}
+
+	public byte getCode() {
+		return code;
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/value/Derive.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/value/Derive.java
@@ -1,0 +1,7 @@
+package io.dropwizard.metrics.collectd.value;
+
+public class Derive extends LongValue {
+	public Derive(final long value) {
+		super(DataType.DERIVE, value);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/value/DoubleValue.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/value/DoubleValue.java
@@ -1,0 +1,12 @@
+package io.dropwizard.metrics.collectd.value;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import io.dropwizard.metrics.collectd.Value;
+
+public class DoubleValue extends Value {
+	public DoubleValue(final DataType dataType, final double value) {
+		super(dataType, ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putDouble(value));
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/value/Gauge.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/value/Gauge.java
@@ -1,0 +1,7 @@
+package io.dropwizard.metrics.collectd.value;
+
+public class Gauge extends DoubleValue {
+	public Gauge(final double value) {
+		super(DataType.GAUGE, value);
+	}
+}

--- a/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/value/LongValue.java
+++ b/metrics-collectd/src/main/java/io/dropwizard/metrics/collectd/value/LongValue.java
@@ -1,0 +1,11 @@
+package io.dropwizard.metrics.collectd.value;
+
+import java.nio.ByteBuffer;
+
+import io.dropwizard.metrics.collectd.Value;
+
+public class LongValue extends Value {
+	public LongValue(final DataType dataType, final long value) {
+		super(dataType, ByteBuffer.allocate(8).putLong(value));
+	}
+}

--- a/metrics-collectd/src/main/resources/types.db.custom
+++ b/metrics-collectd/src/main/resources/types.db.custom
@@ -1,0 +1,4 @@
+histogram		count:GAUGE:0:U, max:GAUGE:U:U, mean:GAUGE:U:U, min:GAUGE:U:U, stddev:GAUGE:0:U, p50:GAUGE:U:U, p75:GAUGE:U:U, p95:GAUGE:U:U, p98:GAUGE:U:U, p99:GAUGE:U:U, p999:GAUGE:U:U
+metered		count:GAUGE:0:U, m1_rate:GAUGE:0:U, m5_rate:GAUGE:0:U, m15_rate:GAUGE:0:U, mean_rate:GAUGE:0:U
+timer		max:GAUGE:U:U, mean:GAUGE:U:U, min:GAUGE:U:U, stddev:GAUGE:0:U, p50:GAUGE:U:U, p75:GAUGE:U:U, p95:GAUGE:U:U, p98:GAUGE:U:U, p99:GAUGE:U:U, p999:GAUGE:U:U
+

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/CollectdReporterTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/CollectdReporterTest.java
@@ -1,0 +1,233 @@
+package io.dropwizard.metrics.collectd;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.net.UnknownHostException;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import io.dropwizard.metrics.Clock;
+import io.dropwizard.metrics.Counter;
+import io.dropwizard.metrics.Gauge;
+import io.dropwizard.metrics.Histogram;
+import io.dropwizard.metrics.Meter;
+import io.dropwizard.metrics.MetricFilter;
+import io.dropwizard.metrics.MetricName;
+import io.dropwizard.metrics.MetricRegistry;
+import io.dropwizard.metrics.Snapshot;
+import io.dropwizard.metrics.Timer;
+
+public class CollectdReporterTest {
+	private final long timestamp = 1000198;
+	private final Clock clock = mock(Clock.class);
+	private final Collectd collectd = mock(Collectd.class);
+	private final MetricRegistry registry = mock(MetricRegistry.class);
+	private final CollectdReporter reporter = CollectdReporter.forRegistry(registry).withClock(clock)
+			.withPluginInstance("pluginInstance").convertRatesTo(TimeUnit.SECONDS)
+			.convertDurationsTo(TimeUnit.MILLISECONDS).filter(MetricFilter.ALL).build(collectd);
+
+	@Before
+	public void setUp() throws Exception {
+		when(clock.getTime()).thenReturn(timestamp * 1000);
+	}
+
+	@Test
+	public void doesNotReportStringGaugeValues() throws Exception {
+		reporter.report(map("gauge", gauge("value")), this.<Counter> map(), this.<Histogram> map(), this.<Meter> map(),
+				this.<Timer> map());
+
+		final InOrder inOrder = inOrder(collectd);
+		inOrder.verify(collectd).isConnected();
+		inOrder.verify(collectd).connect();
+		inOrder.verify(collectd, never()).send(any(Packet.class));
+		inOrder.verify(collectd).flush();
+
+		verifyNoMoreInteractions(collectd);
+	}
+
+	@Test
+	public void reportsNumericGaugeValues() throws Exception {
+		reporter.report(map("gauge", gauge((byte) 1)), this.<Counter> map(), this.<Histogram> map(), this.<Meter> map(),
+				this.<Timer> map());
+
+		final InOrder inOrder = inOrder(collectd);
+		inOrder.verify(collectd).isConnected();
+		inOrder.verify(collectd).connect();
+		inOrder.verify(collectd).send(any(Packet.class));
+		inOrder.verify(collectd).flush();
+
+		verifyNoMoreInteractions(collectd);
+	}
+
+	@Test
+	public void reportsCounters() throws Exception {
+		final Counter counter = mock(Counter.class);
+		when(counter.getCount()).thenReturn(100L);
+
+		reporter.report(this.<Gauge> map(), this.<Counter> map("counter", counter), this.<Histogram> map(),
+				this.<Meter> map(), this.<Timer> map());
+
+		final InOrder inOrder = inOrder(collectd);
+		inOrder.verify(collectd).isConnected();
+		inOrder.verify(collectd).connect();
+		inOrder.verify(collectd).send(any(Packet.class));
+		inOrder.verify(collectd).flush();
+
+		verifyNoMoreInteractions(collectd);
+	}
+
+	@Test
+	public void reportsHistograms() throws Exception {
+		final Histogram histogram = mock(Histogram.class);
+		when(histogram.getCount()).thenReturn(1L);
+
+		final Snapshot snapshot = mock(Snapshot.class);
+		when(snapshot.getMax()).thenReturn(2L);
+		when(snapshot.getMean()).thenReturn(3.0);
+		when(snapshot.getMin()).thenReturn(4L);
+		when(snapshot.getStdDev()).thenReturn(5.0);
+		when(snapshot.getMedian()).thenReturn(6.0);
+		when(snapshot.get75thPercentile()).thenReturn(7.0);
+		when(snapshot.get95thPercentile()).thenReturn(8.0);
+		when(snapshot.get98thPercentile()).thenReturn(9.0);
+		when(snapshot.get99thPercentile()).thenReturn(10.0);
+		when(snapshot.get999thPercentile()).thenReturn(11.0);
+
+		when(histogram.getSnapshot()).thenReturn(snapshot);
+
+		reporter.report(this.<Gauge> map(), this.<Counter> map(), this.<Histogram> map("histogram", histogram),
+				this.<Meter> map(), this.<Timer> map());
+
+		final InOrder inOrder = inOrder(collectd);
+		inOrder.verify(collectd).isConnected();
+		inOrder.verify(collectd).connect();
+		inOrder.verify(collectd).send(any(Packet.class));
+		inOrder.verify(collectd).flush();
+
+		verifyNoMoreInteractions(collectd);
+	}
+
+	@Test
+	public void reportsMeters() throws Exception {
+		final Meter meter = mock(Meter.class);
+		when(meter.getCount()).thenReturn(1L);
+		when(meter.getOneMinuteRate()).thenReturn(2.0);
+		when(meter.getFiveMinuteRate()).thenReturn(3.0);
+		when(meter.getFifteenMinuteRate()).thenReturn(4.0);
+		when(meter.getMeanRate()).thenReturn(5.0);
+
+		reporter.report(this.<Gauge> map(), this.<Counter> map(), this.<Histogram> map(),
+				this.<Meter> map("meter", meter), this.<Timer> map());
+
+		final InOrder inOrder = inOrder(collectd);
+		inOrder.verify(collectd).isConnected();
+		inOrder.verify(collectd).connect();
+		inOrder.verify(collectd).send(any(Packet.class));
+		inOrder.verify(collectd).flush();
+
+		verifyNoMoreInteractions(collectd);
+	}
+
+	@Test
+	public void reportsTimers() throws Exception {
+		final Timer timer = mock(Timer.class);
+		when(timer.getCount()).thenReturn(1L);
+		when(timer.getMeanRate()).thenReturn(2.0);
+		when(timer.getOneMinuteRate()).thenReturn(3.0);
+		when(timer.getFiveMinuteRate()).thenReturn(4.0);
+		when(timer.getFifteenMinuteRate()).thenReturn(5.0);
+
+		final Snapshot snapshot = mock(Snapshot.class);
+		when(snapshot.getMax()).thenReturn(TimeUnit.MILLISECONDS.toNanos(100));
+		when(snapshot.getMean()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(200));
+		when(snapshot.getMin()).thenReturn(TimeUnit.MILLISECONDS.toNanos(300));
+		when(snapshot.getStdDev()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(400));
+		when(snapshot.getMedian()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(500));
+		when(snapshot.get75thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(600));
+		when(snapshot.get95thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(700));
+		when(snapshot.get98thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(800));
+		when(snapshot.get99thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(900));
+		when(snapshot.get999thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(1000));
+
+		when(timer.getSnapshot()).thenReturn(snapshot);
+
+		reporter.report(this.<Gauge> map(), this.<Counter> map(), this.<Histogram> map(), this.<Meter> map(),
+				map("timer", timer));
+
+		final InOrder inOrder = inOrder(collectd);
+		inOrder.verify(collectd).isConnected();
+		inOrder.verify(collectd).connect();
+		inOrder.verify(collectd, times(2)).send(any(Packet.class));
+		inOrder.verify(collectd).flush();
+
+		verifyNoMoreInteractions(collectd);
+	}
+
+	@Test
+	public void closesConnectionIfCollectdIsUnavailable() throws Exception {
+		doThrow(new UnknownHostException("UNKNOWN-HOST")).when(collectd).connect();
+		reporter.report(map("gauge", gauge(1)), this.<Counter> map(), this.<Histogram> map(), this.<Meter> map(),
+				this.<Timer> map());
+
+		final InOrder inOrder = inOrder(collectd);
+		inOrder.verify(collectd).isConnected();
+		inOrder.verify(collectd).connect();
+		inOrder.verify(collectd).close();
+
+		verifyNoMoreInteractions(collectd);
+	}
+
+	@Test
+	public void closesConnectionIfAnUnexpectedExceptionOccurs() throws Exception {
+		final Gauge gauge = mock(Gauge.class);
+		when(gauge.getValue()).thenThrow(new RuntimeException("kaboom"));
+
+		reporter.report(map("gauge", gauge), this.<Counter> map(), this.<Histogram> map(), this.<Meter> map(),
+				this.<Timer> map());
+
+		final InOrder inOrder = inOrder(collectd);
+		inOrder.verify(collectd).isConnected();
+		inOrder.verify(collectd).connect();
+		inOrder.verify(collectd).close();
+
+		verifyNoMoreInteractions(collectd);
+	}
+
+	@Test
+	public void closesConnectionOnReporterStop() throws Exception {
+		reporter.stop();
+
+		verify(collectd).close();
+
+		verifyNoMoreInteractions(collectd);
+	}
+
+	private <T> SortedMap<MetricName, T> map() {
+		return new TreeMap<MetricName, T>();
+	}
+
+	private <T> SortedMap<MetricName, T> map(final String name, final T metric) {
+		final TreeMap<MetricName, T> map = new TreeMap<MetricName, T>();
+		map.put(MetricName.build(name), metric);
+		return map;
+	}
+
+	private <T> Gauge gauge(final T value) {
+		final Gauge gauge = mock(Gauge.class);
+		when(gauge.getValue()).thenReturn(value);
+		return gauge;
+	}
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/CollectdTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/CollectdTest.java
@@ -1,0 +1,100 @@
+package io.dropwizard.metrics.collectd;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.failBecauseExceptionWasNotThrown;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.Test;
+
+import io.dropwizard.metrics.collectd.part.Time;
+
+public class CollectdTest {
+
+	@Test
+	public void opensADatagramChannel() throws Exception {
+		try (final Collectd collectd = new Collectd()) {
+			collectd.connect();
+
+			assertThat(collectd.isConnected(), is(true));
+		}
+	}
+
+	@Test
+	public void disconnectsFromCollectd() throws Exception {
+		try (final Collectd collectd = new Collectd()) {
+			collectd.connect();
+
+			collectd.close();
+
+			assertThat(collectd.isConnected(), is(false));
+		}
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void doesNotAllowDoubleConnections() throws Exception {
+		try (final Collectd collectd = new Collectd()) {
+			collectd.connect();
+			collectd.connect();
+		}
+	}
+
+	@Test(timeout = 500)
+	public void writesValuesToCollectd() throws Exception {
+		final CountDownLatch bindingLatch = new CountDownLatch(1);
+		final CountDownLatch receivedLatch = new CountDownLatch(1);
+		final AtomicReference<InetSocketAddress> addr = new AtomicReference<>();
+		final Packet packet = new Packet(asList(new Time((int) (System.currentTimeMillis() / 1000))));
+		final ByteBuffer buf = ByteBuffer.allocate(packet.getLength());
+		buf.clear();
+		Executors.newSingleThreadExecutor().submit(new Runnable() {
+			@Override
+			public void run() {
+				DatagramChannel channel;
+				try {
+					channel = DatagramChannel.open();
+					channel.socket().bind(null);
+					addr.set((InetSocketAddress) channel.socket().getLocalSocketAddress());
+					bindingLatch.countDown();
+					channel.receive(buf);
+					receivedLatch.countDown();
+				} catch (final IOException e) {
+					throw new RuntimeException(e);
+				}
+			}
+		});
+		bindingLatch.await();
+
+		final Collectd collectd = new Collectd(addr.get());
+		collectd.connect();
+		collectd.send(packet);
+		collectd.flush();
+		collectd.close();
+		receivedLatch.await();
+
+		assertThat(buf.array()).isEqualTo(packet.build().array());
+	}
+
+	@Test
+	public void notifiesIfCollectdIsUnavailable() throws Exception {
+		final String unavailableHost = "unknown-host-10el6m7yg56ge7dm.com";
+		final InetSocketAddress unavailableAddress = new InetSocketAddress(unavailableHost, 1234);
+
+		try (final Collectd unavailableCollectd = new Collectd(unavailableAddress)) {
+			unavailableCollectd.connect();
+			failBecauseExceptionWasNotThrown(UnknownHostException.class);
+		} catch (final Exception e) {
+			assertThat(e.getMessage()).isEqualTo(unavailableHost);
+		}
+	}
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/DatagramChannelFactoryTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/DatagramChannelFactoryTest.java
@@ -1,0 +1,24 @@
+package io.dropwizard.metrics.collectd;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
+import java.io.IOException;
+import java.nio.channels.DatagramChannel;
+
+import org.junit.Test;
+
+public class DatagramChannelFactoryTest {
+
+	@Test
+	public void shouldOpenANewChannel() throws IOException {
+		try (DatagramChannel channel1 = DatagramChannelFactory.getDefault().openDatagramChannel()) {
+			assertThat(channel1.isOpen(), is(true));
+			try (DatagramChannel channel2 = DatagramChannelFactory.getDefault().openDatagramChannel()) {
+				assertThat(channel2.isOpen(), is(true));
+				assertThat(channel1, is(not(channel2)));
+			}
+		}
+	}
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/PacketTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/PacketTest.java
@@ -1,0 +1,47 @@
+package io.dropwizard.metrics.collectd;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.dropwizard.metrics.collectd.part.Host;
+import io.dropwizard.metrics.collectd.part.Interval;
+import io.dropwizard.metrics.collectd.part.NumericPart;
+import io.dropwizard.metrics.collectd.part.StringPart;
+
+public class PacketTest {
+
+	private Packet packet;
+	private StringPart stringPart;
+	private NumericPart numericPart;
+
+	@Before
+	public void setUp() {
+		stringPart = new Host(UUID.randomUUID().toString(), Charset.forName("UTF-8"));
+		numericPart = new Interval(System.nanoTime());
+		packet = new Packet(asList(stringPart, numericPart));
+	}
+
+	@Test
+	public void shouldSumTheLengthsOfItsConstituentParts() {
+		assertThat(packet.getLength(), is(stringPart.getLength() + numericPart.getLength()));
+	}
+
+	@Test
+	public void shouldConcatenateItsPartsTogether() {
+		final byte[] expected = new byte[stringPart.getLength() + numericPart.getLength()];
+		final ByteBuffer bb = ByteBuffer.wrap(expected);
+		stringPart.appendTo(bb);
+		numericPart.appendTo(bb);
+
+		assertThat(packet.build().array(), is(expected));
+	}
+
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/HostTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/HostTest.java
@@ -1,0 +1,17 @@
+package io.dropwizard.metrics.collectd.part;
+
+import java.nio.charset.Charset;
+
+public class HostTest extends StringPartTest<Host> {
+
+	@Override
+	protected Host createPart(final String initialMetric, final Charset charset) {
+		return new Host(initialMetric, charset);
+	}
+
+	@Override
+	protected PartType getExpectedPartType() {
+		return PartType.HOST;
+	}
+
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/IntervalHiResTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/IntervalHiResTest.java
@@ -1,0 +1,13 @@
+package io.dropwizard.metrics.collectd.part;
+
+public class IntervalHiResTest extends NumericPartTest<IntervalHiRes> {
+	@Override
+	protected IntervalHiRes createPart(final long initialMetric) {
+		return new IntervalHiRes(initialMetric);
+	}
+
+	@Override
+	protected PartType getExpectedPartType() {
+		return PartType.INTERVAL_HR;
+	}
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/IntervalTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/IntervalTest.java
@@ -1,0 +1,13 @@
+package io.dropwizard.metrics.collectd.part;
+
+public class IntervalTest extends NumericPartTest<Interval> {
+	@Override
+	protected Interval createPart(final long initialMetric) {
+		return new Interval(initialMetric);
+	}
+
+	@Override
+	protected PartType getExpectedPartType() {
+		return PartType.INTERVAL;
+	}
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/MessageTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/MessageTest.java
@@ -1,0 +1,15 @@
+package io.dropwizard.metrics.collectd.part;
+
+import java.nio.charset.Charset;
+
+public class MessageTest extends StringPartTest<Message> {
+	@Override
+	protected Message createPart(final String initialMetric, final Charset charset) {
+		return new Message(initialMetric, charset);
+	}
+
+	@Override
+	protected PartType getExpectedPartType() {
+		return PartType.MESSAGE;
+	}
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/NumericPartTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/NumericPartTest.java
@@ -1,0 +1,67 @@
+package io.dropwizard.metrics.collectd.part;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public abstract class NumericPartTest<N extends NumericPart> extends PartTest<N> {
+
+	private static final short EXPECTED_LENGTH = 12;
+	private long initialMetric;
+
+	private ByteBuffer buf;
+
+	@Before
+	public void createBuffer() {
+		buf = ByteBuffer.allocate(EXPECTED_LENGTH);
+	}
+
+	@Test
+	public void shouldHaveAFixedLength() {
+		assertThat(part.getLength(), is(EXPECTED_LENGTH));
+	}
+
+	@Test
+	public void shouldAppendAValueOfTheRightLength() {
+		part.appendTo(buf);
+
+		assertThat(buf.position(), is((int) EXPECTED_LENGTH));
+	}
+
+	@Test
+	public void shouldAppendAHeader() {
+		part.appendTo(buf);
+
+		final byte[] actual = buf.array();
+		final short code = part.getType().getPartTypeCode();
+		assertThat(actual[0], is((byte) ((code & 0xFF00) >>> 8)));
+		assertThat(actual[1], is((byte) (code & 0x00FF)));
+		assertThat(actual[2], is((byte) ((EXPECTED_LENGTH & 0xFF00) >>> 8)));
+		assertThat(actual[3], is((byte) (EXPECTED_LENGTH & 0x00FF)));
+	}
+
+	@Test
+	public void shouldAppendTheValue() {
+		final byte[] expected = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(initialMetric).array();
+
+		part.appendTo(buf);
+
+		final byte[] actual = new byte[8];
+		System.arraycopy(buf.array(), 4, actual, 0, actual.length);
+
+		assertThat(actual, is(expected));
+	}
+
+	@Override
+	protected final N createPart() {
+		initialMetric = System.nanoTime();
+		return createPart(initialMetric);
+	}
+
+	protected abstract N createPart(long initialMetric);
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/PartTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/PartTest.java
@@ -1,0 +1,28 @@
+package io.dropwizard.metrics.collectd.part;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.dropwizard.metrics.collectd.Part;
+
+public abstract class PartTest<P extends Part> {
+
+	protected P part;
+
+	@Before
+	public void setUp() {
+		part = createPart();
+	}
+
+	@Test
+	public void shouldHaveAPartType() {
+		assertThat(part.getType(), is(getExpectedPartType()));
+	}
+
+	protected abstract P createPart();
+
+	protected abstract PartType getExpectedPartType();
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/PluginInstanceTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/PluginInstanceTest.java
@@ -1,0 +1,17 @@
+package io.dropwizard.metrics.collectd.part;
+
+import java.nio.charset.Charset;
+
+public class PluginInstanceTest extends StringPartTest<PluginInstance> {
+
+	@Override
+	protected PluginInstance createPart(final String initialMetric, final Charset charset) {
+		return new PluginInstance(initialMetric, charset);
+	}
+
+	@Override
+	protected PartType getExpectedPartType() {
+		return PartType.PLUGIN_INSTANCE;
+	}
+
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/PluginTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/PluginTest.java
@@ -1,0 +1,17 @@
+package io.dropwizard.metrics.collectd.part;
+
+import java.nio.charset.Charset;
+
+public class PluginTest extends StringPartTest<Plugin> {
+
+	@Override
+	protected Plugin createPart(final String initialMetric, final Charset charset) {
+		return new Plugin(initialMetric, charset);
+	}
+
+	@Override
+	protected PartType getExpectedPartType() {
+		return PartType.PLUGIN;
+	}
+
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/SeverityTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/SeverityTest.java
@@ -1,0 +1,13 @@
+package io.dropwizard.metrics.collectd.part;
+
+public class SeverityTest extends NumericPartTest<Severity> {
+	@Override
+	protected Severity createPart(final long initialMetric) {
+		return new Severity(initialMetric);
+	}
+
+	@Override
+	protected PartType getExpectedPartType() {
+		return PartType.SEVERITY;
+	}
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/StringPartTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/StringPartTest.java
@@ -1,0 +1,85 @@
+package io.dropwizard.metrics.collectd.part;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.Charset;
+import java.util.UUID;
+
+import org.junit.Test;
+
+public abstract class StringPartTest<S extends StringPart> extends PartTest<S> {
+
+	private static final Charset CHARSET = Charset.forName("UTF-8");
+	private String initialMetric;
+
+	private short getExpectedLength() {
+		return (short) (4 + getValueLength() + 1);
+	}
+
+	private int getValueLength() {
+		return initialMetric.getBytes(CHARSET).length;
+	}
+
+	@Test
+	public void shouldCalculateLength() {
+		assertThat(part.getLength(), is(getExpectedLength()));
+	}
+
+	@Test
+	public void shouldAppendAValueOfTheRightLength() {
+		final ByteBuffer buf = ByteBuffer.allocate(getExpectedLength());
+
+		part.appendTo(buf);
+
+		assertThat(buf.remaining(), is(0));
+	}
+
+	@Test
+	public void shouldAppendAHeader() {
+		final ByteBuffer buf = ByteBuffer.allocate(getExpectedLength());
+
+		part.appendTo(buf);
+
+		final byte[] actual = buf.array();
+		final short code = part.getType().getPartTypeCode();
+		assertThat(actual[0], is((byte) ((code & 0xFF00) >>> 8)));
+		assertThat(actual[1], is((byte) (code & 0x00FF)));
+		assertThat(actual[2], is((byte) ((getExpectedLength() & 0xFF00) >>> 8)));
+		assertThat(actual[3], is((byte) (getExpectedLength() & 0x00FF)));
+	}
+
+	@Test
+	public void shouldNullTerminateTheString() {
+		final ByteBuffer buf = ByteBuffer.allocate(getExpectedLength());
+
+		part.appendTo(buf);
+
+		final byte[] actual = buf.array();
+		assertThat(actual[getExpectedLength() - 1], is("\0".getBytes(CHARSET)[0]));
+	}
+
+	@Test
+	public void shouldAppendTheValue() {
+		final ByteBuffer buf = ByteBuffer.allocate(getExpectedLength());
+		final byte[] expected = ByteBuffer.allocate(getValueLength()).order(ByteOrder.BIG_ENDIAN)
+				.put(initialMetric.getBytes(CHARSET)).array();
+
+		part.appendTo(buf);
+
+		final byte[] actual = new byte[getValueLength()];
+		System.arraycopy(buf.array(), 4, actual, 0, actual.length);
+
+		assertThat(actual, is(expected));
+	}
+
+	@Override
+	protected final S createPart() {
+		initialMetric = UUID.randomUUID().toString();
+		return createPart(initialMetric, CHARSET);
+	}
+
+	protected abstract S createPart(String initialMetric, Charset charset);
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/TimeHiResTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/TimeHiResTest.java
@@ -1,0 +1,13 @@
+package io.dropwizard.metrics.collectd.part;
+
+public class TimeHiResTest extends NumericPartTest<TimeHiRes> {
+	@Override
+	protected TimeHiRes createPart(final long initialMetric) {
+		return new TimeHiRes(initialMetric);
+	}
+
+	@Override
+	protected PartType getExpectedPartType() {
+		return PartType.TIME_HR;
+	}
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/TimeTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/TimeTest.java
@@ -1,0 +1,13 @@
+package io.dropwizard.metrics.collectd.part;
+
+public class TimeTest extends NumericPartTest<Time> {
+	@Override
+	protected Time createPart(final long initialMetric) {
+		return new Time(initialMetric);
+	}
+
+	@Override
+	protected PartType getExpectedPartType() {
+		return PartType.TIME;
+	}
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/TypeInstanceTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/TypeInstanceTest.java
@@ -1,0 +1,17 @@
+package io.dropwizard.metrics.collectd.part;
+
+import java.nio.charset.Charset;
+
+public class TypeInstanceTest extends StringPartTest<TypeInstance> {
+
+	@Override
+	protected TypeInstance createPart(final String initialMetric, final Charset charset) {
+		return new TypeInstance(initialMetric, charset);
+	}
+
+	@Override
+	protected PartType getExpectedPartType() {
+		return PartType.TYPE_INSTANCE;
+	}
+
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/TypeTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/TypeTest.java
@@ -1,0 +1,17 @@
+package io.dropwizard.metrics.collectd.part;
+
+import java.nio.charset.Charset;
+
+public class TypeTest extends StringPartTest<Type> {
+
+	@Override
+	protected Type createPart(final String initialMetric, final Charset charset) {
+		return new Type(initialMetric, charset);
+	}
+
+	@Override
+	protected PartType getExpectedPartType() {
+		return PartType.TYPE;
+	}
+
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/ValuesTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/ValuesTest.java
@@ -96,7 +96,7 @@ public class ValuesTest extends PartTest<Values> {
 
 		final byte[] actual = buf.array();
 		for (int i = 0; i < values.size(); i++) {
-			final byte[] expected = values.get(i).getValue();
+			final byte[] expected = values.get(i).getValue().array();
 			for (int j = 0, k = 6 + values.size() + i * 8; j < expected.length; j++, k++) {
 				assertThat(actual[k], is(expected[j]));
 			}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/ValuesTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/part/ValuesTest.java
@@ -1,0 +1,105 @@
+package io.dropwizard.metrics.collectd.part;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import org.junit.Test;
+
+import io.dropwizard.metrics.collectd.Value;
+import io.dropwizard.metrics.collectd.value.Absolute;
+import io.dropwizard.metrics.collectd.value.Counter;
+import io.dropwizard.metrics.collectd.value.Derive;
+import io.dropwizard.metrics.collectd.value.Gauge;
+
+public class ValuesTest extends PartTest<Values> {
+
+	private List<Value> values;
+	private Absolute absolute;
+	private Counter counter;
+	private Derive derive;
+	private Gauge gauge;
+
+	@Override
+	protected Values createPart() {
+		absolute = new Absolute(System.nanoTime());
+		counter = new Counter(System.nanoTime());
+		derive = new Derive(System.nanoTime());
+		gauge = new Gauge(Math.PI);
+		values = asList(absolute, counter, derive, gauge);
+		return new Values(values);
+	}
+
+	@Override
+	protected PartType getExpectedPartType() {
+		return PartType.VALUES;
+	}
+
+	private int getExpectedValuesLength() {
+		return 2 + values.size() * 9;
+	}
+
+	private short getExpectedLength() {
+		return (short) (4 + getExpectedValuesLength());
+	}
+
+	@Test
+	public void shouldCalculateLength() {
+		assertThat(part.getLength(), is(getExpectedLength()));
+	}
+
+	@Test
+	public void shouldAppendAValueOfTheRightLength() {
+		final ByteBuffer buf = ByteBuffer.allocate(getExpectedLength());
+
+		part.appendTo(buf);
+
+		assertThat(buf.remaining(), is(0));
+	}
+
+	@Test
+	public void shouldAppendAHeader() {
+		final ByteBuffer buf = ByteBuffer.allocate(getExpectedLength());
+
+		part.appendTo(buf);
+
+		final byte[] actual = buf.array();
+		final short code = part.getType().getPartTypeCode();
+		assertThat(actual[0], is((byte) ((code & 0xFF00) >>> 8)));
+		assertThat(actual[1], is((byte) (code & 0x00FF)));
+		assertThat(actual[2], is((byte) ((getExpectedLength() & 0xFF00) >>> 8)));
+		assertThat(actual[3], is((byte) (getExpectedLength() & 0x00FF)));
+		assertThat(actual[4], is((byte) ((values.size() & 0xFF00) >>> 8)));
+		assertThat(actual[5], is((byte) (values.size() & 0x00FF)));
+	}
+
+	@Test
+	public void shouldAppendTypesFirst() {
+		final ByteBuffer buf = ByteBuffer.allocate(getExpectedLength());
+
+		part.appendTo(buf);
+
+		final byte[] actual = buf.array();
+		for (int i = 0; i < values.size(); i++) {
+			assertThat(actual[i + 6], is(values.get(i).getDataType().getCode()));
+		}
+	}
+
+	@Test
+	public void shouldAppendValuesAfterTypes() {
+		final ByteBuffer buf = ByteBuffer.allocate(getExpectedLength());
+
+		part.appendTo(buf);
+
+		final byte[] actual = buf.array();
+		for (int i = 0; i < values.size(); i++) {
+			final byte[] expected = values.get(i).getValue();
+			for (int j = 0, k = 6 + values.size() + i * 8; j < expected.length; j++, k++) {
+				assertThat(actual[k], is(expected[j]));
+			}
+		}
+	}
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/AbsoluteTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/AbsoluteTest.java
@@ -1,0 +1,15 @@
+package io.dropwizard.metrics.collectd.value;
+
+public class AbsoluteTest extends LongValueTest<Absolute> {
+
+	@Override
+	protected Absolute createValue(final long initialMetric) {
+		return new Absolute(initialMetric);
+	}
+
+	@Override
+	protected DataType getExpectedDataType() {
+		return DataType.ABSOLUTE;
+	}
+
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/CounterTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/CounterTest.java
@@ -1,0 +1,15 @@
+package io.dropwizard.metrics.collectd.value;
+
+public class CounterTest extends LongValueTest<Counter> {
+
+	@Override
+	protected Counter createValue(final long initialMetric) {
+		return new Counter(initialMetric);
+	}
+
+	@Override
+	protected DataType getExpectedDataType() {
+		return DataType.COUNTER;
+	}
+
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/DeriveTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/DeriveTest.java
@@ -1,0 +1,15 @@
+package io.dropwizard.metrics.collectd.value;
+
+public class DeriveTest extends LongValueTest<Derive> {
+
+	@Override
+	protected Derive createValue(final long initialMetric) {
+		return new Derive(initialMetric);
+	}
+
+	@Override
+	protected DataType getExpectedDataType() {
+		return DataType.DERIVE;
+	}
+
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/DoubleValueTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/DoubleValueTest.java
@@ -15,7 +15,7 @@ public abstract class DoubleValueTest<D extends DoubleValue> extends ValueTest<D
 	@Test
 	public void shouldEncodeTheInitialValueAsBytes() {
 		assertThat(value.getValue(),
-				is(ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putDouble(initialMetric).array()));
+				is(ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putDouble(initialMetric)));
 	}
 
 	@Override

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/DoubleValueTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/DoubleValueTest.java
@@ -1,0 +1,28 @@
+package io.dropwizard.metrics.collectd.value;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.Test;
+
+public abstract class DoubleValueTest<D extends DoubleValue> extends ValueTest<D> {
+
+	private double initialMetric;
+
+	@Test
+	public void shouldEncodeTheInitialValueAsBytes() {
+		assertThat(value.getValue(),
+				is(ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putDouble(initialMetric).array()));
+	}
+
+	@Override
+	protected final D createValue() {
+		initialMetric = Math.PI;
+		return createValue(initialMetric);
+	}
+
+	protected abstract D createValue(double initialMetric);
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/GaugeTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/GaugeTest.java
@@ -1,0 +1,15 @@
+package io.dropwizard.metrics.collectd.value;
+
+public class GaugeTest extends DoubleValueTest<Gauge> {
+
+	@Override
+	protected Gauge createValue(final double initialMetric) {
+		return new Gauge(initialMetric);
+	}
+
+	@Override
+	protected DataType getExpectedDataType() {
+		return DataType.GAUGE;
+	}
+
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/LongValueTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/LongValueTest.java
@@ -1,0 +1,28 @@
+package io.dropwizard.metrics.collectd.value;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import org.junit.Test;
+
+public abstract class LongValueTest<L extends LongValue> extends ValueTest<L> {
+
+	private long initialMetric;
+
+	@Test
+	public void shouldEncodeTheInitialValueAsBytes() {
+		assertThat(value.getValue(),
+				is(ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(initialMetric).array()));
+	}
+
+	@Override
+	protected final L createValue() {
+		initialMetric = System.nanoTime();
+		return createValue(initialMetric);
+	}
+
+	protected abstract L createValue(long initialMetric);
+}

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/LongValueTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/LongValueTest.java
@@ -14,8 +14,7 @@ public abstract class LongValueTest<L extends LongValue> extends ValueTest<L> {
 
 	@Test
 	public void shouldEncodeTheInitialValueAsBytes() {
-		assertThat(value.getValue(),
-				is(ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(initialMetric).array()));
+		assertThat(value.getValue(), is(ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(initialMetric)));
 	}
 
 	@Override

--- a/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/ValueTest.java
+++ b/metrics-collectd/src/test/java/io/dropwizard/metrics/collectd/value/ValueTest.java
@@ -1,0 +1,28 @@
+package io.dropwizard.metrics.collectd.value;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.dropwizard.metrics.collectd.Value;
+
+public abstract class ValueTest<V extends Value> {
+
+	protected V value;
+
+	@Before
+	public void setUp() {
+		value = createValue();
+	}
+
+	@Test
+	public void shouldHaveADataType() {
+		assertThat(value.getDataType(), is(getExpectedDataType()));
+	}
+
+	protected abstract DataType getExpectedDataType();
+
+	protected abstract V createValue();
+}

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <module>metrics-logback</module>
         <module>metrics-servlet</module>
         <module>metrics-servlets</module>
+        <module>metrics-collectd</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This is a pull request for adding a new metrics reporter that uses the collectd binary protocol over UDP (https://github.com/dropwizard/metrics/issues/853).
I have been in a situation where I funnel many of my application and reporting metrics through a 3rd-party tool (which has an input codec for collectd over UDP along with a bunch of other protocols), and there appears to be a conflict between the UDP listener that gathers collectd data from the standard collectd plugins and both the listener for metrics logs or the graphite listener that pulls in metrics data from the graphite reporter.
This collectd reporter is an attempt to put metrics data and collectd data on even footing when it is pulled into a 3rd-party tool.
Perhaps someone else will find it useful as well.