### PR TITLE
Create null versions of the metric types and a NullMetricRegistry that builds them

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -112,7 +112,7 @@ public class MetricRegistry implements MetricSet {
      * @return a new or pre-existing {@link Counter}
      */
     public Counter counter(String name) {
-        return getOrAdd(name, MetricBuilder.COUNTERS);
+        return getOrAdd(name, getCounterMetricBuilder());
     }
 
     /**
@@ -123,7 +123,7 @@ public class MetricRegistry implements MetricSet {
      * @return a new or pre-existing {@link Histogram}
      */
     public Histogram histogram(String name) {
-        return getOrAdd(name, MetricBuilder.HISTOGRAMS);
+        return getOrAdd(name, getHistogramMetricBuilder());
     }
 
     /**
@@ -134,7 +134,7 @@ public class MetricRegistry implements MetricSet {
      * @return a new or pre-existing {@link Meter}
      */
     public Meter meter(String name) {
-        return getOrAdd(name, MetricBuilder.METERS);
+        return getOrAdd(name, getMeterMetricBuilder());
     }
 
     /**
@@ -145,7 +145,7 @@ public class MetricRegistry implements MetricSet {
      * @return a new or pre-existing {@link Timer}
      */
     public Timer timer(String name) {
-        return getOrAdd(name, MetricBuilder.TIMERS);
+        return getOrAdd(name, getTimerMetricBuilder());
     }
 
     /**
@@ -397,9 +397,46 @@ public class MetricRegistry implements MetricSet {
     }
 
     /**
-     * A quick and easy way of capturing the notion of default metrics.
+     * Returns a {@link MetricBuilder} that captures the notion of default counters.
+     * This method is protected so that subclasses may override metric building.
+     * @return a builder that can construct a {@link Counter} 
      */
-    private interface MetricBuilder<T extends Metric> {
+    protected MetricBuilder<Counter> getCounterMetricBuilder() {
+    	return MetricBuilder.COUNTERS;
+    }
+
+    /**
+     * Returns a {@link MetricBuilder} that captures the notion of default histograms.
+     * This method is protected so that subclasses may override metric building.
+     * @return a builder that can construct a {@link Histogram} 
+     */
+    protected MetricBuilder<Histogram> getHistogramMetricBuilder() {
+    	return MetricBuilder.HISTOGRAMS;
+    }
+
+    /**
+     * Returns a {@link MetricBuilder} that captures the notion of default meters.
+     * This method is protected so that subclasses may override metric building.
+     * @return a builder that can construct a {@link Meter} 
+     */
+    protected MetricBuilder<Meter> getMeterMetricBuilder() {
+    	return MetricBuilder.METERS;
+    }
+
+    /**
+     * Returns a {@link MetricBuilder} that captures the notion of default timers.
+     * This method is protected so that subclasses may override metric building.
+     * @return a builder that can construct a {@link Timer} 
+     */
+    protected MetricBuilder<Timer> getTimerMetricBuilder() {
+    	return MetricBuilder.TIMERS;
+    }
+
+    /**
+     * A quick and easy way of capturing the notion of default metrics.
+     * @param <T> the type of {@link Metric} that is created by {@link newMetric}
+     */
+    protected interface MetricBuilder<T extends Metric> {
         MetricBuilder<Counter> COUNTERS = new MetricBuilder<Counter>() {
             @Override
             public Counter newMetric() {

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -402,7 +402,7 @@ public class MetricRegistry implements MetricSet {
      * @return a builder that can construct a {@link Counter} 
      */
     protected MetricBuilder<Counter> getCounterMetricBuilder() {
-    	return MetricBuilder.COUNTERS;
+        return MetricBuilder.COUNTERS;
     }
 
     /**
@@ -411,7 +411,7 @@ public class MetricRegistry implements MetricSet {
      * @return a builder that can construct a {@link Histogram} 
      */
     protected MetricBuilder<Histogram> getHistogramMetricBuilder() {
-    	return MetricBuilder.HISTOGRAMS;
+        return MetricBuilder.HISTOGRAMS;
     }
 
     /**
@@ -420,7 +420,7 @@ public class MetricRegistry implements MetricSet {
      * @return a builder that can construct a {@link Meter} 
      */
     protected MetricBuilder<Meter> getMeterMetricBuilder() {
-    	return MetricBuilder.METERS;
+        return MetricBuilder.METERS;
     }
 
     /**
@@ -429,7 +429,7 @@ public class MetricRegistry implements MetricSet {
      * @return a builder that can construct a {@link Timer} 
      */
     protected MetricBuilder<Timer> getTimerMetricBuilder() {
-    	return MetricBuilder.TIMERS;
+        return MetricBuilder.TIMERS;
     }
 
     /**

--- a/metrics-core/src/main/java/com/codahale/metrics/NullCounter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NullCounter.java
@@ -4,28 +4,28 @@ package com.codahale.metrics;
  * A {@link Counter} metric that cannot be changed from its initial value
  */
 public class NullCounter extends Counter {
-	private final long count;
+    private final long count;
 
-	/**
-	 * Initializes the counter's value to 0
-	 */
-	public NullCounter() {
-		this(0);
-	}
+    /**
+     * Initializes the counter's value to 0
+     */
+    public NullCounter() {
+        this(0);
+    }
 
-	/**
-	 * Initializes the counter's value to initialValue
-	 * 
-	 * @param initialValue will be the counter's value
-	 */
-	public NullCounter(long initialValue) {
-		this.count = initialValue;
-	}
+    /**
+     * Initializes the counter's value to initialValue
+     * 
+     * @param initialValue will be the counter's value
+     */
+    public NullCounter(long initialValue) {
+        this.count = initialValue;
+    }
 
-	/**
+    /**
      * Does nothing.
      */
-	@Override
+    @Override
     public void inc() {
     }
 
@@ -34,14 +34,14 @@ public class NullCounter extends Counter {
      *
      * @param n not used
      */
-	@Override
+    @Override
     public void inc(long n) {
     }
 
     /**
      * Does nothing.
      */
-	@Override
+    @Override
     public void dec() {
     }
 
@@ -50,7 +50,7 @@ public class NullCounter extends Counter {
      *
      * @param n not used
      */
-	@Override
+    @Override
     public void dec(long n) {
     }
 

--- a/metrics-core/src/main/java/com/codahale/metrics/NullCounter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NullCounter.java
@@ -1,0 +1,69 @@
+/**
+ * 
+ */
+package com.codahale.metrics;
+
+/**
+ * A {@link Counter} metric that cannot be changed from its initial value
+ */
+public class NullCounter extends Counter {
+	private final long count;
+
+	/**
+	 * Initializes the counter's value to 0
+	 */
+	public NullCounter() {
+		this(0);
+	}
+
+	/**
+	 * Initializes the counter's value to initialValue
+	 * 
+	 * @param initialValue will be the counter's value
+	 */
+	public NullCounter(long initialValue) {
+		this.count = initialValue;
+	}
+
+	/**
+     * Does nothing.
+     */
+	@Override
+    public void inc() {
+    }
+
+    /**
+     * Does nothing.
+     *
+     * @param n not used
+     */
+	@Override
+    public void inc(long n) {
+    }
+
+    /**
+     * Does nothing.
+     */
+	@Override
+    public void dec() {
+    }
+
+    /**
+     * Does nothing.
+     *
+     * @param n not used
+     */
+	@Override
+    public void dec(long n) {
+    }
+
+    /**
+     * Returns the counter's constant value.
+     *
+     * @return the counter's constant value
+     */
+    @Override
+    public long getCount() {
+        return count;
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/NullCounter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NullCounter.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package com.codahale.metrics;
 
 /**

--- a/metrics-core/src/main/java/com/codahale/metrics/NullHistogram.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NullHistogram.java
@@ -4,40 +4,40 @@ package com.codahale.metrics;
  * A {@link Histogram} metric that cannot be changed from its initial value
  */
 public class NullHistogram extends Histogram {
-	private final Snapshot snapshot;
+    private final Snapshot snapshot;
 
-	/**
-	 * Initializes the histogram's value to contain a single 0.
-	 */
-	public NullHistogram() {
-		this(0);
-	}
+    /**
+     * Initializes the histogram's value to contain a single 0.
+     */
+    public NullHistogram() {
+        this(0);
+    }
 
-	/**
-	 * Initializes the histogram's value to contain a single initialValue.
-	 * 
-	 * @param initialValue will be the histogram's lone value
-	 */
-	public NullHistogram(long initialValue) {
-		this(new long[] { initialValue });
-	}
+    /**
+     * Initializes the histogram's value to contain a single initialValue.
+     * 
+     * @param initialValue will be the histogram's lone value
+     */
+    public NullHistogram(long initialValue) {
+        this(new long[] { initialValue });
+    }
 
-	/**
-	 * Initializes the histogram's values to initialValues.
-	 * 
-	 * @param initialValues will be the histogram's values
-	 */
-	public NullHistogram(long[] initialValues) {
-		super(null);
-		this.snapshot = new UniformSnapshot(initialValues);
-	}
+    /**
+     * Initializes the histogram's values to initialValues.
+     * 
+     * @param initialValues will be the histogram's values
+     */
+    public NullHistogram(long[] initialValues) {
+        super(null);
+        this.snapshot = new UniformSnapshot(initialValues);
+    }
 
     /**
      * Does nothing.
      *
      * @param value not used
      */
-	@Override
+    @Override
     public void update(int value) {
     }
 
@@ -46,7 +46,7 @@ public class NullHistogram extends Histogram {
      *
      * @param value not used
      */
-	@Override
+    @Override
     public void update(long value) {
     }
 
@@ -57,7 +57,7 @@ public class NullHistogram extends Histogram {
      */
     @Override
     public long getCount() {
-    	return snapshot.size();
+        return snapshot.size();
     }
 
     /**

--- a/metrics-core/src/main/java/com/codahale/metrics/NullHistogram.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NullHistogram.java
@@ -1,0 +1,72 @@
+package com.codahale.metrics;
+
+/**
+ * A {@link Histogram} metric that cannot be changed from its initial value
+ */
+public class NullHistogram extends Histogram {
+	private final Snapshot snapshot;
+
+	/**
+	 * Initializes the histogram's value to contain a single 0.
+	 */
+	public NullHistogram() {
+		this(0);
+	}
+
+	/**
+	 * Initializes the histogram's value to contain a single initialValue.
+	 * 
+	 * @param initialValue will be the histogram's lone value
+	 */
+	public NullHistogram(long initialValue) {
+		this(new long[] { initialValue });
+	}
+
+	/**
+	 * Initializes the histogram's values to initialValues.
+	 * 
+	 * @param initialValues will be the histogram's values
+	 */
+	public NullHistogram(long[] initialValues) {
+		super(null);
+		this.snapshot = new UniformSnapshot(initialValues);
+	}
+
+    /**
+     * Does nothing.
+     *
+     * @param value not used
+     */
+	@Override
+    public void update(int value) {
+    }
+
+    /**
+     * Does nothing.
+     *
+     * @param value not used
+     */
+	@Override
+    public void update(long value) {
+    }
+
+    /**
+     * Returns the histogram's constant number of values recorded.
+     *
+     * @return the histogram's constant number of values recorded
+     */
+    @Override
+    public long getCount() {
+    	return snapshot.size();
+    }
+
+    /**
+     * Returns a snapshot representing the histogram's constant values.
+     *
+     * @return a snapshot representing the histogram's constant values
+     */
+    @Override
+    public Snapshot getSnapshot() {
+        return snapshot;
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/NullMeter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NullMeter.java
@@ -4,28 +4,28 @@ package com.codahale.metrics;
  * A {@link Meter} metric that cannot be changed from its initial value
  */
 public class NullMeter extends Meter {
-	private final double rate;
+    private final double rate;
 
-	/**
-	 * Initializes the rate value to 0.0.
-	 */
-	public NullMeter() {
-		this(0.0);
-	}
+    /**
+     * Initializes the rate value to 0.0.
+     */
+    public NullMeter() {
+        this(0.0);
+    }
 
-	/**
-	 * Initializes the rate value to initialRate.
-	 * 
-	 * @param initialRate will be the meter's rate value
-	 */
-	public NullMeter(double initialRate) {
-		rate = initialRate;
-	}
+    /**
+     * Initializes the rate value to initialRate.
+     * 
+     * @param initialRate will be the meter's rate value
+     */
+    public NullMeter(double initialRate) {
+        rate = initialRate;
+    }
 
     /**
      * Does nothing.
      */
-	@Override
+    @Override
     public void mark() {
     }
 
@@ -34,13 +34,13 @@ public class NullMeter extends Meter {
      * 
      * @param n not used
      */
-	@Override
+    @Override
     public void mark(long n) {
     }
 
-	/**
-	 * Returns 1.
-	 */
+    /**
+     * Returns 1.
+     */
     @Override
     public long getCount() {
         return 1;

--- a/metrics-core/src/main/java/com/codahale/metrics/NullMeter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NullMeter.java
@@ -1,0 +1,88 @@
+package com.codahale.metrics;
+
+/**
+ * A {@link Meter} metric that cannot be changed from its initial value
+ */
+public class NullMeter extends Meter {
+	private final double rate;
+
+	/**
+	 * Initializes the rate value to 0.0.
+	 */
+	public NullMeter() {
+		this(0.0);
+	}
+
+	/**
+	 * Initializes the rate value to initialRate.
+	 * 
+	 * @param initialRate will be the meter's rate value
+	 */
+	public NullMeter(double initialRate) {
+		rate = initialRate;
+	}
+
+    /**
+     * Does nothing.
+     */
+	@Override
+    public void mark() {
+    }
+
+    /**
+     * Does nothing.
+     * 
+     * @param n not used
+     */
+	@Override
+    public void mark(long n) {
+    }
+
+	/**
+	 * Returns 1.
+	 */
+    @Override
+    public long getCount() {
+        return 1;
+    }
+
+    /**
+     * Returns the meter's rate constant.
+     * 
+     * @return the meter's rate constant
+     */
+    @Override
+    public double getFifteenMinuteRate() {
+        return rate;
+    }
+
+    /**
+     * Returns the meter's rate constant.
+     * 
+     * @return the meter's rate constant
+     */
+    @Override
+    public double getFiveMinuteRate() {
+        return rate;
+    }
+
+    /**
+     * Returns the meter's rate constant.
+     * 
+     * @return the meter's rate constant
+     */
+    @Override
+    public double getMeanRate() {
+        return rate;
+    }
+
+    /**
+     * Returns the meter's rate constant.
+     * 
+     * @return the meter's rate constant
+     */
+    @Override
+    public double getOneMinuteRate() {
+        return rate;
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/NullMetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NullMetricRegistry.java
@@ -1,0 +1,98 @@
+package com.codahale.metrics;
+
+/**
+ * A variant of MetricRegistry that creates the Null versions of metrics
+ */
+public class NullMetricRegistry extends MetricRegistry {
+    /**
+     * Returns a {@link MetricBuilder} that captures the notion of default
+     * counters. This method is protected so that subclasses may override metric
+     * building.
+     * 
+     * @return a builder that can construct a {@link NullCounter}
+     */
+    protected MetricBuilder<Counter> getCounterMetricBuilder() {
+        return NULL_COUNTER_BUILDER;
+    }
+
+    /**
+     * Returns a {@link MetricBuilder} that captures the notion of default
+     * histograms. This method is protected so that subclasses may override
+     * metric building.
+     * 
+     * @return a builder that can construct a {@link NullHistogram}
+     */
+    protected MetricBuilder<Histogram> getHistogramMetricBuilder() {
+        return NULL_HISTOGRAM_BUILDER;
+    }
+
+    /**
+     * Returns a {@link MetricBuilder} that captures the notion of default
+     * meters. This method is protected so that subclasses may override metric
+     * building.
+     * 
+     * @return a builder that can construct a {@link NullMeter}
+     */
+    protected MetricBuilder<Meter> getMeterMetricBuilder() {
+        return NULL_METER_BUILDER;
+    }
+
+    /**
+     * Returns a {@link MetricBuilder} that captures the notion of default
+     * timers. This method is protected so that subclasses may override metric
+     * building.
+     * 
+     * @return a builder that can construct a {@link NullTimer}
+     */
+    protected MetricBuilder<Timer> getTimerMetricBuilder() {
+        return NULL_TIMER_BUILDER;
+    }
+
+    protected static final MetricBuilder<Counter> NULL_COUNTER_BUILDER = new MetricBuilder<Counter>() {
+        @Override
+        public Counter newMetric() {
+            return new NullCounter();
+        }
+
+        @Override
+        public boolean isInstance(Metric metric) {
+            return metric instanceof Counter;
+        }
+    };
+
+    protected static final MetricBuilder<Histogram> NULL_HISTOGRAM_BUILDER = new MetricBuilder<Histogram>() {
+        @Override
+        public Histogram newMetric() {
+            return new NullHistogram();
+        }
+
+        @Override
+        public boolean isInstance(Metric metric) {
+            return metric instanceof Histogram;
+        }
+    };
+
+    protected static final MetricBuilder<Meter> NULL_METER_BUILDER = new MetricBuilder<Meter>() {
+        @Override
+        public Meter newMetric() {
+            return new NullMeter();
+        }
+
+        @Override
+        public boolean isInstance(Metric metric) {
+            return metric instanceof Meter;
+        }
+    };
+
+    protected static final MetricBuilder<Timer> NULL_TIMER_BUILDER = new MetricBuilder<Timer>() {
+        @Override
+        public Timer newMetric() {
+            return new NullTimer();
+        }
+
+        @Override
+        public boolean isInstance(Metric metric) {
+            return metric instanceof Timer;
+        }
+    };
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/NullTimer.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NullTimer.java
@@ -3,6 +3,9 @@ package com.codahale.metrics;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * A {@link Timer} metric that cannot be changed from its initial value
+ */
 public class NullTimer extends Timer {
     private final Snapshot snapshot;
     private final double rate;

--- a/metrics-core/src/main/java/com/codahale/metrics/NullTimer.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NullTimer.java
@@ -4,65 +4,68 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 public class NullTimer extends Timer {
-	private final Snapshot snapshot;
-	private final double rate;
+    private final Snapshot snapshot;
+    private final double rate;
 
-	/**
-	 * Initializes the timer's histogram to contain a single 0 and rate to 0.0.
-	 */
-	public NullTimer() {
-		this(new long[] { 0 }, 0.0);
-	}
+    /**
+     * Initializes the timer's histogram to contain a single 0 and rate to 0.0.
+     */
+    public NullTimer() {
+        this(new long[] { 0 }, 0.0);
+    }
 
-	/**
-	 * Initializes the timer's rate with the given value and the histogram to contain a single 0.
-	 * 
-	 * @param rateValue
-	 */
-	public NullTimer(double rateValue) {
-		this(new long[] { 0 }, rateValue);
-	}
+    /**
+     * Initializes the timer's rate with the given value and the histogram to
+     * contain a single 0.
+     * 
+     * @param rateValue
+     */
+    public NullTimer(double rateValue) {
+        this(new long[] { 0 }, rateValue);
+    }
 
-	/**
-	 * Initializes the timer's histogram with the given inputs and the rate to 0.0.
-	 * 
-	 * @param histogramValues
-	 */
-	public NullTimer(long[] histogramValues) {
-		this(histogramValues, 0.0);
-	}
+    /**
+     * Initializes the timer's histogram with the given inputs and the rate to
+     * 0.0.
+     * 
+     * @param histogramValues
+     */
+    public NullTimer(long[] histogramValues) {
+        this(histogramValues, 0.0);
+    }
 
-	/**
-	 * Initializes the timer's values to the given inputs.
-	 * 
-	 * @param histogramValues the timer's histogram's constant values
-	 * @param rateValue       the timer's constant rate
-	 */
-	public NullTimer(long[] histogramValues, double rateValue) {
-		this.snapshot = new UniformSnapshot(histogramValues);
-		rate = rateValue;
-	}
+    /**
+     * Initializes the timer's values to the given inputs.
+     * 
+     * @param histogramValues the timer's histogram's constant values
+     * @param rateValue the timer's constant rate
+     */
+    public NullTimer(long[] histogramValues, double rateValue) {
+        this.snapshot = new UniformSnapshot(histogramValues);
+        rate = rateValue;
+    }
 
     /**
      * Does nothing.
      * 
      * @param duration not used
-     * @param unit     not used
+     * @param unit not used
      */
     @Override
-	public void update(long duration, TimeUnit unit) {
+    public void update(long duration, TimeUnit unit) {
     }
 
     /**
      * Calls event.call() and returns the result.
      * 
-     * @param event a {@link Callable} whose {@link Callable#call()} should be called
-     * @param <T>   the type of the value returned by {@code event}
+     * @param event a {@link Callable} whose {@link Callable#call()} should be
+     *        called
+     * @param <T> the type of the value returned by {@code event}
      * @return the value returned by {@code event}
      * @throws Exception if {@code event} throws an {@link Exception}
      */
     @Override
-	public <T> T time(Callable<T> event) throws Exception {
+    public <T> T time(Callable<T> event) throws Exception {
         return event.call();
     }
 

--- a/metrics-core/src/main/java/com/codahale/metrics/NullTimer.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NullTimer.java
@@ -49,7 +49,8 @@ public class NullTimer extends Timer {
      * @param duration not used
      * @param unit     not used
      */
-    public void update(long duration, TimeUnit unit) {
+    @Override
+	public void update(long duration, TimeUnit unit) {
     }
 
     /**
@@ -60,7 +61,8 @@ public class NullTimer extends Timer {
      * @return the value returned by {@code event}
      * @throws Exception if {@code event} throws an {@link Exception}
      */
-    public <T> T time(Callable<T> event) throws Exception {
+    @Override
+	public <T> T time(Callable<T> event) throws Exception {
         return event.call();
     }
 

--- a/metrics-core/src/main/java/com/codahale/metrics/NullTimer.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NullTimer.java
@@ -1,0 +1,126 @@
+package com.codahale.metrics;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+public class NullTimer extends Timer {
+	private final Snapshot snapshot;
+	private final double rate;
+
+	/**
+	 * Initializes the timer's histogram to contain a single 0 and rate to 0.0.
+	 */
+	public NullTimer() {
+		this(new long[] { 0 }, 0.0);
+	}
+
+	/**
+	 * Initializes the timer's rate with the given value and the histogram to contain a single 0.
+	 * 
+	 * @param rateValue
+	 */
+	public NullTimer(double rateValue) {
+		this(new long[] { 0 }, rateValue);
+	}
+
+	/**
+	 * Initializes the timer's histogram with the given inputs and the rate to 0.0.
+	 * 
+	 * @param histogramValues
+	 */
+	public NullTimer(long[] histogramValues) {
+		this(histogramValues, 0.0);
+	}
+
+	/**
+	 * Initializes the timer's values to the given inputs.
+	 * 
+	 * @param histogramValues the timer's histogram's constant values
+	 * @param rateValue       the timer's constant rate
+	 */
+	public NullTimer(long[] histogramValues, double rateValue) {
+		this.snapshot = new UniformSnapshot(histogramValues);
+		rate = rateValue;
+	}
+
+    /**
+     * Does nothing.
+     * 
+     * @param duration not used
+     * @param unit     not used
+     */
+    public void update(long duration, TimeUnit unit) {
+    }
+
+    /**
+     * Calls event.call() and returns the result.
+     * 
+     * @param event a {@link Callable} whose {@link Callable#call()} should be called
+     * @param <T>   the type of the value returned by {@code event}
+     * @return the value returned by {@code event}
+     * @throws Exception if {@code event} throws an {@link Exception}
+     */
+    public <T> T time(Callable<T> event) throws Exception {
+        return event.call();
+    }
+
+    /**
+     * Returns the timer's constant number of values recorded.
+     * 
+     * @return the timer's constant number of values recorded
+     */
+    @Override
+    public long getCount() {
+        return snapshot.size();
+    }
+
+    /**
+     * Returns the timer's rate constant.
+     * 
+     * @return the timer's rate constant
+     */
+    @Override
+    public double getFifteenMinuteRate() {
+        return rate;
+    }
+
+    /**
+     * Returns the timer's rate constant.
+     * 
+     * @return the timer's rate constant
+     */
+    @Override
+    public double getFiveMinuteRate() {
+        return rate;
+    }
+
+    /**
+     * Returns the timer's rate constant.
+     * 
+     * @return the timer's rate constant
+     */
+    @Override
+    public double getMeanRate() {
+        return rate;
+    }
+
+    /**
+     * Returns the timer's rate constant.
+     * 
+     * @return the timer's rate constant
+     */
+    @Override
+    public double getOneMinuteRate() {
+        return rate;
+    }
+
+    /**
+     * Returns a snapshot representing the timer's histogram's constant values.
+     *
+     * @return a snapshot representing the timer's histogram's constant values
+     */
+    @Override
+    public Snapshot getSnapshot() {
+        return snapshot;
+    }
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/NullCounterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/NullCounterTest.java
@@ -1,0 +1,57 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NullCounterTest {
+
+    @Test
+    public void startsAtZero() throws Exception {
+        assertThat(new NullCounter().getCount())
+                .isZero();
+    }
+    
+    @Test
+    public void startsAtValue() throws Exception {
+        assertThat(new NullCounter(100).getCount())
+                .isEqualTo(100);
+    }
+
+    @Test
+    public void incrementDoesNothing() throws Exception {
+        Counter counter = new NullCounter(100);
+        counter.inc();
+
+        assertThat(counter.getCount())
+                .isEqualTo(100);
+    }
+
+    @Test
+    public void incrementsByAnArbitraryDeltaDoesNothing() throws Exception {
+        Counter counter = new NullCounter(100);
+        counter.inc(12);
+
+        assertThat(counter.getCount())
+                .isEqualTo(100);
+    }
+
+    @Test
+    public void decrementsByOneDoesNothing() throws Exception {
+        Counter counter = new NullCounter(100);
+        counter.dec();
+
+        assertThat(counter.getCount())
+                .isEqualTo(100);
+    }
+
+    @Test
+    public void decrementsByAnArbitraryDeltaDoesNothing() throws Exception {
+        Counter counter = new NullCounter(100);
+        counter.dec(12);
+
+        assertThat(counter.getCount())
+                .isEqualTo(100);
+    }
+
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/NullHistogramTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/NullHistogramTest.java
@@ -1,0 +1,44 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NullHistogramTest {
+
+    @Test
+    public void startsAtZero() throws Exception {
+        Histogram histogram = new NullHistogram();
+        assertThat(histogram.getCount())
+                .isEqualTo(1);
+        assertThat(histogram.getSnapshot().get75thPercentile())
+                .isZero();
+        assertThat(histogram.getSnapshot().get95thPercentile())
+                .isZero();
+    }
+
+    @Test
+    public void updatesDoNothing() throws Exception {
+        Histogram histogram = new NullHistogram(10);
+        assertThat(histogram.getCount())
+                .isEqualTo(1);
+
+        histogram.update(1);
+
+        assertThat(histogram.getSnapshot().get98thPercentile())
+                .isEqualTo(10);
+        assertThat(histogram.getSnapshot().get99thPercentile())
+                .isEqualTo(10);
+        assertThat(histogram.getSnapshot().get999thPercentile())
+                .isEqualTo(10);
+        assertThat(histogram.getSnapshot().getMax())
+                .isEqualTo(10);
+        assertThat(histogram.getSnapshot().getMin())
+                .isEqualTo(10);
+        assertThat(histogram.getSnapshot().getMean())
+                .isEqualTo(10);
+        assertThat(histogram.getSnapshot().getMedian())
+                .isEqualTo(10);
+    }
+
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/NullMeterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/NullMeterTest.java
@@ -1,0 +1,71 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+public class NullMeterTest {
+    @Test
+    public void startsOutWithZeroRatesAndOneCount() throws Exception {
+        Meter meter = new NullMeter();
+
+        assertThat(meter.getCount())
+                .isEqualTo(1);
+
+        assertThat(meter.getMeanRate())
+                .isEqualTo(0.0, offset(0.001));
+
+        assertThat(meter.getOneMinuteRate())
+                .isEqualTo(0.0, offset(0.001));
+
+        assertThat(meter.getFiveMinuteRate())
+                .isEqualTo(0.0, offset(0.001));
+
+        assertThat(meter.getFifteenMinuteRate())
+                .isEqualTo(0.0, offset(0.001));
+    }
+    
+    @Test
+    public void startsOutWithGivenRates() throws Exception {
+        Meter meter = new NullMeter(29.377);
+
+        assertThat(meter.getCount())
+                .isEqualTo(1);
+
+        assertThat(meter.getMeanRate())
+                .isEqualTo(29.377, offset(0.001));
+
+        assertThat(meter.getOneMinuteRate())
+                .isEqualTo(29.377, offset(0.001));
+
+        assertThat(meter.getFiveMinuteRate())
+                .isEqualTo(29.377, offset(0.001));
+
+        assertThat(meter.getFifteenMinuteRate())
+                .isEqualTo(29.377, offset(0.001));
+    }
+
+    @Test
+    public void marksEventsAndDoesNothingToRatesAndCount() throws Exception {
+        Meter meter = new NullMeter(29.377);
+        meter.mark();
+        meter.mark(2);
+
+        assertThat(meter.getCount())
+                .isEqualTo(1);
+
+        assertThat(meter.getMeanRate())
+                .isEqualTo(29.377, offset(0.001));
+
+        assertThat(meter.getOneMinuteRate())
+                .isEqualTo(29.377, offset(0.001));
+
+        assertThat(meter.getFiveMinuteRate())
+                .isEqualTo(29.377, offset(0.001));
+
+        assertThat(meter.getFifteenMinuteRate())
+                .isEqualTo(29.377, offset(0.001));
+    }
+
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/NullMetricRegistryTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/NullMetricRegistryTest.java
@@ -1,0 +1,152 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NullMetricRegistryTest {
+
+    @Test
+    public void accessingACounterRegistersAndReusesANullCounter() throws Exception {
+        final MetricRegistry registry = new NullMetricRegistry();
+        final Counter counter1 = registry.counter("thing");
+        final Counter counter2 = registry.counter("thing");
+
+        assertThat(counter1)
+                .isSameAs(counter2);
+
+        assertThat(counter1)
+                .isInstanceOf(Counter.class);
+
+        assertThat(counter1)
+                .isExactlyInstanceOf(NullCounter.class);
+    }
+
+    @Test
+    public void accessingAMeterRegistersAndReusesANullMeter() throws Exception {
+        final MetricRegistry registry = new NullMetricRegistry();
+        final Meter meter1 = registry.meter("thing");
+        final Meter meter2 = registry.meter("thing");
+
+        assertThat(meter1)
+                .isSameAs(meter2);
+
+        assertThat(meter1)
+                .isInstanceOf(Meter.class);
+
+        assertThat(meter1)
+                .isExactlyInstanceOf(NullMeter.class);
+    }
+
+    @Test
+    public void accessingAHistogramRegistersAndReusesANullHistogram() throws Exception {
+        final MetricRegistry registry = new NullMetricRegistry();
+        final Histogram histogram1 = registry.histogram("thing");
+        final Histogram histogram2 = registry.histogram("thing");
+
+        assertThat(histogram1)
+                .isSameAs(histogram2);
+
+        assertThat(histogram1)
+                .isInstanceOf(Histogram.class);
+
+        assertThat(histogram1)
+                .isExactlyInstanceOf(NullHistogram.class);
+    }
+
+    @Test
+    public void accessingATimerRegistersAndReusesANullTimer() throws Exception {
+        final MetricRegistry registry = new NullMetricRegistry();
+        final Timer timer1 = registry.timer("thing");
+        final Timer timer2 = registry.timer("thing");
+
+        assertThat(timer1)
+                .isSameAs(timer2);
+
+        assertThat(timer1)
+                .isInstanceOf(Timer.class);
+
+        assertThat(timer1)
+                .isExactlyInstanceOf(NullTimer.class);
+    }
+
+    @Test
+    public void addingRegistriesToNullMetricRegistryKeepsTypes() throws Exception {
+        final MetricRegistry normalRegistry = new MetricRegistry();
+        final Meter meter = normalRegistry.meter("normalMeter");
+
+        final MetricRegistry nullRegistryInitial = new NullMetricRegistry();
+        final Counter counter = nullRegistryInitial.counter("nullCounter");
+
+        final MetricRegistry nullRegistryFinal = new NullMetricRegistry();
+        final Histogram histogram = nullRegistryFinal.histogram("nullHistogram");
+
+        nullRegistryFinal.registerAll(normalRegistry);
+        nullRegistryFinal.registerAll(nullRegistryInitial);
+
+        assertThat(nullRegistryFinal.meter("normalMeter"))
+                .isSameAs(meter);
+
+        assertThat(nullRegistryFinal.meter("normalMeter"))
+                .isSameAs(normalRegistry.meter("normalMeter"));
+
+        assertThat(nullRegistryFinal.meter("normalMeter"))
+                .isInstanceOf(Meter.class);
+
+        assertThat(nullRegistryFinal.meter("normalMeter"))
+                .isExactlyInstanceOf(Meter.class);
+
+        assertThat(nullRegistryFinal.counter("nullCounter"))
+                .isSameAs(nullRegistryInitial.counter("nullCounter"));
+
+        assertThat(nullRegistryFinal.counter("nullCounter"))
+                .isSameAs(counter);
+
+        assertThat(nullRegistryFinal.counter("nullCounter"))
+                .isInstanceOf(Counter.class);
+
+        assertThat(nullRegistryFinal.counter("nullCounter"))
+                .isExactlyInstanceOf(NullCounter.class);
+
+        assertThat(nullRegistryFinal.histogram("nullHistogram"))
+                .isSameAs(histogram);
+        
+        assertThat(nullRegistryFinal.histogram("nullHistogram"))
+                .isInstanceOf(Histogram.class);
+        
+        assertThat(nullRegistryFinal.histogram("nullHistogram"))
+                .isExactlyInstanceOf(NullHistogram.class);
+    }
+
+    @Test
+    public void addingNullMetricRegistryToMetricRegistryKeepsTypes() throws Exception {
+        final MetricRegistry nullRegistry = new NullMetricRegistry();
+        final Counter counter = nullRegistry.counter("nullCounter");
+
+        final MetricRegistry normalRegistry = new MetricRegistry();
+        final Histogram histogram = normalRegistry.histogram("normalHistogram");
+
+        normalRegistry.registerAll(nullRegistry);
+
+        assertThat(normalRegistry.counter("nullCounter"))
+                .isSameAs(nullRegistry.counter("nullCounter"));
+
+        assertThat(normalRegistry.counter("nullCounter"))
+                .isSameAs(counter);
+
+        assertThat(normalRegistry.counter("nullCounter"))
+                .isInstanceOf(Counter.class);
+
+        assertThat(normalRegistry.counter("nullCounter"))
+                .isExactlyInstanceOf(NullCounter.class);
+
+        assertThat(normalRegistry.histogram("normalHistogram"))
+                .isSameAs(histogram);
+        
+        assertThat(normalRegistry.histogram("normalHistogram"))
+                .isInstanceOf(Histogram.class);
+        
+        assertThat(normalRegistry.histogram("normalHistogram"))
+                .isExactlyInstanceOf(Histogram.class);
+    }
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/NullTimerTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/NullTimerTest.java
@@ -1,0 +1,78 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+public class NullTimerTest {
+
+    @Test
+    public void hasRates() throws Exception {
+        final Timer timer = new NullTimer();
+
+        assertThat(timer.getCount())
+                .isEqualTo(1);
+
+        assertThat(timer.getMeanRate())
+                .isEqualTo(0.0, offset(0.001));
+
+        assertThat(timer.getOneMinuteRate())
+                .isEqualTo(0.0, offset(0.001));
+
+        assertThat(timer.getFiveMinuteRate())
+                .isEqualTo(0.0, offset(0.001));
+
+        assertThat(timer.getFifteenMinuteRate())
+                .isEqualTo(0.0, offset(0.001));
+    }
+
+    @Test
+    public void updateDoesNothing() throws Exception {
+        final Timer timer = new NullTimer(5.5);
+
+        assertThat(timer.getCount())
+                .isEqualTo(1);
+
+        timer.update(1, TimeUnit.SECONDS);
+
+        assertThat(timer.getCount())
+                .isEqualTo(1);
+
+        assertThat(timer.getFifteenMinuteRate())
+                .isEqualTo(5.5);
+
+        assertThat(timer.getFiveMinuteRate())
+                .isEqualTo(5.5);
+
+        timer.update(11L, TimeUnit.SECONDS);
+
+        assertThat(timer.getOneMinuteRate())
+                .isEqualTo(5.5);
+
+        assertThat(timer.getMeanRate())
+                .isEqualTo(5.5);
+    }
+
+    @Test
+    public void timesCallableInstances() throws Exception {
+        final Timer timer = new NullTimer(10);
+
+        final String value = timer.time(new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                return "one";
+            }
+        });
+
+        assertThat(timer.getCount())
+                .isEqualTo(1);
+
+        assertThat(value)
+                .isEqualTo("one");
+    }
+
+}


### PR DESCRIPTION
The purpose of this change is to allow users to code against the base metric types and registry but have the flexibility to swap in null implementations of the counters. It enables a usage pattern like:

    class Foo {
        private final MetricRegistry registry;

        Foo(MetricRegistry registry) {
            this.registry = registry;
        }

        Foo() {
            this(new NullMetricRegistry());
        }

        public void someFunction() {
            registry.meter("someFunctionCalled").mark();
        }
    }

A client of Foo can pass in a MetricRegistry if it wants metrics collected, but it also doesn't have to use or be aware of Foo's use of metrics at all.