### PR TITLE
Link Coursera's fork for metrics-datadog

### DIFF
--- a/docs/source/manual/third-party.rst
+++ b/docs/source/manual/third-party.rst
@@ -20,7 +20,7 @@ the many third-party libraries which extend Metrics:
 * `metrics-reporter-config <https://github.com/addthis/metrics-reporter-config>`_ DropWizard-eqsue YAML configuration of reporters.
 * `metrics-elasticsearch-reporter <https://github.com/elasticsearch/elasticsearch-metrics-reporter-java>`_ provides a reporter for `elasticsearch <http://www.elasticsearch.org/>`_
 * `metrics-statsd <https://github.com/ReadyTalk/metrics-statsd>`_ provides a Metrics 2.x and 3.x reporter for `StatsD <https://github.com/etsy/statsd/>`_
-* `metrics-datadog <https://github.com/vistarmedia/metrics-datadog>`_ provides a reporter to send data to `Datadog <http://www.datadoghq.com/>`_
+* `metrics-datadog <https://github.com/coursera/metrics-datadog>`_ provides a reporter to send data to `Datadog <http://www.datadoghq.com/>`_
 * `metrics-new-relic <https://github.com/palominolabs/metrics-new-relic>`_ provides a reporter which sends data to `New Relic <https://newrelic.com/>`_.
 * `metrics-influxdb <https://github.com/novaquark/metrics-influxdb>`_ provides a reporter which announces measurements to `InfluxDB <http://influxdb.org/>`_
 * `metrics-cdi <https://github.com/astefanutti/metrics-cdi>`_ provides integration with `CDI <http://www.cdi-spec.org/>`_ environments


### PR DESCRIPTION
Coursera's fork is much more up to date than the original.