### PR TITLE
To be honest I disagree with the way we do sanitizing here and would …

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteSanitize.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteSanitize.java
@@ -1,26 +1,32 @@
 package com.codahale.metrics.graphite;
 
 class GraphiteSanitize {
+
+    private static final String ACCEPTED_CHARS = ".-_";
+
     /** Replaces all characters from a given string that are not ascii and not alphanumeric
      *  with a dash */
-    static String sanitize(String string, char replacement) {
-        String replaced = replaceFrom(string, replacement);
+    static String sanitize(String string, char replacementCh) {
+        String replaced = replaceFrom(string, replacementCh);
+
+        final String replacementStr = String.valueOf(replacementCh);
+        final String duplicateChars = (replacementStr+replacementStr);
 
         // Consolidate multiple dashes into a single one
-        String result = replaced.replace("--", "-");
+        String result = replaced.replace(duplicateChars, replacementStr);
         while (!result.equals(replaced)) {
             replaced = result;
-            result = replaced.replace("--", "-");
+            result = replaced.replace(duplicateChars, replacementStr);
         }
 
         // Remove any leading or trailing dashes
-        return strip(result, replacement);
+        return strip(result, replacementCh);
     }
 
     /** A char matches when it is a letter or digit and it is ASCII, in Guava terminology,
      *  this would be CharMatcher.ASCII.and(CharMatcher.JAVA_LETTER_OR_DIGIT).negate() */
     private static boolean matches(char c) {
-        return !(Character.isLetterOrDigit(c) && c <= '\u007f');
+        return !((Character.isLetterOrDigit(c) || ACCEPTED_CHARS.contains(String.valueOf(c))) && c <= '\u007f');
     }
 
     /** Replace all characters that we're interested in with a replacement character,

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteSanitizeTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteSanitizeTest.java
@@ -15,12 +15,15 @@ public class GraphiteSanitizeTest {
         softly.assertThat(GraphiteSanitize.sanitize("  Foo Bar  ", '-')).isEqualTo("Foo-Bar");
         softly.assertThat(GraphiteSanitize.sanitize("Foo@Bar", '-')).isEqualTo("Foo-Bar");
         softly.assertThat(GraphiteSanitize.sanitize("Foó Bar", '-')).isEqualTo("Fo-Bar");
-        softly.assertThat(GraphiteSanitize.sanitize("||ó/.", '-')).isEqualTo("");
+        softly.assertThat(GraphiteSanitize.sanitize("||ó/.", '-')).isEqualTo(".");
         softly.assertThat(GraphiteSanitize.sanitize("${Foo:Bar:baz}", '-')).isEqualTo("Foo-Bar-baz");
-        softly.assertThat(GraphiteSanitize.sanitize("St. Foo's of Bar", '-')).isEqualTo("St-Foo-s-of-Bar");
+        softly.assertThat(GraphiteSanitize.sanitize("St. Foo's of Bar", '-')).isEqualTo("St.-Foo-s-of-Bar");
         softly.assertThat(GraphiteSanitize.sanitize("(Foo and (Bar and (Baz)))", '-')).isEqualTo("Foo-and-Bar-and-Baz");
-        softly.assertThat(GraphiteSanitize.sanitize("Foo.bar.baz", '-')).isEqualTo("Foo-bar-baz");
+        softly.assertThat(GraphiteSanitize.sanitize("Foo.bar.baz", '-')).isEqualTo("Foo.bar.baz");
         softly.assertThat(GraphiteSanitize.sanitize("FooBar", '-')).isEqualTo("FooBar");
+        softly.assertThat(GraphiteSanitize.sanitize("##)", '-')).isEqualTo("");
+        softly.assertThat(GraphiteSanitize.sanitize("search_total)", '-')).isEqualTo("search_total");
+        softly.assertThat(GraphiteSanitize.sanitize("search-error)", '-')).isEqualTo("search-error");
 
         softly.assertAll();
     }


### PR DESCRIPTION
To be honest I disagree with the way we do sanitizing here and would even remove it as graphite supports many special characters and it depends on the developer to choose better naming conventions to his/her metrics .. when I upgraded the library to use the new version all my dashboards didn't work as it uses '.' in metric names which in this case has been converted to '-' developers should be able to track metrics in the following formats (e.g., search.total, search.error, search.done) and as soon as these characters are fine with graphite then why would we need to strip them or normalize them?! .. I just added some of the special characters that I'm sure are accepted by graphite and I think we should support whatever graphite supports to be backward compatible .. especially when users upgrade to the new version