### PR TITLE
METRICS-#987: Optimize CsvReporter

### DIFF
--- a/docs/source/manual/core.rst
+++ b/docs/source/manual/core.rst
@@ -384,6 +384,12 @@ of ``.csv`` files in a given directory:
                                             .build(new File("~/projects/data/"));
     reporter.start(1, TimeUnit.SECONDS);
 
+and at the end of its usage,
+
+.. code-block:: java
+
+    reporter.stop();
+
 For each metric registered, a ``.csv`` file will be created, and every second its state will be
 written to it as a new row.
 

--- a/metrics-core/src/test/java/com/codahale/metrics/CsvReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/CsvReporterTest.java
@@ -50,6 +50,7 @@ public class CsvReporterTest {
                         this.<Histogram>map(),
                         this.<Meter>map(),
                         this.<Timer>map());
+        reporter.stop();
 
         assertThat(fileContents("gauge.csv"))
                 .isEqualTo(csv(
@@ -68,6 +69,7 @@ public class CsvReporterTest {
                         this.<Histogram>map(),
                         this.<Meter>map(),
                         this.<Timer>map());
+        reporter.stop();
 
         assertThat(fileContents("test.counter.csv"))
                 .isEqualTo(csv(
@@ -100,6 +102,7 @@ public class CsvReporterTest {
                         map("test.histogram", histogram),
                         this.<Meter>map(),
                         this.<Timer>map());
+        reporter.stop();
 
         assertThat(fileContents("test.histogram.csv"))
                 .isEqualTo(csv(
@@ -122,6 +125,7 @@ public class CsvReporterTest {
                         this.<Histogram>map(),
                         map("test.meter", meter),
                         this.<Timer>map());
+        reporter.stop();
 
         assertThat(fileContents("test.meter.csv"))
                 .isEqualTo(csv(
@@ -158,6 +162,7 @@ public class CsvReporterTest {
                         this.<Histogram>map(),
                         this.<Meter>map(),
                         map("test.another.timer", timer));
+        reporter.stop();
 
         assertThat(fileContents("test.another.timer.csv"))
                 .isEqualTo(csv(


### PR DESCRIPTION
As mentioned in #987, `CsvReporter` is quite slow due to its creation and termination of `PrintWriter`s for every request. Since each request only contains the job for writing a line, if this method is called frequently (like every 10ms for 10000 jobs), it creates a huge burden for the `CsvReporter`. I've experienced a huge improvement of speed when this change have been applied. What it does is that it caches these `PrintWriter`s and reuse them and close them at the end when the `stop()` method is called.

I've been trying to use the `CsvReporter` to record and keep the metrics of a runtime as a file, and discovered this problem and fixed it. I thought it would be nice to share this solution for the original library.

Thanks,
