### PR TITLE
Making collision bit width configurable,

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics/SlidingTimeWindowReservoir.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/SlidingTimeWindowReservoir.java
@@ -53,9 +53,9 @@ public class SlidingTimeWindowReservoir implements Reservoir {
      * @param collisionBitwidth
      */
     public SlidingTimeWindowReservoir(long window, TimeUnit windowUnit, int collisionBitwidth) {
-        this(window, windowUnit, Clock.defaultClock());
+        this(window, windowUnit, Clock.defaultClock(), collisionBitwidth);
     }
-    
+
     /**
      * Creates a new {@link SlidingTimeWindowReservoir} with the given clock, window of time and collisionBitwidth.
      * 

--- a/metrics-core/src/main/java/io/dropwizard/metrics/SlidingTimeWindowReservoir.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/SlidingTimeWindowReservoir.java
@@ -47,10 +47,9 @@ public class SlidingTimeWindowReservoir implements Reservoir {
     /**
      * Creates a new {@link SlidingTimeWindowReservoir} with the given window of time and collisionBitwidth.
      * 
-     * @param window
-     * @param windowUnit
-     * @param clock
-     * @param collisionBitwidth
+     * @param window            the window of time
+     * @param windowUnit        the unit of {@code window}
+     * @param collisionBitwidth the bit size of the collision buffer (default is 8 which will yield 256 observations per nanosecond)
      */
     public SlidingTimeWindowReservoir(long window, TimeUnit windowUnit, int collisionBitwidth) {
         this(window, windowUnit, Clock.defaultClock(), collisionBitwidth);
@@ -59,10 +58,10 @@ public class SlidingTimeWindowReservoir implements Reservoir {
     /**
      * Creates a new {@link SlidingTimeWindowReservoir} with the given clock, window of time and collisionBitwidth.
      * 
-     * @param window
-     * @param windowUnit
-     * @param clock
-     * @param collisionBitwidth
+     * @param window            the window of time
+     * @param windowUnit        the unit of {@code window}
+     * @param clock             the {@link Clock} to use
+     * @param collisionBitwidth the bit size of the collision buffer (default is 8 which will yield 256 observations per nanosecond)
      */
     public SlidingTimeWindowReservoir(long window, TimeUnit windowUnit, Clock clock, int collisionBitwidth) {
         this.collisionBuffer = 1 << collisionBitwidth;

--- a/metrics-core/src/main/java/io/dropwizard/metrics/SlidingTimeWindowReservoir.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/SlidingTimeWindowReservoir.java
@@ -73,7 +73,7 @@ public class SlidingTimeWindowReservoir implements Reservoir {
         this.lastTick = new AtomicLong((clock.getTick() & collisionModulo) * collisionBuffer);
         this.count = new AtomicLong();
     }
-    
+
     @Override
     public int size() {
         trim();

--- a/metrics-core/src/test/java/io/dropwizard/metrics/SlidingTimeWindowReservoirTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/SlidingTimeWindowReservoirTest.java
@@ -27,6 +27,42 @@ public class SlidingTimeWindowReservoirTest {
     }
 
     @Test
+    public void storesMeasurementsWithDuplicateTicksTresholdNeg() throws Exception {
+        when(clock.getTick()).thenReturn(Long.MIN_VALUE / 256);
+        SlidingTimeWindowReservoir reservoir = new SlidingTimeWindowReservoir(10, TimeUnit.NANOSECONDS, clock);
+
+        reservoir.update(1);
+        reservoir.update(2);
+
+        assertThat(reservoir.getSnapshot().getValues())
+                .containsOnly(1, 2);
+    }
+
+    @Test
+    public void storesMeasurementsWithDuplicateTicksMinNeg() throws Exception {
+        when(clock.getTick()).thenReturn(Long.MIN_VALUE);
+        SlidingTimeWindowReservoir reservoir = new SlidingTimeWindowReservoir(10, TimeUnit.NANOSECONDS, clock);
+
+        reservoir.update(1);
+        reservoir.update(2);
+
+        assertThat(reservoir.getSnapshot().getValues())
+                .containsOnly(1, 2);
+    }
+
+    @Test
+    public void storesMeasurementsWithTresholdTicks() throws Exception {
+        // Won't fail on 4 bits, but still fails on default 8 bits
+        SlidingTimeWindowReservoir reservoir = new SlidingTimeWindowReservoir(10, TimeUnit.NANOSECONDS, clock, 4);
+
+        when(clock.getTick()).thenReturn(TimeUnit.DAYS.toNanos(416));
+        reservoir.update(1);
+
+        when(clock.getTick()).thenReturn(TimeUnit.DAYS.toNanos(417));
+        assertThat(reservoir.getSnapshot().getValues()).isEmpty();;
+    }
+
+    @Test
     public void boundsMeasurementsToATimeWindow() throws Exception {
         when(clock.getTick()).thenReturn(0L);
         reservoir.update(1);


### PR DESCRIPTION
Collision buffer will cause overflow at 417 days of server uptime (not
JVM). Making it configurable, so users can choose between precision and
longer period of time without having to reboot physical node to reset
up time
