### PR TITLE
Fix groupId in pom.xml files

### DIFF
--- a/metrics-adapter/pom.xml
+++ b/metrics-adapter/pom.xml
@@ -2,7 +2,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>io.dropwizard.metrics</groupId>
+		<groupId>io.dropwizard.metrics4</groupId>
 		<artifactId>metrics-parent</artifactId>
 		<version>4.0.0-SNAPSHOT</version>
 	</parent>
@@ -11,12 +11,12 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>io.dropwizard.metrics</groupId>
+			<groupId>io.dropwizard.metrics4</groupId>
 			<artifactId>metrics-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>io.dropwizard.metrics</groupId>
+			<groupId>io.dropwizard.metrics4</groupId>
 			<artifactId>metrics-healthchecks</artifactId>
 			<version>${project.version}</version>
 			<optional>true</optional>

--- a/metrics-jersey2/pom.xml
+++ b/metrics-jersey2/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-	<groupId>io.dropwizard.metrics</groupId>
+	<groupId>io.dropwizard.metrics4</groupId>
 	<artifactId>metrics-parent</artifactId>
 	<version>4.0.0-SNAPSHOT</version>
     </parent>


### PR DESCRIPTION
It looks like the groupId was changed to io.dropwizard.metrics4
but was missed in a few places.
