### PR TITLE
Wrap try-catch each report method.

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -170,23 +170,43 @@ public class GraphiteReporter extends ScheduledReporter {
             }
 
             for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
-                reportGauge(entry.getKey(), entry.getValue(), timestamp);
+                try {
+                    reportGauge(entry.getKey(), entry.getValue(), timestamp);
+                } catch (Exception e) {
+                    LOGGER.warn("Unable to report to Graphite", graphite, e);
+                }
             }
 
             for (Map.Entry<String, Counter> entry : counters.entrySet()) {
-                reportCounter(entry.getKey(), entry.getValue(), timestamp);
+                try {
+                    reportCounter(entry.getKey(), entry.getValue(), timestamp);
+                } catch (Exception e) {
+                    LOGGER.warn("Unable to report to Graphite", graphite, e);
+                }
             }
 
             for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
-                reportHistogram(entry.getKey(), entry.getValue(), timestamp);
+                try {
+                    reportHistogram(entry.getKey(), entry.getValue(), timestamp);
+                } catch (Exception e) {
+                    LOGGER.warn("Unable to report to Graphite", graphite, e);
+                }
             }
 
             for (Map.Entry<String, Meter> entry : meters.entrySet()) {
-                reportMetered(entry.getKey(), entry.getValue(), timestamp);
+                try {
+                    reportMetered(entry.getKey(), entry.getValue(), timestamp);
+                } catch (Exception e) {
+                    LOGGER.warn("Unable to report to Graphite", graphite, e);
+                }
             }
 
             for (Map.Entry<String, Timer> entry : timers.entrySet()) {
-                reportTimer(entry.getKey(), entry.getValue(), timestamp);
+                try {
+                    reportTimer(entry.getKey(), entry.getValue(), timestamp);
+                } catch (Exception e) {
+                    LOGGER.warn("Unable to report to Graphite", graphite, e);
+                }
             }
 
             graphite.flush();

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -181,7 +181,7 @@ public class GraphiteReporter extends ScheduledReporter {
                 try {
                     reportCounter(entry.getKey(), entry.getValue(), timestamp);
                 } catch (Exception e) {
-                    LOGGER.warn("Unable to report to Graphite", graphite, e);
+                    LOGGER.warn("Unable to report to Graphite. key : " + entry.getKey(), graphite, e);
                 }
             }
 
@@ -189,7 +189,7 @@ public class GraphiteReporter extends ScheduledReporter {
                 try {
                     reportHistogram(entry.getKey(), entry.getValue(), timestamp);
                 } catch (Exception e) {
-                    LOGGER.warn("Unable to report to Graphite", graphite, e);
+                    LOGGER.warn("Unable to report to Graphite. key : " + entry.getKey(), graphite, e);
                 }
             }
 
@@ -197,7 +197,7 @@ public class GraphiteReporter extends ScheduledReporter {
                 try {
                     reportMetered(entry.getKey(), entry.getValue(), timestamp);
                 } catch (Exception e) {
-                    LOGGER.warn("Unable to report to Graphite", graphite, e);
+                    LOGGER.warn("Unable to report to Graphite. key : " + entry.getKey(), graphite, e);
                 }
             }
 
@@ -205,7 +205,7 @@ public class GraphiteReporter extends ScheduledReporter {
                 try {
                     reportTimer(entry.getKey(), entry.getValue(), timestamp);
                 } catch (Exception e) {
-                    LOGGER.warn("Unable to report to Graphite", graphite, e);
+                    LOGGER.warn("Unable to report to Graphite. key : " + entry.getKey(), graphite, e);
                 }
             }
 

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -173,7 +173,7 @@ public class GraphiteReporter extends ScheduledReporter {
                 try {
                     reportGauge(entry.getKey(), entry.getValue(), timestamp);
                 } catch (Exception e) {
-                    LOGGER.warn("Unable to report to Graphite", graphite, e);
+                    LOGGER.warn("Unable to report to Graphite. key : " + entry.getKey(), graphite, e);
                 }
             }
 


### PR DESCRIPTION
Wrap try-catch each report method for prevent lose metrics when some metric goes wrong.

Following error is occured on Cassandra 3.3 + metrics-graphite.
After that error, i lose all metered, timer metric + some histogram metric.

>  ERROR [metrics-graphite-reporter-1-thread-1] 2016-07-12 16:22:41,625 ScheduledReporter.java:119 - RuntimeException thrown from GraphiteReporter#report. Exception was suppressed.
> java.lang.IllegalStateException: Unable to compute ceiling for max when histogram overflowed
>         at org.apache.cassandra.utils.EstimatedHistogram.rawMean(EstimatedHistogram.java:231) ~[apache-cassandra-3.3.jar:3.3]
>         at org.apache.cassandra.metrics.EstimatedHistogramReservoir$HistogramSnapshot.getMean(EstimatedHistogramReservoir.java:103) ~[apache-cassandra-3.3.jar:3.3]
>         at com.codahale.metrics.graphite.GraphiteReporter.reportHistogram(GraphiteReporter.java:252) ~[metrics-graphite-3.1.0.jar:3.1.0]
>         at com.codahale.metrics.graphite.GraphiteReporter.report(GraphiteReporter.java:166) ~[metrics-graphite-3.1.0.jar:3.1.0]
>         at com.codahale.metrics.ScheduledReporter.report(ScheduledReporter.java:162) ~[metrics-core-3.1.0.jar:3.1.0]
>         at com.codahale.metrics.ScheduledReporter$1.run(ScheduledReporter.java:117) ~[metrics-core-3.1.0.jar:3.1.0]
>         at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [na:1.8.0_45]
>         at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308) [na:1.8.0_45]
>         at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180) [na:1.8.0_45]
>         at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294) [na:1.8.0_45]
>         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) [na:1.8.0_45]
>         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) [na:1.8.0_45]
>         at java.lang.Thread.run(Thread.java:745) [na:1.8.0_45]

Cassandra throw Exception in metric getter logic. https://github.com/apache/cassandra/blob/3dcbe90e02440e6ee534f643c7603d50ca08482b/src/java/org/apache/cassandra/utils/EstimatedHistogram.java
https://github.com/apache/cassandra/blob/3dcbe90e02440e6ee534f643c7603d50ca08482b/src/java/org/apache/cassandra/metrics/EstimatedHistogramReservoir.java

https://issues.apache.org/jira/browse/CASSANDRA-11117

``` java
    /**
     * @return the mean histogram value (average of bucket offsets, weighted by count)
     * @throws IllegalStateException if any values were greater than the largest bucket threshold
     */
    public double rawMean()
    {
        int lastBucket = buckets.length() - 1;
        if (buckets.get(lastBucket) > 0)
            throw new IllegalStateException("Unable to compute ceiling for max when histogram overflowed");

        long elements = 0;
        long sum = 0;
        for (int i = 0; i < lastBucket; i++)
        {
            long bCount = buckets.get(i);
            elements += bCount;
            sum += bCount * bucketOffsets[i];
        }

        return (double) sum / elements;
    }
```
