### PR TITLE
Update Jackson to 2.8.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <servlet.version>3.1.0</servlet.version>
         <slf4j.version>1.7.12</slf4j.version>
-        <jackson.version>2.6.0</jackson.version>
+        <jackson.version>2.8.5</jackson.version>
         <jetty9.version>9.2.12.v20150709</jetty9.version>
         <rabbitmq.version>3.5.4</rabbitmq.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
I've been having problems hooking up Dropwizard Metrics with [Finagle Metrics](https://github.com/rlazoti/finagle-metrics) and [Finatra](https://github.com/twitter/finatra) because of conflicting Jackson versions.

I've bumped the version of Jackson to the latest from Maven Central (2.8.5) and the tests all appear to pass successfully.

Are there any other areas that need looking at to ensure the upgrade doesn't break anything?

It may be worth considering this issue as well: https://github.com/dropwizard/metrics/issues/642
