### PR TITLE
ScheduledReporter.start() starts with undesired delay

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -141,30 +141,6 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
     /**
      * Starts the reporter polling at the given period.
      *
-     * @param initialDelay the time to delay the first execution
-     * @param period       the amount of time between polls
-     * @param unit         the unit for {@code period}
-     */
-    synchronized public void start(long initialDelay, long period, TimeUnit unit) {
-      if (this.scheduledFuture != null) {
-          throw new IllegalArgumentException("Reporter already started");
-      }
-
-      this.scheduledFuture = executor.scheduleAtFixedRate(new Runnable() {
-         @Override
-         public void run() {
-             try {
-                 report();
-             } catch (RuntimeException ex) {
-                 LOG.error("RuntimeException thrown from {}#report. Exception was suppressed.", ScheduledReporter.this.getClass().getSimpleName(), ex);
-             }
-         }
-      }, initialDelay, period, unit);
-    }
-
-    /**
-     * Starts the reporter polling at the given period.
-     *
      * @param period       the amount of time between polls
      * @param initialDelay the time to delay the first execution
      * @param unit         the unit for {@code period}

--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -141,22 +141,26 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
     /**
      * Starts the reporter polling at the given period.
      *
-     * @param period       the amount of time between polls
      * @param initialDelay the time to delay the first execution
+     * @param period       the amount of time between polls
      * @param unit         the unit for {@code period}
      */
-    public void start(long period, long initialDelay, TimeUnit unit) {
-       executor.scheduleAtFixedRate(new Runnable() {
-           @Override
-           public void run() {
-               try {
-                   report();
-               } catch (RuntimeException ex) {
-                   LOG.error("RuntimeException thrown from {}#report. Exception was suppressed.", ScheduledReporter.this.getClass().getSimpleName(), ex);
-               }
-           }
-       }, initialDelay, period, unit);
-   }
+    synchronized public void start(long initialDelay, long period, TimeUnit unit) {
+      if (this.scheduledFuture != null) {
+          throw new IllegalArgumentException("Reporter already started");
+      }
+
+      this.scheduledFuture = executor.scheduleAtFixedRate(new Runnable() {
+         @Override
+         public void run() {
+             try {
+                 report();
+             } catch (RuntimeException ex) {
+                 LOG.error("RuntimeException thrown from {}#report. Exception was suppressed.", ScheduledReporter.this.getClass().getSimpleName(), ex);
+             }
+         }
+      }, initialDelay, period, unit);
+    }
 
     /**
      * Stops the reporter and if shutdownExecutorOnStop is true then shuts down its thread of execution.

--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -134,41 +134,33 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
      * @param period the amount of time between polls
      * @param unit   the unit for {@code period}
      */
-    synchronized public void start(long period, TimeUnit unit) {
-        if (this.scheduledFuture != null) {
-            throw new IllegalArgumentException("Reporter already started");
-        }
-        this.scheduledFuture = executor.scheduleAtFixedRate(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    report();
-                } catch (RuntimeException ex) {
-                    LOG.error("RuntimeException thrown from {}#report. Exception was suppressed.", ScheduledReporter.this.getClass().getSimpleName(), ex);
-                }
-            }
-        }, period, period, unit);
+    public void start(long period, TimeUnit unit) {
+       start(period, period, unit);
     }
 
     /**
      * Starts the reporter polling at the given period.
      *
-     * @param period       the amount of time between polls
      * @param initialDelay the time to delay the first execution
+     * @param period       the amount of time between polls
      * @param unit         the unit for {@code period}
      */
-    public void start(long period, long initialDelay, TimeUnit unit) {
-       executor.scheduleAtFixedRate(new Runnable() {
-           @Override
-           public void run() {
-               try {
-                   report();
-               } catch (RuntimeException ex) {
-                   LOG.error("RuntimeException thrown from {}#report. Exception was suppressed.", ScheduledReporter.this.getClass().getSimpleName(), ex);
-               }
-           }
-       }, initialDelay, period, unit);
-   }
+    synchronized public void start(long initialDelay, long period, TimeUnit unit) {
+      if (this.scheduledFuture != null) {
+          throw new IllegalArgumentException("Reporter already started");
+      }
+
+      this.scheduledFuture = executor.scheduleAtFixedRate(new Runnable() {
+         @Override
+         public void run() {
+             try {
+                 report();
+             } catch (RuntimeException ex) {
+                 LOG.error("RuntimeException thrown from {}#report. Exception was suppressed.", ScheduledReporter.this.getClass().getSimpleName(), ex);
+             }
+         }
+      }, initialDelay, period, unit);
+    }
 
     /**
      * Stops the reporter and if shutdownExecutorOnStop is true then shuts down its thread of execution.

--- a/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
@@ -39,7 +39,7 @@ public class ScheduledReporterTest {
         registry.register("meter", meter);
         registry.register("timer", timer);
 
-        when(executor.scheduleAtFixedRate(any(Runnable.class), eq(200L), eq(200L), eq(TimeUnit.MILLISECONDS)))
+        when(executor.scheduleAtFixedRate(any(Runnable.class), any(Long.class), any(Long.class), eq(TimeUnit.MILLISECONDS)))
                 .thenReturn(scheduledFuture);
     }
 
@@ -61,6 +61,28 @@ public class ScheduledReporterTest {
                 map("meter", meter),
                 map("timer", timer)
         );
+    }
+
+    @Test
+    public void shouldUsePeriodAsInitialDelayIfNotSpecifiedOtherwise() throws Exception {
+        reporterWithCustomExecutor.start(200, TimeUnit.MILLISECONDS);
+
+        verify(executor, times(1)).scheduleAtFixedRate(
+            any(Runnable.class), eq(200L), eq(200L), eq(TimeUnit.MILLISECONDS)
+        );
+
+        Thread.sleep(100);
+    }
+
+    @Test
+    public void shouldStartWithSpecifiedInitialDelay() throws Exception {
+        reporterWithCustomExecutor.start(350, 100, TimeUnit.MILLISECONDS);
+
+        verify(executor).scheduleAtFixedRate(
+            any(Runnable.class), eq(350L), eq(100L), eq(TimeUnit.MILLISECONDS)
+        );
+
+        Thread.sleep(100);
     }
 
     @Test

--- a/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
@@ -70,8 +70,6 @@ public class ScheduledReporterTest {
         verify(executor, times(1)).scheduleAtFixedRate(
             any(Runnable.class), eq(200L), eq(200L), eq(TimeUnit.MILLISECONDS)
         );
-
-        Thread.sleep(100);
     }
 
     @Test
@@ -81,8 +79,6 @@ public class ScheduledReporterTest {
         verify(executor).scheduleAtFixedRate(
             any(Runnable.class), eq(350L), eq(100L), eq(TimeUnit.MILLISECONDS)
         );
-
-        Thread.sleep(100);
     }
 
     @Test

--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/MetricsServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/MetricsServlet.java
@@ -64,9 +64,6 @@ public class MetricsServlet extends HttpServlet {
 
         /**
          * Returns the name of the parameter used to specify the jsonp callback, if any.
-         * 
-         * @return the name of the parameter used to specify the jsonp callback, or <code>null</code>, if 
-         *         no such parameter exists.
          */
         protected String getJsonpCallbackParameter() {
             return null;
@@ -75,9 +72,6 @@ public class MetricsServlet extends HttpServlet {
         /**
          * Returns the {@link MetricFilter} that shall be used to filter metrics, or {@link MetricFilter#ALL} if
          * the default should be used.
-         * 
-         * @return the {@link MetricFilter} that shall be used to filter metrics, or {@link MetricFilter#ALL} if
-         *         the default should be used.
          */
         protected MetricFilter getMetricFilter() {
             // use the default
@@ -173,7 +167,7 @@ public class MetricsServlet extends HttpServlet {
         }
         resp.setHeader("Cache-Control", "must-revalidate,no-cache,no-store");
         resp.setStatus(HttpServletResponse.SC_OK);
-        
+
         final OutputStream output = resp.getOutputStream();
         try {
             if (jsonpParamName != null && req.getParameter(jsonpParamName) != null) {


### PR DESCRIPTION
`ScheduledReporter.start()` incorrectly uses the interval size for the start delay, too:

```
    public void start(long period, TimeUnit unit) {
        executor.scheduleAtFixedRate(new Runnable() {
            @Override
            public void run() {
                try {
                    report();
                } catch (RuntimeException ex) {
                    LOG.error("RuntimeException thrown from {}#report. Exception was suppressed.", ScheduledReporter.this.getClass().getSimpleName(), ex);
                }
            }
        }, period, period, unit);
    }
```

This is a serious problem when the interval is sufficiently big. I suggest to add an alternative version of `ScheduledReporter.start()` to fix the bug without affecting code that relies on this behavior:

```
    public void start(long period, long initialDelay, TimeUnit unit) {
        executor.scheduleAtFixedRate(new Runnable() {
            @Override
            public void run() {
                try {
                    report();
                } catch (RuntimeException ex) {
                    LOG.error("RuntimeException thrown from {}#report. Exception was suppressed.", ScheduledReporter.this.getClass().getSimpleName(), ex);
                }
            }
        }, initialDelay, period, unit);
    }
```
