### PR TITLE
Update Jackson to 2.8.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <servlet.version>3.1.0</servlet.version>
         <slf4j.version>1.7.7</slf4j.version>
-        <jackson.version>2.4.2</jackson.version>
+        <jackson.version>2.8.5</jackson.version>
         <jetty8.version>8.1.11.v20130520</jetty8.version>
         <jetty9.legacy.version>9.0.4.v20130625</jetty9.legacy.version>
         <jetty9.version>9.2.2.v20140723</jetty9.version>


### PR DESCRIPTION
I've been having problems hooking up Dropwizard Metrics with [Finagle Metrics](https://github.com/rlazoti/finagle-metrics) and [Finatra](https://github.com/twitter/finatra) because of conflicting Jackson versions.

I've bumped the version of Jackson to the latest from Maven Central (2.8.5) and the tests all appear to pass successfully.

Are there any other areas that need looking at to ensure the upgrade doesn't break anything?

It may be worth considering this issue as well: https://github.com/dropwizard/metrics/issues/642
