### PR TITLE
Add thread-safe getters for metrics with custom instantiations. 

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -116,6 +116,27 @@ public class MetricRegistry implements MetricSet {
     }
 
     /**
+     * Return the {@link Counter} registered under this name; or create and register
+     * a new {@link Counter} using the provided MetricSupplier if none is registered.
+     *
+     * @param name the name of the metric
+     * @param supplier a MetricSupplier that can be used to manufacture a counter.
+     * @return a new or pre-existing {@link Counter}
+     */
+    public Counter counter(String name, final MetricSupplier<Counter> supplier) {
+        return getOrAdd(name, new MetricBuilder<Counter>() {
+            @Override
+            public Counter newMetric() {
+                return supplier.newMetric();
+            }
+            @Override
+            public boolean isInstance(Metric metric) {
+                return Counter.class.isInstance(metric);
+            }
+        });
+    }
+
+    /**
      * Return the {@link Histogram} registered under this name; or create and register 
      * a new {@link Histogram} if none is registered.
      *
@@ -127,7 +148,28 @@ public class MetricRegistry implements MetricSet {
     }
 
     /**
-     * Return the {@link Meter} registered under this name; or create and register 
+     * Return the {@link Histogram} registered under this name; or create and register
+     * a new {@link Histogram} using the provided MetricSupplier if none is registered.
+     *
+     * @param name the name of the metric
+     * @param supplier a MetricSupplier that can be used to manufacture a histogram
+     * @return a new or pre-existing {@link Histogram}
+     */
+    public Histogram histogram(String name, final MetricSupplier<Histogram> supplier) {
+      return getOrAdd(name, new MetricBuilder<Histogram>() {
+        @Override
+        public Histogram newMetric() {
+          return supplier.newMetric();
+        }
+        @Override
+        public boolean isInstance(Metric metric) {
+          return Histogram.class.isInstance(metric);
+        }
+      });
+    }
+
+    /**
+     * Return the {@link Meter} registered under this name; or create and register
      * a new {@link Meter} if none is registered.
      *
      * @param name the name of the metric
@@ -138,7 +180,28 @@ public class MetricRegistry implements MetricSet {
     }
 
     /**
-     * Return the {@link Timer} registered under this name; or create and register 
+     * Return the {@link Meter} registered under this name; or create and register
+     * a new {@link Meter} using the provided MetricSupplier if none is registered.
+     *
+     * @param name the name of the metric
+     * @param supplier a MetricSupplier that can be used to manufacture a Meter
+     * @return a new or pre-existing {@link Meter}
+     */
+    public Meter meter(String name, final MetricSupplier<Meter> supplier) {
+        return getOrAdd(name, new MetricBuilder<Meter>() {
+            @Override
+            public Meter newMetric() {
+                return supplier.newMetric();
+            }
+            @Override
+            public boolean isInstance(Metric metric) {
+                return Meter.class.isInstance(metric);
+            }
+        });
+    }
+
+    /**
+     * Return the {@link Timer} registered under this name; or create and register
      * a new {@link Timer} if none is registered.
      *
      * @param name the name of the metric
@@ -149,11 +212,54 @@ public class MetricRegistry implements MetricSet {
     }
 
     /**
-     * Removes the metric with the given name.
+     * Return the {@link Timer} registered under this name; or create and register
+     * a new {@link Timer} using the provided MetricSupplier if none is registered.
      *
      * @param name the name of the metric
-     * @return whether or not the metric was removed
+     * @param supplier a MetricSupplier that can be used to manufacture a Timer
+     * @return a new or pre-existing {@link Timer}
      */
+    public Timer timer(String name, final MetricSupplier<Timer> supplier) {
+        return getOrAdd(name, new MetricBuilder<Timer>() {
+            @Override
+            public Timer newMetric() {
+                return supplier.newMetric();
+            }
+            @Override
+            public boolean isInstance(Metric metric) {
+                return Timer.class.isInstance(metric);
+            }
+        });
+    }
+
+    /**
+     * Return the {@link Gauge} registered under this name; or create and register
+     * a new {@link Gauge} using the provided MetricSupplier if none is registered.
+     *
+     * @param name the name of the metric
+     * @param supplier a MetricSupplier that can be used to manufacture a Gauge
+     * @return a new or pre-existing {@link Gauge}
+     */
+    public Gauge gauge(String name, final MetricSupplier<Gauge> supplier) {
+        return getOrAdd(name, new MetricBuilder<Gauge>() {
+            @Override
+            public Gauge newMetric() {
+                return supplier.newMetric();
+            }
+            @Override
+            public boolean isInstance(Metric metric) {
+                return Gauge.class.isInstance(metric);
+            }
+        });
+    }
+
+
+        /**
+         * Removes the metric with the given name.
+         *
+         * @param name the name of the metric
+         * @return whether or not the metric was removed
+         */
     public boolean remove(String name) {
         final Metric metric = metrics.remove(name);
         if (metric != null) {
@@ -394,6 +500,10 @@ public class MetricRegistry implements MetricSet {
     @Override
     public Map<String, Metric> getMetrics() {
         return Collections.unmodifiableMap(metrics);
+    }
+
+    public interface MetricSupplier<T extends Metric> {
+      T newMetric();
     }
 
     /**

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
@@ -64,6 +64,24 @@ public class MetricRegistryTest {
     }
 
     @Test
+    public void accessingACustomCounterRegistersAndReusesTheCounter() throws Exception {
+        final MetricRegistry.MetricSupplier<Counter> supplier = new MetricRegistry.MetricSupplier<Counter>() {
+            @Override
+            public Counter newMetric() {
+                return counter;
+            }
+        };
+        final Counter counter1 = registry.counter("thing", supplier);
+        final Counter counter2 = registry.counter("thing", supplier);
+
+        assertThat(counter1)
+                .isSameAs(counter2);
+
+        verify(listener).onCounterAdded("thing", counter1);
+    }
+
+
+    @Test
     public void removingACounterTriggersANotification() throws Exception {
         registry.register("thing", counter);
 
@@ -85,6 +103,23 @@ public class MetricRegistryTest {
     public void accessingAHistogramRegistersAndReusesIt() throws Exception {
         final Histogram histogram1 = registry.histogram("thing");
         final Histogram histogram2 = registry.histogram("thing");
+
+        assertThat(histogram1)
+                .isSameAs(histogram2);
+
+        verify(listener).onHistogramAdded("thing", histogram1);
+    }
+
+    @Test
+    public void accessingACustomHistogramRegistersAndReusesIt() throws Exception {
+        final MetricRegistry.MetricSupplier<Histogram> supplier = new MetricRegistry.MetricSupplier<Histogram>() {
+            @Override
+            public Histogram newMetric() {
+                return histogram;
+            }
+        };
+        final Histogram histogram1 = registry.histogram("thing", supplier);
+        final Histogram histogram2 = registry.histogram("thing", supplier);
 
         assertThat(histogram1)
                 .isSameAs(histogram2);
@@ -122,6 +157,23 @@ public class MetricRegistryTest {
     }
 
     @Test
+    public void accessingACustomMeterRegistersAndReusesIt() throws Exception {
+        final MetricRegistry.MetricSupplier<Meter> supplier = new MetricRegistry.MetricSupplier<Meter>() {
+            @Override
+            public Meter newMetric() {
+                return meter;
+            }
+        };
+        final Meter meter1 = registry.meter("thing", supplier);
+        final Meter meter2 = registry.meter("thing", supplier);
+
+        assertThat(meter1)
+                .isSameAs(meter2);
+
+        verify(listener).onMeterAdded("thing", meter1);
+    }
+
+        @Test
     public void removingAMeterTriggersANotification() throws Exception {
         registry.register("thing", meter);
 
@@ -151,6 +203,24 @@ public class MetricRegistryTest {
     }
 
     @Test
+    public void accessingACustomTimerRegistersAndReusesIt() throws Exception {
+        final MetricRegistry.MetricSupplier<Timer> supplier = new MetricRegistry.MetricSupplier<Timer>() {
+            @Override
+            public Timer newMetric() {
+                return timer;
+            }
+        };
+        final Timer timer1 = registry.timer("thing", supplier);
+        final Timer timer2 = registry.timer("thing", supplier);
+
+        assertThat(timer1)
+                .isSameAs(timer2);
+
+        verify(listener).onTimerAdded("thing", timer1);
+    }
+
+
+    @Test
     public void removingATimerTriggersANotification() throws Exception {
         registry.register("thing", timer);
 
@@ -159,6 +229,24 @@ public class MetricRegistryTest {
 
         verify(listener).onTimerRemoved("thing");
     }
+
+    @Test
+    public void accessingACustomGaugeRegistersAndReusesIt() throws Exception {
+        final MetricRegistry.MetricSupplier<Gauge> supplier = new MetricRegistry.MetricSupplier<Gauge>() {
+            @Override
+            public Gauge newMetric() {
+                return gauge;
+            }
+        };
+        final Gauge gauge1 = registry.gauge("thing", supplier);
+        final Gauge gauge2 = registry.gauge("thing", supplier);
+
+        assertThat(gauge1)
+                .isSameAs(gauge2);
+
+        verify(listener).onGaugeAdded("thing", gauge1);
+    }
+
 
     @Test
     public void addingAListenerWithExistingMetricsCatchesItUp() throws Exception {
@@ -357,7 +445,7 @@ public class MetricRegistryTest {
         };
 
         assertThat(name(g.getClass(), "one", "two"))
-                .isEqualTo("com.codahale.metrics.MetricRegistryTest$5.one.two");
+                .isEqualTo("com.codahale.metrics.MetricRegistryTest$10.one.two");
     }
 
     @Test


### PR DESCRIPTION
Fixes Issue #780.

A disappointing amount of boilerplate here, but I think this is what you had in mind, @ryantenney.

Once nice thing though, is that this allowed a path for MetricRegistry.gauge, which is a thing I'd wished I'd had last year.