### PR TITLE
Add an overload of Timer#time that takes Runnable

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/Timer.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Timer.java
@@ -105,6 +105,21 @@ public class Timer implements Metered, Sampling {
     }
 
     /**
+     * Times and records the duration of event.
+     *
+     * @param event a {@link Runnable} whose {@link Runnable#run()} method implements a process
+     *              whose duration should be timed
+     */
+    public void time(Runnable event) {
+        final long startTime = clock.getTick();
+        try {
+            event.run();
+        } finally {
+            update(clock.getTick() - startTime);
+        }
+    }
+
+    /**
      * Returns a new {@link Context}.
      *
      * @return a new {@link Context}

--- a/metrics-core/src/test/java/com/codahale/metrics/TimerTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/TimerTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
@@ -65,6 +66,25 @@ public class TimerTest {
 
         assertThat(value)
                 .isEqualTo("one");
+
+        verify(reservoir).update(50000000);
+    }
+
+    @Test
+    public void timesRunnableInstances() throws Exception {
+        final AtomicBoolean called = new AtomicBoolean();
+        timer.time(new Runnable() {
+            @Override
+            public void run() {
+                called.set(true);
+            }
+        });
+
+        assertThat(timer.getCount())
+                .isEqualTo(1);
+
+        assertThat(called.get())
+                .isTrue();
 
         verify(reservoir).update(50000000);
     }


### PR DESCRIPTION
This allows you to invoke method handles or lambdas that
don't return a value easily.
