### PR TITLE
Retry DNS lookups

### DIFF
--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/Graphite.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/Graphite.java
@@ -112,7 +112,12 @@ public class Graphite implements GraphiteSender {
             address = new InetSocketAddress(hostname, port);
         }
         if (address.getAddress() == null) {
-            throw new UnknownHostException(address.getHostName());
+            // retry lookup, just in case the DNS changed
+            address = new InetSocketAddress(address.getHostName(),address.getPort());
+
+            if (address.getAddress() == null) {
+                throw new UnknownHostException(address.getHostName());
+            }
         }
 
         this.socket = socketFactory.createSocket(address.getAddress(), address.getPort());


### PR DESCRIPTION
Do retry DNS lookups, which are just done in the constructor of
InetSocketAddress.

Reason might be that in some environments DNS is very dynamic and thus a name
might be sometimes resolveable and sometimes not. The way this is currently
implemented the InetSocketAddress is always cached, which in itself caches the
return value of the last DNS lookup, even if that failed.