### PR TITLE
Add `getProtocols` method

### DIFF
--- a/metrics-jetty9-legacy/src/main/java/com/codahale/metrics/jetty9/InstrumentedConnectionFactory.java
+++ b/metrics-jetty9-legacy/src/main/java/com/codahale/metrics/jetty9/InstrumentedConnectionFactory.java
@@ -7,19 +7,41 @@ import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+
 public class InstrumentedConnectionFactory extends ContainerLifeCycle implements ConnectionFactory {
     private final ConnectionFactory connectionFactory;
     private final Timer timer;
+    private Method getProtocols;
 
     public InstrumentedConnectionFactory(ConnectionFactory connectionFactory, Timer timer) {
         this.connectionFactory = connectionFactory;
         this.timer = timer;
         addBean(connectionFactory);
+        try {
+            getProtocols = connectionFactory.getClass().getMethod("getProtocols");
+        } catch (NoSuchMethodException ignore) {
+            getProtocols = null;
+        }
     }
 
     @Override
     public String getProtocol() {
         return connectionFactory.getProtocol();
+    }
+
+    @SuppressWarnings("unchecked")
+    public List<String> getProtocols() {
+        try {
+            return getProtocols != null ?
+                    (List<String>) getProtocols.invoke(connectionFactory) :
+                    Collections.<String>emptyList();
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalStateException("Unable to invoke `connectionFactory#getProtocols`", e);
+        }
     }
 
     @Override


### PR DESCRIPTION
This method is declared in `ConnectionFactory` in Jetty 9.3.*.
To be compatible with it, we should have a method with the same
signature.

We can't use a compile-time dependency on Jetty 9.3.*, because
it's compiled against Java 8, but `codahale-metrics` against Java 6.

Therefore, we use reflection to access this method.

Backport of #823