### PR TITLE
Suppress all kinds of Exceptions raised by report()

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -155,8 +155,8 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
          public void run() {
              try {
                  report();
-             } catch (RuntimeException ex) {
-                 LOG.error("RuntimeException thrown from {}#report. Exception was suppressed.", ScheduledReporter.this.getClass().getSimpleName(), ex);
+             } catch (Exception ex) {
+                 LOG.error("Exception thrown from {}#report. Exception was suppressed.", ScheduledReporter.this.getClass().getSimpleName(), ex);
              }
          }
       }, initialDelay, period, unit);


### PR DESCRIPTION
With the current code exceptions that do not inherit from RuntimeException will
make this task die silently.