### PR TITLE
Adding more unit tests for the Counter class to cover corner cases

### DIFF
--- a/metrics-core/src/test/java/com/codahale/metrics/CounterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/CounterTest.java
@@ -44,4 +44,20 @@ public class CounterTest {
         assertThat(counter.getCount())
                 .isEqualTo(-12);
     }
+
+    @Test
+    public void incrementByNegativeDelta() throws Exception {
+        counter.inc(-12);
+
+        assertThat(counter.getCount())
+                .isEqualTo(-12);
+    }
+
+    @Test
+    public void decrementByNegativeDelta() throws Exception {
+        counter.dec(-12);
+
+        assertThat(counter.getCount())
+                .isEqualTo(12);
+    }
 }


### PR DESCRIPTION
Sometimes developers pass variables without checking them .. so it could happen that they pass negative values to the inc method and positive values to the dec methods .. and thats why I added more unit tests to cover these 2 corner cases to the CounterTest class.
