### PR TITLE
Minor fix in docs, using PickledGraphite instead of Graphite

### DIFF
--- a/docs/source/manual/graphite.rst
+++ b/docs/source/manual/graphite.rst
@@ -24,7 +24,7 @@ If you prefer to write metrics in batches using pickle, you can use the ``Pickle
 
 .. code-block:: java
 
-    final Graphite pickledGraphite = new PickledGraphite(new InetSocketAddress("graphite.example.com", 2004));
+    final PickledGraphite pickledGraphite = new PickledGraphite(new InetSocketAddress("graphite.example.com", 2004));
     final GraphiteReporter reporter = GraphiteReporter.forRegistry(registry)
                                                       .prefixedWith("web1.example.com")
                                                       .convertRatesTo(TimeUnit.SECONDS)


### PR DESCRIPTION
`Graphite` and `PickledGraphite` are both subclasses of `GraphiteSender`, so the edited line in docs does not compile.