### PR TITLE
Upgrade Jetty integration to Jetty 9.4

### DIFF
--- a/metrics-jetty9/src/main/java/io/dropwizard/metrics/jetty9/InstrumentedConnectionFactory.java
+++ b/metrics-jetty9/src/main/java/io/dropwizard/metrics/jetty9/InstrumentedConnectionFactory.java
@@ -1,32 +1,22 @@
 package io.dropwizard.metrics.jetty9;
 
+import io.dropwizard.metrics.Timer;
 import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 
-import io.dropwizard.metrics.Timer;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.Collections;
 import java.util.List;
 
 public class InstrumentedConnectionFactory extends ContainerLifeCycle implements ConnectionFactory {
     private final ConnectionFactory connectionFactory;
     private final Timer timer;
-    private Method getProtocols;
 
     public InstrumentedConnectionFactory(ConnectionFactory connectionFactory, Timer timer) {
         this.connectionFactory = connectionFactory;
         this.timer = timer;
         addBean(connectionFactory);
-        try {
-            getProtocols = connectionFactory.getClass().getMethod("getProtocols");
-        } catch (NoSuchMethodException ignore) {
-            getProtocols = null;
-        }
     }
 
     @Override
@@ -34,15 +24,9 @@ public class InstrumentedConnectionFactory extends ContainerLifeCycle implements
         return connectionFactory.getProtocol();
     }
 
-    @SuppressWarnings("unchecked")
+    @Override
     public List<String> getProtocols() {
-        try {
-            return getProtocols != null ?
-                    (List<String>) getProtocols.invoke(connectionFactory) :
-                    Collections.<String>emptyList();
-        } catch (IllegalAccessException | InvocationTargetException e) {
-            throw new IllegalStateException("Unable to invoke `connectionFactory#getProtocols`", e);
-        }
+        return connectionFactory.getProtocols();
     }
 
     @Override
@@ -64,3 +48,4 @@ public class InstrumentedConnectionFactory extends ContainerLifeCycle implements
         return connection;
     }
 }
+

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -60,6 +60,20 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <classifier>tests</classifier>
+            <version>${jetty9.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <classifier>tests</classifier>
+            <version>${jetty9.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jetty9</artifactId>
             <version>${project.version}</version>

--- a/metrics-servlets/src/test/java/io/dropwizard/metrics/servlets/AdminServletTest.java
+++ b/metrics-servlets/src/test/java/io/dropwizard/metrics/servlets/AdminServletTest.java
@@ -58,6 +58,6 @@ public class AdminServletTest extends AbstractServletTest {
                                 "</html>%n"
                 ));
         assertThat(response.get(HttpHeader.CONTENT_TYPE))
-                .isEqualTo("text/html; charset=ISO-8859-1");
+                .isEqualTo("text/html;charset=UTF-8");
     }
 }

--- a/metrics-servlets/src/test/java/io/dropwizard/metrics/servlets/PingServletTest.java
+++ b/metrics-servlets/src/test/java/io/dropwizard/metrics/servlets/PingServletTest.java
@@ -37,7 +37,7 @@ public class PingServletTest extends AbstractServletTest {
     @Test
     public void returnsTextPlain() throws Exception {
         assertThat(response.get(HttpHeader.CONTENT_TYPE))
-                .isEqualTo("text/plain; charset=ISO-8859-1");
+                .isEqualTo("text/plain;charset=ISO-8859-1");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <servlet.version>3.1.0</servlet.version>
         <slf4j.version>1.7.12</slf4j.version>
         <jackson.version>2.8.5</jackson.version>
-        <jetty9.version>9.2.12.v20150709</jetty9.version>
+        <jetty9.version>9.4.0.v20161208</jetty9.version>
         <rabbitmq.version>3.5.4</rabbitmq.version>
         <junit.version>4.12</junit.version>
     </properties>


### PR DESCRIPTION
This update removes reflection hacks for supporting Jetty 9.3 and higher and allows to test the Jetty and Servlets modules against the latest Jetty version 9.4.0.v20161208. Metrics 4.0.0 supports Java 8, so the change is pretty straightforward.