### PR TITLE
Modify Timer.Context for Extensibility

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/Timer.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Timer.java
@@ -19,7 +19,12 @@ public class Timer implements Metered, Sampling {
         private final Clock clock;
         private final long startTime;
 
-        private Context(Timer timer, Clock clock) {
+        /**
+         * Protected constructor for extension.
+         * @param timer the {@link Timer} implementation the context should reference
+         * @param clock the {@link Clock} implementation the context should reference
+         */
+        protected Context(Timer timer, Clock clock) {
             this.timer = timer;
             this.clock = clock;
             this.startTime = clock.getTick();

--- a/metrics-core/src/test/java/com/codahale/metrics/TimerTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/TimerTest.java
@@ -97,4 +97,12 @@ public class TimerTest {
 
         verifyZeroInteractions(reservoir);
     }
+
+    @Test
+    public void testTimerContextExtension() {
+        final Timer.Context subclass = new Timer.Context(timer, clock) {};
+        assertThat(subclass).isNotNull();
+        assertThat(subclass).isInstanceOf(Timer.Context.class);
+        assertThat(subclass.getClass()).isNotEqualTo(Timer.Context.class);
+    }
 }


### PR DESCRIPTION
Change Timer.Context constructor to protected from private so that the class may be extended.