### PR TITLE
Provides extension point to access to individual measurements

### DIFF
--- a/metrics-benchmarks/src/main/java/com/codahale/metrics/benchmarks/CounterBenchmark.java
+++ b/metrics-benchmarks/src/main/java/com/codahale/metrics/benchmarks/CounterBenchmark.java
@@ -9,10 +9,12 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import static com.codahale.metrics.MeasurementPublisher.DO_NOT_PUBLISH;
+
 @State(Scope.Benchmark)
 public class CounterBenchmark {
 
-    private final Counter counter = new Counter();
+    private final Counter counter = new Counter("benchmark-counter", DO_NOT_PUBLISH);
 
     // It's intentionally not declared as final to avoid constant folding
     private long nextValue = 0xFBFBABBA;

--- a/metrics-benchmarks/src/main/java/com/codahale/metrics/benchmarks/MeterBenchmark.java
+++ b/metrics-benchmarks/src/main/java/com/codahale/metrics/benchmarks/MeterBenchmark.java
@@ -9,10 +9,12 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import static com.codahale.metrics.MeasurementPublisher.DO_NOT_PUBLISH;
+
 @State(Scope.Benchmark)
 public class MeterBenchmark {
 
-    private final Meter meter = new Meter();
+    private final Meter meter = new Meter("meter", DO_NOT_PUBLISH);
 
     // It's intentionally not declared as final to avoid constant folding
     private long nextValue = 0xFBFBABBA;

--- a/metrics-core/src/main/java/com/codahale/metrics/Counter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Counter.java
@@ -5,8 +5,12 @@ package com.codahale.metrics;
  */
 public class Counter implements Metric, Counting {
     private final LongAdderAdapter count;
+    private final String name;
+    private final MeasurementPublisher measurementPublisher;
 
-    public Counter() {
+    public Counter(String name, MeasurementPublisher measurementPublisher) {
+        this.name = name;
+        this.measurementPublisher = measurementPublisher;
         this.count = LongAdderProxy.create();
     }
 
@@ -24,6 +28,7 @@ public class Counter implements Metric, Counting {
      */
     public void inc(long n) {
         count.add(n);
+        measurementPublisher.counterIncremented(name, n);
     }
 
     /**
@@ -40,6 +45,7 @@ public class Counter implements Metric, Counting {
      */
     public void dec(long n) {
         count.add(-n);
+        measurementPublisher.counterDecremented(name, n);
     }
 
     /**

--- a/metrics-core/src/main/java/com/codahale/metrics/Histogram.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Histogram.java
@@ -7,15 +7,21 @@ package com.codahale.metrics;
  *      variance</a>
  */
 public class Histogram implements Metric, Sampling, Counting {
+    private final String name;
+    private final MeasurementPublisher measurementPublisher;
     private final Reservoir reservoir;
     private final LongAdderAdapter count;
 
     /**
      * Creates a new {@link Histogram} with the given reservoir.
      *
+     * @param name The name of the metric
+     * @param measurementPublisher a publisher which the metric should notify of any measurements
      * @param reservoir the reservoir to create a histogram from
      */
-    public Histogram(Reservoir reservoir) {
+    public Histogram(String name, MeasurementPublisher measurementPublisher, Reservoir reservoir) {
+        this.name = name;
+        this.measurementPublisher = measurementPublisher;
         this.reservoir = reservoir;
         this.count = LongAdderProxy.create();
     }
@@ -37,6 +43,7 @@ public class Histogram implements Metric, Sampling, Counting {
     public void update(long value) {
         count.increment();
         reservoir.update(value);
+        measurementPublisher.histogramUpdated(name, value);
     }
 
     /**

--- a/metrics-core/src/main/java/com/codahale/metrics/MeasurementListener.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MeasurementListener.java
@@ -1,0 +1,36 @@
+package com.codahale.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+public interface MeasurementListener {
+    /**
+     * @param name the name of the metric
+     * @param n the amount by which the counter was increased
+     */
+    void counterIncremented(String name, long n);
+
+    /**
+     * @param name the name of the metric
+     * @param n the amount by which the counter was decreased
+     */
+    void counterDecremented(String name, long n);
+
+    /**
+     * @param name the name of the metric
+     * @param duration the length of the duration
+     * @param unit     the scale unit of {@code duration}
+     */
+    void timerUpdated(String name, long duration, TimeUnit unit);
+
+    /**
+     * @param name the name of the metric
+     * @param value the length of the value
+     */
+    void histogramUpdated(String name, long value);
+
+    /**
+     * @param name the name of the metric
+     * @param n the number of events
+     */
+    void meterMarked(String name, long n);
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/MeasurementPublisher.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MeasurementPublisher.java
@@ -6,7 +6,6 @@ import java.util.concurrent.TimeUnit;
 
 public interface MeasurementPublisher {
     MeasurementPublisher DO_NOT_PUBLISH = new DoNothingMeasurementPublisher();
-    MeasurementPublisher DEFAULT_MEASUREMENT_PUBLISHER = new DefaultMeasurementPublisher();
 
     void addListener(MeasurementListener listener);
 
@@ -66,7 +65,7 @@ public interface MeasurementPublisher {
     class DefaultMeasurementPublisher implements MeasurementPublisher {
         private Set<MeasurementListener> listeners = new HashSet<MeasurementListener>();
 
-        private DefaultMeasurementPublisher() {
+        DefaultMeasurementPublisher() {
         }
 
         @Override

--- a/metrics-core/src/main/java/com/codahale/metrics/MeasurementPublisher.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MeasurementPublisher.java
@@ -1,0 +1,117 @@
+package com.codahale.metrics;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+public interface MeasurementPublisher {
+    MeasurementPublisher DO_NOT_PUBLISH = new DoNothingMeasurementPublisher();
+    MeasurementPublisher DEFAULT_MEASUREMENT_PUBLISHER = new DefaultMeasurementPublisher();
+
+    void addListener(MeasurementListener listener);
+
+    void removeListener(MeasurementListener listener);
+
+    void counterIncremented(String name, long n);
+
+    void counterDecremented(String name, long n);
+
+    void timerUpdated(String name, long duration, TimeUnit timeUnit);
+
+    void histogramUpdated(String name, long value);
+
+    void meterMarked(String name, long n);
+
+    class DoNothingMeasurementPublisher implements MeasurementPublisher {
+
+        private DoNothingMeasurementPublisher() {
+        }
+
+        @Override
+        public void addListener(MeasurementListener listener) {
+
+        }
+
+        @Override
+        public void removeListener(MeasurementListener listener) {
+
+        }
+
+        @Override
+        public void counterIncremented(String name, long n) {
+
+        }
+
+        @Override
+        public void counterDecremented(String name, long n) {
+
+        }
+
+        @Override
+        public void timerUpdated(String name, long duration, TimeUnit timeUnit) {
+
+        }
+
+        @Override
+        public void histogramUpdated(String name, long value) {
+
+        }
+
+        @Override
+        public void meterMarked(String name, long n) {
+
+        }
+    }
+
+    class DefaultMeasurementPublisher implements MeasurementPublisher {
+        private Set<MeasurementListener> listeners = new HashSet<MeasurementListener>();
+
+        private DefaultMeasurementPublisher() {
+        }
+
+        @Override
+        public void addListener(MeasurementListener listener) {
+            listeners.add(listener);
+        }
+
+        @Override
+        public void removeListener(MeasurementListener listener) {
+            listeners.remove(listener);
+        }
+
+        @Override
+        public void counterIncremented(String name, long n) {
+            for (MeasurementListener listener: listeners) {
+                listener.counterIncremented(name, n);
+            }
+        }
+
+        @Override
+        public void counterDecremented(String name, long n) {
+            for (MeasurementListener listener: listeners) {
+                listener.counterDecremented(name, n);
+            }
+        }
+
+        @Override
+        public void timerUpdated(String name, long duration, TimeUnit unit) {
+            for (MeasurementListener listener: listeners) {
+                listener.timerUpdated(name, duration, unit);
+            }
+        }
+
+        @Override
+        public void histogramUpdated(String name, long value) {
+            for (MeasurementListener listener: listeners) {
+                listener.histogramUpdated(name, value);
+            }
+        }
+
+        @Override
+        public void meterMarked(String name, long n) {
+            for (MeasurementListener listener: listeners) {
+                listener.meterMarked(name, n);
+            }
+        }
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/Meter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Meter.java
@@ -19,21 +19,29 @@ public class Meter implements Metered {
     private final LongAdderAdapter count = LongAdderProxy.create();
     private final long startTime;
     private final AtomicLong lastTick;
+    private final String name;
+    private final MeasurementPublisher measurementPublisher;
     private final Clock clock;
 
     /**
      * Creates a new {@link Meter}.
+     * @param name The name of the metric
+     * @param measurementPublisher a publisher which the metric should notify of any measurements
      */
-    public Meter() {
-        this(Clock.defaultClock());
+    public Meter(String name, MeasurementPublisher measurementPublisher) {
+        this(name, measurementPublisher, Clock.defaultClock());
     }
 
     /**
      * Creates a new {@link Meter}.
      *
+     * @param name The name of the metric
+     * @param measurementPublisher a publisher which the metric should notify of any measurements
      * @param clock      the clock to use for the meter ticks
      */
-    public Meter(Clock clock) {
+    public Meter(String name, MeasurementPublisher measurementPublisher, Clock clock) {
+        this.name = name;
+        this.measurementPublisher = measurementPublisher;
         this.clock = clock;
         this.startTime = this.clock.getTick();
         this.lastTick = new AtomicLong(startTime);
@@ -57,6 +65,7 @@ public class Meter implements Metered {
         m1Rate.update(n);
         m5Rate.update(n);
         m15Rate.update(n);
+        measurementPublisher.meterMarked(name, n);
     }
 
     private void tickIfNecessary() {

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -57,7 +57,7 @@ public class MetricRegistry implements MetricSet {
      * Creates a new {@link MetricRegistry}.
      */
     public MetricRegistry() {
-        this(MeasurementPublisher.DEFAULT_MEASUREMENT_PUBLISHER);
+        this(new MeasurementPublisher.DefaultMeasurementPublisher());
     }
 
     /**

--- a/metrics-core/src/test/java/com/codahale/metrics/CounterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/CounterTest.java
@@ -3,9 +3,12 @@ package com.codahale.metrics;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 public class CounterTest {
-    private final Counter counter = new Counter();
+    private MeasurementPublisher measurementPublisher = mock(MeasurementPublisher.class);
+    private final Counter counter = new Counter("counter", measurementPublisher);
 
     @Test
     public void startsAtZero() throws Exception {
@@ -59,5 +62,12 @@ public class CounterTest {
 
         assertThat(counter.getCount())
                 .isEqualTo(12);
+    }
+
+    @Test
+    public void notifiesMeasurementPublisher() {
+        counter.inc(1);
+        verify(measurementPublisher)
+                .counterIncremented("counter", 1);
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/HistogramTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/HistogramTest.java
@@ -7,7 +7,8 @@ import static org.mockito.Mockito.*;
 
 public class HistogramTest {
     private final Reservoir reservoir = mock(Reservoir.class);
-    private final Histogram histogram = new Histogram(reservoir);
+    private final MeasurementPublisher measurementPublisher = mock(MeasurementPublisher.class);
+    private final Histogram histogram = new Histogram("histogram", measurementPublisher, reservoir);
 
     @Test
     public void updatesTheCountOnUpdates() throws Exception {
@@ -34,5 +35,13 @@ public class HistogramTest {
         histogram.update(1);
 
         verify(reservoir).update(1);
+    }
+
+    @Test
+    public void notifiesMeasurementListeners() {
+        histogram.update(1);
+        verify(measurementPublisher)
+                .histogramUpdated("histogram", 1);
+        verifyNoMoreInteractions(measurementPublisher);
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/MeterApproximationTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MeterApproximationTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
+import static com.codahale.metrics.MeasurementPublisher.DO_NOT_PUBLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
 
@@ -64,7 +65,7 @@ public class MeterApproximationTest {
             long duration, TimeUnit durationUnit) {
         
         final ManualClock clock = new ManualClock();
-        final Meter meter = new Meter(clock);
+        final Meter meter = new Meter("metronome", DO_NOT_PUBLISH, clock);
         
         clock.addNanos(introDelayUnit.toNanos(introDelay));
         

--- a/metrics-core/src/test/java/com/codahale/metrics/MeterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MeterTest.java
@@ -8,11 +8,13 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class MeterTest {
     private final Clock clock = mock(Clock.class);
-    private final Meter meter = new Meter(clock);
+    private final MeasurementPublisher measurementPublisher = mock(MeasurementPublisher.class);
+    private final Meter meter = new Meter("meter", measurementPublisher, clock);
 
     @Before
     public void setUp() throws Exception {
@@ -54,5 +56,12 @@ public class MeterTest {
 
         assertThat(meter.getFifteenMinuteRate())
                 .isEqualTo(0.1988, offset(0.001));
+    }
+
+    @Test
+    public void notifiesMeasurementPublisher() {
+        meter.mark();
+        verify(measurementPublisher)
+                .meterMarked("meter", 1);
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static com.codahale.metrics.MeasurementPublisher.DEFAULT_MEASUREMENT_PUBLISHER;
 import static com.codahale.metrics.MetricRegistry.name;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
@@ -15,7 +14,7 @@ import static org.mockito.Mockito.*;
 
 public class MetricRegistryTest {
     private final MetricRegistryListener listener = mock(MetricRegistryListener.class);
-    private final MeasurementPublisher measurementPublisher = DEFAULT_MEASUREMENT_PUBLISHER;
+    private final MeasurementPublisher measurementPublisher = new MeasurementPublisher.DefaultMeasurementPublisher();
     private final MetricRegistry registry = new MetricRegistry(measurementPublisher);
     @SuppressWarnings("unchecked")
     private final Gauge<String> gauge = mock(Gauge.class);

--- a/metrics-core/src/test/java/com/codahale/metrics/TimerTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/TimerTest.java
@@ -21,7 +21,8 @@ public class TimerTest {
             return val += 50000000;
         }
     };
-    private final Timer timer = new Timer(reservoir, clock);
+    private final MeasurementPublisher measurementPublisher = mock(MeasurementPublisher.class);
+    private final Timer timer = new Timer("timer", measurementPublisher, reservoir, clock);
 
     @Test
     public void hasRates() throws Exception {
@@ -116,5 +117,16 @@ public class TimerTest {
                 .isZero();
 
         verifyZeroInteractions(reservoir);
+    }
+
+    @Test
+    public void notifiesMeasurementListeners() {
+        timer.update(1, TimeUnit.NANOSECONDS);
+        verify(measurementPublisher)
+                .timerUpdated("timer", 1, TimeUnit.NANOSECONDS);
+        verify(measurementPublisher, never())
+                .histogramUpdated(anyString(), anyLong());
+        verify(measurementPublisher, never())
+                .meterMarked(anyString(), anyLong());
     }
 }

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletContextListenerTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletContextListenerTest.java
@@ -4,11 +4,11 @@ import com.codahale.metrics.*;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.servlet.ServletTester;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.codahale.metrics.MeasurementPublisher.DO_NOT_PUBLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -57,8 +57,8 @@ public class MetricsServletContextListenerTest extends AbstractServletTest {
         });
         registry.counter("c").inc();
         registry.histogram("h").update(1);
-        registry.register("m", new Meter(clock)).mark();
-        registry.register("t", new Timer(new ExponentiallyDecayingReservoir(), clock))
+        registry.register("m", new Meter("m", DO_NOT_PUBLISH, clock)).mark();
+        registry.register("t", new Timer("t", DO_NOT_PUBLISH, new ExponentiallyDecayingReservoir(), clock))
                 .update(1, TimeUnit.SECONDS);
 
         request.setMethod("GET");

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletTest.java
@@ -13,6 +13,7 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 
+import static com.codahale.metrics.MeasurementPublisher.DO_NOT_PUBLISH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -46,8 +47,8 @@ public class MetricsServletTest extends AbstractServletTest {
         });
         registry.counter("c").inc();
         registry.histogram("h").update(1);
-        registry.register("m", new Meter(clock)).mark();
-        registry.register("t", new Timer(new ExponentiallyDecayingReservoir(), clock))
+        registry.register("m", new Meter("m", DO_NOT_PUBLISH, clock)).mark();
+        registry.register("t", new Timer("t", DO_NOT_PUBLISH, new ExponentiallyDecayingReservoir(), clock))
                 .update(1, TimeUnit.SECONDS);
 
         request.setMethod("GET");


### PR DESCRIPTION
As suggested in #595.

I’ve done this work on the 3.2-development branch as it seemed most up to date. I’d be happy to move it to 4.0-development as it is a breaking change to the public API of `Metric`.

* `MetricRegistry.addMeasurementListener()` now provides an extension point which lets users add listeners which will receive individual measurements for all registered metrics.
* The registry holds a single `MeasurementPublisher` so that each metric object does not need to hold a separate collection.
* Adds the metric name and a publisher to the signature of all metric constructors to allow them to emit measurements with the associated name. I couldn’t see a nicer simple way of doing this while retaining the metrics as the source of measurements.
* Nested metrics do not report their measurements since these are meta-metrics—aggregations themselves.
* There is now a slightly wrinkly problem around `MetricRegistry.register()` since the name of the metric is supplied *and* present in the metric. I could add a `name()` accessor to `Metric` but this would be a further break to the interface.
* `Gauge` measurements do not make it to the listeners. I can contribute an instance of `ScheduledReporter` which optionally passes (configured through the `MetricRegistry`) `Gauge` samples on a regular interval to listeners, and will contribute this approach if the maintainers are happy.