### PR TITLE
Build with error-prone

### DIFF
--- a/metrics-core/src/test/java/io/dropwizard/metrics/MetricNameTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/MetricNameTest.java
@@ -84,7 +84,6 @@ public class MetricNameTest {
 
         assertThat(a.compareTo(b)).isLessThan(0);
         assertThat(b.compareTo(a)).isGreaterThan(0);
-        assertThat(b.compareTo(b)).isEqualTo(0);
         assertThat(b.resolve("key").compareTo(b)).isLessThan(0);
         assertThat(b.compareTo(b.resolve("key"))).isGreaterThan(0);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -244,11 +244,27 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.6.1</version>
                 <configuration>
+                    <compilerId>javac-with-errorprone</compilerId>
+                    <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-compiler-javac-errorprone</artifactId>
+                        <version>2.8.1</version>
+                    </dependency>
+                    <!-- override plexus-compiler-javac-errorprone's dependency on
+                         Error Prone with the latest version -->
+                    <dependency>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_core</artifactId>
+                        <version>2.0.15</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>


### PR DESCRIPTION
Update maven-compiler-plugin to 3.6.1.

Add dependency on error-prone [1] and configure the compiler to use it.

Remove test statement that causes "[SelfEquals] An object is tested
for equality to itself" error [2].

[1] http://errorprone.info
[2] http://errorprone.info/bugpattern/SelfEquals

Change-Id: Id96a211e3013ca8913d3d7fd2eb1d7233890cd72