### PR TITLE
(#609) Introducing async health checks

### DIFF
--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/AsyncHealthCheckDecorator.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/AsyncHealthCheckDecorator.java
@@ -1,0 +1,60 @@
+package com.codahale.metrics.health;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+
+import com.codahale.metrics.health.annotation.Async;
+
+/**
+ * A health check decorator to manage asynchronous executions.
+ */
+class AsyncHealthCheckDecorator extends HealthCheck implements Runnable {
+    private static final String NO_RESULT_YET_MESSAGE = "Waiting for first asynchronous check result.";
+    private final HealthCheck healthCheck;
+    private final ScheduledFuture<?> future;
+    private volatile Result result;
+
+    AsyncHealthCheckDecorator(HealthCheck healthCheck, ScheduledExecutorService executorService) {
+        check(healthCheck != null, "healthCheck cannot be null");
+        check(executorService != null, "executorService cannot be null");
+        Async async = (Async) healthCheck.getClass().getAnnotation(Async.class);
+        check(async != null, "healthCheck must contain Async annotation");
+        check(async.period() > 0, "period cannot be less than or equal to zero");
+        check(async.initialDelay() >= 0, "initialDelay cannot be less than zero");
+
+        this.healthCheck = healthCheck;
+        result = Async.InitialState.HEALTHY.equals(async.initialState()) ? Result.healthy(NO_RESULT_YET_MESSAGE) :
+                Result.unhealthy(NO_RESULT_YET_MESSAGE);
+        if (Async.ScheduleType.FIXED_RATE.equals(async.scheduleType())) {
+            future = executorService.scheduleAtFixedRate(this, async.initialDelay(), async.period(), async.unit());
+        } else {
+            future = executorService.scheduleWithFixedDelay(this, async.initialDelay(), async.period(), async.unit());
+        }
+
+    }
+
+    @Override
+    public void run() {
+        result = healthCheck.execute();
+    }
+
+    @Override
+    protected Result check() throws Exception {
+        return result;
+    }
+
+    boolean tearDown() {
+        return future.cancel(true);
+    }
+
+    HealthCheck getHealthCheck() {
+        return healthCheck;
+    }
+
+    private void check(boolean expression, String message) {
+        if (!expression) {
+            throw new IllegalArgumentException(message);
+        }
+    }
+
+}

--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
@@ -16,7 +16,7 @@ public abstract class HealthCheck {
      * or unhealthy (with either an error message or a thrown exception and optional details).
      */
     public static class Result {
-        private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+        private static final String DATE_FORMAT_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
         private static final int PRIME = 31;
 
         /**
@@ -115,7 +115,7 @@ public abstract class HealthCheck {
             this.message = message;
             this.error = error;
             this.details = details == null ? null : Collections.unmodifiableMap(details);
-            timestamp = DATE_FORMAT.format(new Date());
+            timestamp = new SimpleDateFormat(DATE_FORMAT_PATTERN).format(new Date());
         }
 
         /**

--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
@@ -1,6 +1,8 @@
 package com.codahale.metrics.health;
 
+import java.text.SimpleDateFormat;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -14,7 +16,7 @@ public abstract class HealthCheck {
      * or unhealthy (with either an error message or a thrown exception and optional details).
      */
     public static class Result {
-        private static final Result HEALTHY = new Result(true, null, null);
+        private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
         private static final int PRIME = 31;
 
         /**
@@ -23,7 +25,7 @@ public abstract class HealthCheck {
          * @return a healthy {@link Result} with no additional message
          */
         public static Result healthy() {
-            return HEALTHY;
+            return new Result(true, null, null);
         }
 
         /**
@@ -98,19 +100,22 @@ public abstract class HealthCheck {
         private final String message;
         private final Throwable error;
         private final Map<String, Object> details;
+        private final String timestamp;
 
         private Result(boolean isHealthy, String message, Throwable error) {
-            this.healthy = isHealthy;
-            this.message = message;
-            this.error = error;
-            this.details = null;
+            this(isHealthy, message, error, null);
         }
 
         private Result(ResultBuilder builder) {
-            this.healthy = builder.healthy;
-            this.message = builder.message;
-            this.error = builder.error;
-            this.details = builder.details == null ? null : Collections.unmodifiableMap(builder.details);
+            this(builder.healthy, builder.message, builder.error, builder.details);
+        }
+
+        private Result(boolean isHealthy, String message, Throwable error, Map<String, Object> details) {
+            this.healthy = isHealthy;
+            this.message = message;
+            this.error = error;
+            this.details = details == null ? null : Collections.unmodifiableMap(details);
+            timestamp = DATE_FORMAT.format(new Date());
         }
 
         /**
@@ -142,18 +147,31 @@ public abstract class HealthCheck {
             return error;
         }
 
+        /**
+         * Returns the timestamp when the result was created.
+         * @return a formatted timestamp
+         */
+        public String getTimestamp() {
+            return timestamp;
+        }
+
         public Map<String, Object> getDetails() {
             return details;
         }
 
         @Override
         public boolean equals(Object o) {
-            if (this == o) { return true; }
-            if (o == null || getClass() != o.getClass()) { return false; }
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
             final Result result = (Result) o;
             return healthy == result.healthy &&
                     !(error != null ? !error.equals(result.error) : result.error != null) &&
-                    !(message != null ? !message.equals(result.message) : result.message != null);
+                    !(message != null ? !message.equals(result.message) : result.message != null) &&
+                    !(timestamp != null ? !timestamp.equals(result.timestamp) : result.timestamp != null);
         }
 
         @Override
@@ -161,6 +179,7 @@ public abstract class HealthCheck {
             int result = (healthy ? 1 : 0);
             result = PRIME * result + (message != null ? message.hashCode() : 0);
             result = PRIME * result + (error != null ? error.hashCode() : 0);
+            result = PRIME * result + (timestamp != null ? timestamp.hashCode() : 0);
             return result;
         }
 
@@ -174,13 +193,14 @@ public abstract class HealthCheck {
             if (error != null) {
                 builder.append(", error=").append(error);
             }
+            builder.append(", timestamp=").append(timestamp);
             if (details != null) {
                 Iterator<Map.Entry<String, Object>> it = details.entrySet().iterator();
                 while (it.hasNext()) {
                     Map.Entry<String, Object> e = it.next();
                     builder.append(e.getKey())
-                        .append("=")
-                        .append(e.getValue().toString());
+                            .append("=")
+                            .append(e.getValue().toString());
                 }
             }
             builder.append('}');
@@ -188,7 +208,7 @@ public abstract class HealthCheck {
         }
     }
 
-	/**
+    /**
      * This a convenient builder for an {@link HealthCheck.Result}. It can be health (with optional message and detail)
      * or unhealthy (with optional message, error and detail)
      */
@@ -203,8 +223,9 @@ public abstract class HealthCheck {
             this.details = new LinkedHashMap<String, Object>();
         }
 
-		/**
+        /**
          * Configure an healthy result
+         *
          * @return
          */
         public ResultBuilder healthy() {
@@ -212,8 +233,9 @@ public abstract class HealthCheck {
             return this;
         }
 
-		/**
+        /**
          * Configure an unhealthy result
+         *
          * @return
          */
         public ResultBuilder unhealthy() {
@@ -223,6 +245,7 @@ public abstract class HealthCheck {
 
         /**
          * Configure an unhealthy result with an {@code error}
+         *
          * @param error the error
          * @return
          */
@@ -231,7 +254,7 @@ public abstract class HealthCheck {
             return this.unhealthy().withMessage(error.getMessage());
         }
 
-		/**
+        /**
          * Set an optional message
          *
          * @param message an informative message
@@ -242,7 +265,7 @@ public abstract class HealthCheck {
             return this;
         }
 
-		/**
+        /**
          * Set an optional formatted message
          * <p/>
          * Message formatting follows the same rules as {@link String#format(String, Object...)}.
@@ -256,10 +279,10 @@ public abstract class HealthCheck {
             return withMessage(String.format(message, args));
         }
 
-		/**
+        /**
          * Add an optional detail
          *
-         * @param key a key for this detail
+         * @param key  a key for this detail
          * @param data an object representing the detail data
          * @return this builder with the given detail added
          */

--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistryListener.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistryListener.java
@@ -9,15 +9,18 @@ public interface HealthCheckRegistryListener extends EventListener {
 
     /**
      * Called when a new {@link HealthCheck} is added to the registry.
-     * @param name the name of the health check
+     *
+     * @param name        the name of the health check
      * @param healthCheck the health check
      */
     void onHealthCheckAdded(String name, HealthCheck healthCheck);
 
     /**
      * Called when a {@link HealthCheck} is removed from the registry.
-     * @param name the name of the health check
+     *
+     * @param name        the name of the health check
+     * @param healthCheck the health check
      */
-    void onHealthCheckRemoved(String name);
+    void onHealthCheckRemoved(String name, HealthCheck healthCheck);
 
 }

--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/annotation/Async.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/annotation/Async.java
@@ -1,0 +1,64 @@
+package com.codahale.metrics.health.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An annotation for marking asynchronous health check execution.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Async {
+    /**
+     * Enum representing the initial health states.
+     */
+    public enum InitialState {
+        HEALTHY, UNHEALTHY;
+    }
+
+    /**
+     * Enum representing the possible schedule types.
+     */
+    public enum ScheduleType {
+        FIXED_RATE, FIXED_DELAY;
+    }
+
+    /**
+     * Period between executions.
+     *
+     * @return period
+     */
+    long period();
+
+    /**
+     * Scheduling type of asynchronous executions.
+     *
+     * @return schedule type
+     */
+    ScheduleType scheduleType() default ScheduleType.FIXED_RATE;
+
+    /**
+     * Initial delay of first execution.
+     *
+     * @return initial delay
+     */
+    long initialDelay() default 0;
+
+    /**
+     * Time unit of initial delay and period.
+     *
+     * @return time unit
+     */
+    TimeUnit unit() default TimeUnit.SECONDS;
+
+    /**
+     * Initial health state until first asynchronous execution completes.
+     *
+     * @return initial health state
+     */
+    InitialState initialState() default InitialState.HEALTHY;
+
+}

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/AsyncHealthCheckDecoratorTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/AsyncHealthCheckDecoratorTest.java
@@ -1,0 +1,224 @@
+package com.codahale.metrics.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.codahale.metrics.health.annotation.Async;
+
+/**
+ * Unit tests for {@link AsyncHealthCheckDecorator}.
+ */
+public class AsyncHealthCheckDecoratorTest {
+    private final HealthCheck mockHealthCheck = mock(HealthCheck.class);
+    private final ScheduledExecutorService mockExecutorService = mock(ScheduledExecutorService.class);
+    private final ScheduledFuture mockFuture = mock(ScheduledFuture.class);
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullHealthCheckTriggersInstantiationFailure() {
+        new AsyncHealthCheckDecorator(null, mockExecutorService);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nullExecutorServiceTriggersInstantiationFailure() {
+        new AsyncHealthCheckDecorator(mockHealthCheck, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void nonAsyncHealthCheckTriggersInstantiationFailure() {
+        new AsyncHealthCheckDecorator(mockHealthCheck, mockExecutorService);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativePeriodTriggersInstantiationFailure() {
+        new AsyncHealthCheckDecorator(new NegativePeriodAsyncHealthCheck(), mockExecutorService);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void zeroPeriodTriggersInstantiationFailure() {
+        new AsyncHealthCheckDecorator(new ZeroPeriodAsyncHealthCheck(), mockExecutorService);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void negativeInitialValueTriggersInstantiationFailure() {
+        new AsyncHealthCheckDecorator(new NegativeInitialDelayAsyncHealthCheck(), mockExecutorService);
+    }
+
+    @Test
+    public void defaultAsyncHealthCheckTriggersSuccessfulInstantiationWithFixedRateAndHealthyState() throws Exception {
+        HealthCheck asyncHealthCheck = new DefaultAsyncHealthCheck();
+        AsyncHealthCheckDecorator asyncDecorator = new AsyncHealthCheckDecorator(asyncHealthCheck, mockExecutorService);
+
+        verify(mockExecutorService, times(1)).scheduleAtFixedRate(any(Runnable.class), eq(0L),
+                eq(1L), eq(TimeUnit.SECONDS));
+        assertThat(asyncDecorator.getHealthCheck()).isEqualTo(asyncHealthCheck);
+        assertThat(asyncDecorator.check().isHealthy()).isTrue();
+    }
+
+    @Test
+    public void fixedDelayAsyncHealthCheckTriggersSuccessfulInstantiationWithFixedDelay() throws Exception {
+        HealthCheck asyncHealthCheck = new FixedDelayAsyncHealthCheck();
+        AsyncHealthCheckDecorator asyncDecorator = new AsyncHealthCheckDecorator(asyncHealthCheck, mockExecutorService);
+
+        verify(mockExecutorService, times(1)).scheduleWithFixedDelay(any(Runnable.class), eq(0L),
+                eq(1L), eq(TimeUnit.SECONDS));
+        assertThat(asyncDecorator.getHealthCheck()).isEqualTo(asyncHealthCheck);
+    }
+
+    @Test
+    public void unhealthyAsyncHealthCheckTriggersSuccessfulInstantiationWithUnhealthyState() throws Exception {
+        HealthCheck asyncHealthCheck = new UnhealthyAsyncHealthCheck();
+        AsyncHealthCheckDecorator asyncDecorator = new AsyncHealthCheckDecorator(asyncHealthCheck, mockExecutorService);
+
+        assertThat(asyncDecorator.check().isHealthy()).isFalse();
+    }
+
+    @Test
+    public void tearDownTriggersCancellation() throws Exception {
+        when(mockExecutorService.scheduleAtFixedRate(any(Runnable.class), eq(0L), eq(1L), eq(TimeUnit.SECONDS))).
+                thenReturn(mockFuture);
+        when(mockFuture.cancel(true)).thenReturn(true);
+
+        AsyncHealthCheckDecorator asyncDecorator = new AsyncHealthCheckDecorator(new DefaultAsyncHealthCheck(), mockExecutorService);
+        asyncDecorator.tearDown();
+
+        verify(mockExecutorService, times(1)).scheduleAtFixedRate(any(Runnable.class), eq(0L),
+                eq(1L), eq(TimeUnit.SECONDS));
+        verify(mockFuture, times(1)).cancel(eq(true));
+    }
+
+    @Test
+    public void afterFirstExecutionDecoratedHealthCheckResultIsProvided() throws Exception {
+        HealthCheck.Result expectedResult = HealthCheck.Result.healthy("AsyncHealthCheckTest");
+        when(mockExecutorService.scheduleAtFixedRate(any(Runnable.class), eq(0L), eq(1L), eq(TimeUnit.SECONDS)))
+                .thenReturn(mockFuture);
+
+        AsyncHealthCheckDecorator asyncDecorator = new AsyncHealthCheckDecorator(new ConfigurableAsyncHealthCheck(expectedResult),
+                mockExecutorService);
+        HealthCheck.Result initialResult = asyncDecorator.check();
+
+        ArgumentCaptor<Runnable> runnableCaptor = forClass(Runnable.class);
+        verify(mockExecutorService, times(1)).scheduleAtFixedRate(runnableCaptor.capture(),
+                eq(0L), eq(1L), eq(TimeUnit.SECONDS));
+        Runnable capturedRunnable = runnableCaptor.getValue();
+        capturedRunnable.run();
+        HealthCheck.Result actualResult = asyncDecorator.check();
+
+        assertThat(actualResult).isEqualTo(expectedResult);
+        assertThat(actualResult).isNotEqualTo(initialResult);
+    }
+
+    @Test
+    public void exceptionInDecoratedHealthCheckWontAffectAsyncDecorator() throws Exception {
+        Exception exception = new Exception("TestException");
+        when(mockExecutorService.scheduleAtFixedRate(any(Runnable.class), eq(0L), eq(1L), eq(TimeUnit.SECONDS)))
+                .thenReturn(mockFuture);
+
+        AsyncHealthCheckDecorator asyncDecorator = new AsyncHealthCheckDecorator(new ConfigurableAsyncHealthCheck(exception),
+                mockExecutorService);
+
+        ArgumentCaptor<Runnable> runnableCaptor = forClass(Runnable.class);
+        verify(mockExecutorService, times(1)).scheduleAtFixedRate(runnableCaptor.capture(),
+                eq(0L), eq(1L), eq(TimeUnit.SECONDS));
+        Runnable capturedRunnable = runnableCaptor.getValue();
+        capturedRunnable.run();
+        HealthCheck.Result result = asyncDecorator.check();
+
+        assertThat(result.isHealthy()).isFalse();
+        assertThat(result.getError()).isEqualTo(exception);
+    }
+
+    @Async(period = -1)
+    private static class NegativePeriodAsyncHealthCheck extends HealthCheck {
+
+        @Override
+        protected Result check() throws Exception {
+            return null;
+        }
+    }
+
+    @Async(period = 0)
+    private static class ZeroPeriodAsyncHealthCheck extends HealthCheck {
+
+        @Override
+        protected Result check() throws Exception {
+            return null;
+        }
+    }
+
+    @Async(period = 1, initialDelay = -1)
+    private static class NegativeInitialDelayAsyncHealthCheck extends HealthCheck {
+
+        @Override
+        protected Result check() throws Exception {
+            return null;
+        }
+    }
+
+    @Async(period = 1)
+    private static class DefaultAsyncHealthCheck extends HealthCheck {
+
+        @Override
+        protected Result check() throws Exception {
+            return null;
+        }
+    }
+
+    @Async(period = 1, scheduleType = Async.ScheduleType.FIXED_DELAY)
+    private static class FixedDelayAsyncHealthCheck extends HealthCheck {
+
+        @Override
+        protected Result check() throws Exception {
+            return null;
+        }
+    }
+
+    @Async(period = 1, initialState = Async.InitialState.UNHEALTHY)
+    private static class UnhealthyAsyncHealthCheck extends HealthCheck {
+
+        @Override
+        protected Result check() throws Exception {
+            return null;
+        }
+    }
+
+    @Async(period = 1, initialState = Async.InitialState.UNHEALTHY)
+    private static class ConfigurableAsyncHealthCheck extends HealthCheck {
+        private final Result result;
+        private final Exception exception;
+
+        ConfigurableAsyncHealthCheck(Result result) {
+            this(result, null);
+        }
+
+        ConfigurableAsyncHealthCheck(Exception exception) {
+            this(null, exception);
+        }
+
+        private ConfigurableAsyncHealthCheck(Result result, Exception exception) {
+            this.result = result;
+            this.exception = exception;
+        }
+
+        @Override
+        protected Result check() throws Exception {
+            if (exception != null) {
+                throw exception;
+            }
+            return result;
+        }
+    }
+
+}

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckRegistryTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckRegistryTest.java
@@ -1,19 +1,32 @@
 package com.codahale.metrics.health;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.codahale.metrics.health.annotation.Async;
 
 public class HealthCheckRegistryTest {
-    private final HealthCheckRegistry registry = new HealthCheckRegistry();
+    private final ScheduledExecutorService executorService = mock(ScheduledExecutorService.class);
+    private final HealthCheckRegistry registry = new HealthCheckRegistry(executorService);
     private final HealthCheckRegistryListener listener = mock(HealthCheckRegistryListener.class);
 
     private final HealthCheck hc1 = mock(HealthCheck.class);
@@ -22,31 +35,54 @@ public class HealthCheckRegistryTest {
     private final HealthCheck.Result r1 = mock(HealthCheck.Result.class);
     private final HealthCheck.Result r2 = mock(HealthCheck.Result.class);
 
+    private final HealthCheck.Result ar = mock(HealthCheck.Result.class);
+    private final HealthCheck ahc = new TestAsyncHealthCheck(ar);
+    private final ScheduledFuture af = mock(ScheduledFuture.class);
+
     @Before
     public void setUp() throws Exception {
         registry.addListener(listener);
 
         when(hc1.execute()).thenReturn(r1);
-
         when(hc2.execute()).thenReturn(r2);
+        when(executorService.scheduleAtFixedRate(any(AsyncHealthCheckDecorator.class),eq(0L), eq(10L), eq(TimeUnit
+                .SECONDS))).thenReturn(af);
 
         registry.register("hc1", hc1);
         registry.register("hc2", hc2);
+        registry.register("ahc", ahc);
+    }
+
+    @Test
+    public void asyncHealthCheckIsScheduledOnExecutor() {
+        ArgumentCaptor<AsyncHealthCheckDecorator> decoratorCaptor = forClass(AsyncHealthCheckDecorator.class);
+        verify(executorService).scheduleAtFixedRate(decoratorCaptor.capture(), eq(0L), eq(10L), eq(TimeUnit.SECONDS));
+        assertThat(decoratorCaptor.getValue().getHealthCheck()).isEqualTo(ahc);
+    }
+
+    @Test
+    public void asyncHealthCheckIsCanceledOnRemove() {
+        registry.unregister("ahc");
+
+        verify(af).cancel(true);
     }
 
     @Test
     public void registeringHealthCheckTriggersNotification() {
         verify(listener).onHealthCheckAdded("hc1", hc1);
         verify(listener).onHealthCheckAdded("hc2", hc2);
+        verify(listener).onHealthCheckAdded(eq("ahc"), any(AsyncHealthCheckDecorator.class));
     }
 
     @Test
     public void removingHealthCheckTriggersNotification() {
         registry.unregister("hc1");
         registry.unregister("hc2");
+        registry.unregister("ahc");
 
-        verify(listener).onHealthCheckRemoved("hc1");
-        verify(listener).onHealthCheckRemoved("hc2");
+        verify(listener).onHealthCheckRemoved("hc1", hc1);
+        verify(listener).onHealthCheckRemoved("hc2", hc2);
+        verify(listener).onHealthCheckRemoved(eq("ahc"), any(AsyncHealthCheckDecorator.class));
     }
 
     @Test
@@ -55,10 +91,12 @@ public class HealthCheckRegistryTest {
         HealthCheckRegistry registry = new HealthCheckRegistry();
         registry.register("hc1", hc1);
         registry.register("hc2", hc2);
+        registry.register("ahc", ahc);
         registry.addListener(listener);
 
         verify(listener).onHealthCheckAdded("hc1", hc1);
         verify(listener).onHealthCheckAdded("hc2", hc2);
+        verify(listener).onHealthCheckAdded(eq("ahc"), any(AsyncHealthCheckDecorator.class));
     }
 
     @Test
@@ -77,11 +115,9 @@ public class HealthCheckRegistryTest {
     public void runsRegisteredHealthChecks() throws Exception {
         final Map<String, HealthCheck.Result> results = registry.runHealthChecks();
 
-        assertThat(results)
-                .contains(entry("hc1", r1));
-
-        assertThat(results)
-                .contains(entry("hc2", r2));
+        assertThat(results).contains(entry("hc1", r1));
+        assertThat(results).contains(entry("hc2", r2));
+        assertThat(results).containsKey("ahc");
     }
 
     @Test
@@ -92,11 +128,9 @@ public class HealthCheckRegistryTest {
         executor.shutdown();
         executor.awaitTermination(1, TimeUnit.SECONDS);
 
-        assertThat(results)
-                .contains(entry("hc1", r1));
-
-        assertThat(results)
-                .contains(entry("hc2", r2));
+        assertThat(results).contains(entry("hc1", r1));
+        assertThat(results).contains(entry("hc2", r2));
+        assertThat(results).containsKey("ahc");
     }
 
     @Test
@@ -105,23 +139,19 @@ public class HealthCheckRegistryTest {
 
         final Map<String, HealthCheck.Result> results = registry.runHealthChecks();
 
-        assertThat(results)
-                .doesNotContainKey("hc1");
-
-        assertThat(results)
-                .containsKey("hc2");
+        assertThat(results).doesNotContainKey("hc1");
+        assertThat(results).containsKey("hc2");
+        assertThat(results).containsKey("ahc");
     }
 
     @Test
     public void hasASetOfHealthCheckNames() throws Exception {
-        assertThat(registry.getNames())
-                .containsOnly("hc1", "hc2");
+        assertThat(registry.getNames()).containsOnly("hc1", "hc2", "ahc");
     }
 
     @Test
     public void runsHealthChecksByName() throws Exception {
-        assertThat(registry.runHealthCheck("hc1"))
-                .isEqualTo(r1);
+        assertThat(registry.runHealthCheck("hc1")).isEqualTo(r1);
     }
 
     @Test
@@ -134,5 +164,19 @@ public class HealthCheckRegistryTest {
                     .isEqualTo("No health check named what exists");
         }
 
+    }
+
+    @Async(period = 10)
+    private static class TestAsyncHealthCheck extends HealthCheck {
+        private final Result result;
+
+        TestAsyncHealthCheck(Result result) {
+            this.result = result;
+        }
+
+        @Override
+        protected Result check() throws Exception {
+            return result;
+        }
     }
 }

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
@@ -1,10 +1,10 @@
 package com.codahale.metrics.health;
 
-import org.junit.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+
+import org.junit.Test;
 
 public class HealthCheckTest {
     private static class ExampleHealthCheck extends HealthCheck {
@@ -189,8 +189,15 @@ public class HealthCheckTest {
         when(e.getMessage()).thenReturn("oh noes");
 
         when(underlying.execute()).thenThrow(e);
+        HealthCheck.Result actual = healthCheck.execute();
 
-        assertThat(healthCheck.execute())
-                .isEqualTo(HealthCheck.Result.unhealthy(e));
+        assertThat(actual.isHealthy())
+                .isFalse();
+        assertThat(actual.getMessage())
+                .isEqualTo("oh noes");
+        assertThat(actual.getError())
+                .isEqualTo(e);
+        assertThat(actual.getDetails())
+                .isNull();
     }
 }


### PR DESCRIPTION
A backward compatible solution for asynchronous health checks (#609). HealthCheck implementations can be marked with the Async annotation while providing:
- execution period (mandatory)
- scheduling type (fixed rate or fixed delay)
- initial delay before first execution
- unit of period and delay
- initial health state until the first result is available

Async checks can be registered the same way regular health checks. On registration the health check registry is wrapping the async health check with a decorator that caches the last result and schedules a periodic execution. This decorator object is put into the underlying map and when its check is invoked it simply returns a cached result. On unregistration the registry cancels the task. To preserve the asynchronous behavior elsewhere the listeners are notified with the async decorator instead of the original health check.