### PR TITLE
Graphite: Replace names with non-alphanumeric chars with '-'

### DIFF
--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteRabbitMQ.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteRabbitMQ.java
@@ -9,14 +9,11 @@ import java.io.IOException;
 import java.net.Socket;
 import java.nio.charset.Charset;
 import java.util.concurrent.TimeoutException;
-import java.util.regex.Pattern;
 
 /**
  * A rabbit-mq client to a Carbon server.
  */
 public class GraphiteRabbitMQ implements GraphiteSender {
-
-    private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
 
     private static final Charset UTF_8 = Charset.forName("UTF-8");
 
@@ -167,7 +164,7 @@ public class GraphiteRabbitMQ implements GraphiteSender {
     }
 
     public String sanitize(String s) {
-        return WHITESPACE.matcher(s).replaceAll("-");
+        return GraphiteSanitize.sanitize(s, '-');
     }
 
 }

--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteSanitize.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteSanitize.java
@@ -1,0 +1,71 @@
+package io.dropwizard.metrics.graphite;
+
+class GraphiteSanitize {
+    /** Replaces all characters from a given string that are not ascii and not alphanumeric
+     *  with a dash */
+    static String sanitize(String string, char replacement) {
+        String replaced = replaceFrom(string, replacement);
+
+        // Consolidate multiple dashes into a single one
+        String result = replaced.replace("--", "-");
+        while (!result.equals(replaced)) {
+            replaced = result;
+            result = replaced.replace("--", "-");
+        }
+
+        // Remove any leading or trailing dashes
+        return strip(result, replacement);
+    }
+
+    /** A char matches when it is a letter or digit and it is ASCII, in Guava terminology,
+     *  this would be CharMatcher.ASCII.and(CharMatcher.JAVA_LETTER_OR_DIGIT).negate() */
+    private static boolean matches(char c) {
+        return !(Character.isLetterOrDigit(c) && c <= '\u007f');
+    }
+
+    /** Replace all characters that we're interested in with a replacement character,
+     *  heavily inspired by the same code in Guava's CharMatcher */
+    private static String replaceFrom(String string, char replacement) {
+        int pos = indexIn(string, 0);
+        if (pos == -1) {
+            return string;
+        }
+        char[] chars = string.toCharArray();
+        chars[pos] = replacement;
+        for (int i = pos + 1; i < chars.length; i++) {
+            if (matches(chars[i])) {
+                chars[i] = replacement;
+            }
+        }
+        return new String(chars).trim();
+    }
+
+    /** Finds the first index (or -1) of a character we're interested in */
+    private static int indexIn(String sequence, int start) {
+        int length = sequence.length();
+        for (int i = start; i < length; i++) {
+            if (matches(sequence.charAt(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /** Strips a given character from the beginning and end of a string,
+     *  heavily inspired by Apache's StringUtils.strip
+     */
+    private static String strip(String str, char strip) {
+        int strLen = str.length();
+        int start = 0;
+        int end = strLen - 1;
+        while (start != strLen && str.charAt(start) == strip) {
+            start++;
+        }
+
+        while (end > start && str.charAt(end) == strip) {
+            end--;
+        }
+
+        return start != 0 || end != strLen - 1 ? str.substring(start, end + 1) : str;
+    }
+}

--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteUDP.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/GraphiteUDP.java
@@ -5,14 +5,11 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.nio.charset.Charset;
-import java.util.regex.Pattern;
 
 /**
  * A client to a Carbon server using unconnected UDP
  */
 public class GraphiteUDP implements GraphiteSender {
-
-    private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
 
     private static final Charset UTF_8 = Charset.forName("UTF-8");
 
@@ -111,7 +108,7 @@ public class GraphiteUDP implements GraphiteSender {
     }
 
     protected String sanitize(String s) {
-        return WHITESPACE.matcher(s).replaceAll("-");
+        return GraphiteSanitize.sanitize(s, '-');
     }
 
 }

--- a/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/PickledGraphite.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics/graphite/PickledGraphite.java
@@ -18,14 +18,12 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * A client to a Carbon server that sends all metrics after they have been pickled in configurable sized batches
  */
 public class PickledGraphite implements GraphiteSender {
 
-    private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
     private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PickledGraphite.class);
@@ -360,7 +358,7 @@ public class PickledGraphite implements GraphiteSender {
     }
 
     protected String sanitize(String s) {
-        return WHITESPACE.matcher(s).replaceAll("-");
+        return GraphiteSanitize.sanitize(s, '-');
     }
 
 }

--- a/metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteSanitizeTest.java
+++ b/metrics-graphite/src/test/java/io/dropwizard/metrics/graphite/GraphiteSanitizeTest.java
@@ -1,0 +1,27 @@
+package io.dropwizard.metrics.graphite;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+
+public class GraphiteSanitizeTest {
+    @Test
+    public void sanitizeGraphiteValues() {
+        SoftAssertions softly = new SoftAssertions();
+
+        softly.assertThat(GraphiteSanitize.sanitize("Foo Bar", '-')).isEqualTo("Foo-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize(" Foo Bar ", '-')).isEqualTo("Foo-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize(" Foo Bar", '-')).isEqualTo("Foo-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize("Foo Bar ", '-')).isEqualTo("Foo-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize("  Foo Bar  ", '-')).isEqualTo("Foo-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize("Foo@Bar", '-')).isEqualTo("Foo-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize("Foó Bar", '-')).isEqualTo("Fo-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize("||ó/.", '-')).isEqualTo("");
+        softly.assertThat(GraphiteSanitize.sanitize("${Foo:Bar:baz}", '-')).isEqualTo("Foo-Bar-baz");
+        softly.assertThat(GraphiteSanitize.sanitize("St. Foo's of Bar", '-')).isEqualTo("St-Foo-s-of-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize("(Foo and (Bar and (Baz)))", '-')).isEqualTo("Foo-and-Bar-and-Baz");
+        softly.assertThat(GraphiteSanitize.sanitize("Foo.bar.baz", '-')).isEqualTo("Foo-bar-baz");
+        softly.assertThat(GraphiteSanitize.sanitize("FooBar", '-')).isEqualTo("FooBar");
+
+        softly.assertAll();
+    }
+}


### PR DESCRIPTION
Fix for #637, that supersedes #731 

The fix won't allow any characters that will interfere with Graphite's display or functions.

Instead of using fancy regex, this PR uses code ported from Guava's CharMatcher and Apache's StringUtils.

This PR was made against master because this may break other's graphite metric names, even if some of them aren't 100% valid (eg. `foo:bar` will be logged fine, but some graphite functions will break). Any potential breakage should be able to be fixed through [whisper-merge](https://github.com/graphite-project/whisper/blob/master/bin/whisper-merge.py). If this is wanted for 3.2.0, I'd be more than happy to send another PR against that.