### PR TITLE
Code quality fix - Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/PickledGraphite.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/PickledGraphite.java
@@ -252,7 +252,7 @@ public class PickledGraphite implements GraphiteSender {
      * 3. Clear out the list of metrics
      */
     private void writeMetrics() throws IOException {
-        if (metrics.size() > 0) {
+        if (!metrics.isEmpty()) {
             try {
                 byte[] payload = pickleMetrics(metrics);
                 byte[] header = ByteBuffer.allocate(4).putInt(payload.length).array();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1155

Please let me know if you have any questions.

Ahmed