### PR TITLE
New feature: ability to query individual health checks

### DIFF
--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/AdminServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/AdminServlet.java
@@ -20,6 +20,7 @@ public class AdminServlet extends HttpServlet {
     public static final String PING_URI_PARAM_KEY = "ping-uri";
     public static final String THREADS_URI_PARAM_KEY = "threads-uri";
     public static final String HEALTHCHECK_URI_PARAM_KEY = "healthcheck-uri";
+    public static final String HEALTHCHECK_PARAM_ATTRIBUTE_KEY = "healthcheck-param";
     public static final String SERVICE_NAME_PARAM_KEY= "service-name";
     public static final String CPU_PROFILE_URI_PARAM_KEY = "cpu-profile-uri";
 
@@ -107,7 +108,9 @@ public class AdminServlet extends HttpServlet {
         final String uri = req.getPathInfo();
         if (uri == null || uri.equals("/")) {
             super.service(req, resp);
-        } else if (uri.equals(healthcheckUri)) {
+        } else if (uri.startsWith(healthcheckUri)) {
+            String healthCheckParam = uri.substring(healthcheckUri.length());
+            req.setAttribute(HEALTHCHECK_PARAM_ATTRIBUTE_KEY, healthCheckParam);
             healthCheckServlet.service(req, resp);
         } else if (uri.startsWith(metricsUri)) {
             metricsServlet.service(req, resp);

--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collections;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.SortedMap;
 import java.util.concurrent.ExecutorService;
 
@@ -88,10 +89,14 @@ public class HealthCheckServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req,
                          HttpServletResponse resp) throws ServletException, IOException {
-        final Map<String, HealthCheck.Result> results;
+        Map<String, HealthCheck.Result> results;
         String name = getHealthCheckName(req);
         if (name != null) {
-            results = Collections.singletonMap(name, registry.runHealthCheck(name));
+            try {
+                results = Collections.singletonMap(name, registry.runHealthCheck(name));
+            } catch (NoSuchElementException e) {
+                results = Collections.emptyMap();
+            }
         } else {
             results = runHealthChecks();
         }

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
@@ -188,7 +188,7 @@ public class HealthCheckServletTest extends AbstractServletTest {
         assertThat(response.get(HttpHeader.CONTENT_TYPE))
                 .isEqualTo("application/json");
     }
-
+    
     @Test
     public void returns500ForOneCheckIfUnhealthy() throws Exception {
         registry.register("notFun", new HealthCheck() {


### PR DESCRIPTION
We have few health checks in our application. and one of them is basic dead-lock threads.
When this happens we have no choice than to restart the app.
We would like to automate it but we don't like to query all health checks and then parse the response, because it is useless to call all of them and bring some logic to the monitoring tool. Instead we would like to query individual check and act immediately if its failing.

thanks to @ingwarsw  for sorting out unit-tests
