### PR TITLE
Add log4j2 xml-based config support

### DIFF
--- a/docs/source/manual/log4j.rst
+++ b/docs/source/manual/log4j.rst
@@ -33,3 +33,19 @@ For log4j 2.x:
     Configuration config = context.getConfiguration();
     config.getLoggerConfig(LogManager.ROOT_LOGGER_NAME).addAppender(appender, level, filter);
     context.updateLoggers(config);
+
+You can also use standard log4j2 configuration, via plugin support:
+
+.. code-block:: xml
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <Configuration status="INFO" name="log4j2-config" packages="com.codahale.metrics.log4j2">
+    <Appenders>
+        <MetricsAppender name="metrics" registryName="shared-metrics-registry"/>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="metrics" />
+        </Root>
+    </Loggers>
+    </Configuration>

--- a/metrics-log4j2/pom.xml
+++ b/metrics-log4j2/pom.xml
@@ -19,6 +19,19 @@
         <log4j2.version>2.0.2</log4j2.version>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <parallel>suites</parallel>
+                    <threadCount>1</threadCount>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>

--- a/metrics-log4j2/src/main/java/com/codahale/metrics/log4j2/InstrumentedAppender.java
+++ b/metrics-log4j2/src/main/java/com/codahale/metrics/log4j2/InstrumentedAppender.java
@@ -8,6 +8,9 @@ import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
 
 import java.io.Serializable;
 
@@ -18,6 +21,7 @@ import static com.codahale.metrics.MetricRegistry.name;
  * number of statements being logged. The meter names are the logging level names appended to the
  * name of the appender.
  */
+@Plugin(name = "MetricsAppender", category = "Core", elementType = "appender")
 public class InstrumentedAppender extends AbstractAppender {
     private final MetricRegistry registry;
 
@@ -73,6 +77,23 @@ public class InstrumentedAppender extends AbstractAppender {
     public InstrumentedAppender(MetricRegistry registry, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions) {
         super(name(Appender.class), filter, layout, ignoreExceptions);
         this.registry = registry;
+    }
+
+    /**
+     * Create a new instrumented appender using the given appender name and registry.
+     * @param appenderName The name of the appender.
+     * @param registry the metric registry
+     */
+    public InstrumentedAppender(String appenderName, MetricRegistry registry) {
+        super(appenderName, null, null, true);
+        this.registry = registry;
+    }
+
+    @PluginFactory
+    public static InstrumentedAppender createAppender(
+            @PluginAttribute("name") String name,
+            @PluginAttribute( value = "registryName", defaultString = "log4j2Metrics") String registry) {
+        return new InstrumentedAppender(name, SharedMetricRegistries.getOrCreate(registry));
     }
 
     @Override

--- a/metrics-log4j2/src/test/java/com/codahale/metrics/log4j2/InstrumentedAppenderConfigTest.java
+++ b/metrics-log4j2/src/test/java/com/codahale/metrics/log4j2/InstrumentedAppenderConfigTest.java
@@ -1,0 +1,65 @@
+package com.codahale.metrics.log4j2;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.ConfigurationSource;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstrumentedAppenderConfigTest {
+  public static final String METRIC_NAME_PREFIX = "metrics";
+  public static final String REGISTRY_NAME = "shared-metrics-registry";
+
+  private final MetricRegistry registry = SharedMetricRegistries.getOrCreate(REGISTRY_NAME);
+  private ConfigurationSource source;
+  private LoggerContext context;
+
+  @Before
+  public void setUp() throws Exception {
+    source = new ConfigurationSource(this.getClass().getClassLoader().getResourceAsStream("log4j2-testconfig.xml"));
+    context = Configurator.initialize(null, source);
+  }
+  @After
+  public void tearDown() throws Exception {
+    context.stop();
+  }
+
+  // The biggest test is that we can initialize the log4j2 config at all.
+
+  @Test
+  public void canRecordAll() throws Exception {
+    Logger logger = context.getLogger(this.getClass().getName());
+
+    long initialAllCount = registry.meter(METRIC_NAME_PREFIX + ".all").getCount();
+    logger.error("an error message");
+    assertThat(registry.meter(METRIC_NAME_PREFIX + ".all").getCount())
+            .isEqualTo(initialAllCount + 1);
+  }
+
+  @Test
+  public void canRecordError() throws Exception {
+    Logger logger = context.getLogger(this.getClass().getName());
+
+    long initialErrorCount = registry.meter(METRIC_NAME_PREFIX + ".error").getCount();
+    logger.error("an error message");
+    assertThat(registry.meter(METRIC_NAME_PREFIX + ".all").getCount())
+            .isEqualTo(initialErrorCount + 1);
+  }
+
+  @Test
+  public void noInvalidRecording() throws Exception {
+    Logger logger = context.getLogger(this.getClass().getName());
+
+    long initialInfoCount = registry.meter(METRIC_NAME_PREFIX + ".info").getCount();
+    logger.error("an error message");
+    assertThat(registry.meter(METRIC_NAME_PREFIX + ".info").getCount())
+            .isEqualTo(initialInfoCount);
+  }
+
+}

--- a/metrics-log4j2/src/test/resources/log4j2-testconfig.xml
+++ b/metrics-log4j2/src/test/resources/log4j2-testconfig.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO" name="log4j2-config" packages="com.codahale.metrics.log4j2">
+    <Appenders>
+        <MetricsAppender name="metrics" registryName="shared-metrics-registry"/>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="metrics" />
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
This allows the use of the log4j2 InstrumentedAppender without needing code-based config. ie:

    <?xml version="1.0" encoding="UTF-8"?>
    <Configuration status="INFO" name="log4j2-config" packages="com.codahale.metrics.log4j2">
        <Appenders>
            <MetricsAppender name="metrics" registryName="shared-metrics-registry"/>
        </Appenders>
        <Loggers>
            <Root level="INFO">
                <AppenderRef ref="metrics" />
            </Root>
        </Loggers>
    </Configuration>

For the most part, this was simply a matter of adding the right log4j2 plugin hooks. 

However, I ended up adding a new constructor because the concept of the appender name and the metrics prefix were tightly coupled. This was an irritation because the appender name is used as the logger reference in the XML config.
Also, since the test I added was actually initializing a logging system, I removed the test parallelism for the metrics-log4j2 suite to avoid potential race conditions among the two test files.

Please note that this is a patch against 3.1-maintenance. I wasn't sure where most development is occurring and what the best place to put it would be.
