### PR TITLE
added the metrics-newrelic-reporter 3rd party

### DIFF
--- a/docs/source/manual/third-party.rst
+++ b/docs/source/manual/third-party.rst
@@ -39,3 +39,4 @@ the many third-party libraries which extend Metrics:
 * `finagle-metrics <https://github.com/rlazoti/finagle-metrics>`_ provides a reporter for a finagle service.
 * `metrics-atsd <https://github.com/axibase/metrics-atsd>`_ provides a reporter for `ATSD <https://axibase.com/products/axibase-time-series-database/>`_.
 * `metrics-mongodb-reporter <https://github.com/aparnachaudhary/mongodb-metrics-reporter>`_ provides a reporter for `MongoDB <https://www.mongodb.org/>`_
+* `metrics-newrelic-reporter <http://github.com/amirkibbar/banana>` _ provides a reporter for `New Relic <http://newrelic.com>`_


### PR DESCRIPTION
Hi, I've created a simple reporter that can report the metrics into a New Relic account. I'm not a New Relic employee, I just work with their product and thought others might find this reporter useful.