### PR TITLE
Support the JDK's ThreadLocalRandom

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
@@ -95,7 +95,7 @@ public class ExponentiallyDecayingReservoir implements Reservoir {
         try {
             final double itemWeight = weight(timestamp - startTime);
             final WeightedSample sample = new WeightedSample(value, itemWeight);
-            final double priority = itemWeight / ThreadLocalRandom.current().nextDouble();
+            final double priority = itemWeight / ThreadLocalRandomProxy.current().nextDouble();
             
             final long newCount = count.incrementAndGet();
             if (newCount <= size) {

--- a/metrics-core/src/main/java/com/codahale/metrics/ThreadLocalRandomProxy.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ThreadLocalRandomProxy.java
@@ -1,0 +1,48 @@
+package com.codahale.metrics;
+
+import java.util.Random;
+
+/**
+ * Proxy for creating thread local {@link Random} instances depending on the runtime.
+ * By default it tries to use the JDK's implementation and fallbacks to the internal
+ * one if the JDK doesn't provide any.
+ */
+class ThreadLocalRandomProxy {
+
+    private interface Provider {
+        Random current();
+    }
+
+    /**
+     * To avoid NoClassDefFoundError during loading {@link ThreadLocalRandomProxy}
+     */
+    private static class JdkProvider implements Provider {
+
+        @Override
+        public Random current() {
+            return java.util.concurrent.ThreadLocalRandom.current();
+        }
+    }
+
+    private static class InternalProvider implements Provider {
+
+        @Override
+        public Random current() {
+            return ThreadLocalRandom.current();
+        }
+    }
+
+    private static final Provider INSTANCE = getThreadLocalProvider();
+    private static Provider getThreadLocalProvider() {
+        try {
+            return new JdkProvider();
+        } catch (NoClassDefFoundError e) {
+            return new InternalProvider();
+        }
+    }
+
+    public static Random current() {
+        return INSTANCE.current();
+    }
+
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/UniformReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/UniformReservoir.java
@@ -70,7 +70,7 @@ public class UniformReservoir implements Reservoir {
     private static long nextLong(long n) {
         long bits, val;
         do {
-            bits = ThreadLocalRandom.current().nextLong() & (~(1L << BITS_PER_LONG));
+            bits = ThreadLocalRandomProxy.current().nextLong() & (~(1L << BITS_PER_LONG));
             val = bits % n;
         } while (bits - val + (n - 1) < 0L);
         return val;


### PR DESCRIPTION
Add a factory which provides a ThreadLocalRandom implementation depending on its availability in runtime. If the JDK provides ThreadLocalRandom, use it. Otherwise, fallback to the internal implementation.