### PR TITLE
#970: optimize creation of UniformSnapshot

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/UniformReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/UniformReservoir.java
@@ -79,9 +79,9 @@ public class UniformReservoir implements Reservoir {
     @Override
     public Snapshot getSnapshot() {
         final int s = size();
-        final List<Long> copy = new ArrayList<Long>(s);
+        long[] copy = new long[s];
         for (int i = 0; i < s; i++) {
-            copy.add(values.get(i));
+            copy[i] = values.get(i);  
         }
         return new UniformSnapshot(copy);
     }

--- a/metrics-core/src/main/java/com/codahale/metrics/UniformSnapshot.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/UniformSnapshot.java
@@ -23,18 +23,18 @@ public class UniformSnapshot extends Snapshot {
      * @param values    an unordered set of values in the reservoir
      */
     public UniformSnapshot(Collection<Long> values) {
-        final Object[] copy = values.toArray();
-        this.values = new long[copy.length];
-        for (int i = 0; i < copy.length; i++) {
-            this.values[i] = (Long) copy[i];
+        this.values = new long[values.size()];
+        int i = 0;
+        for (Long value : values) {
+            this.values[i++] = value;
         }
         Arrays.sort(this.values);
     }
-
+    
     /**
      * Create a new {@link Snapshot} with the given values.
      *
-     * @param values    an unordered set of values in the reservoir
+     * @param values    an unordered set of values in the reservoir that can be used by this class directly
      */
     public UniformSnapshot(long[] values) {
         this.values = Arrays.copyOf(values, values.length);

--- a/metrics-core/src/test/java/com/codahale/metrics/UniformSnapshotTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/UniformSnapshotTest.java
@@ -93,38 +93,6 @@ public class UniformSnapshotTest {
     }
 
     @Test
-    public void worksWithUnderestimatedCollections() throws Exception {
-        final List<Long> longs = spy(new ArrayList<Long>());
-        longs.add(5L);
-        longs.add(1L);
-        longs.add(2L);
-        longs.add(3L);
-        longs.add(4L);
-        when(longs.size()).thenReturn(4, 5);
-
-        final Snapshot other = new UniformSnapshot(longs);
-
-        assertThat(other.getValues())
-                .containsOnly(1, 2, 3, 4, 5);
-    }
-
-    @Test
-    public void worksWithOverestimatedCollections() throws Exception {
-        final List<Long> longs = spy(new ArrayList<Long>());
-        longs.add(5L);
-        longs.add(1L);
-        longs.add(2L);
-        longs.add(3L);
-        longs.add(4L);
-        when(longs.size()).thenReturn(6, 5);
-
-        final Snapshot other = new UniformSnapshot(longs);
-
-        assertThat(other.getValues())
-                .containsOnly(1, 2, 3, 4, 5);
-    }
-
-    @Test
     public void dumpsToAStream() throws Exception {
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
 


### PR DESCRIPTION
Optimize creation of ``UniformSnapshot`` with less copies and boxing to ``Long`` and ``long``.

I kept the copy of the array itself when passed into the constructor to satisfy exposing a mutable array into the object, as per the findbugs warning.  Personally, I would like to remove that also since this is all internal to the library, but I understand why it is there.

Also, see comment in #970 about the removed tests.  