### PR TITLE
Add support for Pickled Graphite over UDP

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphitePickler.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphitePickler.java
@@ -1,0 +1,100 @@
+package com.codahale.metrics.graphite;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.nio.charset.Charset;
+
+/**
+ * Created by p.willoughby on 27/11/14.
+ */
+public class GraphitePickler {
+    private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
+    /**
+     * Minimally necessary pickle opcodes.
+     */
+    private static final char
+            MARK = '(',
+            STOP = '.',
+            LONG = 'L',
+            STRING = 'S',
+            APPEND = 'a',
+            LIST = 'l',
+            TUPLE = 't',
+            QUOTE = '\'',
+            LF = '\n';
+
+    /**
+     * See: http://readthedocs.org/docs/graphite/en/1.0/feeding-carbon.html
+     *
+     * @throws java.io.IOException
+     */
+    static byte[] pickleMetrics(List<MetricTuple> metrics, Charset charset) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream(metrics.size() * 75); // Extremely rough estimate of 75 bytes per message
+        Writer pickled = new OutputStreamWriter(out, charset);
+
+        pickled.append(MARK);
+        pickled.append(LIST);
+
+        for (MetricTuple tuple : metrics) {
+            // start the outer tuple
+            pickled.append(MARK);
+
+            // the metric name is a string.
+            pickled.append(STRING);
+            // the single quotes are to match python's repr("abcd")
+            pickled.append(QUOTE);
+            pickled.append(sanitize(tuple.name));
+            pickled.append(QUOTE);
+            pickled.append(LF);
+
+            // start the inner tuple
+            pickled.append(MARK);
+
+            // timestamp is a long
+            pickled.append(LONG);
+            pickled.append(Long.toString(tuple.timestamp));
+            // the trailing L is to match python's repr(long(1234))
+            pickled.append(LONG);
+            pickled.append(LF);
+
+            // and the value is a string.
+            pickled.append(STRING);
+            pickled.append(QUOTE);
+            pickled.append(sanitize(tuple.value));
+            pickled.append(QUOTE);
+            pickled.append(LF);
+
+            pickled.append(TUPLE); // inner close
+            pickled.append(TUPLE); // outer close
+
+            pickled.append(APPEND);
+        }
+
+        // every pickle ends with STOP
+        pickled.append(STOP);
+
+        pickled.flush();
+
+        return out.toByteArray();
+    }
+
+    public static class MetricTuple {
+        String name;
+        long timestamp;
+        String value;
+
+        MetricTuple(String name, long timestamp, String value) {
+            this.name = name;
+            this.timestamp = timestamp;
+            this.value = value;
+        }
+    }
+
+    protected static String sanitize(String s) {
+        return WHITESPACE.matcher(s).replaceAll("-");
+    }
+}

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphitePickler.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphitePickler.java
@@ -8,10 +8,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.nio.charset.Charset;
 
-/**
- * Created by p.willoughby on 27/11/14.
- */
-public class GraphitePickler {
+public final class GraphitePickler {
     private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
     /**
      * Minimally necessary pickle opcodes.

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/PickledGraphite.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/PickledGraphite.java
@@ -6,7 +6,6 @@ import org.slf4j.LoggerFactory;
 import javax.net.SocketFactory;
 
 import java.io.BufferedWriter;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -31,7 +30,7 @@ public class PickledGraphite implements GraphiteSender {
 
     private int batchSize;
     // graphite expects a python-pickled list of nested tuples.
-    private List<MetricTuple> metrics = new LinkedList<MetricTuple>();
+    private List<GraphitePickler.MetricTuple> metrics = new LinkedList<GraphitePickler.MetricTuple>();
 
     private final String hostname;
     private final int port;
@@ -207,7 +206,7 @@ public class PickledGraphite implements GraphiteSender {
      */
     @Override
     public void send(String name, String value, long timestamp) throws IOException {
-        metrics.add(new MetricTuple(sanitize(name), timestamp, sanitize(value)));
+        metrics.add(new GraphitePickler.MetricTuple(name, timestamp, value));
 
         if (metrics.size() >= batchSize) {
             writeMetrics();
@@ -252,7 +251,7 @@ public class PickledGraphite implements GraphiteSender {
     private void writeMetrics() throws IOException {
         if (metrics.size() > 0) {
             try {
-                byte[] payload = pickleMetrics(metrics);
+                byte[] payload = GraphitePickler.pickleMetrics(metrics,charset);
                 byte[] header = ByteBuffer.allocate(4).putInt(payload.length).array();
 
                 @SuppressWarnings("resource")
@@ -275,90 +274,4 @@ public class PickledGraphite implements GraphiteSender {
 
         }
     }
-
-    /**
-     * Minimally necessary pickle opcodes.
-     */
-    private final char
-            MARK = '(',
-            STOP = '.',
-            LONG = 'L',
-            STRING = 'S',
-            APPEND = 'a',
-            LIST = 'l',
-            TUPLE = 't',
-            QUOTE = '\'',
-            LF = '\n';
-
-    /**
-     * See: http://readthedocs.org/docs/graphite/en/1.0/feeding-carbon.html
-     *
-     * @throws IOException
-     */
-    byte[] pickleMetrics(List<MetricTuple> metrics) throws IOException {
-        ByteArrayOutputStream out = new ByteArrayOutputStream(metrics.size() * 75); // Extremely rough estimate of 75 bytes per message
-        Writer pickled = new OutputStreamWriter(out, charset);
-
-        pickled.append(MARK);
-        pickled.append(LIST);
-
-        for (MetricTuple tuple : metrics) {
-            // start the outer tuple
-            pickled.append(MARK);
-
-            // the metric name is a string.
-            pickled.append(STRING);
-            // the single quotes are to match python's repr("abcd")
-            pickled.append(QUOTE);
-            pickled.append(tuple.name);
-            pickled.append(QUOTE);
-            pickled.append(LF);
-
-            // start the inner tuple
-            pickled.append(MARK);
-
-            // timestamp is a long
-            pickled.append(LONG);
-            pickled.append(Long.toString(tuple.timestamp));
-            // the trailing L is to match python's repr(long(1234))
-            pickled.append(LONG);
-            pickled.append(LF);
-
-            // and the value is a string.
-            pickled.append(STRING);
-            pickled.append(QUOTE);
-            pickled.append(tuple.value);
-            pickled.append(QUOTE);
-            pickled.append(LF);
-
-            pickled.append(TUPLE); // inner close
-            pickled.append(TUPLE); // outer close
-
-            pickled.append(APPEND);
-        }
-
-        // every pickle ends with STOP
-        pickled.append(STOP);
-
-        pickled.flush();
-
-        return out.toByteArray();
-    }
-
-    static class MetricTuple {
-        String name;
-        long timestamp;
-        String value;
-
-        MetricTuple(String name, long timestamp, String value) {
-            this.name = name;
-            this.timestamp = timestamp;
-            this.value = value;
-        }
-    }
-
-    protected String sanitize(String s) {
-        return GraphiteSanitize.sanitize(s, '-');
-    }
-
 }

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/PickledGraphiteUDP.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/PickledGraphiteUDP.java
@@ -162,8 +162,11 @@ public final class PickledGraphiteUDP implements GraphiteSender {
 
     @Override
     public void close() throws IOException {
-        datagramChannel.socket().close();
-        datagramChannel = null;
+        try {
+            datagramChannel.socket().close();
+        } finally {
+            datagramChannel = null;
+        }
     }
 
     @Override
@@ -186,7 +189,6 @@ public final class PickledGraphiteUDP implements GraphiteSender {
                 ByteBuffer byteBuffer = ByteBuffer.allocate(4 + payload.length).putInt(payload.length).put(payload);
 
                 datagramChannel.send(byteBuffer, address);
-                this.failures = 0;
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Wrote {} metrics", metrics.size());
                 }

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/PickledGraphiteUDP.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/PickledGraphiteUDP.java
@@ -1,0 +1,203 @@
+package com.codahale.metrics.graphite;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.SocketFactory;
+import java.io.*;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.nio.charset.Charset;
+import java.util.LinkedList;
+import java.util.List;
+
+public final class PickledGraphiteUDP implements GraphiteSender {
+
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PickledGraphite.class);
+    private final static int DEFAULT_BATCH_SIZE = 100;
+
+    private int batchSize;
+    // graphite expects a python-pickled list of nested tuples.
+    private final List<GraphitePickler.MetricTuple> metrics = new LinkedList<GraphitePickler.MetricTuple>();
+
+    private DatagramChannel datagramChannel = null;
+    private int failures;
+    private final InetSocketAddress address;
+    private final Charset charset;
+
+    /**
+     * Creates a new client which connects to the given address using the default {@link SocketFactory}. This defaults
+     * to a batchSize of 100
+     *
+     * @param address
+     *            the address of the Carbon server
+     */
+    public PickledGraphiteUDP(InetSocketAddress address) {
+        this(address, DEFAULT_BATCH_SIZE);
+    }
+
+    /**
+     * Creates a new client which connects to the given address using the default {@link SocketFactory}.
+     *
+     * @param address
+     *            the address of the Carbon server
+     * @param batchSize
+     *            how many metrics are bundled into a single pickle request to graphite
+     */
+    public PickledGraphiteUDP(InetSocketAddress address, int batchSize) {
+        this(address, UTF_8, batchSize);
+    }
+
+    /**
+     * Creates a new client which connects to the given address using the given character set.
+     *
+     * @param address
+     *            the address of the Carbon server
+     * @param charset
+     *            the character set used by the server
+     * @param batchSize
+     *            how many metrics are bundled into a single pickle request to graphite
+     */
+    public PickledGraphiteUDP(InetSocketAddress address, Charset charset, int batchSize) {
+        this.address = address;
+        this.charset = charset;
+        this.batchSize = batchSize;
+    }
+
+    /**
+     * Creates a new client which connects to the given address using the default {@link SocketFactory}. This defaults
+     * to a batchSize of 100
+     *
+     * @param hostname
+     *            the hostname of the Carbon server
+     * @param port
+     *            the port of the Carbon server
+     */
+    public PickledGraphiteUDP(String hostname, int port) {
+        this(hostname, port, DEFAULT_BATCH_SIZE);
+    }
+
+    /**
+     * Creates a new client which connects to the given address and socket factory.
+     *
+     * @param hostname
+     *            the hostname of the Carbon server
+     * @param port
+     *            the port of the Carbon server
+     * @param batchSize
+     *            how many metrics are bundled into a single pickle request to graphite
+     */
+    public PickledGraphiteUDP(String hostname, int port, int batchSize) {
+        this(hostname, port, UTF_8, batchSize);
+    }
+
+    /**
+     * Creates a new client which connects to the given address and socket factory using the given character set.
+     *
+     * @param hostname
+     *            the hostname of the Carbon server
+     * @param port
+     *            the port of the Carbon server
+     * @param charset
+     *            the character set used by the server
+     * @param batchSize
+     *            how many metrics are bundled into a single pickle request to graphite
+     */
+    public PickledGraphiteUDP(String hostname, int port, Charset charset, int batchSize) {
+        this(new InetSocketAddress(hostname, port), charset, batchSize);
+    }
+
+    @Override
+    public void connect() throws IllegalStateException, IOException {
+        if (isConnected()) {
+            throw new IllegalStateException("Already connected");
+        }
+        InetSocketAddress address = this.address;
+        if (address.getAddress() == null) {
+            throw new UnknownHostException(address.getHostName());
+        }
+
+        datagramChannel = DatagramChannel.open();
+        datagramChannel.connect(address);
+    }
+
+    @Override
+    public boolean isConnected() {
+        return datagramChannel != null && !datagramChannel.socket().isClosed();
+    }
+
+    /**
+     * Convert the metric to a python tuple of the form:
+     * <p/>
+     * (timestamp, (name, value))
+     * <p/>
+     * And add it to the list of metrics. If we reach the batch size, write them out.
+     *
+     * @param name
+     *            the name of the metric
+     * @param value
+     *            the value of the metric
+     * @param timestamp
+     *            the timestamp of the metric
+     * @throws IOException
+     *             if there was an error sending the metric
+     */
+    @Override
+    public void send(String name, String value, long timestamp) throws IOException {
+        metrics.add(new GraphitePickler.MetricTuple(name, timestamp, value));
+
+        if (metrics.size() >= batchSize) {
+            writeMetrics();
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+        // No such concept in UDP
+    }
+
+    @Override
+    public void close() throws IOException {
+        datagramChannel.socket().close();
+        datagramChannel = null;
+    }
+
+    @Override
+    public int getFailures() {
+        return failures;
+    }
+
+    /**
+     * 1. Run the pickler script to package all the pending metrics into a single message
+     * 2. Send the message to graphite
+     * 3. Clear out the list of metrics
+     */
+    private void writeMetrics() throws IOException {
+        if (!isConnected()) {
+            connect();
+        }
+        if (metrics.size() > 0) {
+            try {
+                byte[] payload = GraphitePickler.pickleMetrics(metrics,charset);
+                ByteBuffer byteBuffer = ByteBuffer.allocate(4 + payload.length).putInt(payload.length).put(payload);
+
+                datagramChannel.send(byteBuffer, address);
+                this.failures = 0;
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Wrote {} metrics", metrics.size());
+                }
+            } catch (IOException e) {
+                failures++;
+                throw e;
+            } finally {
+                // if there was an error, we might miss some data. for now, drop those on the floor and
+                // try to keep going.
+                metrics.clear();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Redo of https://github.com/dropwizard/metrics/pull/714

> Pulled the logic to create the Pickled data format into its own class (GraphitePickler).
> Adjusted PickledGraphite to use the GraphitePickler class.
> Created PickledGraphiteUDP class which is to PickledGraphite what GraphiteUDP is to Graphite.