### PR TITLE
Code quality fix - Serializable classes should have a version id

### DIFF
--- a/metrics-json/src/main/java/io/dropwizard/metrics/json/HealthCheckModule.java
+++ b/metrics-json/src/main/java/io/dropwizard/metrics/json/HealthCheckModule.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 
 public class HealthCheckModule extends Module {
     private static class HealthCheckResultSerializer extends StdSerializer<HealthCheck.Result> {
+        private static final long serialVersionUID = 7926472295622776147L;
         private HealthCheckResultSerializer() {
             super(HealthCheck.Result.class);
         }

--- a/metrics-json/src/main/java/io/dropwizard/metrics/json/MetricsModule.java
+++ b/metrics-json/src/main/java/io/dropwizard/metrics/json/MetricsModule.java
@@ -26,6 +26,7 @@ public class MetricsModule extends Module {
     static final Version VERSION = new Version(4, 0, 0, "", "io.dropwizard.metrics", "metrics-json");
 
     private static class GaugeSerializer extends StdSerializer<Gauge> {
+        private static final long serialVersionUID = 7926472295622776147L;
         private GaugeSerializer() {
             super(Gauge.class);
         }
@@ -47,6 +48,7 @@ public class MetricsModule extends Module {
     }
 
     private static class CounterSerializer extends StdSerializer<Counter> {
+        private static final long serialVersionUID = 7526471295622776148L;
         private CounterSerializer() {
             super(Counter.class);
         }
@@ -62,6 +64,7 @@ public class MetricsModule extends Module {
     }
 
     private static class HistogramSerializer extends StdSerializer<Histogram> {
+        private static final long serialVersionUID = 7526472295622796148L;
         private final boolean showSamples;
 
         private HistogramSerializer(boolean showSamples) {
@@ -96,6 +99,7 @@ public class MetricsModule extends Module {
     }
 
     private static class MeterSerializer extends StdSerializer<Meter> {
+        private static final long serialVersionUID = 7526472295622776138L;
         private final String rateUnit;
         private final double rateFactor;
 
@@ -121,6 +125,7 @@ public class MetricsModule extends Module {
     }
 
     private static class TimerSerializer extends StdSerializer<Timer> {
+        private static final long serialVersionUID = 7526472295622776148L;
         private final String rateUnit;
         private final double rateFactor;
         private final String durationUnit;
@@ -177,7 +182,6 @@ public class MetricsModule extends Module {
     }
 
     private static class MetricRegistrySerializer extends StdSerializer<MetricRegistry> {
-
         private final MetricFilter filter;
 
         private MetricRegistrySerializer(MetricFilter filter) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2057 - “Serializable classes should have a version id”. You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2057

Please let me know if you have any questions.

Ahmed