### PR TITLE
#859 fix inherited timed annotation

### DIFF
--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
@@ -6,7 +6,6 @@ import com.codahale.metrics.Timer;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
-
 import org.glassfish.jersey.server.model.Invocable;
 import org.glassfish.jersey.server.model.ModelProcessor;
 import org.glassfish.jersey.server.model.Resource;
@@ -16,11 +15,9 @@ import org.glassfish.jersey.server.monitoring.ApplicationEvent;
 import org.glassfish.jersey.server.monitoring.ApplicationEventListener;
 import org.glassfish.jersey.server.monitoring.RequestEvent;
 import org.glassfish.jersey.server.monitoring.RequestEventListener;
-import org.omg.CORBA.DefinitionKind;
 
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.ext.Provider;
-
 import java.lang.reflect.Method;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
@@ -3,7 +3,10 @@ package com.codahale.metrics.jersey2;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.codahale.metrics.jersey2.resources.InstrumentedChildResource;
+import com.codahale.metrics.jersey2.resources.InstrumentedParentResource;
 import com.codahale.metrics.jersey2.resources.InstrumentedResource;
+import com.codahale.metrics.jersey2.resources.InstrumentedSecondChildResource;
 import com.codahale.metrics.jersey2.resources.InstrumentedSubResource;
 import org.glassfish.jersey.client.ClientResponse;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -41,6 +44,8 @@ public class SingletonMetricsJerseyTest extends JerseyTest {
         ResourceConfig config = new ResourceConfig();
         config = config.register(new MetricsFeature(this.registry));
         config = config.register(InstrumentedResource.class);
+        config = config.register(InstrumentedChildResource.class);
+        config = config.register(InstrumentedSecondChildResource.class);
 
         return config;
     }
@@ -53,6 +58,18 @@ public class SingletonMetricsJerseyTest extends JerseyTest {
                 .isEqualTo("yay");
 
         final Timer timer = registry.timer(name(InstrumentedResource.class, "timed"));
+
+        assertThat(timer.getCount()).isEqualTo(1);
+    }
+    
+    @Test
+    public void childTimedMethodsAreTimed() {
+        assertThat(target("/child/timed")
+                .request()
+                .get(String.class))
+                .isEqualTo("yay");
+
+        final Timer timer = registry.timer(name(InstrumentedParentResource.class, "timed"));
 
         assertThat(timer.getCount()).isEqualTo(1);
     }

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedChildResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedChildResource.java
@@ -1,0 +1,7 @@
+package com.codahale.metrics.jersey2.resources;
+
+import javax.ws.rs.Path;
+
+@Path("/child")
+public class InstrumentedChildResource extends InstrumentedParentResource {
+}

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedParentResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedParentResource.java
@@ -6,12 +6,11 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 
 @Produces(MediaType.TEXT_PLAIN)
-public class InstrumentedSubResource {
+public class InstrumentedParentResource {
     @GET
     @Timed
     @Path("/timed")
     public String timed() {
         return "yay";
     }
-
 }

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
@@ -19,6 +19,20 @@ public class InstrumentedResource {
     }
 
     @GET
+    @Timed(absolute = true, name = "absoluteTimed")
+    @Path("/timed/absolute")
+    public String timedAbsolute() {
+        return "yay";
+    }
+
+    @GET
+    @Timed(name="namedTimed")
+    @Path("/timed/named")
+    public String timedNamed() {
+        return "yay";
+    }
+
+    @GET
     @Metered
     @Path("/metered")
     public String metered() {
@@ -26,9 +40,43 @@ public class InstrumentedResource {
     }
 
     @GET
+    @Metered(absolute = true, name = "absoluteMetered")
+    @Path("/metered/absolute")
+    public String meteredAbsolute() {
+        return "woo";
+    }
+
+    @GET
+    @Metered(name = "namedMetered")
+    @Path("/metered/named")
+    public String meteredNamed() {
+        return "woo";
+    }
+
+    @GET
     @ExceptionMetered(cause = IOException.class)
     @Path("/exception-metered")
     public String exceptionMetered(@QueryParam("splode") @DefaultValue("false") boolean splode) throws IOException {
+        if (splode) {
+            throw new IOException("AUGH");
+        }
+        return "fuh";
+    }
+
+    @GET
+    @ExceptionMetered(cause = IOException.class, absolute = true, name = "absoluteExceptionMetered")
+    @Path("/exception-metered/absolute")
+    public String absoluteExceptionMetered(@QueryParam("splode") @DefaultValue("false") boolean splode) throws IOException {
+        if (splode) {
+            throw new IOException("AUGH");
+        }
+        return "fuh";
+    }
+
+    @GET
+    @ExceptionMetered(cause = IOException.class, name = "namedExceptionMeteredOtherName")
+    @Path("/exception-metered/named")
+    public String namedExceptionMetered(@QueryParam("splode") @DefaultValue("false") boolean splode) throws IOException {
         if (splode) {
             throw new IOException("AUGH");
         }

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedSecondChildResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedSecondChildResource.java
@@ -1,0 +1,7 @@
+package com.codahale.metrics.jersey2.resources;
+
+import javax.ws.rs.Path;
+
+@Path("/secondchild")
+public class InstrumentedSecondChildResource extends InstrumentedParentResource {
+}


### PR DESCRIPTION
Suggestion for fixing the the issue #859 that prevented having resources inheriting annotated methods.
Also fixing the support for absolute metric names that apparently was not working properly.
