### PR TITLE
File per day csvreporter

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics/FilePerDayCsvFileProvider.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/FilePerDayCsvFileProvider.java
@@ -1,0 +1,73 @@
+package io.dropwizard.metrics;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * This implementation of the {@link CsvFileProvider} will create a file
+ * per day for each metric using the format 'metricname-yyyyMMdd.csv'.
+ * It will also automatically delete old files, depending on the 'numberOfDaysToKeep' parameter.
+ */
+public class FilePerDayCsvFileProvider implements CsvFileProvider {
+
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyyMMdd");
+
+    private Clock clock;
+    private int numberOfDaysToKeep;
+
+    public FilePerDayCsvFileProvider(Clock clock, int numberOfDaysToKeep) {
+        this.clock = clock;
+        this.numberOfDaysToKeep = numberOfDaysToKeep;
+    }
+
+    @Override
+    public File getFile(File directory, MetricName metricName) {
+        checkIfOldFilesNeedToBeDeleted(directory, metricName);
+
+        return new File(directory, sanitize(metricName) + "_" + formatDate() + ".csv");
+    }
+
+    private void checkIfOldFilesNeedToBeDeleted(File directory, final MetricName metricName) {
+        Calendar oldestToKeep = Calendar.getInstance();
+        oldestToKeep.setTimeInMillis(clock.getTime());
+        oldestToKeep.add(Calendar.DAY_OF_MONTH, -numberOfDaysToKeep);
+
+        String[] fileNames = directory.list(new FileNamesOfCurrentMetricFilenameFilter(metricName));
+        for (String fileName : fileNames) {
+            try {
+                String day = fileName.substring(fileName.lastIndexOf('_') + 1, fileName.length() - 4);
+                if (DATE_FORMAT.parse(day).before(oldestToKeep.getTime())) {
+                    new File(directory, fileName).delete();
+                }
+            } catch (ParseException e) {
+                e.printStackTrace();
+            }
+        }
+
+    }
+
+    private String formatDate() {
+        return DATE_FORMAT.format(new Date(clock.getTime()));
+    }
+
+    private String sanitize(MetricName metricName) {
+        return metricName.getKey();
+    }
+
+    private class FileNamesOfCurrentMetricFilenameFilter implements FilenameFilter {
+        private final MetricName metricName;
+
+        public FileNamesOfCurrentMetricFilenameFilter(MetricName metricName) {
+            this.metricName = metricName;
+        }
+
+        @Override
+        public boolean accept(File dir, String name) {
+            return name.startsWith(sanitize(metricName));
+        }
+    }
+}

--- a/metrics-core/src/main/java/io/dropwizard/metrics/FilePerDayCsvFileProvider.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/FilePerDayCsvFileProvider.java
@@ -28,6 +28,10 @@ public class FilePerDayCsvFileProvider implements CsvFileProvider {
     private Clock clock;
     private int numberOfDaysToKeep;
 
+    public FilePerDayCsvFileProvider(int numberOfDaysToKeep) {
+        this(Clock.defaultClock(), numberOfDaysToKeep);
+    }
+
     public FilePerDayCsvFileProvider(Clock clock, int numberOfDaysToKeep) {
         this.clock = clock;
         this.numberOfDaysToKeep = numberOfDaysToKeep;

--- a/metrics-core/src/test/java/io/dropwizard/metrics/FilePerDayCsvFileProviderTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/FilePerDayCsvFileProviderTest.java
@@ -1,0 +1,163 @@
+package io.dropwizard.metrics;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.CharBuffer;
+import java.util.Locale;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FilePerDayCsvFileProviderTest
+{
+    private static final int ONE_DAY = 1000 * 60 * 60 * 24;
+
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    private final MetricRegistry registry = mock(MetricRegistry.class);
+    private final Clock clock = mock(Clock.class);
+
+    private File dataDirectory;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        this.dataDirectory = folder.newFolder();
+    }
+
+    @Test
+    public void testGetFile() {
+        FilePerDayCsvFileProvider provider = new FilePerDayCsvFileProvider(clock, 10);
+
+        when(clock.getTime()).thenReturn(1446194864095L);
+        File file = provider.getFile(dataDirectory, MetricName.build( "test" ));
+        assertThat(file.getParentFile()).isEqualTo(dataDirectory);
+        assertThat(file.getName()).isEqualTo("test_20151030.csv");
+
+        when(clock.getTime()).thenReturn(1446194864095L + ONE_DAY);
+        file = provider.getFile(dataDirectory, MetricName.build( "test" ));
+        assertThat(file.getParentFile()).isEqualTo(dataDirectory);
+        assertThat(file.getName()).isEqualTo("test_20151031.csv");
+    }
+
+    @Test
+    public void oldestFilesShouldBeCleanedUp() throws IOException
+    {
+
+        FilePerDayCsvFileProvider fileProvider = new FilePerDayCsvFileProvider(clock, 3);
+        CsvReporter reporter = CsvReporter.forRegistry( registry )
+                .formatFor( Locale.US)
+                .convertRatesTo( TimeUnit.SECONDS)
+                .convertDurationsTo( TimeUnit.MILLISECONDS)
+                .withClock(clock)
+                .filter( MetricFilter.ALL)
+                .withCsvFileProvider(fileProvider)
+                .build(dataDirectory);
+
+
+        when(clock.getTime()).thenReturn(1446194864095L);
+
+        final Gauge gauge = mock(Gauge.class);
+        when(gauge.getValue()).thenReturn(1);
+
+        reporter.report(map("gauge", gauge),
+                this.<Counter>map(),
+                this.<Histogram>map(),
+                this.<Meter>map(),
+                this.<Timer>map());
+
+        assertThat(fileContents("gauge_20151030.csv"))
+                .isEqualTo(csv(
+                        "t,value",
+                        "1446194864,1"
+                ));
+
+        when(clock.getTime()).thenReturn(1446194864095L + ONE_DAY);
+        when(gauge.getValue()).thenReturn(2);
+
+        reporter.report(map("gauge", gauge),
+                this.<Counter>map(),
+                this.<Histogram>map(),
+                this.<Meter>map(),
+                this.<Timer>map());
+        assertThat(fileContents("gauge_20151030.csv"))
+                .isEqualTo(csv(
+                        "t,value",
+                        "1446194864,1"
+                ));
+        assertThat(fileContents("gauge_20151031.csv"))
+                .isEqualTo(csv(
+                        "t,value",
+                        "1446281264,2"
+                ));
+
+        when(clock.getTime()).thenReturn(1446194864095L + (ONE_DAY*3));
+        when(gauge.getValue()).thenReturn(3);
+
+        reporter.report(map("gauge", gauge),
+                this.<Counter>map(),
+                this.<Histogram>map(),
+                this.<Meter>map(),
+                this.<Timer>map());
+
+        assertThat( new File( dataDirectory, "gauge_20151030.csv") ).doesNotExist();
+        assertThat( new File( dataDirectory, "gauge_20151031.csv") ).exists();
+        assertThat(fileContents("gauge_20151102.csv"))
+                .isEqualTo(csv(
+                        "t,value",
+                        "1446454064,3"
+                ));
+
+    }
+
+    private String csv(String... lines) {
+        final StringBuilder builder = new StringBuilder();
+        for (String line : lines) {
+            builder.append(line).append( String.format( "%n" ));
+        }
+        return builder.toString();
+    }
+
+    private String fileContents(String filename) throws IOException
+    {
+        final StringBuilder builder = new StringBuilder();
+        final FileInputStream input = new FileInputStream(new File(dataDirectory, filename));
+        try {
+            final InputStreamReader reader = new InputStreamReader(input);
+            final BufferedReader bufferedReader = new BufferedReader(reader);
+            final CharBuffer buf = CharBuffer.allocate( 1024 );
+            while (bufferedReader.read(buf) != -1) {
+                buf.flip();
+                builder.append(buf);
+                buf.clear();
+            }
+        } finally {
+            input.close();
+        }
+        return builder.toString();
+    }
+
+    private <T> SortedMap<MetricName, T> map() {
+        return new TreeMap<MetricName, T>();
+    }
+
+    private <T> SortedMap<MetricName, T> map(String name, T metric) {
+        final TreeMap<MetricName, T> map = new TreeMap<MetricName, T>();
+        map.put( MetricName.build( name ), metric);
+        return map;
+    }
+
+}


### PR DESCRIPTION
This PR adds a FilePerDayCsvFileProvider which provides a very basic rolling file strategy. It creates a file using the format `metricsname_yyyyMMdd.csv` and allows to specify how many days of metrics should be kept.
