### PR TITLE
Support JDK's LongAdder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ install: echo "I trust Maven."
 script: mvn verify
 
 jdk:
-  - oraclejdk7
   - oraclejdk8
 
 notifications:

--- a/metrics-core/src/main/java/com/codahale/metrics/Counter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Counter.java
@@ -4,10 +4,10 @@ package com.codahale.metrics;
  * An incrementing and decrementing counter metric.
  */
 public class Counter implements Metric, Counting {
-    private final LongAdder count;
+    private final LongAdderAdapter count;
 
     public Counter() {
-        this.count = new LongAdder();
+        this.count = LongAdderProxy.create();
     }
 
     /**

--- a/metrics-core/src/main/java/com/codahale/metrics/EWMA.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/EWMA.java
@@ -26,7 +26,7 @@ public class EWMA {
     private volatile boolean initialized = false;
     private volatile double rate = 0.0;
 
-    private final LongAdder uncounted = new LongAdder();
+    private final LongAdderAdapter uncounted = LongAdderProxy.create();
     private final double alpha, interval;
 
     /**

--- a/metrics-core/src/main/java/com/codahale/metrics/Histogram.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Histogram.java
@@ -8,7 +8,7 @@ package com.codahale.metrics;
  */
 public class Histogram implements Metric, Sampling, Counting {
     private final Reservoir reservoir;
-    private final LongAdder count;
+    private final LongAdderAdapter count;
 
     /**
      * Creates a new {@link Histogram} with the given reservoir.
@@ -17,7 +17,7 @@ public class Histogram implements Metric, Sampling, Counting {
      */
     public Histogram(Reservoir reservoir) {
         this.reservoir = reservoir;
-        this.count = new LongAdder();
+        this.count = LongAdderProxy.create();
     }
 
     /**

--- a/metrics-core/src/main/java/com/codahale/metrics/LongAdderAdapter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/LongAdderAdapter.java
@@ -1,0 +1,18 @@
+package com.codahale.metrics;
+
+/**
+ * Interface which exposes the LongAdder functionality. Allows different
+ * LongAdder implementations to coexist together.
+ */
+interface LongAdderAdapter {
+
+    void add(long x);
+
+    long sum();
+
+    void increment();
+
+    void decrement();
+
+    long sumThenReset();
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/LongAdderProxy.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/LongAdderProxy.java
@@ -1,0 +1,108 @@
+package com.codahale.metrics;
+
+/**
+ * Proxy for creating long adders depending on the runtime. By default it tries to
+ * the JDK's implementation and fallbacks to the internal one if the JDK doesn't provide
+ * any. The JDK's LongAdder and the internal one don't have a common interface, therefore
+ * we adapten them to {@link InternalLongAdderProvider}, which serves as a common interface for
+ * long adders.
+ */
+class LongAdderProxy {
+
+    private interface Provider {
+        LongAdderAdapter get();
+    }
+
+    /**
+     * To avoid NoClassDefFoundError during loading {@link LongAdderProxy}
+     */
+    private static class JdkProvider implements Provider {
+
+        @Override
+        public LongAdderAdapter get() {
+            return new LongAdderAdapter() {
+                private final java.util.concurrent.atomic.LongAdder longAdder =
+                        new java.util.concurrent.atomic.LongAdder();
+
+                @Override
+                public void add(long x) {
+                    longAdder.add(x);
+                }
+
+                @Override
+                public long sum() {
+                    return longAdder.sum();
+                }
+
+                @Override
+                public void increment() {
+                    longAdder.increment();
+                }
+
+                @Override
+                public void decrement() {
+                    longAdder.decrement();
+                }
+
+                @Override
+                public long sumThenReset() {
+                    return longAdder.sumThenReset();
+                }
+            };
+        }
+    }
+
+    /**
+     * Backed by the internal LongAdder
+     */
+    private static class InternalLongAdderProvider implements Provider {
+
+        @Override
+        public LongAdderAdapter get() {
+            return new LongAdderAdapter() {
+                private final LongAdder longAdder = new LongAdder();
+
+                @Override
+                public void add(long x) {
+                    longAdder.add(x);
+                }
+
+                @Override
+                public long sum() {
+                    return longAdder.sum();
+                }
+
+                @Override
+                public void increment() {
+                    longAdder.increment();
+                }
+
+                @Override
+                public void decrement() {
+                    longAdder.decrement();
+                }
+
+                @Override
+                public long sumThenReset() {
+                    return longAdder.sumThenReset();
+                }
+            };
+        }
+
+    }
+
+    private static final Provider INSTANCE = getLongAdderProvider();
+    private static Provider getLongAdderProvider() {
+        try {
+            final JdkProvider jdkProvider = new JdkProvider();
+            jdkProvider.get(); // To trigger a possible `NoClassDefFoundError` exception
+            return jdkProvider;
+        } catch (NoClassDefFoundError e) {
+            return new InternalLongAdderProvider();
+        }
+    }
+
+    public static LongAdderAdapter create() {
+        return INSTANCE.get();
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/Meter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Meter.java
@@ -16,7 +16,7 @@ public class Meter implements Metered {
     private final EWMA m5Rate = EWMA.fiveMinuteEWMA();
     private final EWMA m15Rate = EWMA.fifteenMinuteEWMA();
 
-    private final LongAdder count = new LongAdder();
+    private final LongAdderAdapter count = LongAdderProxy.create();
     private final long startTime;
     private final AtomicLong lastTick;
     private final Clock clock;


### PR DESCRIPTION
Add an ability to use the JDK's implementation if it's available in runtime. Add a factory for creating LongAdders which tries to use the JDK's implementation and fallbacks to the internal one if the JDK doesn't provide any. Unfortunately, LongAdders don't have a common interface, therefore we introduce `LongAdderAdapter`. It will be used in other components as an interface, a concrete implementation of it will be created by `LongAdderFactory`.