### PR TITLE
Format Number and Map instances for graphite Gauge values.

### DIFF
--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
@@ -294,35 +294,24 @@ public class GraphiteReporter extends ScheduledReporter {
     }
 
     private String format(Object o) {
-        if (o instanceof Float) {
-            return format(((Float) o).doubleValue());
-        } else if (o instanceof Double) {
-            return format(((Double) o).doubleValue());
-        } else if (o instanceof Byte) {
-            return format(((Byte) o).longValue());
-        } else if (o instanceof Short) {
-            return format(((Short) o).longValue());
-        } else if (o instanceof Integer) {
-            return format(((Integer) o).longValue());
-        } else if (o instanceof Long) {
-            return format(((Long) o).longValue());
-        } else if (o instanceof Number) {
-            return format(((Number) o).longValue());
+        String value = null;
+        if (o instanceof Number) {
+            Number n = (Number) o;
+            if (o instanceof Float || o instanceof Double) {
+                // the Carbon plaintext format is pretty underspecified, but it seems like it just wants
+                // US-formatted digits
+                value = String.format(Locale.US, "%2.2f", n.doubleValue());
+            } else {
+                value = Long.toString(n.longValue());
+            }
+        } else {
+            LOGGER.warn("Unable to format value for Graphite.", o);
         }
-        return null;
+        return value;
     }
 
     private String prefix(MetricName name, String... components) {
         return MetricName.join(MetricName.join(prefix, name), MetricName.build(components)).getKey();
     }
 
-    private String format(long n) {
-        return Long.toString(n);
-    }
-
-    private String format(double v) {
-        // the Carbon plaintext format is pretty underspecified, but it seems like it just wants
-        // US-formatted digits
-        return String.format(Locale.US, "%2.2f", v);
-    }
 }

--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
@@ -287,10 +287,24 @@ public class GraphiteReporter extends ScheduledReporter {
     }
 
     private void reportGauge(MetricName name, Gauge gauge, long timestamp) throws IOException {
-        final String value = format(gauge.getValue());
-        if (value != null) {
-            graphite.send(prefix(name), value, timestamp);
+
+        String nameToReport;
+        String valueToReport;
+        Object value = gauge.getValue();
+
+        if (value instanceof Map) {
+            for (Object k : ((Map) value).keySet()) {
+                nameToReport = k.toString();
+                valueToReport = format(((Map) value).get(k));
+                graphite.send(prefix(name)+"."+nameToReport, valueToReport, timestamp);
+            }
+        } else {
+            valueToReport = format(gauge.getValue());
+            if (valueToReport != null) {
+                graphite.send(prefix(name), valueToReport, timestamp);
+            }
         }
+
     }
 
     private String format(Object o) {

--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
@@ -294,7 +294,7 @@ public class GraphiteReporter extends ScheduledReporter {
 
         if (value instanceof Map) {
             for (Object k : ((Map) value).keySet()) {
-                nameToReport = k.toString();
+                nameToReport = formatMetricNameForGraphite(k.toString());
                 valueToReport = format(((Map) value).get(k));
                 graphite.send(prefix(name)+"."+nameToReport, valueToReport, timestamp);
             }
@@ -326,10 +326,6 @@ public class GraphiteReporter extends ScheduledReporter {
         return value;
     }
 
-    private String prefix(MetricName name, String... components) {
-        return MetricName.join(MetricName.join(prefix, name), MetricName.build(components)).getKey();
-    }
-
     private String format(long n) {
         return Long.toString(n);
     }
@@ -342,6 +338,10 @@ public class GraphiteReporter extends ScheduledReporter {
 
     private String prefix(MetricName name, String... components) {
         return MetricName.join(MetricName.join(prefix, name), MetricName.build(components)).getKey();
+    }
+
+    private String formatMetricNameForGraphite(String string) {
+        return string.replaceAll("[^\\p{IsAlphabetic}^\\p{IsDigit}]", "_");
     }
 
 }

--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
@@ -330,14 +330,14 @@ public class GraphiteReporter extends ScheduledReporter {
         return Long.toString(n);
     }
 
+    private String prefix(MetricName name, String... components) {
+        return MetricName.join(MetricName.join(prefix, name), MetricName.build(components)).getKey();
+    }
+
     private String format(double v) {
         // the Carbon plaintext format is pretty underspecified, but it seems like it just wants
         // US-formatted digits
         return String.format(Locale.US, "%2.2f", v);
-    }
-
-    private String prefix(MetricName name, String... components) {
-        return MetricName.join(MetricName.join(prefix, name), MetricName.build(components)).getKey();
     }
 
     private String formatMetricNameForGraphite(String string) {

--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
@@ -306,6 +306,8 @@ public class GraphiteReporter extends ScheduledReporter {
             return format(((Integer) o).longValue());
         } else if (o instanceof Long) {
             return format(((Long) o).longValue());
+        } else if (o instanceof Number) {
+            return format(((Number) o).longValue());
         }
         return null;
     }

--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
@@ -326,12 +326,12 @@ public class GraphiteReporter extends ScheduledReporter {
         return value;
     }
 
-    private String format(long n) {
-        return Long.toString(n);
-    }
-
     private String prefix(MetricName name, String... components) {
         return MetricName.join(MetricName.join(prefix, name), MetricName.build(components)).getKey();
+    }
+
+    private String format(long n) {
+        return Long.toString(n);
     }
 
     private String format(double v) {

--- a/metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterTest.java
@@ -15,8 +15,10 @@ import org.junit.Test;
 import org.mockito.InOrder;
 
 import io.dropwizard.metrics.*;
+import org.python.google.common.collect.ImmutableMap;
 
 import java.net.UnknownHostException;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
@@ -155,6 +157,25 @@ public class GraphiteReporterTest {
         inOrder.verify(graphite).isConnected();
         inOrder.verify(graphite).connect();
         inOrder.verify(graphite).send("prefix.gauge", "1.10", timestamp);
+        inOrder.verify(graphite).flush();
+
+        verifyNoMoreInteractions(graphite);
+    }
+
+    @Test
+    public void reportsMapGaugeValues() throws Exception {
+        reporter.report(map("gauge", gauge(ImmutableMap.of("a", 1, "b", 2, "c", 3))),
+                this.<Counter>map(),
+                this.<Histogram>map(),
+                this.<Meter>map(),
+                this.<Timer>map());
+
+        final InOrder inOrder = inOrder(graphite);
+        inOrder.verify(graphite).isConnected();
+        inOrder.verify(graphite).connect();
+        inOrder.verify(graphite).send("prefix.gauge.a", "1", timestamp);
+        inOrder.verify(graphite).send("prefix.gauge.b", "2", timestamp);
+        inOrder.verify(graphite).send("prefix.gauge.c", "3", timestamp);
         inOrder.verify(graphite).flush();
 
         verifyNoMoreInteractions(graphite);


### PR DESCRIPTION
Fall back to java.lang.Number interface for publishing values to graphite.  This allows alternate number types to be used as gauges, such as guava's AtomicDouble .

Issue: #922 