### PR TITLE
Fix SlidingTimeWindowReservoir trim operation after overflow

### DIFF
--- a/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowReservoirTest.java
@@ -2,18 +2,21 @@ package com.codahale.metrics;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class SlidingTimeWindowReservoirTest {
-    private final Clock clock = mock(Clock.class);
-    private final SlidingTimeWindowReservoir reservoir = new SlidingTimeWindowReservoir(10, TimeUnit.NANOSECONDS, clock);
-
     @Test
     public void storesMeasurementsWithDuplicateTicks() throws Exception {
+        final Clock clock = mock(Clock.class);
+        final SlidingTimeWindowReservoir reservoir = new SlidingTimeWindowReservoir(10, NANOSECONDS, clock);
+
         when(clock.getTick()).thenReturn(20L);
 
         reservoir.update(1);
@@ -25,6 +28,9 @@ public class SlidingTimeWindowReservoirTest {
 
     @Test
     public void boundsMeasurementsToATimeWindow() throws Exception {
+        final Clock clock = mock(Clock.class);
+        final SlidingTimeWindowReservoir reservoir = new SlidingTimeWindowReservoir(10, NANOSECONDS, clock);
+
         when(clock.getTick()).thenReturn(0L);
         reservoir.update(1);
 
@@ -42,5 +48,70 @@ public class SlidingTimeWindowReservoirTest {
 
         assertThat(reservoir.getSnapshot().getValues())
                 .containsOnly(4, 5);
+    }
+
+    @Test
+    public void testGetTickOverflow () {
+        final Random random = new Random(0);
+        final int window = 128;
+
+        // Note: 'threshold' defines the number of updates submitted to the reservoir after overflowing
+        for (int threshold : Arrays.asList(0, 1, 2, 127, 128, 129, 255, 256, 257)) {
+
+            // Note: 'updatePerTick' defines the number of updates submitted to the reservoir between each tick
+            for (int updatesPerTick : Arrays.asList(1, 2, 127, 128, 129, 255, 256, 257)) {
+                //logger.info("Executing test: threshold={}, updatesPerTick={}", threshold, updatesPerTick);
+
+                // Set the clock to overflow in (2*window+1)ns
+                final ManualClock clock = new ManualClock();
+                clock.addNanos(Long.MAX_VALUE/256 - 2*window - clock.getTick());
+                assertThat(clock.getTick() * 256).isGreaterThan(0);
+
+                // Create the reservoir
+                final SlidingTimeWindowReservoir reservoir = new SlidingTimeWindowReservoir(window, NANOSECONDS, clock);
+
+                int updatesAfterThreshold = 0;
+                while (true) {
+                    // Update the reservoir
+                    for (int i = 0; i < updatesPerTick; i++)
+                        reservoir.update(0);
+
+                    // Randomly check the reservoir size
+                    if (random.nextDouble() < 0.1) {
+                        assertThat(reservoir.size())
+                                .as("Bad reservoir size with: threshold=%d, updatesPerTick=%d", threshold, updatesPerTick)
+                                .isLessThanOrEqualTo(window * 256);
+                    }
+
+                    // Update the clock
+                    clock.addNanos(1);
+
+                    // If the clock has overflowed start counting updates
+                    if ((clock.getTick() * 256) < 0) {
+                        if (updatesAfterThreshold++ >= threshold)
+                            break;
+                    }
+                }
+
+                // Check the final reservoir size
+                assertThat(reservoir.size())
+                        .as("Bad final reservoir size with: threshold=%d, updatesPerTick=%d", threshold, updatesPerTick)
+                        .isLessThanOrEqualTo(window * 256);
+
+                // Advance the clock far enough to clear the reservoir.  Note that here the window only loosely defines
+                // the reservoir window; when updatesPerTick is greater than 128 the sliding window will always be well
+                // ahead of the current clock time, and advances in getTick while in trim (called randomly above from
+                // size and every 256 updates).  Until the clock "catches up" advancing the clock will have no effect on
+                // the reservoir, and reservoir.size() will merely move the window forward 1/256th of a ns - as such, an
+                // arbitrary increment of 1s here was used instead to advance the clock well beyond any updates recorded
+                // above.
+                clock.addSeconds(1);
+
+                // The reservoir should now be empty
+                assertThat(reservoir.size())
+                        .as("Bad reservoir size after delay with: threshold=%d, updatesPerTick=%d", threshold, updatesPerTick)
+                        .isEqualTo(0);
+            }
+        }
     }
 }


### PR DESCRIPTION
The existing `trim` operation in `SlidingTimeWindowReservoir` assumes that values returned by `getTick` are strictly increasing.  When the result returned by `getTick` overflows, the `trim` operation will behave improperly - `trim` operations just after the overflow event will likely clear values within the current window, and `trim` operations well past the overflow event will likely fail to clear updates outside the current window (updates added before the overflow event).

To illustrate this behavior consider a reservoir with an 8-bit value returned by `getTick`, a window size of 2, and ignore the `trim` operations effect on the tick count:

```
update @123: 1
update @124: 2
update @125: 3
update @126: 4
update @127: 5
trim @127 - clears values before @125 (1, 2)
update @-128: 6
trim @-128 - clears values before @126 (3, 6) - 6 cleared improperly
update @-127: 7
update @-126: 8
trim @-126 - clears values before @-128 (none) - 4,5 "leaked"
```

The proposed fix properly clears any values in the reservoir outside of the sliding time window.  For the purposes of that operation, the start of the time window is defined as `now-window`, and the end of the time window is defined as `now+CLEAR_BUFFER`, where `now` is the value returned by `getTick` at the start of the `trim` operation.  This prevents `trim` from improperly clearing updates added concurrently while the operation is underway.