### PR TITLE
Fix race condition in ExponentiallyDecayingReservoir's rescale method

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
@@ -159,9 +159,9 @@ public class ExponentiallyDecayingReservoir implements Reservoir {
      * a linear pass over whatever data structure is being used."
      */
     private void rescale(long now, long next) {
-        if (nextScaleTime.compareAndSet(next, now + RESCALE_THRESHOLD)) {
-            lockForRescale();
-            try {
+        lockForRescale();
+        try {
+            if (nextScaleTime.compareAndSet(next, now + RESCALE_THRESHOLD)) {
                 final long oldStartTime = startTime;
                 this.startTime = currentTimeInSeconds();
                 final double scalingFactor = exp(-alpha * (startTime - oldStartTime));
@@ -175,9 +175,9 @@ public class ExponentiallyDecayingReservoir implements Reservoir {
 
                 // make sure the counter is in sync with the number of stored samples.
                 count.set(values.size());
-            } finally {
-                unlockForRescale();
             }
+        } finally {
+            unlockForRescale();
         }
     }
 


### PR DESCRIPTION
Fixes issues #1005 and #793 - note that in #793 the `longPeriodsOfInactivityShouldNotCorruptSamplingState` test did not cover multiple concurrent requests after a long idle period.

The race condition currently occurs when two threads update the reservoir concurrently - after the first thread has successfully updated `nextScaleTime` (line 162) but before the write lock is obtained (line 163) a second thread updates the reservoir (line 95+).  With several threads pushing updates concurrently this presents a narrow window during which the second thread may obtain the lock before the first resulting in a corrupt reservoir state.  Note, however, that if a snapshot is requested just prior to the two concurrent updates the read lock will already be active when the two threads enter `rescaleIfNeeded`, resulting in a much larger window for this race condition.