### PR TITLE
Improve hostname extraction for wrapped HTTP requests

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -77,7 +77,7 @@ return the number of evictions from the cache.
 JMX Gauges
 ----------
 
-Given that many third-party library often expose metrics only via JMX, Metrics provides the
+Given that many third-party libraries often expose metrics only via JMX, Metrics provides the
 ``JmxAttributeGauge`` class, which takes the object name of a JMX MBean and the name of an attribute
 and produces a gauge implementation which returns the value of that attribute:
 

--- a/docs/source/manual/third-party.rst
+++ b/docs/source/manual/third-party.rst
@@ -30,3 +30,4 @@ the many third-party libraries which extend Metrics:
 * `jersey2-metrics <https://bitbucket.org/marshallpierce/jersey2-metrics>`_ provides integration with `Jersey 2 <https://jersey.java.net/>`_.
 * `jersey-metrics-filter <https://github.com/palominolabs/jersey-metrics-filter>`_ provides integration with Jersey 1.
 * `hdrhistogram-metrics-reservoir <https://bitbucket.org/marshallpierce/hdrhistogram-metrics-reservoir>`_ provides a Reservoir backed by `HdrHistogram <http://hdrhistogram.org/>`_.
+* `metrics-circonus <https://github.com/circonus-labs/metrics-circonus>`_ provides a registry and reporter for sending metrics (including full histograms) to `Circonus <https://www.circonus.com/>`_.

--- a/docs/source/manual/third-party.rst
+++ b/docs/source/manual/third-party.rst
@@ -24,3 +24,4 @@ the many third-party libraries which extend Metrics:
 * `metrics-cdi <https://github.com/astefanutti/metrics-cdi>`_ provides integration with `CDI <http://www.cdi-spec.org/>`_ environments
 * `metrics-aspectj <https://github.com/astefanutti/metrics-aspectj>`_ provides integration with `AspectJ <http://eclipse.org/aspectj/>`_
 * `camel-metrics <https://github.com/InitiumIo/camel-metrics>`_ provides component for your `Apache Camel <https://camel.apache.org/>`_ route
+* `metrics-munin-reporter <https://github.com/slashidea/metrics-munin-reporter>`_ provides a reporter for `Munin <http://munin-monitoring.org/>`_

--- a/docs/source/manual/third-party.rst
+++ b/docs/source/manual/third-party.rst
@@ -12,6 +12,7 @@ the many third-party libraries which extend Metrics:
 * `sematext-metrics-reporter <https://github.com/sematext/sematext-metrics-reporter>`_ provides a reporter for `SPM <http://sematext.com/spm/index.html>`_.
 * `wicket-metrics <https://github.com/NitorCreations/wicket-metrics>`_ provides easy integration for your `Wicket <http://wicket.apache.org/>`_ application.
 * `metrics-guice <https://github.com/palominolabs/metrics-guice>`_ provides integration with `Guice <https://code.google.com/p/google-guice/>`_.
+* `metrics-guice-servlet <https://github.com/palominolabs/metrics-guice-servlet>`_ provides `Guice Servlet <https://github.com/google/guice/wiki/Servlets>`_ integration with AdminServlet.
 * `metrics-scala <https://github.com/erikvanoosten/metrics-scala>`_ provides an API optimized for Scala.
 * `metrics-clojure <https://github.com/sjl/metrics-clojure>`_ provides an API optimized for Clojure.
 * `metrics-cassandra <https://github.com/brndnmtthws/metrics-cassandra>`_ provides a reporter for `Apache Cassandra <https://cassandra.apache.org/>`_.
@@ -20,8 +21,12 @@ the many third-party libraries which extend Metrics:
 * `metrics-elasticsearch-reporter <https://github.com/elasticsearch/elasticsearch-metrics-reporter-java>`_ provides a reporter for `elasticsearch <http://www.elasticsearch.org/>`_
 * `metrics-statsd <https://github.com/ReadyTalk/metrics-statsd>`_ provides a Metrics 2.x and 3.x reporter for `StatsD <https://github.com/etsy/statsd/>`_
 * `metrics-datadog <https://github.com/vistarmedia/metrics-datadog>`_ provides a reporter to send data to `Datadog <http://www.datadoghq.com/>`_
+* `metrics-new-relic <https://github.com/palominolabs/metrics-new-relic>`_ provides a reporter which sends data to `New Relic <https://newrelic.com/>`_.
 * `metrics-influxdb <https://github.com/novaquark/metrics-influxdb>`_ provides a reporter which announces measurements to `InfluxDB <http://influxdb.org/>`_
 * `metrics-cdi <https://github.com/astefanutti/metrics-cdi>`_ provides integration with `CDI <http://www.cdi-spec.org/>`_ environments
 * `metrics-aspectj <https://github.com/astefanutti/metrics-aspectj>`_ provides integration with `AspectJ <http://eclipse.org/aspectj/>`_
 * `camel-metrics <https://github.com/InitiumIo/camel-metrics>`_ provides component for your `Apache Camel <https://camel.apache.org/>`_ route
 * `metrics-munin-reporter <https://github.com/slashidea/metrics-munin-reporter>`_ provides a reporter for `Munin <http://munin-monitoring.org/>`_
+* `jersey2-metrics <https://bitbucket.org/marshallpierce/jersey2-metrics>`_ provides integration with `Jersey 2 <https://jersey.java.net/>`_.
+* `jersey-metrics-filter <https://github.com/palominolabs/jersey-metrics-filter>`_ provides integration with Jersey 1.
+* `hdrhistogram-metrics-reservoir <https://bitbucket.org/marshallpierce/hdrhistogram-metrics-reservoir>`_ provides a Reservoir backed by `HdrHistogram <http://hdrhistogram.org/>`_.

--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-annotation</artifactId>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-benchmarks</artifactId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-core</artifactId>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-ehcache</artifactId>

--- a/metrics-ganglia/pom.xml
+++ b/metrics-ganglia/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-ganglia</artifactId>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-graphite</artifactId>

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteRabbitMQ.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteRabbitMQ.java
@@ -8,14 +8,11 @@ import com.rabbitmq.client.DefaultSocketConfigurator;
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.charset.Charset;
-import java.util.regex.Pattern;
 
 /**
  * A rabbit-mq client to a Carbon server.
  */
 public class GraphiteRabbitMQ implements GraphiteSender {
-
-    private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
 
     private static final Charset UTF_8 = Charset.forName("UTF-8");
 
@@ -161,7 +158,7 @@ public class GraphiteRabbitMQ implements GraphiteSender {
     }
 
     public String sanitize(String s) {
-        return WHITESPACE.matcher(s).replaceAll("-");
+        return GraphiteSanitize.sanitize(s, '-');
     }
 
 }

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -5,8 +5,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.Locale;
 import java.util.Map;
 import java.util.SortedMap;
@@ -299,10 +297,6 @@ public class GraphiteReporter extends ScheduledReporter {
             return format(((Integer) o).longValue());
         } else if (o instanceof Long) {
             return format(((Long) o).longValue());
-        } else if (o instanceof BigInteger) {
-            return format(((BigInteger) o).longValue());
-        } else if (o instanceof BigDecimal) {
-            return format(((BigDecimal) o).longValue());
         }
         return null;
     }

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -5,6 +5,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Locale;
 import java.util.Map;
 import java.util.SortedMap;
@@ -297,7 +299,10 @@ public class GraphiteReporter extends ScheduledReporter {
             return format(((Integer) o).longValue());
         } else if (o instanceof Long) {
             return format(((Long) o).longValue());
-        }
+        } else if (o instanceof BigInteger) {
+            return format(((BigInteger) o).doubleValue());
+        } else if (o instanceof BigDecimal) {
+            return format(((BigDecimal) o).doubleValue());        }
         return null;
     }
 

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteSanitize.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteSanitize.java
@@ -1,0 +1,71 @@
+package com.codahale.metrics.graphite;
+
+class GraphiteSanitize {
+    /** Replaces all characters from a given string that are not ascii and not alphanumeric
+     *  with a dash */
+    static String sanitize(String string, char replacement) {
+        String replaced = replaceFrom(string, replacement);
+
+        // Consolidate multiple dashes into a single one
+        String result = replaced.replace("--", "-");
+        while (!result.equals(replaced)) {
+            replaced = result;
+            result = replaced.replace("--", "-");
+        }
+
+        // Remove any leading or trailing dashes
+        return strip(result, replacement);
+    }
+
+    /** A char matches when it is a letter or digit and it is ASCII, in Guava terminology,
+     *  this would be CharMatcher.ASCII.and(CharMatcher.JAVA_LETTER_OR_DIGIT).negate() */
+    private static boolean matches(char c) {
+        return !(Character.isLetterOrDigit(c) && c <= '\u007f');
+    }
+
+    /** Replace all characters that we're interested in with a replacement character,
+     *  heavily inspired by the same code in Guava's CharMatcher */
+    private static String replaceFrom(String string, char replacement) {
+        int pos = indexIn(string, 0);
+        if (pos == -1) {
+            return string;
+        }
+        char[] chars = string.toCharArray();
+        chars[pos] = replacement;
+        for (int i = pos + 1; i < chars.length; i++) {
+            if (matches(chars[i])) {
+                chars[i] = replacement;
+            }
+        }
+        return new String(chars).trim();
+    }
+
+    /** Finds the first index (or -1) of a character we're interested in */
+    private static int indexIn(String sequence, int start) {
+        int length = sequence.length();
+        for (int i = start; i < length; i++) {
+            if (matches(sequence.charAt(i))) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /** Strips a given character from the beginning and end of a string,
+     *  heavily inspired by Apache's StringUtils.strip
+     */
+    private static String strip(String str, char strip) {
+        int strLen = str.length();
+        int start = 0;
+        int end = strLen - 1;
+        while (start != strLen && str.charAt(start) == strip) {
+            start++;
+        }
+
+        while (end > start && str.charAt(end) == strip) {
+            end--;
+        }
+
+        return start != 0 || end != strLen - 1 ? str.substring(start, end + 1) : str;
+    }
+}

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteUDP.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteUDP.java
@@ -5,14 +5,11 @@ import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 import java.nio.charset.Charset;
-import java.util.regex.Pattern;
 
 /**
  * A client to a Carbon server using unconnected UDP
  */
 public class GraphiteUDP implements GraphiteSender {
-
-    private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
 
     private static final Charset UTF_8 = Charset.forName("UTF-8");
 
@@ -111,7 +108,7 @@ public class GraphiteUDP implements GraphiteSender {
     }
 
     protected String sanitize(String s) {
-        return WHITESPACE.matcher(s).replaceAll("-");
+        return GraphiteSanitize.sanitize(s, '-');
     }
 
 }

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/PickledGraphite.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/PickledGraphite.java
@@ -18,14 +18,12 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.regex.Pattern;
 
 /**
  * A client to a Carbon server that sends all metrics after they have been pickled in configurable sized batches
  */
 public class PickledGraphite implements GraphiteSender {
 
-    private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
     private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PickledGraphite.class);
@@ -360,7 +358,7 @@ public class PickledGraphite implements GraphiteSender {
     }
 
     protected String sanitize(String s) {
-        return WHITESPACE.matcher(s).replaceAll("-");
+        return GraphiteSanitize.sanitize(s, '-');
     }
 
 }

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteSanitizeTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteSanitizeTest.java
@@ -1,0 +1,27 @@
+package com.codahale.metrics.graphite;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+
+public class GraphiteSanitizeTest {
+    @Test
+    public void sanitizeGraphiteValues() {
+        SoftAssertions softly = new SoftAssertions();
+
+        softly.assertThat(GraphiteSanitize.sanitize("Foo Bar", '-')).isEqualTo("Foo-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize(" Foo Bar ", '-')).isEqualTo("Foo-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize(" Foo Bar", '-')).isEqualTo("Foo-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize("Foo Bar ", '-')).isEqualTo("Foo-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize("  Foo Bar  ", '-')).isEqualTo("Foo-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize("Foo@Bar", '-')).isEqualTo("Foo-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize("Foó Bar", '-')).isEqualTo("Fo-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize("||ó/.", '-')).isEqualTo("");
+        softly.assertThat(GraphiteSanitize.sanitize("${Foo:Bar:baz}", '-')).isEqualTo("Foo-Bar-baz");
+        softly.assertThat(GraphiteSanitize.sanitize("St. Foo's of Bar", '-')).isEqualTo("St-Foo-s-of-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize("(Foo and (Bar and (Baz)))", '-')).isEqualTo("Foo-and-Bar-and-Baz");
+        softly.assertThat(GraphiteSanitize.sanitize("Foo.bar.baz", '-')).isEqualTo("Foo-bar-baz");
+        softly.assertThat(GraphiteSanitize.sanitize("FooBar", '-')).isEqualTo("FooBar");
+
+        softly.assertAll();
+    }
+}

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-healthchecks</artifactId>

--- a/metrics-httpasyncclient/pom.xml
+++ b/metrics-httpasyncclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-httpasyncclient</artifactId>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-httpclient</artifactId>

--- a/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategiesTest.java
+++ b/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategiesTest.java
@@ -1,9 +1,15 @@
 package com.codahale.metrics.httpclient;
 
+import org.apache.http.HttpRequest;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestWrapper;
+import org.apache.http.client.utils.URIUtils;
 import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import static com.codahale.metrics.httpclient.HttpClientMetricNameStrategies.*;
 import static org.hamcrest.CoreMatchers.is;
@@ -36,10 +42,43 @@ public class HttpClientMetricNameStrategiesTest {
     }
 
     @Test
+    public void hostAndMethodWithNameInWrappedRequest() throws URISyntaxException {
+        HttpRequest request = rewriteRequestURI(new HttpPost("http://my.host.com/whatever"));
+
+        assertThat(HOST_AND_METHOD.getNameFor("some-service", request),
+                is("org.apache.http.client.HttpClient.some-service.my.host.com.post-requests"));
+    }
+
+    @Test
+    public void hostAndMethodWithoutNameInWrappedRequest() throws URISyntaxException {
+        HttpRequest request = rewriteRequestURI(new HttpPost("http://my.host.com/whatever"));
+
+        assertThat(HOST_AND_METHOD.getNameFor(null, request),
+                is("org.apache.http.client.HttpClient.my.host.com.post-requests"));
+    }
+
+    @Test
     public void querylessUrlAndMethodWithName() {
         assertThat(QUERYLESS_URL_AND_METHOD.getNameFor(
                 "some-service",
                 new HttpPut("https://thing.com:8090/my/path?ignore=this&and=this")),
                 is("org.apache.http.client.HttpClient.some-service.https://thing.com:8090/my/path.put-requests"));
+    }
+
+    @Test
+    public void querylessUrlAndMethodWithNameInWrappedRequest() throws URISyntaxException {
+        HttpRequest request = rewriteRequestURI(new HttpPut("https://thing.com:8090/my/path?ignore=this&and=this"));
+        assertThat(QUERYLESS_URL_AND_METHOD.getNameFor(
+                "some-service",
+                request),
+                is("org.apache.http.client.HttpClient.some-service.https://thing.com:8090/my/path.put-requests"));
+    }
+
+    private static HttpRequest rewriteRequestURI(HttpRequest request) throws URISyntaxException {
+        HttpRequestWrapper wrapper = HttpRequestWrapper.wrap(request);
+        URI uri = URIUtils.rewriteURI(wrapper.getURI(), null, true);
+        wrapper.setURI(uri);
+
+        return wrapper;
     }
 }

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jdbi</artifactId>

--- a/metrics-jersey/pom.xml
+++ b/metrics-jersey/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jersey</artifactId>

--- a/metrics-jersey2/pom.xml
+++ b/metrics-jersey2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
 	<groupId>io.dropwizard.metrics</groupId>
 	<artifactId>metrics-parent</artifactId>
-	<version>3.1.3-SNAPSHOT</version>
+	<version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jersey2</artifactId>

--- a/metrics-jetty8/pom.xml
+++ b/metrics-jetty8/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jetty8</artifactId>

--- a/metrics-jetty9-legacy/pom.xml
+++ b/metrics-jetty9-legacy/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jetty9-legacy</artifactId>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jetty9</artifactId>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-json</artifactId>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-jvm</artifactId>

--- a/metrics-log4j/pom.xml
+++ b/metrics-log4j/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-log4j</artifactId>

--- a/metrics-log4j2/pom.xml
+++ b/metrics-log4j2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-log4j2</artifactId>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-logback</artifactId>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-servlet</artifactId>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.dropwizard.metrics</groupId>
         <artifactId>metrics-parent</artifactId>
-        <version>3.1.3-SNAPSHOT</version>
+        <version>3.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>metrics-servlets</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>io.dropwizard.metrics</groupId>
     <artifactId>metrics-parent</artifactId>
-    <version>3.1.3-SNAPSHOT</version>
+    <version>3.2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Metrics Parent</name>
     <description>


### PR DESCRIPTION
When executing a request, HttpClient will wrap the original request in `HttpRequestWrapper` so that e.g. redirects can be handled with ease. In such cases, the wrapper request has its URI rewritten (see `org.apache.http.impl.execchain.ProtocolExec#rewriteRequestUri`): the host part is stripped, so the wrapper's `RequestLine` can no longer be used to reliably obtain the hostname.

This pull request improves `HOST_AND_METHOD` and `QUERYLESS_URL_AND_METHOD` metric naming strategies by checking if the request is actually a wrapper and trying to obtain URI from the original request.