### PR TITLE
ability to query individual health checks

### DIFF
--- a/metrics-servlets/src/main/java/io/dropwizard/metrics/servlets/AdminServlet.java
+++ b/metrics-servlets/src/main/java/io/dropwizard/metrics/servlets/AdminServlet.java
@@ -19,6 +19,7 @@ public class AdminServlet extends HttpServlet {
     public static final String PING_URI_PARAM_KEY = "ping-uri";
     public static final String THREADS_URI_PARAM_KEY = "threads-uri";
     public static final String HEALTHCHECK_URI_PARAM_KEY = "healthcheck-uri";
+    public static final String HEALTHCHECK_PARAM_ATTRIBUTE_KEY = "healthcheck-param";
     public static final String SERVICE_NAME_PARAM_KEY= "service-name";
 
     private static final String TEMPLATE = String.format(
@@ -97,7 +98,9 @@ public class AdminServlet extends HttpServlet {
         final String uri = req.getPathInfo();
         if (uri == null || uri.equals("/")) {
             super.service(req, resp);
-        } else if (uri.equals(healthcheckUri)) {
+        } else if (uri.startsWith(healthcheckUri)) {
+            String healthCheckParam = uri.substring(healthcheckUri.length());
+            req.setAttribute(HEALTHCHECK_PARAM_ATTRIBUTE_KEY, healthCheckParam);
             healthCheckServlet.service(req, resp);
         } else if (uri.startsWith(metricsUri)) {
             metricsServlet.service(req, resp);


### PR DESCRIPTION
New feature: ability to query individual health checks

We have few health checks in our application. and one of them is basic dead-lock threads.
When this happens we have no choice than to restart the app.
We would like to automate it but we don't like to query all health checks and then parse the response, because it is useless to call all of them and bring some logic to the monitoring tool. Instead we would like to query individual check and act immediately if its failing.


