### PR TITLE
Refactor influxdb reporter to use Apache HttpClient

### DIFF
--- a/metrics-influxdb/pom.xml
+++ b/metrics-influxdb/pom.xml
@@ -30,7 +30,11 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.1</version>
         </dependency>
     </dependencies>
 

--- a/metrics-influxdb/pom.xml
+++ b/metrics-influxdb/pom.xml
@@ -28,6 +28,11 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>
@@ -35,6 +40,12 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/metrics-influxdb/src/main/java/io/dropwizard/metrics/influxdb/InfluxDbHttpSender.java
+++ b/metrics-influxdb/src/main/java/io/dropwizard/metrics/influxdb/InfluxDbHttpSender.java
@@ -42,11 +42,12 @@ public class InfluxDbHttpSender implements InfluxDbSender {
      * @param hostname   the influxDb hostname
      * @param port       the influxDb http port
      * @param database   the influxDb database to write to
-     * @param authString the authorization string to be used to connect to InfluxDb, of format username:password
+     * @param username   the username used to connect to influxDb
+     * @param password   the password used to connect to influxDb
      * @throws Exception exception while creating the influxDb sender(MalformedURLException)
      */
-    public InfluxDbHttpSender(final String hostname, final int port, final String database, final String authString) throws Exception {
-        this(hostname, port, database, authString, TimeUnit.MILLISECONDS);
+    public InfluxDbHttpSender(final String hostname, final int port, final String database, final String username, final String password) throws Exception {
+        this(hostname, port, database, username, password, TimeUnit.MILLISECONDS);
     }
 
     /**
@@ -55,24 +56,17 @@ public class InfluxDbHttpSender implements InfluxDbSender {
      * @param hostname      the influxDb hostname
      * @param port          the influxDb http port
      * @param database      the influxDb database to write to
-     * @param authString    the authorization string to be used to connect to InfluxDb, of format username:password
+     * @param username      the influxDb username
+     * @param password      the influxDb password
      * @param timePrecision the time precision of the metrics
      * @throws Exception exception while creating the influxDb sender(MalformedURLException)
      */
-    public InfluxDbHttpSender(final String hostname, final int port, final String database, final String authString,
+    public InfluxDbHttpSender(final String hostname, final int port, final String database, final String username, final String password,
                               final TimeUnit timePrecision) throws Exception {
         this.url = new URL("http", hostname, port, "/write");
         this.closeableHttpClient = HttpClients.createDefault();
-        //this is a bit ugly - would be nicer to configure "structured", e.g. username/pw as input
-        if (authString != null && !authString.isEmpty()) {
-            String[] parts = authString.split( ":" );
-            this.username = parts[0];
-            this.password = parts[1];
-        } else {
-            this.username = null;
-            this.password = null;
-        }
-
+        this.username = username;
+        this.password = password;
         this.influxDbWriteObject = new InfluxDbWriteObject(database, timePrecision);
         this.influxDbWriteObjectSerializer = new InfluxDbWriteObjectSerializer();
     }

--- a/metrics-influxdb/src/test/java/sandbox/SendToLocalInfluxDB.java
+++ b/metrics-influxdb/src/test/java/sandbox/SendToLocalInfluxDB.java
@@ -57,7 +57,7 @@ public final class SendToLocalInfluxDB {
     }
 
     private static InfluxDbReporter startInfluxDbReporter(MetricRegistry registry) throws Exception {
-        final InfluxDbHttpSender influxDb = new InfluxDbHttpSender("127.0.0.1", 8086, "dropwizard", "root:root");
+        final InfluxDbHttpSender influxDb = new InfluxDbHttpSender("127.0.0.1", 8086, "dropwizard", "root", "root");
         final Map<String, String> tags = new HashMap<>();
         tags.put("host", "localhost");
         final InfluxDbReporter reporter = InfluxDbReporter

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.10</version>
+            </dependency>
+            <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
                 <version>${slf4j.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <version>1.10</version>


### PR DESCRIPTION
A drop-in replacement for the current url-based impl.
However I'd like to "structure" the configuration better, and take username, password parameters instead of an username:pw authstring. WDYT?