### PR TITLE
generics fix in ScheduledReporter and depending classes

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics/ConsoleReporter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/ConsoleReporter.java
@@ -165,7 +165,7 @@ public class ConsoleReporter extends ScheduledReporter {
     }
 
     @Override
-    public void report(SortedMap<MetricName, Gauge> gauges,
+    public void report(SortedMap<MetricName, Gauge<?>> gauges,
                        SortedMap<MetricName, Counter> counters,
                        SortedMap<MetricName, Histogram> histograms,
                        SortedMap<MetricName, Meter> meters,
@@ -176,7 +176,7 @@ public class ConsoleReporter extends ScheduledReporter {
 
         if (!gauges.isEmpty()) {
             printWithBanner("-- Gauges", '-');
-            for (Map.Entry<MetricName, Gauge> entry : gauges.entrySet()) {
+            for (Map.Entry<MetricName, Gauge<?>> entry : gauges.entrySet()) {
                 output.println(entry.getKey());
                 printGauge(entry);
             }
@@ -235,7 +235,7 @@ public class ConsoleReporter extends ScheduledReporter {
         output.printf(locale, "             count = %d%n", entry.getValue().getCount());
     }
 
-    private void printGauge(Map.Entry<MetricName, Gauge> entry) {
+    private void printGauge(Map.Entry<MetricName, Gauge<?>> entry) {
         output.printf(locale, "             value = %s%n", entry.getValue().getValue());
     }
 

--- a/metrics-core/src/main/java/io/dropwizard/metrics/CsvReporter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/CsvReporter.java
@@ -150,14 +150,14 @@ public class CsvReporter extends ScheduledReporter {
     }
 
     @Override
-    public void report(SortedMap<MetricName, Gauge> gauges,
+    public void report(SortedMap<MetricName, Gauge<?>> gauges,
                        SortedMap<MetricName, Counter> counters,
                        SortedMap<MetricName, Histogram> histograms,
                        SortedMap<MetricName, Meter> meters,
                        SortedMap<MetricName, Timer> timers) {
         final long timestamp = TimeUnit.MILLISECONDS.toSeconds(clock.getTime());
 
-        for (Map.Entry<MetricName, Gauge> entry : gauges.entrySet()) {
+        for (Map.Entry<MetricName, Gauge<?>> entry : gauges.entrySet()) {
             reportGauge(timestamp, entry.getKey(), entry.getValue());
         }
 

--- a/metrics-core/src/main/java/io/dropwizard/metrics/InstrumentedScheduledExecutorService.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/InstrumentedScheduledExecutorService.java
@@ -75,7 +75,7 @@ public class InstrumentedScheduledExecutorService implements ScheduledExecutorSe
     @Override
     public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
         scheduledOnce.mark();
-        return delegate.schedule(new InstrumentedCallable<V>(callable), delay, unit);
+        return delegate.schedule(new InstrumentedCallable<>(callable), delay, unit);
     }
 
     /**
@@ -142,7 +142,7 @@ public class InstrumentedScheduledExecutorService implements ScheduledExecutorSe
     @Override
     public <T> Future<T> submit(Callable<T> task) {
         submitted.mark();
-        return delegate.submit(new InstrumentedCallable<T>(task));
+        return delegate.submit(new InstrumentedCallable<>(task));
     }
 
     /**
@@ -204,9 +204,9 @@ public class InstrumentedScheduledExecutorService implements ScheduledExecutorSe
     }
 
     private <T> Collection<? extends Callable<T>> instrument(Collection<? extends Callable<T>> tasks) {
-        final List<InstrumentedCallable<T>> instrumented = new ArrayList<InstrumentedCallable<T>>(tasks.size());
+        final List<InstrumentedCallable<T>> instrumented = new ArrayList<>(tasks.size());
         for (Callable<T> task : tasks) {
-            instrumented.add(new InstrumentedCallable(task));
+            instrumented.add(new InstrumentedCallable<>(task));
         }
         return instrumented;
     }

--- a/metrics-core/src/main/java/io/dropwizard/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/ScheduledReporter.java
@@ -174,7 +174,7 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
      * @param meters     all of the meters in the registry
      * @param timers     all of the timers in the registry
      */
-    public abstract void report(SortedMap<MetricName, Gauge> gauges,
+    public abstract void report(SortedMap<MetricName, Gauge<?>> gauges,
                                 SortedMap<MetricName, Counter> counters,
                                 SortedMap<MetricName, Histogram> histograms,
                                 SortedMap<MetricName, Meter> meters,

--- a/metrics-core/src/main/java/io/dropwizard/metrics/Slf4jReporter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/Slf4jReporter.java
@@ -177,13 +177,13 @@ public class Slf4jReporter extends ScheduledReporter {
     }
 
     @Override
-    public void report(SortedMap<MetricName, Gauge> gauges,
+    public void report(SortedMap<MetricName, Gauge<?>> gauges,
                        SortedMap<MetricName, Counter> counters,
                        SortedMap<MetricName, Histogram> histograms,
                        SortedMap<MetricName, Meter> meters,
                        SortedMap<MetricName, Timer> timers) {
         if (loggerProxy.isEnabled(marker)) {
-            for (Entry<MetricName, Gauge> entry : gauges.entrySet()) {
+            for (Entry<MetricName, Gauge<?>> entry : gauges.entrySet()) {
                 logGauge(entry.getKey(), entry.getValue());
             }
 

--- a/metrics-core/src/test/java/io/dropwizard/metrics/ConsoleReporterTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/ConsoleReporterTest.java
@@ -53,7 +53,7 @@ public class ConsoleReporterTest {
         final Gauge gauge = mock(Gauge.class);
         when(gauge.getValue()).thenReturn(1);
 
-        reporter.report(map("gauge", gauge),
+        reporter.report(this.<Gauge<?>>map("gauge", gauge),
                         this.<Counter>map(),
                         this.<Histogram>map(),
                         this.<Meter>map(),
@@ -76,7 +76,7 @@ public class ConsoleReporterTest {
         final Counter counter = mock(Counter.class);
         when(counter.getCount()).thenReturn(100L);
 
-        reporter.report(this.<Gauge>map(),
+        reporter.report(this.<Gauge<?>>map(),
                         map("test.counter", counter),
                         this.<Histogram>map(),
                         this.<Meter>map(),
@@ -113,7 +113,7 @@ public class ConsoleReporterTest {
 
         when(histogram.getSnapshot()).thenReturn(snapshot);
 
-        reporter.report(this.<Gauge>map(),
+        reporter.report(this.<Gauge<?>>map(),
                         this.<Counter>map(),
                         map("test.histogram", histogram),
                         this.<Meter>map(),
@@ -150,7 +150,7 @@ public class ConsoleReporterTest {
         when(meter.getFiveMinuteRate()).thenReturn(4.0);
         when(meter.getFifteenMinuteRate()).thenReturn(5.0);
 
-        reporter.report(this.<Gauge>map(),
+        reporter.report(this.<Gauge<?>>map(),
                         this.<Counter>map(),
                         this.<Histogram>map(),
                         map("test.meter", meter),
@@ -196,7 +196,7 @@ public class ConsoleReporterTest {
 
         when(timer.getSnapshot()).thenReturn(snapshot);
 
-        reporter.report(this.<Gauge>map(),
+        reporter.report(this.<Gauge<?>>map(),
                         this.<Counter>map(),
                         this.<Histogram>map(),
                         this.<Meter>map(),

--- a/metrics-core/src/test/java/io/dropwizard/metrics/CsvReporterTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/CsvReporterTest.java
@@ -41,10 +41,10 @@ public class CsvReporterTest {
 
     @Test
     public void reportsGaugeValues() throws Exception {
-        final Gauge gauge = mock(Gauge.class);
+        final Gauge<?> gauge = mock(Gauge.class);
         when(gauge.getValue()).thenReturn(1);
 
-        reporter.report(map("gauge", gauge),
+        reporter.report(this.<Gauge<?>>map("gauge", gauge),
                         this.<Counter>map(),
                         this.<Histogram>map(),
                         this.<Meter>map(),
@@ -62,7 +62,7 @@ public class CsvReporterTest {
         final Counter counter = mock(Counter.class);
         when(counter.getCount()).thenReturn(100L);
 
-        reporter.report(this.<Gauge>map(),
+        reporter.report(this.<Gauge<?>>map(),
                         map("test.counter", counter),
                         this.<Histogram>map(),
                         this.<Meter>map(),
@@ -94,7 +94,7 @@ public class CsvReporterTest {
 
         when(histogram.getSnapshot()).thenReturn(snapshot);
 
-        reporter.report(this.<Gauge>map(),
+        reporter.report(this.<Gauge<?>>map(),
                         this.<Counter>map(),
                         map("test.histogram", histogram),
                         this.<Meter>map(),
@@ -116,7 +116,7 @@ public class CsvReporterTest {
         when(meter.getFiveMinuteRate()).thenReturn(4.0);
         when(meter.getFifteenMinuteRate()).thenReturn(5.0);
 
-        reporter.report(this.<Gauge>map(),
+        reporter.report(this.<Gauge<?>>map(),
                         this.<Counter>map(),
                         this.<Histogram>map(),
                         map("test.meter", meter),
@@ -152,7 +152,7 @@ public class CsvReporterTest {
 
         when(timer.getSnapshot()).thenReturn(snapshot);
 
-        reporter.report(this.<Gauge>map(),
+        reporter.report(this.<Gauge<?>>map(),
                         this.<Counter>map(),
                         this.<Histogram>map(),
                         this.<Meter>map(),
@@ -177,7 +177,7 @@ public class CsvReporterTest {
         final Gauge gauge = mock(Gauge.class);
         when(gauge.getValue()).thenReturn(1);
 
-        reporter.report(map("gauge", gauge),
+        reporter.report(this.<Gauge<?>>map("gauge", gauge),
                 this.<Counter>map(),
                 this.<Histogram>map(),
                 this.<Meter>map(),
@@ -213,11 +213,11 @@ public class CsvReporterTest {
     }
 
     private <T> SortedMap<MetricName, T> map() {
-        return new TreeMap<MetricName, T>();
+        return new TreeMap<>();
     }
 
     private <T> SortedMap<MetricName, T> map(String name, T metric) {
-        final TreeMap<MetricName, T> map = new TreeMap<MetricName, T>();
+        final TreeMap<MetricName, T> map = new TreeMap<>();
         map.put(MetricName.build(name), metric);
         return map;
     }

--- a/metrics-core/src/test/java/io/dropwizard/metrics/ScheduledReporterTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/ScheduledReporterTest.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 import static org.mockito.Mockito.*;
 
 public class ScheduledReporterTest {
-    private final Gauge gauge = mock(Gauge.class);
+    private final Gauge<?> gauge = mock(Gauge.class);
     private final Counter counter = mock(Counter.class);
     private final Histogram histogram = mock(Histogram.class);
     private final Meter meter = mock(Meter.class);
@@ -35,7 +35,7 @@ public class ScheduledReporterTest {
                                   TimeUnit.SECONDS,
                                   TimeUnit.MILLISECONDS) {
                 @Override
-                public void report(SortedMap<MetricName, Gauge> gauges,
+                public void report(SortedMap<MetricName, Gauge<?>> gauges,
                                    SortedMap<MetricName, Counter> counters,
                                    SortedMap<MetricName, Histogram> histograms,
                                    SortedMap<MetricName, Meter> meters,
@@ -65,7 +65,7 @@ public class ScheduledReporterTest {
     public void pollsPeriodically() throws Exception {
         Thread.sleep(500);
         verify(reporter, times(2)).report(
-                map("gauge", gauge),
+                this.<Gauge<?>>map("gauge", gauge),
                 map("counter", counter),
                 map("histogram", histogram),
                 map("meter", meter),
@@ -74,7 +74,7 @@ public class ScheduledReporterTest {
     }
 
     private <T> SortedMap<MetricName, T> map(String name, T value) {
-        final SortedMap<MetricName, T> map = new TreeMap<MetricName, T>();
+        final SortedMap<MetricName, T> map = new TreeMap<>();
         map.put(MetricName.build(name), value);
         return map;
     }

--- a/metrics-core/src/test/java/io/dropwizard/metrics/Slf4jReporterTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/Slf4jReporterTest.java
@@ -47,7 +47,7 @@ public class Slf4jReporterTest {
     @Test
     public void reportsGaugeValuesAtError() throws Exception {
         when(logger.isErrorEnabled(marker)).thenReturn(true);
-        errorReporter.report(map("gauge", gauge("value")),
+        errorReporter.report(this.<Gauge<?>>map("gauge", gauge("value")),
                 this.<Counter>map(),
                 this.<Histogram>map(),
                 this.<Meter>map(),
@@ -62,7 +62,7 @@ public class Slf4jReporterTest {
         when(counter.getCount()).thenReturn(100L);
         when(logger.isErrorEnabled(marker)).thenReturn(true);
 
-        errorReporter.report(this.<Gauge>map(),
+        errorReporter.report(this.<Gauge<?>>map(),
                 map("test.counter", counter),
                 this.<Histogram>map(),
                 this.<Meter>map(),
@@ -91,7 +91,7 @@ public class Slf4jReporterTest {
         when(histogram.getSnapshot()).thenReturn(snapshot);
         when(logger.isErrorEnabled(marker)).thenReturn(true);
 
-        errorReporter.report(this.<Gauge>map(),
+        errorReporter.report(this.<Gauge<?>>map(),
                 this.<Counter>map(),
                 map("test.histogram", histogram),
                 this.<Meter>map(),
@@ -124,7 +124,7 @@ public class Slf4jReporterTest {
         when(meter.getFifteenMinuteRate()).thenReturn(5.0);
         when(logger.isErrorEnabled(marker)).thenReturn(true);
 
-        errorReporter.report(this.<Gauge>map(),
+        errorReporter.report(this.<Gauge<?>>map(),
                 this.<Counter>map(),
                 this.<Histogram>map(),
                 map("test.meter", meter),
@@ -169,7 +169,7 @@ public class Slf4jReporterTest {
 
         when(logger.isErrorEnabled(marker)).thenReturn(true);
 
-        errorReporter.report(this.<Gauge>map(),
+        errorReporter.report(this.<Gauge<?>>map(),
                 this.<Counter>map(),
                 this.<Histogram>map(),
                 this.<Meter>map(),
@@ -201,7 +201,7 @@ public class Slf4jReporterTest {
     @Test
     public void reportsGaugeValues() throws Exception {
         when(logger.isInfoEnabled(marker)).thenReturn(true);
-        infoReporter.report(map("gauge", gauge("value")),
+        infoReporter.report(this.<Gauge<?>>map("gauge", gauge("value")),
                 this.<Counter>map(),
                 this.<Histogram>map(),
                 this.<Meter>map(),
@@ -216,7 +216,7 @@ public class Slf4jReporterTest {
         when(counter.getCount()).thenReturn(100L);
         when(logger.isInfoEnabled(marker)).thenReturn(true);
 
-        infoReporter.report(this.<Gauge>map(),
+        infoReporter.report(this.<Gauge<?>>map(),
                 map("test.counter", counter),
                 this.<Histogram>map(),
                 this.<Meter>map(),
@@ -245,7 +245,7 @@ public class Slf4jReporterTest {
         when(histogram.getSnapshot()).thenReturn(snapshot);
         when(logger.isInfoEnabled(marker)).thenReturn(true);
 
-        infoReporter.report(this.<Gauge>map(),
+        infoReporter.report(this.<Gauge<?>>map(),
                 this.<Counter>map(),
                 map("test.histogram", histogram),
                 this.<Meter>map(),
@@ -278,7 +278,7 @@ public class Slf4jReporterTest {
         when(meter.getFifteenMinuteRate()).thenReturn(5.0);
         when(logger.isInfoEnabled(marker)).thenReturn(true);
 
-        infoReporter.report(this.<Gauge>map(),
+        infoReporter.report(this.<Gauge<?>>map(),
                 this.<Counter>map(),
                 this.<Histogram>map(),
                 map("test.meter", meter),
@@ -322,7 +322,7 @@ public class Slf4jReporterTest {
         when(timer.getSnapshot()).thenReturn(snapshot);
         when(logger.isInfoEnabled(marker)).thenReturn(true);
 
-        infoReporter.report(this.<Gauge>map(),
+        infoReporter.report(this.<Gauge<?>>map(),
                 this.<Counter>map(),
                 this.<Histogram>map(),
                 this.<Meter>map(),
@@ -361,8 +361,8 @@ public class Slf4jReporterTest {
         return map;
     }
 
-    private <T> Gauge gauge(T value) {
-        final Gauge gauge = mock(Gauge.class);
+    private <T> Gauge<?> gauge(T value) {
+        final Gauge<?> gauge = mock(Gauge.class);
         when(gauge.getValue()).thenReturn(value);
         return gauge;
     }

--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteReporter.java
@@ -154,7 +154,7 @@ public class GraphiteReporter extends ScheduledReporter {
     }
 
     @Override
-    public void report(SortedMap<MetricName, Gauge> gauges,
+    public void report(SortedMap<MetricName, Gauge<?>> gauges,
                        SortedMap<MetricName, Counter> counters,
                        SortedMap<MetricName, Histogram> histograms,
                        SortedMap<MetricName, Meter> meters,
@@ -167,7 +167,7 @@ public class GraphiteReporter extends ScheduledReporter {
     	          graphite.connect();
             }
 
-            for (Map.Entry<MetricName, Gauge> entry : gauges.entrySet()) {
+            for (Map.Entry<MetricName, Gauge<?>> entry : gauges.entrySet()) {
                 reportGauge(entry.getKey(), entry.getValue(), timestamp);
             }
 

--- a/metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteReporterTest.java
@@ -43,7 +43,7 @@ public class GraphiteReporterTest {
 
     @Test
     public void doesNotReportStringGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge("value")),
+        reporter.report(this.<Gauge<?>>map("gauge", gauge("value")),
                         this.<Counter>map(),
                         this.<Histogram>map(),
                         this.<Meter>map(),
@@ -60,7 +60,7 @@ public class GraphiteReporterTest {
 
     @Test
     public void reportsByteGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge((byte) 1)),
+        reporter.report(this.<Gauge<?>>map("gauge", gauge((byte) 1)),
                         this.<Counter>map(),
                         this.<Histogram>map(),
                         this.<Meter>map(),
@@ -77,7 +77,7 @@ public class GraphiteReporterTest {
 
     @Test
     public void reportsShortGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge((short) 1)),
+        reporter.report(this.<Gauge<?>>map("gauge", gauge((short) 1)),
                         this.<Counter>map(),
                         this.<Histogram>map(),
                         this.<Meter>map(),
@@ -94,7 +94,7 @@ public class GraphiteReporterTest {
 
     @Test
     public void reportsIntegerGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1)),
+        reporter.report(this.<Gauge<?>>map("gauge", gauge(1)),
                         this.<Counter>map(),
                         this.<Histogram>map(),
                         this.<Meter>map(),
@@ -111,7 +111,7 @@ public class GraphiteReporterTest {
 
     @Test
     public void reportsLongGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1L)),
+        reporter.report(this.<Gauge<?>>map("gauge", gauge(1L)),
                         this.<Counter>map(),
                         this.<Histogram>map(),
                         this.<Meter>map(),
@@ -128,7 +128,7 @@ public class GraphiteReporterTest {
 
     @Test
     public void reportsFloatGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1.1f)),
+        reporter.report(this.<Gauge<?>>map("gauge", gauge(1.1f)),
                         this.<Counter>map(),
                         this.<Histogram>map(),
                         this.<Meter>map(),
@@ -145,7 +145,7 @@ public class GraphiteReporterTest {
 
     @Test
     public void reportsDoubleGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1.1)),
+        reporter.report(this.<Gauge<?>>map("gauge", gauge(1.1)),
                         this.<Counter>map(),
                         this.<Histogram>map(),
                         this.<Meter>map(),
@@ -165,8 +165,8 @@ public class GraphiteReporterTest {
         final Counter counter = mock(Counter.class);
         when(counter.getCount()).thenReturn(100L);
 
-        reporter.report(this.<Gauge>map(),
-                        this.<Counter>map("counter", counter),
+        reporter.report(this.<Gauge<?>>map(),
+                        this.map("counter", counter),
                         this.<Histogram>map(),
                         this.<Meter>map(),
                         this.<Timer>map());
@@ -199,7 +199,7 @@ public class GraphiteReporterTest {
 
         when(histogram.getSnapshot()).thenReturn(snapshot);
 
-        reporter.report(this.<Gauge>map(),
+        reporter.report(this.<Gauge<?>>map(),
                         this.<Counter>map(),
                         this.<Histogram>map("histogram", histogram),
                         this.<Meter>map(),
@@ -233,10 +233,10 @@ public class GraphiteReporterTest {
         when(meter.getFifteenMinuteRate()).thenReturn(4.0);
         when(meter.getMeanRate()).thenReturn(5.0);
 
-        reporter.report(this.<Gauge>map(),
+        reporter.report(this.<Gauge<?>>map(),
                         this.<Counter>map(),
                         this.<Histogram>map(),
-                        this.<Meter>map("meter", meter),
+                        this.map("meter", meter),
                         this.<Timer>map());
 
         final InOrder inOrder = inOrder(graphite);
@@ -276,7 +276,7 @@ public class GraphiteReporterTest {
 
         when(timer.getSnapshot()).thenReturn(snapshot);
 
-        reporter.report(this.<Gauge>map(),
+        reporter.report(this.<Gauge<?>>map(),
                         this.<Counter>map(),
                         this.<Histogram>map(),
                         this.<Meter>map(),
@@ -308,7 +308,7 @@ public class GraphiteReporterTest {
     @Test
     public void closesConnectionIfGraphiteIsUnavailable() throws Exception {
         doThrow(new UnknownHostException("UNKNOWN-HOST")).when(graphite).connect();
-        reporter.report(map("gauge", gauge(1)),
+        reporter.report(this.<Gauge<?>>map("gauge", gauge(1)),
             this.<Counter>map(),
             this.<Histogram>map(),
             this.<Meter>map(),
@@ -327,7 +327,7 @@ public class GraphiteReporterTest {
         final Gauge gauge = mock(Gauge.class);
         when(gauge.getValue()).thenThrow(new RuntimeException("kaboom"));
 
-        reporter.report(map("gauge", gauge),
+        reporter.report(this.<Gauge<?>>map("gauge", gauge),
                         this.<Counter>map(),
                         this.<Histogram>map(),
                         this.<Meter>map(),

--- a/metrics-influxdb/src/main/java/io/dropwizard/metrics/influxdb/InfluxDbReporter.java
+++ b/metrics-influxdb/src/main/java/io/dropwizard/metrics/influxdb/InfluxDbReporter.java
@@ -120,14 +120,14 @@ public final class InfluxDbReporter extends ScheduledReporter {
     }
 
     @Override
-    public void report(final SortedMap<MetricName, Gauge> gauges, final SortedMap<MetricName, Counter> counters,
+    public void report(final SortedMap<MetricName, Gauge<?>> gauges, final SortedMap<MetricName, Counter> counters,
                        final SortedMap<MetricName, Histogram> histograms, final SortedMap<MetricName, Meter> meters, final SortedMap<MetricName, Timer> timers) {
         final long now = System.currentTimeMillis();
 
         try {
             influxDb.flush();
 
-            for (Map.Entry<MetricName, Gauge> entry : gauges.entrySet()) {
+            for (Map.Entry<MetricName, Gauge<?>> entry : gauges.entrySet()) {
                 reportGauge(entry.getKey(), entry.getValue(), now);
             }
 

--- a/metrics-influxdb/src/test/java/io/dropwizard/metrics/influxdb/InfluxDbReporterTest.java
+++ b/metrics-influxdb/src/test/java/io/dropwizard/metrics/influxdb/InfluxDbReporterTest.java
@@ -52,7 +52,7 @@ public class InfluxDbReporterTest {
         final Counter counter = mock(Counter.class);
         Mockito.when(counter.getCount()).thenReturn(100L);
 
-        reporter.report(this.<Gauge>map(), this.map("counter", counter), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
+        reporter.report(this.<Gauge<?>>map(), this.map("counter", counter), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
         final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
         Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
         InfluxDbPoint point = influxDbPointCaptor.getValue();
@@ -81,7 +81,7 @@ public class InfluxDbReporterTest {
 
         when(histogram.getSnapshot()).thenReturn(snapshot);
 
-        reporter.report(this.<Gauge>map(), this.<Counter>map(), this.map("histogram", histogram), this.<Meter>map(), this.<Timer>map());
+        reporter.report(this.<Gauge<?>>map(), this.<Counter>map(), this.map("histogram", histogram), this.<Meter>map(), this.<Timer>map());
 
         final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
         Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
@@ -111,7 +111,7 @@ public class InfluxDbReporterTest {
         when(meter.getFifteenMinuteRate()).thenReturn(4.0);
         when(meter.getMeanRate()).thenReturn(5.0);
 
-        reporter.report(this.<Gauge>map(), this.<Counter>map(), this.<Histogram>map(), this.map("meter", meter), this.<Timer>map());
+        reporter.report(this.<Gauge<?>>map(), this.<Counter>map(), this.<Histogram>map(), this.map("meter", meter), this.<Timer>map());
 
         final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
         Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
@@ -150,7 +150,7 @@ public class InfluxDbReporterTest {
 
         when(timer.getSnapshot()).thenReturn(snapshot);
 
-        reporter.report(this.<Gauge>map(), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), map("timer", timer));
+        reporter.report(this.<Gauge<?>>map(), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), map("timer", timer));
 
         final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
         Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
@@ -178,7 +178,7 @@ public class InfluxDbReporterTest {
 
     @Test
     public void reportsIntegerGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
+        reporter.report(this.<Gauge<?>>map("gauge", gauge(1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
 
         final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
         Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
@@ -192,7 +192,7 @@ public class InfluxDbReporterTest {
 
     @Test
     public void reportsLongGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1L)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
+        reporter.report(this.<Gauge<?>>map("gauge", gauge(1L)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
 
         final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
         Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
@@ -206,7 +206,7 @@ public class InfluxDbReporterTest {
 
     @Test
     public void reportsFloatGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1.1f)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
+        reporter.report(this.<Gauge<?>>map("gauge", gauge(1.1f)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
 
         final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
         Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
@@ -220,7 +220,7 @@ public class InfluxDbReporterTest {
 
     @Test
     public void reportsDoubleGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1.1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
+        reporter.report(this.<Gauge<?>>map("gauge", gauge(1.1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
 
         final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
         Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
@@ -235,7 +235,7 @@ public class InfluxDbReporterTest {
     @Test
     public void reportsByteGaugeValues() throws Exception {
         reporter
-                .report(map("gauge", gauge((byte) 1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
+                .report(this.<Gauge<?>>map("gauge", gauge((byte) 1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(), this.<Timer>map());
 
         final ArgumentCaptor<InfluxDbPoint> influxDbPointCaptor = ArgumentCaptor.forClass(InfluxDbPoint.class);
         Mockito.verify(influxDb, atLeastOnce()).appendPoints(influxDbPointCaptor.capture());
@@ -257,8 +257,8 @@ public class InfluxDbReporterTest {
         return map;
     }
 
-    private <T> Gauge gauge(T value) {
-        final Gauge gauge = mock(Gauge.class);
+    private <T> Gauge<?> gauge(T value) {
+        final Gauge<?> gauge = mock(Gauge.class);
         when(gauge.getValue()).thenReturn(value);
         return gauge;
     }


### PR DESCRIPTION
Hi!
I tried to create a class derived from ScheduledReporter. Since I want to have clean code and no warnings, I was not able to do it, because the gauge interface is defined with a type parameter "Gauge<T>" whereas the abstract method "report" in ScheduledReporter.java only uses the raw type in it's method signature.
I digged into the code and the use of generics there is quite tricky sometimes. My little fix is no perfect solution, but I hope it makes it a little better than before.

Regards,
Sebastian
