### PR TITLE
Negative and large tick value fixes

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/SlidingTimeWindowReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SlidingTimeWindowReservoir.java
@@ -9,8 +9,6 @@ import java.util.concurrent.atomic.AtomicLong;
  * in the last {@code N} seconds (or other time unit).
  */
 public class SlidingTimeWindowReservoir implements Reservoir {
-    // allow for this many duplicate ticks before overwriting measurements
-    private static final int COLLISION_BUFFER = 256;
     // only trim on updating once every N
     private static final int TRIM_THRESHOLD = 256;
 
@@ -40,8 +38,8 @@ public class SlidingTimeWindowReservoir implements Reservoir {
     public SlidingTimeWindowReservoir(long window, TimeUnit windowUnit, Clock clock) {
         this.clock = clock;
         this.measurements = new ConcurrentSkipListMap<Long, Long>();
-        this.window = windowUnit.toNanos(window) * COLLISION_BUFFER;
-        this.lastTick = new AtomicLong(clock.getTick() * COLLISION_BUFFER);
+        this.window = windowUnit.toNanos(window);
+        this.lastTick = new AtomicLong(clock.getTick());
         this.count = new AtomicLong();
     }
 
@@ -68,7 +66,7 @@ public class SlidingTimeWindowReservoir implements Reservoir {
     private long getTick() {
         for (; ; ) {
             final long oldTick = lastTick.get();
-            final long tick = clock.getTick() * COLLISION_BUFFER;
+            final long tick = clock.getTick();
             // ensure the tick is strictly incrementing even if there are duplicate ticks
             final long newTick = tick - oldTick > 0 ? tick : oldTick + 1;
             if (lastTick.compareAndSet(oldTick, newTick)) {
@@ -78,6 +76,9 @@ public class SlidingTimeWindowReservoir implements Reservoir {
     }
 
     private void trim() {
-        measurements.headMap(getTick() - window).clear();
+        long tick = getTick();
+        if (Long.MIN_VALUE + window < tick) {
+            measurements.headMap(tick - window).clear();
+        }
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowReservoirTest.java
@@ -24,6 +24,39 @@ public class SlidingTimeWindowReservoirTest {
     }
 
     @Test
+    public void storesMeasurementsWithDuplicateTicksTresholdNeg() throws Exception {
+        when(clock.getTick()).thenReturn(Long.MIN_VALUE / 256);
+        SlidingTimeWindowReservoir reservoir = new SlidingTimeWindowReservoir(10, TimeUnit.NANOSECONDS, clock);
+
+        reservoir.update(1);
+        reservoir.update(2);
+
+        assertThat(reservoir.getSnapshot().getValues())
+                .containsOnly(1, 2);
+    }
+
+    @Test
+    public void storesMeasurementsWithDuplicateTicksMinNeg() throws Exception {
+        when(clock.getTick()).thenReturn(Long.MIN_VALUE);
+        SlidingTimeWindowReservoir reservoir = new SlidingTimeWindowReservoir(10, TimeUnit.NANOSECONDS, clock);
+
+        reservoir.update(1);
+        reservoir.update(2);
+
+        assertThat(reservoir.getSnapshot().getValues())
+                .containsOnly(1, 2);
+    }
+
+    @Test
+    public void storesMeasurementsWithTresholdTicks() throws Exception {
+        when(clock.getTick()).thenReturn(TimeUnit.DAYS.toNanos(416));
+        reservoir.update(1);
+
+        when(clock.getTick()).thenReturn(TimeUnit.DAYS.toNanos(417));
+        assertThat(reservoir.getSnapshot().getValues()).isEmpty();;
+    }
+
+    @Test
     public void boundsMeasurementsToATimeWindow() throws Exception {
         when(clock.getTick()).thenReturn(0L);
         reservoir.update(1);


### PR DESCRIPTION
Collision buffer will cause overflow at 417 days of server uptime (not
JVM). Also it would take 1,000,000 requests in the same millisecond to
cause loss of accuracy of 1 ms, so this buffer is not needed and given
that it causes problems, should be removed.
Also added test case for large negative values of tick (rarely happens,
but according to nanoTime api, it can)