### PR TITLE
Move closing` DatagramChannel` to the close method

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteUDP.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteUDP.java
@@ -45,13 +45,8 @@ public class GraphiteUDP implements GraphiteSender {
 
     @Override
     public void connect() throws IllegalStateException, IOException {
-        // Only open the channel the first time...
         if (isConnected()) {
             throw new IllegalStateException("Already connected");
-        }
-
-        if (datagramChannel != null) {
-            datagramChannel.close();
         }
 
         // Resolve hostname
@@ -69,11 +64,6 @@ public class GraphiteUDP implements GraphiteSender {
 
     @Override
     public void send(String name, String value, long timestamp) throws IOException {
-        // Underlying socket can be closed by ICMP
-        if (!isConnected()) {
-            connect();
-        }
-
         try {
             StringBuilder buf = new StringBuilder();
             buf.append(sanitize(name));
@@ -104,11 +94,32 @@ public class GraphiteUDP implements GraphiteSender {
 
     @Override
     public void close() throws IOException {
-        // Leave channel & socket open for next metrics
+        if (datagramChannel != null) {
+            try {
+                datagramChannel.close();
+            } finally {
+                datagramChannel = null;
+            }
+        }
     }
 
     protected String sanitize(String s) {
         return GraphiteSanitize.sanitize(s, '-');
     }
 
+    DatagramChannel getDatagramChannel() {
+        return datagramChannel;
+    }
+
+    void setDatagramChannel(DatagramChannel datagramChannel) {
+        this.datagramChannel = datagramChannel;
+    }
+
+    InetSocketAddress getAddress() {
+        return address;
+    }
+
+    void setAddress(InetSocketAddress address) {
+        this.address = address;
+    }
 }

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteUDPTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteUDPTest.java
@@ -1,0 +1,43 @@
+package com.codahale.metrics.graphite;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+public class GraphiteUDPTest {
+
+    private final String host = "example.com";
+    private final int port = 1234;
+
+    private GraphiteUDP graphiteUDP;
+
+    @Test
+    public void connects() throws Exception {
+        graphiteUDP = new GraphiteUDP(host, port);
+        graphiteUDP.connect();
+
+        assertThat(graphiteUDP.getDatagramChannel()).isNotNull();
+        assertThat(graphiteUDP.getAddress()).isEqualTo(new InetSocketAddress(host, port));
+
+        graphiteUDP.close();
+    }
+
+    @Test
+    public void writesValue() throws Exception {
+        graphiteUDP = new GraphiteUDP(host, port);
+        DatagramChannel mockDatagramChannel = Mockito.mock(DatagramChannel.class);
+        graphiteUDP.setDatagramChannel(mockDatagramChannel);
+        graphiteUDP.setAddress(new InetSocketAddress(host, port));
+
+        graphiteUDP.send("name woo", "value", 100);
+        verify(mockDatagramChannel).send(ByteBuffer.wrap("name-woo value 100\n".getBytes("UTF-8")),
+                new InetSocketAddress(host, port));
+    }
+
+}


### PR DESCRIPTION
We can align `GraphiteUDP` with the TCP based `Graphite` and close the
socket in the `close` method instead of the connect method. The close
method will be invoked every time after a portion of metrics has been
sent, so we can close the socket there. We also do not need to call
the method `isConnected` during sending metrics because the socket is
opened right before sending data, so it can't be closed by timeout.