### PR TITLE
Executor did not terminate message to use logger

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/ScheduledReporter.java
@@ -145,7 +145,7 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
                 executor.shutdownNow(); // Cancel currently executing tasks
                 // Wait a while for tasks to respond to being cancelled
                 if (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
-                    System.err.println(getClass().getSimpleName() + ": ScheduledExecutorService did not terminate");
+                    LOG.warn(getClass().getSimpleName() + ": ScheduledExecutorService did not terminate");
                 }
             }
         } catch (InterruptedException ie) {


### PR DESCRIPTION
I noticed this message on the console occasionally and figured it could do to have it under the logger control like the others. 
Setting it at warn since there is not much the user could really do about it.