### PR TITLE
Shutdown health check registry

### DIFF
--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistry.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistry.java
@@ -252,7 +252,7 @@ public class HealthCheckRegistry {
     }
 
     private static class NamedThreadFactory implements ThreadFactory {
-        private static final AtomicInteger poolNumber = new AtomicInteger(1);
+
         private final ThreadGroup group;
         private final AtomicInteger threadNumber = new AtomicInteger(1);
         private final String namePrefix;
@@ -266,8 +266,7 @@ public class HealthCheckRegistry {
         @Override
         public Thread newThread(Runnable r) {
             Thread t = new Thread(group, r, namePrefix + threadNumber.getAndIncrement(), 0);
-            if (t.isDaemon())
-                t.setDaemon(false);
+            t.setDaemon(true);
             if (t.getPriority() != Thread.NORM_PRIORITY)
                 t.setPriority(Thread.NORM_PRIORITY);
             return t;

--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistry.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistry.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -208,6 +209,22 @@ public class HealthCheckRegistry {
     private void onHealthCheckRemoved(String name, HealthCheck healthCheck) {
         for (HealthCheckRegistryListener listener : listeners) {
             listener.onHealthCheckRemoved(name, healthCheck);
+        }
+    }
+
+    /**
+     * Shuts down the scheduled executor for async health checks
+     */
+    public void shutdown() {
+        asyncExecutorService.shutdown(); // Disable new health checks from being submitted
+        try {
+            // Give some time to the current healtch checks to finish gracefully
+            if (!asyncExecutorService.awaitTermination(1, TimeUnit.SECONDS)) {
+                asyncExecutorService.shutdownNow();
+            }
+        } catch (InterruptedException ie) {
+            asyncExecutorService.shutdownNow();
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistry.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistry.java
@@ -35,6 +35,7 @@ import com.codahale.metrics.health.annotation.Async;
  */
 public class HealthCheckRegistry {
     private static final Logger LOGGER = LoggerFactory.getLogger(HealthCheckRegistry.class);
+    private static final int ASYNC_EXECUTOR_POOL_SIZE = 2;
 
     private final ConcurrentMap<String, HealthCheck> healthChecks;
     private final List<HealthCheckRegistryListener> listeners;
@@ -45,7 +46,7 @@ public class HealthCheckRegistry {
      * Creates a new {@link HealthCheckRegistry}.
      */
     public HealthCheckRegistry() {
-        this(Runtime.getRuntime().availableProcessors());
+        this(ASYNC_EXECUTOR_POOL_SIZE);
     }
 
     /**

--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
@@ -84,6 +84,12 @@ public class HealthCheckServlet extends HttpServlet {
     }
 
     @Override
+    public void destroy() {
+        super.destroy();
+        registry.shutdown();
+    }
+
+    @Override
     protected void doGet(HttpServletRequest req,
                          HttpServletResponse resp) throws ServletException, IOException {
         final SortedMap<String, HealthCheck.Result> results = runHealthChecks();


### PR DESCRIPTION
A follow-up for #1077 

* Add a method for graceful shutdown of HealthCheckRegistry
Add an ability to gracefully shutdown the executor for async tasks in `HealthCheckRegistry`.
Now it creates a ScheduledExecutorService which should be correctly closed when `HealthCheckRegistry` is not used anymore.

*  Make the pool size more pessimistic by default
Some CI environments return the amount of available processors as 128.
It's rather expensive to create such big thread pools by default. Let's start
with 2 threads and the user wants to increase the amount,  she can do that.

* Make the async health check threads as daemons
So they don't prevent the JVM from shutdown if the user didn't shut down
the executor gracefully.