### PR TITLE
Introduce a MetricNameFormatter 

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics/ConsoleReporter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/ConsoleReporter.java
@@ -44,7 +44,7 @@ public class ConsoleReporter extends ScheduledReporter {
             this.rateUnit = TimeUnit.SECONDS;
             this.durationUnit = TimeUnit.MILLISECONDS;
             this.filter = MetricFilter.ALL;
-            this.nameFormatter = name -> name.toString();
+            this.nameFormatter = MetricNameFormatter.METRIC_NAME_TOSTRING;
         }
 
         /**

--- a/metrics-core/src/main/java/io/dropwizard/metrics/ConsoleReporter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/ConsoleReporter.java
@@ -33,6 +33,7 @@ public class ConsoleReporter extends ScheduledReporter {
         private TimeUnit rateUnit;
         private TimeUnit durationUnit;
         private MetricFilter filter;
+        private MetricNameFormatter nameFormatter;
 
         private Builder(MetricRegistry registry) {
             this.registry = registry;
@@ -43,6 +44,7 @@ public class ConsoleReporter extends ScheduledReporter {
             this.rateUnit = TimeUnit.SECONDS;
             this.durationUnit = TimeUnit.MILLISECONDS;
             this.filter = MetricFilter.ALL;
+            this.nameFormatter = name -> name.toString();
         }
 
         /**
@@ -121,6 +123,16 @@ public class ConsoleReporter extends ScheduledReporter {
             this.filter = filter;
             return this;
         }
+        
+        /**
+         * Use given {@link MetricNameFormatter} when creating the metric name string
+         * @param nameformatter the formatter to use
+         * @return {@code this}
+         */
+        public Builder withNameFormatter(MetricNameFormatter nameformatter) {
+            this.nameFormatter = nameformatter;
+            return this;
+        }
 
         /**
          * Builds a {@link ConsoleReporter} with the given properties.
@@ -135,7 +147,8 @@ public class ConsoleReporter extends ScheduledReporter {
                                        timeZone,
                                        rateUnit,
                                        durationUnit,
-                                       filter);
+                                       filter,
+                                       nameFormatter);
         }
     }
 
@@ -145,6 +158,7 @@ public class ConsoleReporter extends ScheduledReporter {
     private final Locale locale;
     private final Clock clock;
     private final DateFormat dateFormat;
+    private final MetricNameFormatter nameFormatter;
 
     private ConsoleReporter(MetricRegistry registry,
                             PrintStream output,
@@ -153,7 +167,8 @@ public class ConsoleReporter extends ScheduledReporter {
                             TimeZone timeZone,
                             TimeUnit rateUnit,
                             TimeUnit durationUnit,
-                            MetricFilter filter) {
+                            MetricFilter filter,
+                            MetricNameFormatter nameFormatter) {
         super(registry, "console-reporter", filter, rateUnit, durationUnit);
         this.output = output;
         this.locale = locale;
@@ -162,6 +177,7 @@ public class ConsoleReporter extends ScheduledReporter {
                                                          DateFormat.MEDIUM,
                                                          locale);
         dateFormat.setTimeZone(timeZone);
+        this.nameFormatter = nameFormatter;
     }
 
     @Override
@@ -177,7 +193,7 @@ public class ConsoleReporter extends ScheduledReporter {
         if (!gauges.isEmpty()) {
             printWithBanner("-- Gauges", '-');
             for (Map.Entry<MetricName, Gauge> entry : gauges.entrySet()) {
-                output.println(entry.getKey());
+                output.println(nameFormatter.formatMetricName(entry.getKey()));
                 printGauge(entry);
             }
             output.println();
@@ -186,7 +202,7 @@ public class ConsoleReporter extends ScheduledReporter {
         if (!counters.isEmpty()) {
             printWithBanner("-- Counters", '-');
             for (Map.Entry<MetricName, Counter> entry : counters.entrySet()) {
-                output.println(entry.getKey());
+                output.println(nameFormatter.formatMetricName(entry.getKey()));
                 printCounter(entry);
             }
             output.println();
@@ -195,7 +211,7 @@ public class ConsoleReporter extends ScheduledReporter {
         if (!histograms.isEmpty()) {
             printWithBanner("-- Histograms", '-');
             for (Map.Entry<MetricName, Histogram> entry : histograms.entrySet()) {
-                output.println(entry.getKey());
+                output.println(nameFormatter.formatMetricName(entry.getKey()));
                 printHistogram(entry.getValue());
             }
             output.println();
@@ -204,7 +220,7 @@ public class ConsoleReporter extends ScheduledReporter {
         if (!meters.isEmpty()) {
             printWithBanner("-- Meters", '-');
             for (Map.Entry<MetricName, Meter> entry : meters.entrySet()) {
-                output.println(entry.getKey());
+                output.println(nameFormatter.formatMetricName(entry.getKey()));
                 printMeter(entry.getValue());
             }
             output.println();
@@ -213,7 +229,7 @@ public class ConsoleReporter extends ScheduledReporter {
         if (!timers.isEmpty()) {
             printWithBanner("-- Timers", '-');
             for (Map.Entry<MetricName, Timer> entry : timers.entrySet()) {
-                output.println(entry.getKey());
+                output.println(nameFormatter.formatMetricName(entry.getKey()));
                 printTimer(entry.getValue());
             }
             output.println();
@@ -281,5 +297,5 @@ public class ConsoleReporter extends ScheduledReporter {
             output.print(c);
         }
         output.println();
-    }
+    } 
 }

--- a/metrics-core/src/main/java/io/dropwizard/metrics/FixedNameCsvFileProvider.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/FixedNameCsvFileProvider.java
@@ -7,6 +7,7 @@ import java.io.File;
  * for the same metric. This means the CSV file will grow indefinitely.
  */
 public class FixedNameCsvFileProvider implements CsvFileProvider {
+    private static final MetricNameFormatter nameFormatter = MetricNameFormatter.APPEND_TAGS;
     @Override
     public File getFile(File directory, MetricName metricName) {
         return new File(directory, sanitize(metricName) + ".csv");
@@ -15,7 +16,8 @@ public class FixedNameCsvFileProvider implements CsvFileProvider {
     private String sanitize(MetricName metricName) {
         //Forward slash character is definitely illegal in both Windows and Linux
         //https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
-        final String sanitizedName = metricName.getKey().replaceFirst("^/","").replaceAll("/",".");
+        final String name = nameFormatter.formatMetricName(metricName);
+        final String sanitizedName = name.replaceFirst("^/","").replaceAll("/",".");
         return sanitizedName;
     }
 }

--- a/metrics-core/src/main/java/io/dropwizard/metrics/MetricNameFormatter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/MetricNameFormatter.java
@@ -21,14 +21,19 @@ public interface MetricNameFormatter {
      * A {@link MetricNameFormatter} that will only use the name part of the {@link MetricName} and
      * ignore all tags
      */
-    public static MetricNameFormatter NAME_ONLY = name -> name.getKey();
+    public static final MetricNameFormatter NAME_ONLY = name -> name.getKey();
+    
+    /**
+     * A {@link MetricNameFormatter} that will invoke {@link MetricName#toString()}
+     */
+    public static final MetricNameFormatter METRIC_NAME_TOSTRING =name -> name.toString();
     
     /**
      * A {@link MetricNameFormatter} that will append tag names and values to the metric string.
      * The tags are sorted by tag key and then appended in sorted order to the name.
      * For example: <code>foo.bar.time[m=b,d=e]</code> will result in <code>foo.bar.time.d.e.m.b</code>
      */
-    public static MetricNameFormatter APPEND_TAGS = name -> {
+    public static final MetricNameFormatter APPEND_TAGS = name -> {
         StringBuilder sb = new StringBuilder(name.getKey());
         Map<String,String> tags = name.getTags();
         List<String> tagNames = new ArrayList<>(tags.keySet());
@@ -48,7 +53,7 @@ public interface MetricNameFormatter {
      * tag values are sorted and then appended in sorted order.
      * For example: <code>foo.bar.time[m=b,d=e,f=a]</code> will result in <code>foo.bar.time.a.b.e</code>
      */
-    public static MetricNameFormatter APPEND_TAG_VALUES = name -> {
+    public static final MetricNameFormatter APPEND_TAG_VALUES = name -> {
         StringBuilder sb = new StringBuilder(name.getKey());
         List<String> tagValues = new ArrayList<>(name.getTags().values());
         Collections.sort(tagValues);

--- a/metrics-core/src/main/java/io/dropwizard/metrics/MetricNameFormatter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/MetricNameFormatter.java
@@ -1,0 +1,63 @@
+package io.dropwizard.metrics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A MetricNameFormatter is used to convert a {@link MetricName} into a string.
+ */
+public interface MetricNameFormatter {
+
+    /**
+     * Format the given {@link MetricName} into a String
+     * @param name the MetricName to format
+     * @return the formatted string from the MetricName
+     */
+    public String formatMetricName(MetricName name);
+    
+    /**
+     * A {@link MetricNameFormatter} that will only use the name part of the {@link MetricName} and
+     * ignore all tags
+     */
+    public static MetricNameFormatter NAME_ONLY = name -> name.getKey();
+    
+    /**
+     * A {@link MetricNameFormatter} that will append tag names and values to the metric string.
+     * The tags are sorted by tag key and then appended in sorted order to the name.
+     * For example: <code>foo.bar.time[m=b,d=e]</code> will result in <code>foo.bar.time.d.e.m.b</code>
+     */
+    public static MetricNameFormatter APPEND_TAGS = name -> {
+        StringBuilder sb = new StringBuilder(name.getKey());
+        Map<String,String> tags = name.getTags();
+        List<String> tagNames = new ArrayList<>(tags.keySet());
+        Collections.sort(tagNames);
+        tagNames.forEach( tag -> {
+            sb.append(".");
+            sb.append(tag);
+            sb.append(".");
+            sb.append(tags.get(tag));
+        });
+        
+        return sb.toString();
+    };
+    
+    /**
+     * A {@link MetricNameFormatter} that will append only the values to the metric string. The 
+     * tag values are sorted and then appended in sorted order.
+     * For example: <code>foo.bar.time[m=b,d=e,f=a]</code> will result in <code>foo.bar.time.a.b.e</code>
+     */
+    public static MetricNameFormatter APPEND_TAG_VALUES = name -> {
+        StringBuilder sb = new StringBuilder(name.getKey());
+        List<String> tagValues = new ArrayList<>(name.getTags().values());
+        Collections.sort(tagValues);
+        tagValues.forEach( value -> {
+            sb.append(".");
+            sb.append(value);
+        });
+        
+        return sb.toString();
+    };
+    
+}

--- a/metrics-core/src/main/java/io/dropwizard/metrics/Slf4jReporter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/Slf4jReporter.java
@@ -52,7 +52,7 @@ public class Slf4jReporter extends ScheduledReporter {
             this.durationUnit = TimeUnit.MILLISECONDS;
             this.filter = MetricFilter.ALL;
             this.loggingLevel = LoggingLevel.INFO;
-            this.nameFormatter = name -> name.toString();
+            this.nameFormatter = MetricNameFormatter.METRIC_NAME_TOSTRING;
         }
 
         /**

--- a/metrics-core/src/test/java/io/dropwizard/metrics/MetricNameFormatterTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/MetricNameFormatterTest.java
@@ -1,0 +1,52 @@
+package io.dropwizard.metrics;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MetricNameFormatterTest {
+	
+	@Test
+	public void nameOnlyFormatterTest() {
+		MetricName name = new MetricName("this.is.a.test",Collections.singletonMap("k1", "v2"));
+		Assert.assertEquals("this.is.a.test", MetricNameFormatter.NAME_ONLY.formatMetricName(name));		
+	}
+	
+	@Test
+	public void appendTagsFormatterTest() {
+		MetricNameFormatter formatter = MetricNameFormatter.APPEND_TAGS;
+		MetricName name = new MetricName("this.is.a.test",Collections.singletonMap("k1", "v2"));
+		Assert.assertEquals("this.is.a.test.k1.v2",formatter.formatMetricName(name));
+		
+		// test sorting is done
+		Map<String,String> tags = new HashMap<>();
+		tags.put("tag1", "value1");
+		tags.put("key1", "kv1");
+		tags.put("a", "b");
+		name = new MetricName("this.is.a.test",tags);
+		
+		Assert.assertEquals("this.is.a.test.a.b.key1.kv1.tag1.value1", formatter.formatMetricName(name));
+	}
+	
+	@Test
+	public void appendTagValuesFormatterTest() {
+		MetricNameFormatter formatter = MetricNameFormatter.APPEND_TAG_VALUES;
+		MetricName name = new MetricName("this.is.a.test",Collections.singletonMap("k1", "v2"));
+		Assert.assertEquals("this.is.a.test.v2",formatter.formatMetricName(name));
+		
+		// test sorting is done correctly
+		Map<String,String> tags = new HashMap<>();
+		tags.put("tag1", "value1");
+		tags.put("zkey1", "kv1");
+		tags.put("a", "b");
+		name = new MetricName("this.is.a.test",tags);
+		
+		Assert.assertEquals("this.is.a.test.b.kv1.value1", formatter.formatMetricName(name));
+	}
+	
+	
+
+}

--- a/metrics-core/src/test/java/io/dropwizard/metrics/MetricNameFormatterTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/MetricNameFormatterTest.java
@@ -47,6 +47,18 @@ public class MetricNameFormatterTest {
 		Assert.assertEquals("this.is.a.test.b.kv1.value1", formatter.formatMetricName(name));
 	}
 	
+	@Test
+	public void toStringFormatterTest() {
+		Map<String,String> tags = new HashMap<>();
+		tags.put("tag1", "value1");
+		tags.put("key1", "kv1");
+		tags.put("a", "b");
+		MetricName name = new MetricName("this.is.a.test",tags);
+		
+		Assert.assertEquals(name.toString(), MetricNameFormatter.METRIC_NAME_TOSTRING.formatMetricName(name));
+		
+	}
+	
 	
 
 }

--- a/metrics-core/src/test/java/io/dropwizard/metrics/Slf4jReporterTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/Slf4jReporterTest.java
@@ -1,25 +1,19 @@
 package io.dropwizard.metrics;
 
-import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.Marker;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-import io.dropwizard.metrics.Counter;
-import io.dropwizard.metrics.Gauge;
-import io.dropwizard.metrics.Histogram;
-import io.dropwizard.metrics.Meter;
-import io.dropwizard.metrics.MetricFilter;
-import io.dropwizard.metrics.MetricName;
-import io.dropwizard.metrics.MetricRegistry;
-import io.dropwizard.metrics.Slf4jReporter;
-import io.dropwizard.metrics.Snapshot;
-import io.dropwizard.metrics.Timer;
-
+import java.util.HashMap;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
-import static org.mockito.Mockito.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
 
 public class Slf4jReporterTest {
     private final Logger logger = mock(Logger.class);
@@ -43,17 +37,27 @@ public class Slf4jReporterTest {
             .withLoggingLevel(Slf4jReporter.LoggingLevel.ERROR)
             .filter(MetricFilter.ALL)
             .build();
+    
+    private Map<String,String> testTags;
+    
+    @Before
+    public void setup() {
+    	testTags = new HashMap<>();
+    	testTags.put("t1", "v1");
+    	testTags.put("k2", "v2");
+    	
+    }
 
     @Test
     public void reportsGaugeValuesAtError() throws Exception {
         when(logger.isErrorEnabled(marker)).thenReturn(true);
-        errorReporter.report(map("gauge", gauge("value")),
+        errorReporter.report(map("gauge", testTags, gauge("value")),
                 this.<Counter>map(),
                 this.<Histogram>map(),
                 this.<Meter>map(),
                 this.<Timer>map());
 
-        verify(logger).error(marker, "type={}, name={}, value={}", new Object[]{"GAUGE", "gauge", "value"});
+        verify(logger).error(marker, "type={}, name={}, value={}", new Object[]{"GAUGE", "gauge{t1=v1, k2=v2}", "value"});
     }
 
     @Test
@@ -63,12 +67,12 @@ public class Slf4jReporterTest {
         when(logger.isErrorEnabled(marker)).thenReturn(true);
 
         errorReporter.report(this.<Gauge>map(),
-                map("test.counter", counter),
+                map("test.counter", testTags, counter),
                 this.<Histogram>map(),
                 this.<Meter>map(),
                 this.<Timer>map());
 
-        verify(logger).error(marker, "type={}, name={}, count={}", new Object[]{"COUNTER", "test.counter", 100L});
+        verify(logger).error(marker, "type={}, name={}, count={}", new Object[]{"COUNTER", "test.counter{t1=v1, k2=v2}", 100L});
     }
 
     @Test
@@ -93,14 +97,14 @@ public class Slf4jReporterTest {
 
         errorReporter.report(this.<Gauge>map(),
                 this.<Counter>map(),
-                map("test.histogram", histogram),
+                map("test.histogram", testTags, histogram),
                 this.<Meter>map(),
                 this.<Timer>map());
 
         verify(logger).error(marker,
                 "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}",
                 "HISTOGRAM",
-                "test.histogram",
+                "test.histogram{t1=v1, k2=v2}",
                 1L,
                 4L,
                 2L,
@@ -127,13 +131,13 @@ public class Slf4jReporterTest {
         errorReporter.report(this.<Gauge>map(),
                 this.<Counter>map(),
                 this.<Histogram>map(),
-                map("test.meter", meter),
+                map("test.meter", testTags, meter),
                 this.<Timer>map());
 
         verify(logger).error(marker,
                 "type={}, name={}, count={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}",
                 "METER",
-                "test.meter",
+                "test.meter{t1=v1, k2=v2}",
                 1L,
                 2.0,
                 3.0,
@@ -173,12 +177,12 @@ public class Slf4jReporterTest {
                 this.<Counter>map(),
                 this.<Histogram>map(),
                 this.<Meter>map(),
-                map("test.another.timer", timer));
+                map("test.another.timer", testTags, timer));
 
         verify(logger).error(marker,
                 "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}, duration_unit={}",
                 "TIMER",
-                "test.another.timer",
+                "test.another.timer{t1=v1, k2=v2}",
                 1L,
                 300.0,
                 100.0,
@@ -201,13 +205,13 @@ public class Slf4jReporterTest {
     @Test
     public void reportsGaugeValues() throws Exception {
         when(logger.isInfoEnabled(marker)).thenReturn(true);
-        infoReporter.report(map("gauge", gauge("value")),
+        infoReporter.report(map("gauge", testTags, gauge("value")),
                 this.<Counter>map(),
                 this.<Histogram>map(),
                 this.<Meter>map(),
                 this.<Timer>map());
 
-        verify(logger).info(marker, "type={}, name={}, value={}", new Object[]{"GAUGE", "prefix.gauge", "value"});
+        verify(logger).info(marker, "type={}, name={}, value={}", new Object[]{"GAUGE", "prefix.gauge{t1=v1, k2=v2}", "value"});
     }
 
     @Test
@@ -217,12 +221,12 @@ public class Slf4jReporterTest {
         when(logger.isInfoEnabled(marker)).thenReturn(true);
 
         infoReporter.report(this.<Gauge>map(),
-                map("test.counter", counter),
+                map("test.counter", testTags, counter),
                 this.<Histogram>map(),
                 this.<Meter>map(),
                 this.<Timer>map());
 
-        verify(logger).info(marker, "type={}, name={}, count={}", new Object[]{"COUNTER", "prefix.test.counter", 100L});
+        verify(logger).info(marker, "type={}, name={}, count={}", new Object[]{"COUNTER", "prefix.test.counter{t1=v1, k2=v2}", 100L});
     }
 
     @Test
@@ -247,14 +251,14 @@ public class Slf4jReporterTest {
 
         infoReporter.report(this.<Gauge>map(),
                 this.<Counter>map(),
-                map("test.histogram", histogram),
+                map("test.histogram", testTags, histogram),
                 this.<Meter>map(),
                 this.<Timer>map());
 
         verify(logger).info(marker,
                 "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}",
                 "HISTOGRAM",
-                "prefix.test.histogram",
+                "prefix.test.histogram{t1=v1, k2=v2}",
                 1L,
                 4L,
                 2L,
@@ -281,13 +285,13 @@ public class Slf4jReporterTest {
         infoReporter.report(this.<Gauge>map(),
                 this.<Counter>map(),
                 this.<Histogram>map(),
-                map("test.meter", meter),
+                map("test.meter", testTags, meter),
                 this.<Timer>map());
 
         verify(logger).info(marker,
                 "type={}, name={}, count={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}",
                 "METER",
-                "prefix.test.meter",
+                "prefix.test.meter{t1=v1, k2=v2}",
                 1L,
                 2.0,
                 3.0,
@@ -326,12 +330,12 @@ public class Slf4jReporterTest {
                 this.<Counter>map(),
                 this.<Histogram>map(),
                 this.<Meter>map(),
-                map("test.another.timer", timer));
+                map("test.another.timer", testTags, timer));
 
         verify(logger).info(marker,
                 "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}, duration_unit={}",
                 "TIMER",
-                "prefix.test.another.timer",
+                "prefix.test.another.timer{t1=v1, k2=v2}",
                 1L,
                 300.0,
                 100.0,
@@ -350,14 +354,37 @@ public class Slf4jReporterTest {
                 "events/second",
                 "milliseconds");
     }
+    
+    @Test
+    public void testNameFormatterIsUsed() {
+    	Slf4jReporter reporter = Slf4jReporter.forRegistry(registry)
+    			.outputTo(logger)
+                .markWith(marker)
+                .prefixedWith("prefix")
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .withLoggingLevel(Slf4jReporter.LoggingLevel.INFO)
+                .filter(MetricFilter.ALL)
+    			.withNameFormatter(MetricNameFormatter.APPEND_TAG_VALUES)
+    			.build();
+    	
+    	when(logger.isInfoEnabled(marker)).thenReturn(true);
+    	reporter.report(map("gauge", testTags, gauge("value")),
+                this.<Counter>map(),
+                this.<Histogram>map(),
+                this.<Meter>map(),
+                this.<Timer>map());
+
+        verify(logger).info(marker, "type={}, name={}, value={}", new Object[]{"GAUGE", "prefix.gauge.v1.v2", "value"});
+    }
 
     private <T> SortedMap<MetricName, T> map() {
         return new TreeMap<MetricName, T>();
     }
 
-    private <T> SortedMap<MetricName, T> map(String name, T metric) {
+    private <T> SortedMap<MetricName, T> map(String name, Map<String,String> tags, T metric) {
         final TreeMap<MetricName, T> map = new TreeMap<MetricName, T>();
-        map.put(MetricName.build(name), metric);
+        map.put(new MetricName(name,tags), metric);
         return map;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
+                <version>2.5.4</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>


### PR DESCRIPTION
This PR is an initial proposal on adding a `MetricNameFormatter`. The idea is users can provide an implementation that will format a `MetricName` into a string for reporters that only support single strings. This PR also makes the reporters aware of tags in the `MetricName`. Most of them currently just print out `MetricName.getKey()` which is not guaranteed to provide uniqueness for things such as the slf4j and console reporters. Let me know your thoughts