### PR TITLE
Support for disabled metrics

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/MetricAttribute.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricAttribute.java
@@ -1,9 +1,9 @@
 package com.codahale.metrics;
 
 /**
- * Represents types of metrics which can be reported.
+ * Represents attributes of metrics which can be reported.
  */
-public enum MetricType {
+public enum MetricAttribute {
 
     MAX("max"),
     MEAN("mean"),
@@ -23,7 +23,7 @@ public enum MetricType {
 
     private final String code;
 
-    MetricType(String code) {
+    MetricAttribute(String code) {
         this.code = code;
     }
 

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricType.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricType.java
@@ -1,0 +1,33 @@
+package com.codahale.metrics;
+
+/**
+ * Represents types of metrics which can be reported.
+ */
+public enum MetricType {
+
+    MAX("max"),
+    MEAN("mean"),
+    MIN("min"),
+    STDDEV("stddev"),
+    P50("p50"),
+    P75("p75"),
+    P95("p95"),
+    P98("p98"),
+    P99("p99"),
+    P999("p999"),
+    COUNT("count"),
+    M1_RATE("m1_rate"),
+    M5_RATE("m5_rate"),
+    M15_RATE("m15_rate"),
+    MEAN_RATE("mean_rate");
+
+    private final String code;
+
+    MetricType(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -60,7 +60,7 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
     private final MetricRegistry registry;
     private final ScheduledExecutorService executor;
     private final boolean shutdownExecutorOnStop;
-    private final Set<MetricType> disabledMetricTypes;
+    private final Set<MetricAttribute> disabledMetricAttributes;
     private ScheduledFuture<?> scheduledFuture;
     private final MetricFilter filter;
     private final double durationFactor;
@@ -122,7 +122,7 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
                                 ScheduledExecutorService executor,
                                 boolean shutdownExecutorOnStop) {
        this(registry, name, filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop,
-               Collections.<MetricType>emptySet());
+               Collections.<MetricAttribute>emptySet());
     }
 
     protected ScheduledReporter(MetricRegistry registry,
@@ -132,7 +132,7 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
                                 TimeUnit durationUnit,
                                 ScheduledExecutorService executor,
                                 boolean shutdownExecutorOnStop,
-                                Set<MetricType> disabledMetricTypes) {
+                                Set<MetricAttribute> disabledMetricAttributes) {
         this.registry = registry;
         this.filter = filter;
         this.executor = executor == null? createDefaultExecutor(name) : executor;
@@ -141,8 +141,8 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
         this.rateUnit = calculateRateUnit(rateUnit);
         this.durationFactor = 1.0 / durationUnit.toNanos(1);
         this.durationUnit = durationUnit.toString().toLowerCase(Locale.US);
-        this.disabledMetricTypes = disabledMetricTypes != null ? disabledMetricTypes :
-                Collections.<MetricType>emptySet();
+        this.disabledMetricAttributes = disabledMetricAttributes != null ? disabledMetricAttributes :
+                Collections.<MetricAttribute>emptySet();
     }
 
     /**
@@ -291,8 +291,8 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
         return shutdownExecutorOnStop;
     }
 
-    protected Set<MetricType> getDisabledMetricTypes() {
-        return disabledMetricTypes;
+    protected Set<MetricAttribute> getDisabledMetricAttributes() {
+        return disabledMetricAttributes;
     }
 
     private String calculateRateUnit(TimeUnit unit) {

--- a/metrics-ganglia/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java
+++ b/metrics-ganglia/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java
@@ -1,7 +1,7 @@
 package com.codahale.metrics.ganglia;
 
 import com.codahale.metrics.*;
-import com.codahale.metrics.MetricType;
+import com.codahale.metrics.MetricAttribute;
 import info.ganglia.gmetric4j.gmetric.GMetric;
 import info.ganglia.gmetric4j.gmetric.GMetricSlope;
 import info.ganglia.gmetric4j.gmetric.GMetricType;
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import static com.codahale.metrics.MetricRegistry.name;
-import static com.codahale.metrics.MetricType.*;
+import static com.codahale.metrics.MetricAttribute.*;
 
 /**
  * A reporter which announces metric values to a Ganglia cluster.
@@ -55,7 +55,7 @@ public class GangliaReporter extends ScheduledReporter {
         private MetricFilter filter;
         private ScheduledExecutorService executor;
         private boolean shutdownExecutorOnStop;
-        private Set<MetricType> disabledMetricTypes = Collections.emptySet();
+        private Set<MetricAttribute> disabledMetricAttributes = Collections.emptySet();
 
         private Builder(MetricRegistry registry) {
             this.registry = registry;
@@ -161,14 +161,14 @@ public class GangliaReporter extends ScheduledReporter {
         }
 
         /**
-         * Don't report the passed metrics types for all metrics (e.g. "p999", "stddev" or "m15").
-         * See {@link MetricType}.
+         * Don't report the passed metric attributes for all metrics (e.g. "p999", "stddev" or "m15").
+         * See {@link MetricAttribute}.
          *
-         * @param disabledMetricTypes a {@link MetricFilter}
+         * @param disabledMetricAttributes a {@link MetricFilter}
          * @return {@code this}
          */
-        public Builder disabledMetricTypes(Set<MetricType> disabledMetricTypes) {
-            this.disabledMetricTypes = disabledMetricTypes;
+        public Builder disabledMetricAttributes(Set<MetricAttribute> disabledMetricAttributes) {
+            this.disabledMetricAttributes = disabledMetricAttributes;
             return this;
         }
 
@@ -181,7 +181,7 @@ public class GangliaReporter extends ScheduledReporter {
          */
         public GangliaReporter build(GMetric gmetric) {
             return new GangliaReporter(registry, gmetric, null, prefix, tMax, dMax, rateUnit, durationUnit, filter,
-                    executor, shutdownExecutorOnStop, disabledMetricTypes);
+                    executor, shutdownExecutorOnStop, disabledMetricAttributes);
         }
 
         /**
@@ -193,7 +193,7 @@ public class GangliaReporter extends ScheduledReporter {
          */
         public GangliaReporter build(GMetric... gmetrics) {
             return new GangliaReporter(registry, null, gmetrics, prefix, tMax, dMax, rateUnit, durationUnit,
-                    filter, executor, shutdownExecutorOnStop ,disabledMetricTypes);
+                    filter, executor, shutdownExecutorOnStop , disabledMetricAttributes);
         }
     }
 
@@ -216,9 +216,9 @@ public class GangliaReporter extends ScheduledReporter {
                             MetricFilter filter,
                             ScheduledExecutorService executor,
                             boolean shutdownExecutorOnStop,
-                            Set<MetricType> disabledMetricTypes) {
+                            Set<MetricAttribute> disabledMetricAttributes) {
         super(registry, "ganglia-reporter", filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop,
-                disabledMetricTypes);
+                disabledMetricAttributes);
         this.gmetric = gmetric;
         this.gmetrics = gmetrics;
         this.prefix = prefix;
@@ -358,21 +358,21 @@ public class GangliaReporter extends ScheduledReporter {
 
     private static final double MIN_VAL = 1E-300;
 
-    private void announceIfEnabled(MetricType metricType, String metricName, String group, double value, String units)
+    private void announceIfEnabled(MetricAttribute metricAttribute, String metricName, String group, double value, String units)
             throws GangliaException {
-        if (getDisabledMetricTypes().contains(metricType)) {
+        if (getDisabledMetricAttributes().contains(metricAttribute)) {
             return;
         }
         final String string = Math.abs(value) < MIN_VAL ? "0" : Double.toString(value);
-        announce(prefix(metricName, metricType.getCode()), group, string, GMetricType.DOUBLE, units);
+        announce(prefix(metricName, metricAttribute.getCode()), group, string, GMetricType.DOUBLE, units);
     }
 
-    private void announceIfEnabled(MetricType metricType, String metricName, String group, long value, String units)
+    private void announceIfEnabled(MetricAttribute metricAttribute, String metricName, String group, long value, String units)
             throws GangliaException {
-        if (getDisabledMetricTypes().contains(metricType)) {
+        if (getDisabledMetricAttributes().contains(metricAttribute)) {
             return;
         }
-        announce(prefix(metricName, metricType.getCode()), group, Long.toString(value), GMetricType.DOUBLE, units);
+        announce(prefix(metricName, metricAttribute.getCode()), group, Long.toString(value), GMetricType.DOUBLE, units);
     }
 
     private void announce(String name, String group, String value, GMetricType type, String units)

--- a/metrics-ganglia/src/test/java/com/codahale/metrics/ganglia/GangliaReporterTest.java
+++ b/metrics-ganglia/src/test/java/com/codahale/metrics/ganglia/GangliaReporterTest.java
@@ -5,10 +5,8 @@ import info.ganglia.gmetric4j.gmetric.GMetric;
 import info.ganglia.gmetric4j.gmetric.GMetricSlope;
 import info.ganglia.gmetric4j.gmetric.GMetricType;
 import org.junit.Test;
-import org.mockito.InOrder;
 
 import java.util.EnumSet;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
@@ -251,7 +249,7 @@ public class GangliaReporterTest {
     }
 
     @Test
-    public void disabledMetricsType() throws Exception {
+    public void disabledMetricAttributes() throws Exception {
         final Meter meter = mock(Meter.class);
         when(meter.getCount()).thenReturn(1L);
         when(meter.getMeanRate()).thenReturn(2.0);
@@ -266,7 +264,7 @@ public class GangliaReporterTest {
                 .convertRatesTo(TimeUnit.SECONDS)
                 .convertDurationsTo(TimeUnit.MILLISECONDS)
                 .filter(MetricFilter.ALL)
-                .disabledMetricTypes(EnumSet.of(MetricType.COUNT, MetricType.MEAN_RATE, MetricType.M15_RATE))
+                .disabledMetricAttributes(EnumSet.of(MetricAttribute.COUNT, MetricAttribute.MEAN_RATE, MetricAttribute.M15_RATE))
                 .build(ganglia);
 
         reporter.report(this.<Gauge>map(),

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -16,7 +16,7 @@ import java.util.SortedMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import static com.codahale.metrics.MetricType.*;
+import static com.codahale.metrics.MetricAttribute.*;
 
 /**
  * A reporter which publishes metric values to a Graphite server.
@@ -48,7 +48,7 @@ public class GraphiteReporter extends ScheduledReporter {
         private MetricFilter filter;
         private ScheduledExecutorService executor;
         private boolean shutdownExecutorOnStop;
-        private Set<MetricType> disabledMetricTypes;
+        private Set<MetricAttribute> disabledMetricAttributes;
 
         private Builder(MetricRegistry registry) {
             this.registry = registry;
@@ -59,7 +59,7 @@ public class GraphiteReporter extends ScheduledReporter {
             this.filter = MetricFilter.ALL;
             this.executor = null;
             this.shutdownExecutorOnStop = true;
-            this.disabledMetricTypes = Collections.emptySet();
+            this.disabledMetricAttributes = Collections.emptySet();
         }
 
         /**
@@ -144,13 +144,14 @@ public class GraphiteReporter extends ScheduledReporter {
         }
 
         /**
-         * Don't report the passed metrics types for all metrics (e.g. "p999", "stddev" or "m15"). See {@link MetricType}.
+         * Don't report the passed metric attributes for all metrics (e.g. "p999", "stddev" or "m15").
+         * See {@link MetricAttribute}.
          *
-         * @param disabledMetricTypes a {@link MetricFilter}
+         * @param disabledMetricAttributes a {@link MetricFilter}
          * @return {@code this}
          */
-        public Builder disabledMetricTypes(Set<MetricType> disabledMetricTypes) {
-            this.disabledMetricTypes = disabledMetricTypes;
+        public Builder disabledMetricAttributes(Set<MetricAttribute> disabledMetricAttributes) {
+            this.disabledMetricAttributes = disabledMetricAttributes;
             return this;
         }
 
@@ -184,7 +185,7 @@ public class GraphiteReporter extends ScheduledReporter {
                                         filter,
                                         executor,
                                         shutdownExecutorOnStop,
-                                        disabledMetricTypes);
+                    disabledMetricAttributes);
         }
     }
 
@@ -203,9 +204,9 @@ public class GraphiteReporter extends ScheduledReporter {
                              MetricFilter filter,
                              ScheduledExecutorService executor,
                              boolean shutdownExecutorOnStop,
-                             Set<MetricType> disabledMetricTypes) {
+                             Set<MetricAttribute> disabledMetricAttributes) {
         super(registry, "graphite-reporter", filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop,
-                disabledMetricTypes);
+                disabledMetricAttributes);
         this.graphite = graphite;
         this.clock = clock;
         this.prefix = prefix;
@@ -305,15 +306,15 @@ public class GraphiteReporter extends ScheduledReporter {
         sendIfEnabled(P999, name, snapshot.get999thPercentile(), timestamp);
     }
 
-    private void sendIfEnabled(MetricType type, String name, double value, long timestamp) throws IOException {
-        if (getDisabledMetricTypes().contains(type)){
+    private void sendIfEnabled(MetricAttribute type, String name, double value, long timestamp) throws IOException {
+        if (getDisabledMetricAttributes().contains(type)){
             return;
         }
         graphite.send(prefix(name, type.getCode()), format(value), timestamp);
     }
 
-    private void sendIfEnabled(MetricType type, String name, long value, long timestamp) throws IOException {
-        if (getDisabledMetricTypes().contains(type)){
+    private void sendIfEnabled(MetricAttribute type, String name, long value, long timestamp) throws IOException {
+        if (getDisabledMetricAttributes().contains(type)){
             return;
         }
         graphite.send(prefix(name, type.getCode()), format(value), timestamp);

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -1,17 +1,22 @@
 package com.codahale.metrics.graphite;
 
 import com.codahale.metrics.*;
+import com.codahale.metrics.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import static com.codahale.metrics.MetricType.*;
 
 /**
  * A reporter which publishes metric values to a Graphite server.
@@ -43,6 +48,7 @@ public class GraphiteReporter extends ScheduledReporter {
         private MetricFilter filter;
         private ScheduledExecutorService executor;
         private boolean shutdownExecutorOnStop;
+        private Set<MetricType> disabledMetricTypes;
 
         private Builder(MetricRegistry registry) {
             this.registry = registry;
@@ -53,6 +59,7 @@ public class GraphiteReporter extends ScheduledReporter {
             this.filter = MetricFilter.ALL;
             this.executor = null;
             this.shutdownExecutorOnStop = true;
+            this.disabledMetricTypes = Collections.emptySet();
         }
 
         /**
@@ -137,6 +144,17 @@ public class GraphiteReporter extends ScheduledReporter {
         }
 
         /**
+         * Don't report the passed metrics types for all metrics (e.g. "p999", "stddev" or "m15"). See {@link MetricType}.
+         *
+         * @param disabledMetricTypes a {@link MetricFilter}
+         * @return {@code this}
+         */
+        public Builder disabledMetricTypes(Set<MetricType> disabledMetricTypes) {
+            this.disabledMetricTypes = disabledMetricTypes;
+            return this;
+        }
+
+        /**
          * Builds a {@link GraphiteReporter} with the given properties, sending metrics using the
          * given {@link GraphiteSender}.
          *
@@ -165,7 +183,8 @@ public class GraphiteReporter extends ScheduledReporter {
                                         durationUnit,
                                         filter,
                                         executor,
-                                        shutdownExecutorOnStop);
+                                        shutdownExecutorOnStop,
+                                        disabledMetricTypes);
         }
     }
 
@@ -183,8 +202,10 @@ public class GraphiteReporter extends ScheduledReporter {
                              TimeUnit durationUnit,
                              MetricFilter filter,
                              ScheduledExecutorService executor,
-                             boolean shutdownExecutorOnStop) {
-        super(registry, "graphite-reporter", filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop);
+                             boolean shutdownExecutorOnStop,
+                             Set<MetricType> disabledMetricTypes) {
+        super(registry, "graphite-reporter", filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop,
+                disabledMetricTypes);
         this.graphite = graphite;
         this.clock = clock;
         this.prefix = prefix;
@@ -248,68 +269,58 @@ public class GraphiteReporter extends ScheduledReporter {
 
     private void reportTimer(String name, Timer timer, long timestamp) throws IOException {
         final Snapshot snapshot = timer.getSnapshot();
-
-        graphite.send(prefix(name, "max"), format(convertDuration(snapshot.getMax())), timestamp);
-        graphite.send(prefix(name, "mean"), format(convertDuration(snapshot.getMean())), timestamp);
-        graphite.send(prefix(name, "min"), format(convertDuration(snapshot.getMin())), timestamp);
-        graphite.send(prefix(name, "stddev"),
-                      format(convertDuration(snapshot.getStdDev())),
-                      timestamp);
-        graphite.send(prefix(name, "p50"),
-                      format(convertDuration(snapshot.getMedian())),
-                      timestamp);
-        graphite.send(prefix(name, "p75"),
-                      format(convertDuration(snapshot.get75thPercentile())),
-                      timestamp);
-        graphite.send(prefix(name, "p95"),
-                      format(convertDuration(snapshot.get95thPercentile())),
-                      timestamp);
-        graphite.send(prefix(name, "p98"),
-                      format(convertDuration(snapshot.get98thPercentile())),
-                      timestamp);
-        graphite.send(prefix(name, "p99"),
-                      format(convertDuration(snapshot.get99thPercentile())),
-                      timestamp);
-        graphite.send(prefix(name, "p999"),
-                      format(convertDuration(snapshot.get999thPercentile())),
-                      timestamp);
-
+        sendIfEnabled(MAX, name, convertDuration(snapshot.getMax()), timestamp);
+        sendIfEnabled(MEAN, name, convertDuration(snapshot.getMean()), timestamp);
+        sendIfEnabled(MIN, name, convertDuration(snapshot.getMin()), timestamp);
+        sendIfEnabled(STDDEV, name, convertDuration(snapshot.getStdDev()), timestamp);
+        sendIfEnabled(P50, name, convertDuration(snapshot.getMedian()), timestamp);
+        sendIfEnabled(P75, name, convertDuration(snapshot.get75thPercentile()), timestamp);
+        sendIfEnabled(P95, name, convertDuration(snapshot.get95thPercentile()), timestamp);
+        sendIfEnabled(P98, name, convertDuration(snapshot.get98thPercentile()), timestamp);
+        sendIfEnabled(P99, name, convertDuration(snapshot.get99thPercentile()), timestamp);
+        sendIfEnabled(P999, name, convertDuration(snapshot.get999thPercentile()), timestamp);
         reportMetered(name, timer, timestamp);
     }
 
     private void reportMetered(String name, Metered meter, long timestamp) throws IOException {
-        graphite.send(prefix(name, "count"), format(meter.getCount()), timestamp);
-        graphite.send(prefix(name, "m1_rate"),
-                      format(convertRate(meter.getOneMinuteRate())),
-                      timestamp);
-        graphite.send(prefix(name, "m5_rate"),
-                      format(convertRate(meter.getFiveMinuteRate())),
-                      timestamp);
-        graphite.send(prefix(name, "m15_rate"),
-                      format(convertRate(meter.getFifteenMinuteRate())),
-                      timestamp);
-        graphite.send(prefix(name, "mean_rate"),
-                      format(convertRate(meter.getMeanRate())),
-                      timestamp);
+        sendIfEnabled(COUNT, name, meter.getCount(), timestamp);
+        sendIfEnabled(M1_RATE, name, meter.getOneMinuteRate(), timestamp);
+        sendIfEnabled(M5_RATE, name, meter.getFiveMinuteRate(), timestamp);
+        sendIfEnabled(M15_RATE, name, meter.getFifteenMinuteRate(), timestamp);
+        sendIfEnabled(MEAN_RATE, name, meter.getMeanRate(), timestamp);
     }
 
     private void reportHistogram(String name, Histogram histogram, long timestamp) throws IOException {
         final Snapshot snapshot = histogram.getSnapshot();
-        graphite.send(prefix(name, "count"), format(histogram.getCount()), timestamp);
-        graphite.send(prefix(name, "max"), format(snapshot.getMax()), timestamp);
-        graphite.send(prefix(name, "mean"), format(snapshot.getMean()), timestamp);
-        graphite.send(prefix(name, "min"), format(snapshot.getMin()), timestamp);
-        graphite.send(prefix(name, "stddev"), format(snapshot.getStdDev()), timestamp);
-        graphite.send(prefix(name, "p50"), format(snapshot.getMedian()), timestamp);
-        graphite.send(prefix(name, "p75"), format(snapshot.get75thPercentile()), timestamp);
-        graphite.send(prefix(name, "p95"), format(snapshot.get95thPercentile()), timestamp);
-        graphite.send(prefix(name, "p98"), format(snapshot.get98thPercentile()), timestamp);
-        graphite.send(prefix(name, "p99"), format(snapshot.get99thPercentile()), timestamp);
-        graphite.send(prefix(name, "p999"), format(snapshot.get999thPercentile()), timestamp);
+        sendIfEnabled(COUNT, name, histogram.getCount(), timestamp);
+        sendIfEnabled(MAX, name, snapshot.getMax(), timestamp);
+        sendIfEnabled(MEAN, name, snapshot.getMean(), timestamp);
+        sendIfEnabled(MIN, name, snapshot.getMin(), timestamp);
+        sendIfEnabled(STDDEV, name, snapshot.getStdDev(), timestamp);
+        sendIfEnabled(P50, name, snapshot.getMedian(), timestamp);
+        sendIfEnabled(P75, name, snapshot.get75thPercentile(), timestamp);
+        sendIfEnabled(P95, name, snapshot.get95thPercentile(), timestamp);
+        sendIfEnabled(P98, name, snapshot.get98thPercentile(), timestamp);
+        sendIfEnabled(P99, name, snapshot.get99thPercentile(), timestamp);
+        sendIfEnabled(P999, name, snapshot.get999thPercentile(), timestamp);
+    }
+
+    private void sendIfEnabled(MetricType type, String name, double value, long timestamp) throws IOException {
+        if (getDisabledMetricTypes().contains(type)){
+            return;
+        }
+        graphite.send(prefix(name, type.getCode()), format(value), timestamp);
+    }
+
+    private void sendIfEnabled(MetricType type, String name, long value, long timestamp) throws IOException {
+        if (getDisabledMetricTypes().contains(type)){
+            return;
+        }
+        graphite.send(prefix(name, type.getCode()), format(value), timestamp);
     }
 
     private void reportCounter(String name, Counter counter, long timestamp) throws IOException {
-        graphite.send(prefix(name, "count"), format(counter.getCount()), timestamp);
+        sendIfEnabled(COUNT, name, counter.getCount(), timestamp);
     }
 
     private void reportGauge(String name, Gauge gauge, long timestamp) throws IOException {

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -27,7 +27,7 @@ public class GraphiteReporterTest {
                                                               .convertRatesTo(TimeUnit.SECONDS)
                                                               .convertDurationsTo(TimeUnit.MILLISECONDS)
                                                               .filter(MetricFilter.ALL)
-                                                              .disabledMetricTypes(Collections.<MetricType>emptySet())
+                                                              .disabledMetricAttributes(Collections.<MetricAttribute>emptySet())
                                                               .build(graphite);
 
     @Before
@@ -328,7 +328,7 @@ public class GraphiteReporterTest {
     }
 
     @Test
-    public void disabledMetricsType() throws Exception {
+    public void disabledMetricsAttribute() throws Exception {
         final Meter meter = mock(Meter.class);
         when(meter.getCount()).thenReturn(1L);
         when(meter.getOneMinuteRate()).thenReturn(2.0);
@@ -336,16 +336,16 @@ public class GraphiteReporterTest {
         when(meter.getFifteenMinuteRate()).thenReturn(4.0);
         when(meter.getMeanRate()).thenReturn(5.0);
 
-        Set<MetricType> disabledMetricTypes = EnumSet.of(MetricType.M15_RATE, MetricType.M5_RATE);
-        GraphiteReporter reporterWithDisabledMetricTypes = GraphiteReporter.forRegistry(registry)
+        Set<MetricAttribute> disabledMetricAttributes = EnumSet.of(MetricAttribute.M15_RATE, MetricAttribute.M5_RATE);
+        GraphiteReporter reporterWithdisabledMetricAttributes = GraphiteReporter.forRegistry(registry)
                 .withClock(clock)
                 .prefixedWith("prefix")
                 .convertRatesTo(TimeUnit.SECONDS)
                 .convertDurationsTo(TimeUnit.MILLISECONDS)
                 .filter(MetricFilter.ALL)
-                .disabledMetricTypes(disabledMetricTypes)
+                .disabledMetricAttributes(disabledMetricAttributes)
                 .build(graphite);
-        reporterWithDisabledMetricTypes.report(this.<Gauge>map(),
+        reporterWithdisabledMetricAttributes.report(this.<Gauge>map(),
                 this.<Counter>map(),
                 this.<Histogram>map(),
                 this.<Meter>map("meter", meter),

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -1,11 +1,15 @@
 package com.codahale.metrics.graphite;
 
 import com.codahale.metrics.*;
+import com.codahale.metrics.Timer;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
 
 import java.net.UnknownHostException;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
@@ -23,6 +27,7 @@ public class GraphiteReporterTest {
                                                               .convertRatesTo(TimeUnit.SECONDS)
                                                               .convertDurationsTo(TimeUnit.MILLISECONDS)
                                                               .filter(MetricFilter.ALL)
+                                                              .disabledMetricTypes(Collections.<MetricType>emptySet())
                                                               .build(graphite);
 
     @Before
@@ -292,6 +297,8 @@ public class GraphiteReporterTest {
         inOrder.verify(graphite).close();
 
         verifyNoMoreInteractions(graphite);
+
+        reporter.close();
     }
 
     @Test
@@ -319,6 +326,42 @@ public class GraphiteReporterTest {
 
         verifyNoMoreInteractions(graphite);
     }
+
+    @Test
+    public void disabledMetricsType() throws Exception {
+        final Meter meter = mock(Meter.class);
+        when(meter.getCount()).thenReturn(1L);
+        when(meter.getOneMinuteRate()).thenReturn(2.0);
+        when(meter.getFiveMinuteRate()).thenReturn(3.0);
+        when(meter.getFifteenMinuteRate()).thenReturn(4.0);
+        when(meter.getMeanRate()).thenReturn(5.0);
+
+        Set<MetricType> disabledMetricTypes = EnumSet.of(MetricType.M15_RATE, MetricType.M5_RATE);
+        GraphiteReporter reporterWithDisabledMetricTypes = GraphiteReporter.forRegistry(registry)
+                .withClock(clock)
+                .prefixedWith("prefix")
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .filter(MetricFilter.ALL)
+                .disabledMetricTypes(disabledMetricTypes)
+                .build(graphite);
+        reporterWithDisabledMetricTypes.report(this.<Gauge>map(),
+                this.<Counter>map(),
+                this.<Histogram>map(),
+                this.<Meter>map("meter", meter),
+                this.<Timer>map());
+
+        final InOrder inOrder = inOrder(graphite);
+        inOrder.verify(graphite).connect();
+        inOrder.verify(graphite).send("prefix.meter.count", "1", timestamp);
+        inOrder.verify(graphite).send("prefix.meter.m1_rate", "2.00", timestamp);
+        inOrder.verify(graphite).send("prefix.meter.mean_rate", "5.00", timestamp);
+        inOrder.verify(graphite).flush();
+        inOrder.verify(graphite).close();
+
+        verifyNoMoreInteractions(graphite);
+    }
+
 
     private <T> SortedMap<String, T> map() {
         return new TreeMap<String, T>();


### PR DESCRIPTION
This is for based on the work of @phauer in #1008. The set of disabled metrics is implemented in `ScheduledReporter`, so all reporters have an opportunity to implement this feature, but it's not necessarily (for instance `ConsoleReporter` doesn't really need it). Along with the Graphite reporter, the Ganglia reporter is also updated to support of disabling sending metrics.