### PR TITLE
Make SharedMetricRegistries thread-safe

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/SharedMetricRegistries.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SharedMetricRegistries.java
@@ -3,6 +3,7 @@ package com.codahale.metrics;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A map of shared, named metric registries.
@@ -11,7 +12,12 @@ public class SharedMetricRegistries {
     private static final ConcurrentMap<String, MetricRegistry> REGISTRIES =
             new ConcurrentHashMap<String, MetricRegistry>();
 
-    private static volatile String defaultRegistryName = null;
+    private static AtomicReference<String> defaultRegistryName = new AtomicReference<String>();
+
+    /* Visible for testing */
+    static void setDefaultRegistryName(AtomicReference<String> defaultRegistryName) {
+        SharedMetricRegistries.defaultRegistryName = defaultRegistryName;
+    }
 
     private SharedMetricRegistries() { /* singleton */ }
 
@@ -44,23 +50,43 @@ public class SharedMetricRegistries {
         return existing;
     }
 
+    /**
+     * Creates a new registry and sets it as the default one under the provided name.
+     *
+     * @param name the registry name
+     * @return the default registry
+     * @throws IllegalStateException if the name has already been set
+     */
     public synchronized static MetricRegistry setDefault(String name) {
         final MetricRegistry registry = getOrCreate(name);
         return setDefault(name, registry);
     }
 
+    /**
+     * Sets the provided registry as the default one under the provided name
+     *
+     * @param name           the default registry name
+     * @param metricRegistry the default registry
+     * @throws IllegalStateException if the default registry has already been set
+     */
     public static MetricRegistry setDefault(String name, MetricRegistry metricRegistry) {
-        if (defaultRegistryName == null) {
-            defaultRegistryName = name;
+        if (defaultRegistryName.compareAndSet(null, name)) {
             add(name, metricRegistry);
             return metricRegistry;
         }
         throw new IllegalStateException("Default metric registry name is already set.");
     }
 
+    /**
+     * Gets the name of the default registry, if it has been set
+     *
+     * @return the default registry
+     * @throws IllegalStateException if the default has not been set
+     */
     public static MetricRegistry getDefault() {
-        if (defaultRegistryName != null) {
-            return getOrCreate(defaultRegistryName);
+        final String name = defaultRegistryName.get();
+        if (name != null) {
+            return getOrCreate(name);
         }
         throw new IllegalStateException("Default registry name has not been set.");
     }

--- a/metrics-core/src/test/java/com/codahale/metrics/SharedMetricRegistriesTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SharedMetricRegistriesTest.java
@@ -5,19 +5,12 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class SharedMetricRegistriesTest {
     @Before
     public void setUp() throws Exception {
-        // Unset the defaultRegistryName field between tests for better isolation.
-        final Field field = SharedMetricRegistries.class.getDeclaredField("defaultRegistryName");
-        field.setAccessible(true);
-        final Field modfiers = Field.class.getDeclaredField("modifiers");
-        modfiers.setAccessible(true);
-        modfiers.setInt(field, field.getModifiers() & ~Modifier.FINAL);
-        field.set(null, null);
+        SharedMetricRegistries.setDefaultRegistryName(new AtomicReference<String>());
         SharedMetricRegistries.clear();
     }
 


### PR DESCRIPTION
Change `defaultRegistryName` from volatile to `AtomicReference`. This allows to us to perform an atomic set of the default registry bane and not end  up with a lost update.

This also adds a package-private setter for `defaultRegistryName` for testing purposes, so we don't perform any reflection hacks in the unit tests.