### PR TITLE
Switched to AtomicLongFieldUpdater so it works on AppEngine

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/Striped64.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Striped64.java
@@ -9,6 +9,7 @@
 package com.codahale.metrics;
 
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 // CHECKSTYLE:OFF
 /**
@@ -98,23 +99,10 @@ abstract class Striped64 extends Number {
         }
 
         final boolean cas(long cmp, long val) {
-            return UNSAFE.compareAndSwapLong(this, valueOffset, cmp, val);
+            return valueUpdater.compareAndSet(this, cmp, val);
         }
 
-        // Unsafe mechanics
-        private static final sun.misc.Unsafe UNSAFE;
-        private static final long valueOffset;
-
-        static {
-            try {
-                UNSAFE = getUnsafe();
-                Class<?> ak = Cell.class;
-                valueOffset = UNSAFE.objectFieldOffset
-                        (ak.getDeclaredField("value"));
-            } catch (Exception e) {
-                throw new Error(e);
-            }
-        }
+        private static final AtomicLongFieldUpdater<Cell> valueUpdater = AtomicLongFieldUpdater.newUpdater(Cell.class, "value");
 
     }
 
@@ -136,10 +124,14 @@ abstract class Striped64 extends Number {
      * The corresponding ThreadLocal class
      */
     static final class ThreadHashCode extends ThreadLocal<HashCode> {
+        @Override
         public HashCode initialValue() {
             return new HashCode();
         }
     }
+
+    static final AtomicLongFieldUpdater<Striped64> baseUpdater = AtomicLongFieldUpdater.newUpdater(Striped64.class, "base");
+    static final AtomicLongFieldUpdater<Striped64> busyUpdater = AtomicLongFieldUpdater.newUpdater(Striped64.class, "busy");
 
     /**
      * Static per-thread hash codes. Shared across all instances to reduce ThreadLocal pollution and
@@ -166,7 +158,7 @@ abstract class Striped64 extends Number {
     /**
      * Spinlock (locked via CAS) used when resizing and/or creating Cells.
      */
-    transient volatile int busy;
+    transient volatile long busy;
 
     /**
      * Package-private default constructor
@@ -178,14 +170,14 @@ abstract class Striped64 extends Number {
      * CASes the base field.
      */
     final boolean casBase(long cmp, long val) {
-        return UNSAFE.compareAndSwapLong(this, baseOffset, cmp, val);
+        return baseUpdater.compareAndSet(this, cmp, val);
     }
 
     /**
      * CASes the busy field from 0 to 1 to acquire lock.
      */
     final boolean casBusy() {
-        return UNSAFE.compareAndSwapInt(this, busyOffset, 0, 1);
+        return busyUpdater.compareAndSet(this, 0, 1);
     }
 
     /**
@@ -301,54 +293,5 @@ abstract class Striped64 extends Number {
         }
     }
 
-    // Unsafe mechanics
-    private static final sun.misc.Unsafe UNSAFE;
-    private static final long baseOffset;
-    private static final long busyOffset;
-
-    static {
-        try {
-            UNSAFE = getUnsafe();
-            Class<?> sk = Striped64.class;
-            baseOffset = UNSAFE.objectFieldOffset
-                    (sk.getDeclaredField("base"));
-            busyOffset = UNSAFE.objectFieldOffset
-                    (sk.getDeclaredField("busy"));
-        } catch (Exception e) {
-            throw new Error(e);
-        }
-    }
-
-    /**
-     * Returns a sun.misc.Unsafe.  Suitable for use in a 3rd party package. Replace with a simple
-     * call to Unsafe.getUnsafe when integrating into a jdk.
-     *
-     * @return a sun.misc.Unsafe
-     */
-    private static sun.misc.Unsafe getUnsafe() {
-        try {
-            return sun.misc.Unsafe.getUnsafe();
-        } catch (SecurityException ignored) {
-
-        }
-        try {
-            return java.security.AccessController.doPrivileged
-                    (new java.security.PrivilegedExceptionAction<sun.misc.Unsafe>() {
-                        public sun.misc.Unsafe run() throws Exception {
-                            Class<sun.misc.Unsafe> k = sun.misc.Unsafe.class;
-                            for (java.lang.reflect.Field f : k.getDeclaredFields()) {
-                                f.setAccessible(true);
-                                Object x = f.get(null);
-                                if (k.isInstance(x))
-                                    return k.cast(x);
-                            }
-                            throw new NoSuchFieldError("the Unsafe");
-                        }
-                    });
-        } catch (java.security.PrivilegedActionException e) {
-            throw new RuntimeException("Could not initialize intrinsics",
-                                       e.getCause());
-        }
-    }
 }
 // CHECKSTYLE:ON


### PR DESCRIPTION
I am not sure why in 3.2 and also 3.1.2 the AtomicLongFieldUpdater has been replaced with sun.misc.Unsafe again. Applied the patch made by ryantenney (commits f9b4572 and d83b989) in the old project to make it work on AppEngine.  Let me know if there are any reasons why you needed to switch it back.

Many thanks


