### PR TITLE
Remove usage of Unsafe

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics/Striped64.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/Striped64.java
@@ -10,6 +10,7 @@ package io.dropwizard.metrics;
 
 import io.dropwizard.metrics.Striped64;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 // CHECKSTYLE:OFF
 /**
@@ -99,23 +100,10 @@ abstract class Striped64 extends Number {
         }
 
         final boolean cas(long cmp, long val) {
-            return UNSAFE.compareAndSwapLong(this, valueOffset, cmp, val);
+            return valueUpdater.compareAndSet(this, cmp, val);
         }
 
-        // Unsafe mechanics
-        private static final sun.misc.Unsafe UNSAFE;
-        private static final long valueOffset;
-
-        static {
-            try {
-                UNSAFE = getUnsafe();
-                Class<?> ak = Cell.class;
-                valueOffset = UNSAFE.objectFieldOffset
-                        (ak.getDeclaredField("value"));
-            } catch (Exception e) {
-                throw new Error(e);
-            }
-        }
+        private static final AtomicLongFieldUpdater<Cell> valueUpdater = AtomicLongFieldUpdater.newUpdater(Cell.class, "value");
 
     }
 
@@ -142,6 +130,9 @@ abstract class Striped64 extends Number {
             return new HashCode();
         }
     }
+
+    static final AtomicLongFieldUpdater<Striped64> baseUpdater = AtomicLongFieldUpdater.newUpdater(Striped64.class, "base");
+    static final AtomicLongFieldUpdater<Striped64> busyUpdater = AtomicLongFieldUpdater.newUpdater(Striped64.class, "busy");
 
     /**
      * Static per-thread hash codes. Shared across all instances to reduce ThreadLocal pollution and
@@ -180,14 +171,14 @@ abstract class Striped64 extends Number {
      * CASes the base field.
      */
     final boolean casBase(long cmp, long val) {
-        return UNSAFE.compareAndSwapLong(this, baseOffset, cmp, val);
+        return baseUpdater.compareAndSet(this, cmp, val);
     }
 
     /**
      * CASes the busy field from 0 to 1 to acquire lock.
      */
     final boolean casBusy() {
-        return UNSAFE.compareAndSwapInt(this, busyOffset, 0, 1);
+        return busyUpdater.compareAndSet(this, 0, 1);
     }
 
     /**
@@ -303,55 +294,5 @@ abstract class Striped64 extends Number {
         }
     }
 
-    // Unsafe mechanics
-    private static final sun.misc.Unsafe UNSAFE;
-    private static final long baseOffset;
-    private static final long busyOffset;
-
-    static {
-        try {
-            UNSAFE = getUnsafe();
-            Class<?> sk = Striped64.class;
-            baseOffset = UNSAFE.objectFieldOffset
-                    (sk.getDeclaredField("base"));
-            busyOffset = UNSAFE.objectFieldOffset
-                    (sk.getDeclaredField("busy"));
-        } catch (Exception e) {
-            throw new Error(e);
-        }
-    }
-
-    /**
-     * Returns a sun.misc.Unsafe.  Suitable for use in a 3rd party package. Replace with a simple
-     * call to Unsafe.getUnsafe when integrating into a jdk.
-     *
-     * @return a sun.misc.Unsafe
-     */
-    private static sun.misc.Unsafe getUnsafe() {
-        try {
-            return sun.misc.Unsafe.getUnsafe();
-        } catch (SecurityException ignored) {
-
-        }
-        try {
-            return java.security.AccessController.doPrivileged
-                    (new java.security.PrivilegedExceptionAction<sun.misc.Unsafe>() {
-                        @Override
-                        public sun.misc.Unsafe run() throws Exception {
-                            Class<sun.misc.Unsafe> k = sun.misc.Unsafe.class;
-                            for (java.lang.reflect.Field f : k.getDeclaredFields()) {
-                                f.setAccessible(true);
-                                Object x = f.get(null);
-                                if (k.isInstance(x))
-                                    return k.cast(x);
-                            }
-                            throw new NoSuchFieldError("the Unsafe");
-                        }
-                    });
-        } catch (java.security.PrivilegedActionException e) {
-            throw new RuntimeException("Could not initialize intrinsics",
-                                       e.getCause());
-        }
-    }
 }
 // CHECKSTYLE:ON

--- a/metrics-core/src/main/java/io/dropwizard/metrics/Striped64.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/Striped64.java
@@ -10,6 +10,7 @@ package io.dropwizard.metrics;
 
 import io.dropwizard.metrics.Striped64;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 // CHECKSTYLE:OFF
@@ -132,7 +133,7 @@ abstract class Striped64 extends Number {
     }
 
     static final AtomicLongFieldUpdater<Striped64> baseUpdater = AtomicLongFieldUpdater.newUpdater(Striped64.class, "base");
-    static final AtomicLongFieldUpdater<Striped64> busyUpdater = AtomicLongFieldUpdater.newUpdater(Striped64.class, "busy");
+    static final AtomicIntegerFieldUpdater<Striped64> busyUpdater = AtomicIntegerFieldUpdater.newUpdater(Striped64.class, "busy");
 
     /**
      * Static per-thread hash codes. Shared across all instances to reduce ThreadLocal pollution and


### PR DESCRIPTION
Thanks to @ikedahi for making me aware of AtomicLongFieldUpdater.

Seems to be a small-ish performance hit, 92,000,000 ops/s now vs 105,000,000 ops/s before.