### PR TITLE
Export boolean values to graphite as 1/0

### DIFF
--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
@@ -306,6 +306,8 @@ public class GraphiteReporter extends ScheduledReporter {
             return format(((Integer) o).longValue());
         } else if (o instanceof Long) {
             return format(((Long) o).longValue());
+        } else if (o instanceof Boolean) {
+            return format(((Boolean) o) ? 1 : 0);
         }
         return null;
     }

--- a/metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterTest.java
@@ -161,6 +161,32 @@ public class GraphiteReporterTest {
     }
 
     @Test
+    public void reportsBooleanGaugeValues() throws Exception {
+        reporter.report(map("gauge", gauge(true)),
+                        this.<Counter>map(),
+                        this.<Histogram>map(),
+                        this.<Meter>map(),
+                        this.<Timer>map());
+
+        reporter.report(map("gauge", gauge(false)),
+                        this.<Counter>map(),
+                        this.<Histogram>map(),
+                        this.<Meter>map(),
+                        this.<Timer>map());
+        final InOrder inOrder = inOrder(graphite);
+        inOrder.verify(graphite).isConnected();
+        inOrder.verify(graphite).connect();
+        inOrder.verify(graphite).send("prefix.gauge", "1", timestamp);
+        inOrder.verify(graphite).flush();
+        inOrder.verify(graphite).isConnected();
+        inOrder.verify(graphite).connect();
+        inOrder.verify(graphite).send("prefix.gauge", "0", timestamp);
+        inOrder.verify(graphite).flush();
+
+        verifyNoMoreInteractions(graphite);
+    }
+
+    @Test
     public void reportsCounters() throws Exception {
         final Counter counter = mock(Counter.class);
         when(counter.getCount()).thenReturn(100L);


### PR DESCRIPTION
When exporting metrics from hystrix to graphite (https://github.com/Netflix/Hystrix using  https://github.com/Netflix/Hystrix/tree/master/hystrix-contrib/hystrix-codahale-metrics-publisher) we've seen that there are some interesting properties  like isCircuitBreakerOpen that are not exported to Graphite.
These properties are boolean values. We think it'd make sense to export them as 0/1 so they can be graphed alongside some other values.