### PR TITLE
Add basic sanitization for default CsvFileProvider

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics/FixedNameCsvFileProvider.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/FixedNameCsvFileProvider.java
@@ -13,6 +13,9 @@ public class FixedNameCsvFileProvider implements CsvFileProvider {
     }
 
     private String sanitize(MetricName metricName) {
-        return metricName.getKey();
+        //Forward slash character is definitely illegal in both Windows and Linux
+        //https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
+        final String sanitizedName = metricName.getKey().replaceFirst("^/","").replaceAll("/",".");
+        return sanitizedName;
     }
 }

--- a/metrics-core/src/test/java/io/dropwizard/metrics/FixedNameCsvFileProviderTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/FixedNameCsvFileProviderTest.java
@@ -27,4 +27,12 @@ public class FixedNameCsvFileProviderTest {
         assertThat(file.getParentFile()).isEqualTo(dataDirectory);
         assertThat(file.getName()).isEqualTo("test.csv");
     }
+
+    @Test
+    public void testGetFileSanitize() {
+        FixedNameCsvFileProvider provider = new FixedNameCsvFileProvider();
+        File file = provider.getFile(dataDirectory, MetricName.build("/myfake/uri"));
+        assertThat(file.getParentFile()).isEqualTo(dataDirectory);
+        assertThat(file.getName()).isEqualTo("myfake.uri.csv");
+    }
 }


### PR DESCRIPTION
The current sanitization offered by the default CsvFileProvider does nothing.
Although this may be acceptable in most cases there are some known bad filename chars that we can restrict that cover
99% of the dropwizard user base (windows, unix, linux).

The forward slash '/' is illegal in all three OS and should be at a minimum sanitizied. The forward slash is a common
character in metric names if people are constructing metric names from URIs.