### PR TITLE
Meters for httpclient exceptions

### DIFF
--- a/metrics-httpclient/src/main/java/io/dropwizard/metrics/httpclient/HttpClientMetricNameStrategy.java
+++ b/metrics-httpclient/src/main/java/io/dropwizard/metrics/httpclient/HttpClientMetricNameStrategy.java
@@ -1,9 +1,17 @@
 package io.dropwizard.metrics.httpclient;
 
+import static io.dropwizard.metrics.MetricRegistry.name;
+
 import org.apache.http.HttpRequest;
+import org.apache.http.client.HttpClient;
 
 import io.dropwizard.metrics.MetricName;
 
 public interface HttpClientMetricNameStrategy {
     MetricName getNameFor(String name, HttpRequest request);
+    default MetricName getNameFor(String name, Exception exception) {
+        return name(HttpClient.class,
+            name,
+            exception.getClass().getSimpleName());
+    }
 }


### PR DESCRIPTION
Adds counters for exceptions that happen after `InstrumentedHttpRequestExecutor.execute` has been invoked (some errors, like connection refused, invalid URLs, etc. don't make it that far). By default, use the simple name of the exception as the name of the meter, yielding names like     `org.apache.http.client.HttpClient.foobar.SocketTimeoutException`.
