### PR TITLE
Fix for the monitoring jetty9 async servlet requests.

### DIFF
--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -227,6 +227,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             // new request
             activeRequests.inc();
             start = request.getTimeStamp();
+            state.addListener(listener);
         } else {
             // resumed request
             start = System.currentTimeMillis();
@@ -246,9 +247,6 @@ public class InstrumentedHandler extends HandlerWrapper {
             dispatches.update(dispatched, TimeUnit.MILLISECONDS);
 
             if (state.isSuspended()) {
-                if (state.isInitial()) {
-                    state.addListener(listener);
-                }
                 activeSuspended.inc();
             } else if (state.isInitial()) {
                 updateResponses(httpRequest, httpResponse, start);

--- a/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHandlerTest.java
+++ b/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHandlerTest.java
@@ -3,12 +3,24 @@ package com.codahale.metrics.jetty9;
 import com.codahale.metrics.MetricRegistry;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,7 +34,7 @@ public class InstrumentedHandlerTest {
     @Before
     public void setUp() throws Exception {
         handler.setName("handler");
-        handler.setHandler(new DefaultHandler());
+        handler.setHandler(new TestHandler());
         server.addConnector(connector);
         server.setHandler(handler);
         server.start();
@@ -43,41 +55,146 @@ public class InstrumentedHandlerTest {
 
     @Test
     public void createsMetricsForTheHandler() throws Exception {
-        final ContentResponse response = client.GET("http://localhost:" + connector.getLocalPort() + "/hello");
+        final ContentResponse response = client.GET(uri("/hello"));
 
         assertThat(response.getStatus())
                 .isEqualTo(404);
 
         assertThat(registry.getNames())
                 .containsOnly(
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.1xx-responses",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.2xx-responses",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.3xx-responses",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.4xx-responses",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.5xx-responses",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.percent-4xx-1m",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.percent-4xx-5m",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.percent-4xx-15m",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.percent-5xx-1m",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.percent-5xx-5m",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.percent-5xx-15m",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.active-suspended",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.async-dispatches",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.async-timeouts",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.get-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.put-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.active-dispatches",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.trace-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.other-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.connect-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.dispatches",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.head-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.post-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.options-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.active-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.delete-requests",
-                        "org.eclipse.jetty.server.handler.DefaultHandler.handler.move-requests"
+                        MetricRegistry.name(TestHandler.class,"handler.1xx-responses"),
+                        MetricRegistry.name(TestHandler.class,"handler.2xx-responses"),
+                        MetricRegistry.name(TestHandler.class,"handler.3xx-responses"),
+                        MetricRegistry.name(TestHandler.class,"handler.4xx-responses"),
+                        MetricRegistry.name(TestHandler.class,"handler.5xx-responses"),
+                        MetricRegistry.name(TestHandler.class,"handler.percent-4xx-1m"),
+                        MetricRegistry.name(TestHandler.class,"handler.percent-4xx-5m"),
+                        MetricRegistry.name(TestHandler.class,"handler.percent-4xx-15m"),
+                        MetricRegistry.name(TestHandler.class,"handler.percent-5xx-1m"),
+                        MetricRegistry.name(TestHandler.class,"handler.percent-5xx-5m"),
+                        MetricRegistry.name(TestHandler.class,"handler.percent-5xx-15m"),
+                        MetricRegistry.name(TestHandler.class,"handler.requests"),
+                        MetricRegistry.name(TestHandler.class,"handler.active-suspended"),
+                        MetricRegistry.name(TestHandler.class,"handler.async-dispatches"),
+                        MetricRegistry.name(TestHandler.class,"handler.async-timeouts"),
+                        MetricRegistry.name(TestHandler.class,"handler.get-requests"),
+                        MetricRegistry.name(TestHandler.class,"handler.put-requests"),
+                        MetricRegistry.name(TestHandler.class,"handler.active-dispatches"),
+                        MetricRegistry.name(TestHandler.class,"handler.trace-requests"),
+                        MetricRegistry.name(TestHandler.class,"handler.other-requests"),
+                        MetricRegistry.name(TestHandler.class,"handler.connect-requests"),
+                        MetricRegistry.name(TestHandler.class,"handler.dispatches"),
+                        MetricRegistry.name(TestHandler.class,"handler.head-requests"),
+                        MetricRegistry.name(TestHandler.class,"handler.post-requests"),
+                        MetricRegistry.name(TestHandler.class,"handler.options-requests"),
+                        MetricRegistry.name(TestHandler.class,"handler.active-requests"),
+                        MetricRegistry.name(TestHandler.class,"handler.delete-requests"),
+                        MetricRegistry.name(TestHandler.class,"handler.move-requests")
                 );
+    }
+
+
+    @Test
+    public void responseTimesAreRecordedForBlockingResponses() throws Exception {
+
+        final ContentResponse response = client.GET(uri("/blocking"));
+
+        assertThat(response.getStatus())
+                .isEqualTo(200);
+
+        assertResponseTimesValid();
+    }
+
+    @Test
+    public void responseTimesAreRecordedForAsyncResponses() throws Exception {
+
+        final ContentResponse response = client.GET(uri("/async"));
+
+        assertThat(response.getStatus())
+                .isEqualTo(200);
+
+        assertResponseTimesValid();
+    }
+
+    private void assertResponseTimesValid() {
+        assertThat(registry.getMeters().get(metricName() + ".2xx-responses")
+                .getCount()).isGreaterThan(0L);
+
+
+        assertThat(registry.getTimers().get(metricName() + ".get-requests")
+                .getSnapshot().getMedian()).isGreaterThan(0.0).isLessThan(TimeUnit.SECONDS.toNanos(1));
+
+        assertThat(registry.getTimers().get(metricName() + ".requests")
+                .getSnapshot().getMedian()).isGreaterThan(0.0).isLessThan(TimeUnit.SECONDS.toNanos(1));
+    }
+
+    private String uri(String path) {
+        return "http://localhost:" + connector.getLocalPort() + path;
+    }
+
+    private String metricName() {
+        return MetricRegistry.name(TestHandler.class.getName(), "handler");
+    }
+
+    /**
+     * test handler.
+     *
+     * Supports
+     *
+     * /blocking - uses the standard servlet api
+     * /async - uses the 3.1 async api to complete the request
+     *
+     * all other requests will return 404
+     */
+    private static class TestHandler extends AbstractHandler {
+        @Override
+        public void handle(
+                String path,
+                Request request,
+                final HttpServletRequest httpServletRequest,
+                final HttpServletResponse httpServletResponse
+        ) throws IOException, ServletException {
+            request.setHandled(true);
+            if (path.equals("/blocking")) {
+                LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1));
+                httpServletResponse.setStatus(200);
+                httpServletResponse.setContentType("text/plain");
+                httpServletResponse.getWriter().write("some content from the blocking request\n");
+            } else if (path.equals("/async")) {
+                final AsyncContext context = request.startAsync();
+                Thread t = new Thread() {
+                    public void run() {
+                        LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1));
+                        httpServletResponse.setStatus(200);
+                        httpServletResponse.setContentType("text/plain");
+                        final ServletOutputStream servletOutputStream;
+                        try {
+                            servletOutputStream = httpServletResponse.getOutputStream();
+                            servletOutputStream.setWriteListener(
+                                    new WriteListener() {
+                                        @Override
+                                        public void onWritePossible() throws IOException {
+                                            servletOutputStream.write("some content from the async\n".getBytes());
+                                            context.complete();
+                                        }
+
+                                        @Override
+                                        public void onError(Throwable throwable) {
+                                            context.complete();
+                                        }
+                                    }
+                            );
+                        } catch (IOException e) {
+                            context.complete();
+                        }
+                    }
+                };
+                t.start();
+            } else {
+                httpServletResponse.setStatus(404);
+                httpServletResponse.setContentType("text/plain");
+                httpServletResponse.getWriter().write("Not Found\n");
+            }
+        }
     }
 }


### PR DESCRIPTION
Async requests are monitored via the addition of an async listener.
The bug was that `onStartAsync(AsyncEvent)` is called when the handler
invokes `startAsync()` but the `InstrumentedHandler` only added the
listener after the call to the delegate handler, thus would miss
the all onStartAsync event.

The net result of the bug was that the start time of all async requests
was reported as 0 so the calculated elapsed times where then rather
large (i.e. currentTimeMillis()).