### PR TITLE
Link to rolling-metrics library

### DIFF
--- a/docs/source/manual/third-party.rst
+++ b/docs/source/manual/third-party.rst
@@ -55,3 +55,7 @@ Reporters
 * `metrics-statsd <https://github.com/ReadyTalk/metrics-statsd>`_ provides a Metrics 2.x and 3.x reporter for `StatsD <https://github.com/etsy/statsd/>`_
 * `metrics-zabbiz <https://github.com/hengyunabc/metrics-zabbix>`_ provides a reporter for `Zabbix <http://www.zabbix.com/>`_.
 * `sematext-metrics-reporter <https://github.com/sematext/sematext-metrics-reporter>`_ provides a reporter for `SPM <http://sematext.com/spm/index.html>`_.
+
+Advansed metrics implementations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* `rolling-metrics <https://github.com/vladimir-bukhtoyarov/rolling-metrics>`_ provides a collection of advanced metrics with rolling time window semantic, such as Rolling-Counter, Hit-Ratio, Top and Reservoir backed by HdrHistogram.


### PR DESCRIPTION
- Added new section for custom metrics implementations.
- Added link to rolling-metrics.

@marshallpierce, also I think that it would be better to move hdrhistogram-metrics-reservoir  to the new "Advansed metrics implementations" section because it is really provide new implementation of histogram and does not provide ability to monitor any library or server.