### PR TITLE
When the developer wants to ignore the counter attribute in the defin…

### DIFF
--- a/metrics-ganglia/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java
+++ b/metrics-ganglia/src/main/java/com/codahale/metrics/ganglia/GangliaReporter.java
@@ -337,7 +337,7 @@ public class GangliaReporter extends ScheduledReporter {
         final String sanitizedName = escapeSlashes(name);
         final String group = group(name);
         try {
-            announceIfEnabled(COUNT, sanitizedName, group, counter.getCount(), "");
+            announce(prefix(sanitizedName, COUNT.getCode()), group, Long.toString(counter.getCount()), GMetricType.DOUBLE, "");
         } catch (GangliaException e) {
             LOGGER.warn("Unable to report counter {}", name, e);
         }

--- a/metrics-ganglia/src/test/java/com/codahale/metrics/ganglia/GangliaReporterTest.java
+++ b/metrics-ganglia/src/test/java/com/codahale/metrics/ganglia/GangliaReporterTest.java
@@ -251,11 +251,15 @@ public class GangliaReporterTest {
     @Test
     public void disabledMetricAttributes() throws Exception {
         final Meter meter = mock(Meter.class);
+        final Counter counter = mock(Counter.class);
+
         when(meter.getCount()).thenReturn(1L);
         when(meter.getMeanRate()).thenReturn(2.0);
         when(meter.getOneMinuteRate()).thenReturn(3.0);
         when(meter.getFiveMinuteRate()).thenReturn(4.0);
         when(meter.getFifteenMinuteRate()).thenReturn(5.0);
+
+        when(counter.getCount()).thenReturn(1L);
 
         GangliaReporter reporter = GangliaReporter.forRegistry(registry)
                 .prefixedWith("m")
@@ -268,11 +272,12 @@ public class GangliaReporterTest {
                 .build(ganglia);
 
         reporter.report(this.<Gauge>map(),
-                this.<Counter>map(),
+                map("test.counter", counter),
                 this.<Histogram>map(),
                 map("test.meter", meter),
                 this.<Timer>map());
 
+        verify(ganglia).announce("m.test.counter.count", "1", GMetricType.DOUBLE, "", GMetricSlope.BOTH, 60, 0,  "test");
         verify(ganglia).announce("m.test.meter.m1_rate", "3.0", GMetricType.DOUBLE, "events/second", GMetricSlope.BOTH, 60, 0, "test");
         verify(ganglia).announce("m.test.meter.m5_rate", "4.0", GMetricType.DOUBLE, "events/second", GMetricSlope.BOTH, 60, 0, "test");
         verifyNoMoreInteractions(ganglia);

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -336,7 +336,7 @@ public class GraphiteReporter extends ScheduledReporter {
     }
 
     private void reportCounter(String name, Counter counter, long timestamp) throws IOException {
-        sendIfEnabled(COUNT, name, counter.getCount(), timestamp);
+        graphite.send(prefix(name, COUNT.getCode()), format(counter.getCount()), timestamp);
     }
 
     private void reportGauge(String name, Gauge gauge, long timestamp) throws IOException {

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -388,6 +388,9 @@ public class GraphiteReporterTest {
         when(meter.getFifteenMinuteRate()).thenReturn(4.0);
         when(meter.getMeanRate()).thenReturn(5.0);
 
+        final Counter counter = mock(Counter.class);
+        when(counter.getCount()).thenReturn(11L);
+
         Set<MetricAttribute> disabledMetricAttributes = EnumSet.of(MetricAttribute.M15_RATE, MetricAttribute.M5_RATE);
         GraphiteReporter reporterWithdisabledMetricAttributes = GraphiteReporter.forRegistry(registry)
                 .withClock(clock)
@@ -398,13 +401,14 @@ public class GraphiteReporterTest {
                 .disabledMetricAttributes(disabledMetricAttributes)
                 .build(graphite);
         reporterWithdisabledMetricAttributes.report(this.<Gauge>map(),
-                this.<Counter>map(),
+                this.<Counter>map("counter", counter),
                 this.<Histogram>map(),
                 this.<Meter>map("meter", meter),
                 this.<Timer>map());
 
         final InOrder inOrder = inOrder(graphite);
         inOrder.verify(graphite).connect();
+        inOrder.verify(graphite).send("prefix.counter.count", "11", timestamp);
         inOrder.verify(graphite).send("prefix.meter.count", "1", timestamp);
         inOrder.verify(graphite).send("prefix.meter.m1_rate", "2.00", timestamp);
         inOrder.verify(graphite).send("prefix.meter.mean_rate", "5.00", timestamp);


### PR DESCRIPTION
When the developer wants to ignore the counter attribute in the defined meters metrics .. that doesn't mean he/she is still not interested in the defined counter metrics to be logged .. especially that counter metrics contains only the count attribute - this PR will force sending the counter.count even if its configured to be ignored for meters