### PR TITLE
Improve hostname extraction for wrapped HTTP requests

### DIFF
--- a/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategiesTest.java
+++ b/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategiesTest.java
@@ -1,9 +1,15 @@
 package com.codahale.metrics.httpclient;
 
+import org.apache.http.HttpRequest;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestWrapper;
+import org.apache.http.client.utils.URIUtils;
 import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import static com.codahale.metrics.httpclient.HttpClientMetricNameStrategies.*;
 import static org.hamcrest.CoreMatchers.is;
@@ -36,10 +42,43 @@ public class HttpClientMetricNameStrategiesTest {
     }
 
     @Test
+    public void hostAndMethodWithNameInWrappedRequest() throws URISyntaxException {
+        HttpRequest request = rewriteRequestURI(new HttpPost("http://my.host.com/whatever"));
+
+        assertThat(HOST_AND_METHOD.getNameFor("some-service", request),
+                is("org.apache.http.client.HttpClient.some-service.my.host.com.post-requests"));
+    }
+
+    @Test
+    public void hostAndMethodWithoutNameInWrappedRequest() throws URISyntaxException {
+        HttpRequest request = rewriteRequestURI(new HttpPost("http://my.host.com/whatever"));
+
+        assertThat(HOST_AND_METHOD.getNameFor(null, request),
+                is("org.apache.http.client.HttpClient.my.host.com.post-requests"));
+    }
+
+    @Test
     public void querylessUrlAndMethodWithName() {
         assertThat(QUERYLESS_URL_AND_METHOD.getNameFor(
                 "some-service",
                 new HttpPut("https://thing.com:8090/my/path?ignore=this&and=this")),
                 is("org.apache.http.client.HttpClient.some-service.https://thing.com:8090/my/path.put-requests"));
+    }
+
+    @Test
+    public void querylessUrlAndMethodWithNameInWrappedRequest() throws URISyntaxException {
+        HttpRequest request = rewriteRequestURI(new HttpPut("https://thing.com:8090/my/path?ignore=this&and=this"));
+        assertThat(QUERYLESS_URL_AND_METHOD.getNameFor(
+                "some-service",
+                request),
+                is("org.apache.http.client.HttpClient.some-service.https://thing.com:8090/my/path.put-requests"));
+    }
+
+    private static HttpRequest rewriteRequestURI(HttpRequest request) throws URISyntaxException {
+        HttpRequestWrapper wrapper = HttpRequestWrapper.wrap(request);
+        URI uri = URIUtils.rewriteURI(wrapper.getURI(), null, true);
+        wrapper.setURI(uri);
+
+        return wrapper;
     }
 }


### PR DESCRIPTION
When executing a request, HttpClient will wrap the original request in HttpRequestWrapper so that e.g. redirects can be handled with ease. In such cases, the wrapper request has its URI rewritten (see org.apache.http.impl.execchain.ProtocolExec#rewriteRequestUri): the host part is stripped, so the wrapper's RequestLine can no longer be used to reliably obtain the hostname.

This pull request improves HOST_AND_METHOD and QUERYLESS_URL_AND_METHOD metric naming strategies by checking if the request is actually a wrapper and trying to obtain URI from the original request.