### PR TITLE
Register metrics defined at Resource level

### DIFF
--- a/metrics-jersey2/src/main/java/io/dropwizard/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
+++ b/metrics-jersey2/src/main/java/io/dropwizard/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
@@ -21,6 +21,7 @@ import io.dropwizard.metrics.Timer;
 
 import javax.ws.rs.ext.Provider;
 import javax.ws.rs.core.Configuration;
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -178,17 +179,27 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
 
     private void registerMetricsForModel(ResourceModel resourceModel) {
         for (final Resource resource : resourceModel.getResources()) {
+
+            final Timed classLevelTimed = getClassLevelAnnotation(resource, Timed.class);
+            final Metered classLevelMetered = getClassLevelAnnotation(resource, Metered.class);
+            final ExceptionMetered classLevelExceptionMetered = getClassLevelAnnotation(resource, ExceptionMetered.class);
+
             for (final ResourceMethod method : resource.getAllMethods()) {
-                registerTimedAnnotations(method);
-                registerMeteredAnnotations(method);
-                registerExceptionMeteredAnnotations(method);
+                registerTimedAnnotations(method, classLevelTimed);
+                registerMeteredAnnotations(method, classLevelMetered);
+                registerExceptionMeteredAnnotations(method, classLevelExceptionMetered);
             }
 
             for (final Resource childResource : resource.getChildResources()) {
+
+                final Timed classLevelTimedChild = getClassLevelAnnotation(childResource, Timed.class);
+                final Metered classLevelMeteredChild = getClassLevelAnnotation(childResource, Metered.class);
+                final ExceptionMetered classLevelExceptionMeteredChild = getClassLevelAnnotation(childResource, ExceptionMetered.class);
+
                 for (final ResourceMethod method : childResource.getAllMethods()) {
-                    registerTimedAnnotations(method);
-                    registerMeteredAnnotations(method);
-                    registerExceptionMeteredAnnotations(method);
+                    registerTimedAnnotations(method, classLevelTimedChild);
+                    registerMeteredAnnotations(method, classLevelMeteredChild);
+                    registerExceptionMeteredAnnotations(method, classLevelExceptionMeteredChild);
                 }
             }
         }
@@ -205,8 +216,26 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         return listener;
     }
 
-    private void registerTimedAnnotations(final ResourceMethod method) {
+    private <T extends Annotation> T getClassLevelAnnotation(final Resource resource, final Class<T> annotationClazz) {
+        T annotation = null;
+
+        for (final Class<?> clazz : resource.getHandlerClasses()) {
+            annotation = clazz.getAnnotation(annotationClazz);
+
+            if (annotation != null) {
+                break;
+            }
+        }
+        return annotation;
+    }
+
+    private void registerTimedAnnotations(final ResourceMethod method, final Timed classLevelTimed) {
         final Method definitionMethod = method.getInvocable().getDefinitionMethod();
+        if (classLevelTimed != null) {
+            timers.putIfAbsent(definitionMethod, timerMetric(this.metrics, method, classLevelTimed));
+            return;
+        }
+
         final Timed annotation = definitionMethod.getAnnotation(Timed.class);
 
         if (annotation != null) {
@@ -214,8 +243,13 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         }
     }
 
-    private void registerMeteredAnnotations(final ResourceMethod method) {
+    private void registerMeteredAnnotations(final ResourceMethod method, final Metered classLevelMetered) {
         final Method definitionMethod = method.getInvocable().getDefinitionMethod();
+
+        if (classLevelMetered != null) {
+            meters.putIfAbsent(definitionMethod, meterMetric(metrics, method, classLevelMetered));
+            return;
+        }
         final Metered annotation = definitionMethod.getAnnotation(Metered.class);
 
         if (annotation != null) {
@@ -223,8 +257,13 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         }
     }
 
-    private void registerExceptionMeteredAnnotations(final ResourceMethod method) {
+    private void registerExceptionMeteredAnnotations(final ResourceMethod method, final ExceptionMetered classLevelExceptionMetered) {
         final Method definitionMethod = method.getInvocable().getDefinitionMethod();
+
+        if (classLevelExceptionMetered != null) {
+            exceptionMeters.putIfAbsent(definitionMethod, new ExceptionMeterMetric(metrics, method, classLevelExceptionMetered));
+            return;
+        }
         final ExceptionMetered annotation = definitionMethod.getAnnotation(ExceptionMetered.class);
 
         if (annotation != null) {

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/SingletonMetricsExceptionMeteredPerClassJerseyTest.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/SingletonMetricsExceptionMeteredPerClassJerseyTest.java
@@ -2,18 +2,14 @@ package io.dropwizard.metrics.jersey2;
 
 import io.dropwizard.metrics.Meter;
 import io.dropwizard.metrics.MetricRegistry;
-import io.dropwizard.metrics.Timer;
-import io.dropwizard.metrics.jersey2.resources.InstrumentedResource;
-import io.dropwizard.metrics.jersey2.resources.InstrumentedSubResource;
-import org.glassfish.jersey.client.ClientResponse;
+import io.dropwizard.metrics.jersey2.resources.InstrumentedResourceExceptionMeteredPerClass;
+import io.dropwizard.metrics.jersey2.resources.InstrumentedSubResourceExceptionMeteredPerClass;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.junit.Test;
 
-import javax.ws.rs.NotFoundException;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.core.Application;
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -24,10 +20,10 @@ import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
 
 /**
  * Tests registering {@link InstrumentedResourceMethodApplicationListener} as a singleton
- * in a Jersey {@link org.glassfish.jersey.server.ResourceConfig}
+ * in a Jersey {@link ResourceConfig}
  */
 
-public class SingletonMetricsJerseyTest extends JerseyTest {
+public class SingletonMetricsExceptionMeteredPerClassJerseyTest extends JerseyTest {
     static {
         Logger.getLogger("org.glassfish.jersey").setLevel(Level.OFF);
     }
@@ -39,38 +35,16 @@ public class SingletonMetricsJerseyTest extends JerseyTest {
         this.registry = new MetricRegistry();
 
         ResourceConfig config = new ResourceConfig();
+
         config = config.register(new MetricsFeature(this.registry));
-        config = config.register(InstrumentedResource.class);
+        config = config.register(InstrumentedResourceExceptionMeteredPerClass.class);
 
         return config;
     }
 
     @Test
-    public void timedMethodsAreTimed() {
-        assertThat(target("timed")
-                .request()
-                .get(String.class))
-                .isEqualTo("yay");
-
-        final Timer timer = registry.timer(name(InstrumentedResource.class, "timed"));
-
-        assertThat(timer.getCount()).isEqualTo(1);
-    }
-
-    @Test
-    public void meteredMethodsAreMetered() {
-        assertThat(target("metered")
-                .request()
-                .get(String.class))
-                .isEqualTo("woo");
-
-        final Meter meter = registry.meter(name(InstrumentedResource.class, "metered"));
-        assertThat(meter.getCount()).isEqualTo(1);
-    }
-
-    @Test
     public void exceptionMeteredMethodsAreExceptionMetered() {
-        final Meter meter = registry.meter(name(InstrumentedResource.class,
+        final Meter meter = registry.meter(name(InstrumentedResourceExceptionMeteredPerClass.class,
                 "exceptionMetered",
                 "exceptions"));
 
@@ -96,27 +70,30 @@ public class SingletonMetricsJerseyTest extends JerseyTest {
     }
 
     @Test
-    public void testResourceNotFound() {
-        final Response response = target().path("not-found").request().get();
-        assertThat(response.getStatus()).isEqualTo(404);
-
-        try {
-            target().path("not-found").request().get(ClientResponse.class);
-            failBecauseExceptionWasNotThrown(NotFoundException.class);
-        } catch (NotFoundException e) {
-            assertThat(e.getMessage()).isEqualTo("HTTP 404 Not Found");
-        }
-    }
-
-    @Test
     public void subresourcesFromLocatorsRegisterMetrics() {
-        assertThat(target("subresource/timed")
+        final Meter meter = registry.meter(name(InstrumentedSubResourceExceptionMeteredPerClass.class,
+                "exceptionMetered",
+                "exceptions"));
+
+        assertThat(target("subresource/exception-metered")
                 .request()
                 .get(String.class))
-                .isEqualTo("yay");
+                .isEqualTo("fuh");
 
-        final Timer timer = registry.timer(name(InstrumentedSubResource.class, "timed"));
-        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(meter.getCount()).isZero();
 
+        try {
+            target("subresource/exception-metered")
+                    .queryParam("splode", true)
+                    .request()
+                    .get(String.class);
+
+            failBecauseExceptionWasNotThrown(ProcessingException.class);
+        } catch (ProcessingException e) {
+            assertThat(e.getCause()).isInstanceOf(IOException.class);
+        }
+
+        assertThat(meter.getCount()).isEqualTo(1);
     }
+
 }

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/SingletonMetricsMeteredPerClassJerseyTest.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/SingletonMetricsMeteredPerClassJerseyTest.java
@@ -1,0 +1,67 @@
+package io.dropwizard.metrics.jersey2;
+
+import io.dropwizard.metrics.Meter;
+import io.dropwizard.metrics.MetricRegistry;
+import io.dropwizard.metrics.jersey2.resources.InstrumentedResourceMeteredPerClass;
+import io.dropwizard.metrics.jersey2.resources.InstrumentedSubResourceMeteredPerClass;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
+
+import javax.ws.rs.core.Application;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static io.dropwizard.metrics.MetricRegistry.name;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests registering {@link InstrumentedResourceMethodApplicationListener} as a singleton
+ * in a Jersey {@link ResourceConfig}
+ */
+
+public class SingletonMetricsMeteredPerClassJerseyTest extends JerseyTest {
+    static {
+        Logger.getLogger("org.glassfish.jersey").setLevel(Level.OFF);
+    }
+
+    private MetricRegistry registry;
+
+    @Override
+    protected Application configure() {
+        this.registry = new MetricRegistry();
+
+        ResourceConfig config = new ResourceConfig();
+
+        config = config.register(new MetricsFeature(this.registry));
+        config = config.register(InstrumentedResourceMeteredPerClass.class);
+
+        return config;
+    }
+
+    @Test
+    public void meteredPerClassMethodsAreMetered() {
+        assertThat(target("meteredPerClass")
+                .request()
+                .get(String.class))
+                .isEqualTo("yay");
+
+        final Meter meter = registry.meter(name(InstrumentedResourceMeteredPerClass.class, "meteredPerClass"));
+
+        assertThat(meter.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void subresourcesFromLocatorsRegisterMetrics() {
+        assertThat(target("subresource/meteredPerClass")
+                .request()
+                .get(String.class))
+                .isEqualTo("yay");
+
+        final Meter meter = registry.meter(name(InstrumentedSubResourceMeteredPerClass.class, "meteredPerClass"));
+        assertThat(meter.getCount()).isEqualTo(1);
+
+    }
+
+
+}

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/SingletonMetricsTimedPerClassJerseyTest.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/SingletonMetricsTimedPerClassJerseyTest.java
@@ -1,0 +1,67 @@
+package io.dropwizard.metrics.jersey2;
+
+import io.dropwizard.metrics.MetricRegistry;
+import io.dropwizard.metrics.Timer;
+import io.dropwizard.metrics.jersey2.resources.InstrumentedResourceTimedPerClass;
+import io.dropwizard.metrics.jersey2.resources.InstrumentedSubResourceTimedPerClass;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
+
+import javax.ws.rs.core.Application;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static io.dropwizard.metrics.MetricRegistry.name;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests registering {@link InstrumentedResourceMethodApplicationListener} as a singleton
+ * in a Jersey {@link ResourceConfig}
+ */
+
+public class SingletonMetricsTimedPerClassJerseyTest extends JerseyTest {
+    static {
+        Logger.getLogger("org.glassfish.jersey").setLevel(Level.OFF);
+    }
+
+    private MetricRegistry registry;
+
+    @Override
+    protected Application configure() {
+        this.registry = new MetricRegistry();
+
+        ResourceConfig config = new ResourceConfig();
+
+        config = config.register(new MetricsFeature(this.registry));
+        config = config.register(InstrumentedResourceTimedPerClass.class);
+
+        return config;
+    }
+
+    @Test
+    public void timedPerClassMethodsAreTimed() {
+        assertThat(target("timedPerClass")
+                .request()
+                .get(String.class))
+                .isEqualTo("yay");
+
+        final Timer timer = registry.timer(name(InstrumentedResourceTimedPerClass.class, "timedPerClass"));
+
+        assertThat(timer.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void subresourcesFromLocatorsRegisterMetrics() {
+        assertThat(target("subresource/timedPerClass")
+                .request()
+                .get(String.class))
+                .isEqualTo("yay");
+
+        final Timer timer = registry.timer(name(InstrumentedSubResourceTimedPerClass.class, "timedPerClass"));
+        assertThat(timer.getCount()).isEqualTo(1);
+
+    }
+
+
+}

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedResourceExceptionMeteredPerClass.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedResourceExceptionMeteredPerClass.java
@@ -1,0 +1,28 @@
+package io.dropwizard.metrics.jersey2.resources;
+
+import io.dropwizard.metrics.annotation.ExceptionMetered;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+
+@ExceptionMetered(cause = IOException.class)
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+public class InstrumentedResourceExceptionMeteredPerClass {
+
+    @GET
+    @Path("/exception-metered")
+    public String exceptionMetered(@QueryParam("splode") @DefaultValue("false") boolean splode) throws IOException {
+        if (splode) {
+            throw new IOException("AUGH");
+        }
+        return "fuh";
+    }
+
+    @Path("/subresource")
+    public InstrumentedSubResourceExceptionMeteredPerClass locateSubResource() {
+        return new InstrumentedSubResourceExceptionMeteredPerClass();
+    }
+
+}

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedResourceMeteredPerClass.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedResourceMeteredPerClass.java
@@ -1,0 +1,26 @@
+package io.dropwizard.metrics.jersey2.resources;
+
+import io.dropwizard.metrics.annotation.Metered;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Metered
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+public class InstrumentedResourceMeteredPerClass {
+
+    @GET
+    @Path("/meteredPerClass")
+    public String meteredPerClass() {
+        return "yay";
+    }
+
+    @Path("/subresource")
+    public InstrumentedSubResourceMeteredPerClass locateSubResource() {
+        return new InstrumentedSubResourceMeteredPerClass();
+    }
+
+}

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedResourceTimedPerClass.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedResourceTimedPerClass.java
@@ -1,0 +1,26 @@
+package io.dropwizard.metrics.jersey2.resources;
+
+import io.dropwizard.metrics.annotation.Timed;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Timed
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+public class InstrumentedResourceTimedPerClass {
+
+    @GET
+    @Path("/timedPerClass")
+    public String timedPerClass() {
+        return "yay";
+    }
+
+    @Path("/subresource")
+    public InstrumentedSubResourceTimedPerClass locateSubResource() {
+        return new InstrumentedSubResourceTimedPerClass();
+    }
+
+}

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedSubResourceExceptionMeteredPerClass.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedSubResourceExceptionMeteredPerClass.java
@@ -1,0 +1,20 @@
+package io.dropwizard.metrics.jersey2.resources;
+
+import io.dropwizard.metrics.annotation.ExceptionMetered;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+
+@ExceptionMetered(cause = IOException.class)
+@Produces(MediaType.TEXT_PLAIN)
+public class InstrumentedSubResourceExceptionMeteredPerClass {
+    @GET
+    @Path("/exception-metered")
+    public String exceptionMetered(@QueryParam("splode") @DefaultValue("false") boolean splode) throws IOException {
+        if (splode) {
+            throw new IOException("AUGH");
+        }
+        return "fuh";
+    }
+}

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedSubResourceMeteredPerClass.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedSubResourceMeteredPerClass.java
@@ -1,0 +1,18 @@
+package io.dropwizard.metrics.jersey2.resources;
+
+import io.dropwizard.metrics.annotation.Metered;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Metered
+@Produces(MediaType.TEXT_PLAIN)
+public class InstrumentedSubResourceMeteredPerClass {
+    @GET
+    @Path("/meteredPerClass")
+    public String meteredPerClass() {
+        return "yay";
+    }
+}

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedSubResourceTimedPerClass.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedSubResourceTimedPerClass.java
@@ -1,0 +1,18 @@
+package io.dropwizard.metrics.jersey2.resources;
+
+import io.dropwizard.metrics.annotation.Timed;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Timed
+@Produces(MediaType.TEXT_PLAIN)
+public class InstrumentedSubResourceTimedPerClass {
+    @GET
+    @Path("/timedPerClass")
+    public String timedPerClass() {
+        return "yay";
+    }
+}


### PR DESCRIPTION
If a `Resource` class is annotated with either:

* `@Timed`,
* `@Metered`
* `@ExceptionMetered`

all method defined in such class will 'inherit' the corresponding annotation.