### PR TITLE
Allow a pluggable strategy for the name of the CSV files that the CsvReporter uses

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics/CsvFileProvider.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/CsvFileProvider.java
@@ -1,0 +1,12 @@
+package io.dropwizard.metrics;
+
+import java.io.File;
+
+/**
+ * This interface allows a pluggable implementation of what file names
+ * the {@link CsvReporter} will write to.
+ */
+public interface CsvFileProvider
+{
+	File getFile( File directory, MetricName metricName );
+}

--- a/metrics-core/src/main/java/io/dropwizard/metrics/CsvReporter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/CsvReporter.java
@@ -140,7 +140,7 @@ public class CsvReporter extends ScheduledReporter {
     }
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CsvReporter.class);
-    private static final Charset UTF_8 = Charset.forName( "UTF-8" );
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     private final File directory;
     private final Locale locale;
@@ -168,7 +168,7 @@ public class CsvReporter extends ScheduledReporter {
                        SortedMap<MetricName, Histogram> histograms,
                        SortedMap<MetricName, Meter> meters,
                        SortedMap<MetricName, Timer> timers) {
-        final long timestamp = TimeUnit.MILLISECONDS.toSeconds( clock.getTime() );
+        final long timestamp = TimeUnit.MILLISECONDS.toSeconds(clock.getTime());
 
         for (Map.Entry<MetricName, Gauge> entry : gauges.entrySet()) {
             reportGauge(timestamp, entry.getKey(), entry.getValue());
@@ -223,10 +223,10 @@ public class CsvReporter extends ScheduledReporter {
                "count,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit",
                "%d,%f,%f,%f,%f,events/%s",
                meter.getCount(),
-               convertRate( meter.getMeanRate() ),
-               convertRate( meter.getOneMinuteRate() ),
-               convertRate( meter.getFiveMinuteRate() ),
-               convertRate( meter.getFifteenMinuteRate() ),
+               convertRate(meter.getMeanRate()),
+               convertRate(meter.getOneMinuteRate()),
+               convertRate(meter.getFiveMinuteRate()),
+               convertRate(meter.getFifteenMinuteRate()),
                getRateUnit());
     }
 

--- a/metrics-core/src/main/java/io/dropwizard/metrics/FixedNameCsvFileProvider.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/FixedNameCsvFileProvider.java
@@ -1,0 +1,18 @@
+package io.dropwizard.metrics;
+
+import java.io.File;
+
+/**
+ * This implementation of the {@link CsvFileProvider} will always return the same name
+ * for the same metric. This means the CSV file will grow indefinitely.
+ */
+public class FixedNameCsvFileProvider implements CsvFileProvider {
+    @Override
+    public File getFile(File directory, MetricName metricName) {
+        return new File(directory, sanitize(metricName) + ".csv");
+    }
+
+    private String sanitize(MetricName metricName) {
+        return metricName.getKey();
+    }
+}

--- a/metrics-core/src/test/java/io/dropwizard/metrics/FixedNameCsvFileProviderTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/FixedNameCsvFileProviderTest.java
@@ -1,0 +1,30 @@
+package io.dropwizard.metrics;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FixedNameCsvFileProviderTest {
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    private File dataDirectory;
+
+    @Before
+    public void setUp() throws Exception {
+        this.dataDirectory = folder.newFolder();
+    }
+
+    @Test
+    public void testGetFile() {
+        FixedNameCsvFileProvider provider = new FixedNameCsvFileProvider();
+        File file = provider.getFile(dataDirectory, MetricName.build("test"));
+        assertThat(file.getParentFile()).isEqualTo(dataDirectory);
+        assertThat(file.getName()).isEqualTo("test.csv");
+    }
+}


### PR DESCRIPTION
This PR extracts the naming of the CSV file from the CSV reporter itself. This allows users to come up with their own naming strategy. 
Using this code as a base, I have implemented a naming strategy that uses the current date to generate a file per day and allows to keep x days of files. If interested I can also contribute this in a separate pull request.

NOTE: Something went wrong when I tried to [fix my username](https://help.github.com/articles/changing-author-info/) so I had to delete my fork and create a new fork. So https://github.com/dropwizard/metrics/pull/879 is no longer valid. Sorry about that.