### PR TITLE
Async health check

### DIFF
--- a/metrics-healthchecks/src/main/java/io/dropwizard/metrics/health/AsyncHealthCheck.java
+++ b/metrics-healthchecks/src/main/java/io/dropwizard/metrics/health/AsyncHealthCheck.java
@@ -1,0 +1,43 @@
+package io.dropwizard.metrics.health;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+public class AsyncHealthCheck extends HealthCheck implements Runnable {
+    private final HealthCheck synchronousHealthCheck;
+    private final int maxStaleAge;
+    private final TimeUnit maxStaleAgeUnit;
+
+    private volatile CachedResult lastResult;
+
+    public AsyncHealthCheck(HealthCheck synchronousHealthCheck, int maxStaleAge, TimeUnit maxStaleAgeUnit) {
+        this.synchronousHealthCheck = synchronousHealthCheck;
+        this.maxStaleAge = maxStaleAge;
+        this.maxStaleAgeUnit = maxStaleAgeUnit;
+    }
+
+    @Override
+    protected Result check() throws Exception {
+        if (new Date(lastResult.whenCheckFinished.getTime() + maxStaleAgeUnit.toSeconds(maxStaleAge)).before(new Date())) {
+            return Result.unhealthy("Stale");
+        } else {
+            return lastResult.result;
+        }
+    }
+
+    @Override
+    public void run() {
+        Result check = synchronousHealthCheck.execute();
+        lastResult = new CachedResult(check, new Date());
+    }
+
+    private static class CachedResult {
+        public final Result result;
+        public final Date whenCheckFinished;
+
+        private CachedResult(Result result, Date whenCheckFinished) {
+            this.result = result;
+            this.whenCheckFinished = whenCheckFinished;
+        }
+    }
+}


### PR DESCRIPTION
For issue #609

Proposed API for users is:

```
HealthCheckRegistry registry = new HealthCheckRegistry();
ScheduledExecutorService e = new ScheduledThreadPoolExecutor(1);
HealthCheck foo = ...
AsyncHealthCheck asyncFoo = new AsyncHealthCheck(foo, 2, TimeUnit.MINUTES);
e.scheduleWithFixedDelay(asyncFoo, 0, 30, TimeUnit.SECONDS);
registry.register("foo", asyncFoo)
```

In the above example, the ScheduledExecutorService will execute the health checks with 30s delay. The health check will fail if its cached result is older than 2 minutes.

Design choices:
- Give user control over the async checking, so they can plug it into whatever executor service they have
- Reads must be quick
- Detect if the cached result is too old, and allow user to define what too old is
