### PR TITLE
Fix metrics httpasyncclient timing master

### DIFF
--- a/metrics-httpasyncclient/src/main/java/io/dropwizard/metrics/httpasyncclient/InstrumentedNHttpClientBuilder.java
+++ b/metrics-httpasyncclient/src/main/java/io/dropwizard/metrics/httpasyncclient/InstrumentedNHttpClientBuilder.java
@@ -68,7 +68,7 @@ public class InstrumentedNHttpClientBuilder extends HttpAsyncClientBuilder {
                 try {
                     timerContext = timer(requestProducer.generateRequest()).time();
                 } catch (IOException | HttpException ex) {
-                    throw new AssertionError(ex);
+                    throw new RuntimeException(ex);
                 }
                 return ac.execute(requestProducer, responseConsumer, context,
                         new TimingFutureCallback<>(callback, timerContext));

--- a/metrics-httpasyncclient/src/test/java/io/dropwizard/metrics/httpasyncclient/HttpClientTestBase.java
+++ b/metrics-httpasyncclient/src/test/java/io/dropwizard/metrics/httpasyncclient/HttpClientTestBase.java
@@ -1,0 +1,81 @@
+package io.dropwizard.metrics.httpasyncclient;
+
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.impl.nio.bootstrap.HttpServer;
+import org.apache.http.impl.nio.bootstrap.ServerBootstrap;
+import org.apache.http.nio.protocol.BasicAsyncRequestHandler;
+import org.apache.http.nio.reactor.ListenerEndpoint;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpRequestHandler;
+import org.junit.After;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.concurrent.TimeUnit;
+
+public abstract class HttpClientTestBase {
+
+    /**
+     * {@link HttpRequestHandler} that responds with a {@code 200 OK}.
+     */
+    public static HttpRequestHandler STATUS_OK = new HttpRequestHandler() {
+        @Override
+        public void handle(HttpRequest request, HttpResponse response, HttpContext context)
+                throws HttpException, IOException {
+            response.setStatusCode(200);
+        }
+    };
+
+    private HttpServer server;
+
+    /**
+     * @return A free local port or {@code -1} on error.
+     */
+    public static int findAvailableLocalPort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            return -1;
+        }
+    }
+
+    /**
+     * Start a local server that uses the {@code handler} to handle requests.
+     * <p>
+     * The server will be (if started) terminated in the {@link #tearDown()} {@link After} method.
+     *
+     * @param handler The request handler that will be used to respond to every request.
+     * @return The {@link HttpHost} of the server
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public HttpHost startServerWithGlobalRequestHandler(HttpRequestHandler handler)
+            throws IOException, InterruptedException {
+        // If there is an existing instance, terminate it
+        tearDown();
+
+        ServerBootstrap serverBootstrap = ServerBootstrap.bootstrap();
+
+        serverBootstrap.registerHandler("/*", new BasicAsyncRequestHandler(handler));
+
+        server = serverBootstrap.create();
+        server.start();
+
+        ListenerEndpoint endpoint = server.getEndpoint();
+        endpoint.waitFor();
+
+        InetSocketAddress address = (InetSocketAddress) endpoint.getAddress();
+        return new HttpHost("localhost", address.getPort(), "http");
+    }
+
+    @After
+    public void tearDown() {
+        if (server != null) {
+            server.shutdown(5, TimeUnit.SECONDS);
+        }
+    }
+}

--- a/metrics-httpasyncclient/src/test/java/io/dropwizard/metrics/httpasyncclient/InstrumentedHttpClientsTest.java
+++ b/metrics-httpasyncclient/src/test/java/io/dropwizard/metrics/httpasyncclient/InstrumentedHttpClientsTest.java
@@ -1,6 +1,7 @@
 package io.dropwizard.metrics.httpasyncclient;
 
 import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.nio.client.HttpAsyncClient;
@@ -14,19 +15,32 @@ import io.dropwizard.metrics.MetricName;
 import io.dropwizard.metrics.MetricRegistry;
 import io.dropwizard.metrics.MetricRegistryListener;
 import io.dropwizard.metrics.Timer;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
+@RunWith(MockitoJUnitRunner.class)
 public class InstrumentedHttpClientsTest {
-    private final HttpClientMetricNameStrategy metricNameStrategy =
-            mock(HttpClientMetricNameStrategy.class);
-    private final MetricRegistryListener registryListener =
-            mock(MetricRegistryListener.class);
+
+    @Mock
+    private HttpClientMetricNameStrategy metricNameStrategy;
+
+    @Mock
+    private MetricRegistryListener registryListener;
+
     private final MetricRegistry metricRegistry = new MetricRegistry();
 
-    private  HttpAsyncClient hac;
+    private HttpAsyncClient hac;
 
     @Before
     public void setUp() throws Exception {

--- a/metrics-httpasyncclient/src/test/java/io/dropwizard/metrics/httpasyncclient/InstrumentedHttpClientsTest.java
+++ b/metrics-httpasyncclient/src/test/java/io/dropwizard/metrics/httpasyncclient/InstrumentedHttpClientsTest.java
@@ -1,65 +1,56 @@
 package io.dropwizard.metrics.httpasyncclient;
 
+import io.dropwizard.metrics.MetricName;
+import io.dropwizard.metrics.MetricRegistry;
+import io.dropwizard.metrics.MetricRegistryListener;
+import io.dropwizard.metrics.Timer;
+import io.dropwizard.metrics.httpclient.HttpClientMetricNameStrategy;
+import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
-import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.nio.client.HttpAsyncClient;
 import org.junit.Before;
 import org.junit.Test;
-
-import io.dropwizard.metrics.httpclient.HttpClientMetricNameStrategy;
-
-import io.dropwizard.metrics.httpasyncclient.InstrumentedNHttpClientBuilder;
-import io.dropwizard.metrics.MetricName;
-import io.dropwizard.metrics.MetricRegistry;
-import io.dropwizard.metrics.MetricRegistryListener;
-import io.dropwizard.metrics.Timer;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
-public class InstrumentedHttpClientsTest {
-
-    @Mock
-    private HttpClientMetricNameStrategy metricNameStrategy;
-
-    @Mock
-    private MetricRegistryListener registryListener;
+public class InstrumentedHttpClientsTest extends HttpClientTestBase {
 
     private final MetricRegistry metricRegistry = new MetricRegistry();
 
-    private HttpAsyncClient hac;
+    private HttpAsyncClient asyncHttpClient;
 
-    @Before
-    public void setUp() throws Exception {
-        CloseableHttpAsyncClient chac = new InstrumentedNHttpClientBuilder(metricRegistry, metricNameStrategy).build();
-        chac.start();
-        hac = chac;
-        metricRegistry.addListener(registryListener);
-    }
+    @Mock
+    private HttpClientMetricNameStrategy metricNameStrategy;
+    @Mock
+    private MetricRegistryListener registryListener;
 
     @Test
     public void registersExpectedMetricsGivenNameStrategy() throws Exception {
-        final HttpGet get = new HttpGet("http://example.com?q=anything");
+        HttpHost host = startServerWithGlobalRequestHandler(STATUS_OK);
+        final HttpGet get = new HttpGet("/q=anything");
         final MetricName metricName = MetricName.build("some.made.up.metric.name");
 
         when(metricNameStrategy.getNameFor(anyString(), any(HttpRequest.class)))
                 .thenReturn(metricName);
 
-        hac.execute(get,null).get();
+        asyncHttpClient.execute(host, get, null).get();
 
         verify(registryListener).onTimerAdded(eq(metricName), any(Timer.class));
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        CloseableHttpAsyncClient chac = new InstrumentedNHttpClientBuilder(metricRegistry, metricNameStrategy).build();
+        chac.start();
+        asyncHttpClient = chac;
+        metricRegistry.addListener(registryListener);
     }
 }

--- a/metrics-httpasyncclient/src/test/java/io/dropwizard/metrics/httpasyncclient/InstrumentedHttpClientsTimerTest.java
+++ b/metrics-httpasyncclient/src/test/java/io/dropwizard/metrics/httpasyncclient/InstrumentedHttpClientsTimerTest.java
@@ -1,0 +1,92 @@
+package io.dropwizard.metrics.httpasyncclient;
+
+import io.dropwizard.metrics.MetricName;
+import io.dropwizard.metrics.MetricRegistry;
+import io.dropwizard.metrics.Timer;
+import io.dropwizard.metrics.httpclient.HttpClientMetricNameStrategy;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.nio.client.HttpAsyncClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InstrumentedHttpClientsTimerTest {
+
+    private HttpAsyncClient hac;
+
+    @Mock
+    private MetricRegistry metricRegistry;
+
+    @Mock
+    private Timer.Context context;
+
+    @Before
+    public void setUp() throws Exception {
+        CloseableHttpAsyncClient chac = new InstrumentedNHttpClientBuilder(metricRegistry, mock(HttpClientMetricNameStrategy.class)).build();
+        chac.start();
+        hac = chac;
+
+        Timer timer = mock(Timer.class);
+        when(timer.time()).thenReturn(context);
+        when(metricRegistry.timer(Matchers.<MetricName>anyObject())).thenReturn(timer);
+    }
+
+    @Test
+    public void timerIsStoppedCorrectly() throws Exception {
+        HttpGet get = new HttpGet("http://example.com?q=anything");
+
+        // Timer hasn't been stopped prior to executing the request
+        verify(context, never()).stop();
+
+        Future<HttpResponse> responseFuture = hac.execute(get, null);
+
+        // Timer should still be running
+        verify(context, never()).stop();
+
+        responseFuture.get(20, TimeUnit.SECONDS);
+
+        // After the computation is complete timer must be stopped
+        // Materialzing the future and calling the future callback is not an atomic operation so
+        // we need to wait for callback to succeed
+        verify(context, timeout(100).times(1)).stop();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void timerIsStoppedCorrectlyWithProvidedFutureCallback() throws Exception {
+        HttpGet get = new HttpGet("http://example.com?q=something");
+
+        FutureCallback<HttpResponse> futureCallback = mock(FutureCallback.class);
+
+        // Timer hasn't been stopped prior to executing the request
+        verify(context, never()).stop();
+
+        Future<HttpResponse> responseFuture = hac.execute(get, futureCallback);
+
+        // Timer should still be running
+        verify(context, never()).stop();
+
+        responseFuture.get(20, TimeUnit.SECONDS);
+
+        // Callback must have been called
+        assertTrue(responseFuture.isDone());
+        // After the computation is complete timer must be stopped
+        // Materialzing the future and calling the future callback is not an atomic operation so
+        // we need to wait for callback to succeed
+        verify(futureCallback, timeout(100).times(1)).completed(Matchers.<HttpResponse>anyObject());
+        verify(context, timeout(100).times(1)).stop();
+    }
+}


### PR DESCRIPTION
This PR fixes a problem with the httpasyncclient metrics integration. 

The previous approach did not actually time the request execution but the time to return the `Future` of the response. This was discovered when introducing latency in our code that wasn't reflected at all in the metrics we gathered from the async client library.

Changes:
- The first commit is the minimal change, it does slightly tweak the existing test (using Mockito annotations) as part of introducing another test suite for the timing tests.
- The second commit replaces the `AssertionError` that is being thrown with a `RuntimeException` (this code should not throw an `Error`).
- The last commit refactors and enhances the tests to use a local server instead of making requests to `example.com`.

Happy to change the scope of this PR. Also happy to backport this change to the 3.1 branch if desired.
