### PR TITLE
Use ${project.groupId} in child pom.xml dependency declarations

### DIFF
--- a/metrics-adapter/pom.xml
+++ b/metrics-adapter/pom.xml
@@ -11,12 +11,12 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>io.dropwizard.metrics4</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>metrics-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>io.dropwizard.metrics4</groupId>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>metrics-healthchecks</artifactId>
 			<version>${project.version}</version>
 			<optional>true</optional>

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -20,7 +20,7 @@
 
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/metrics-collectd/pom.xml
+++ b/metrics-collectd/pom.xml
@@ -17,7 +17,7 @@
 
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -17,7 +17,7 @@
 
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -17,7 +17,7 @@
 
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -18,7 +18,7 @@
     
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-jvm</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>

--- a/metrics-httpasyncclient/pom.xml
+++ b/metrics-httpasyncclient/pom.xml
@@ -18,7 +18,7 @@
 
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-httpclient</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -18,7 +18,7 @@
 
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/metrics-influxdb/pom.xml
+++ b/metrics-influxdb/pom.xml
@@ -18,7 +18,7 @@
 
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -17,7 +17,7 @@
 
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/metrics-jersey2/pom.xml
+++ b/metrics-jersey2/pom.xml
@@ -22,12 +22,12 @@
 
     <dependencies>
 	<dependency>
-	   <groupId>io.dropwizard.metrics4</groupId>
+	    <groupId>${project.groupId}</groupId>
 	    <artifactId>metrics-core</artifactId>
 	    <version>${project.version}</version>
 	</dependency>
 	<dependency>
-	   <groupId>io.dropwizard.metrics4</groupId>
+	    <groupId>${project.groupId}</groupId>
 	    <artifactId>metrics-annotation</artifactId>
 	    <version>${project.version}</version>
 	</dependency>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -18,7 +18,7 @@
 
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -17,12 +17,12 @@
 
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-healthchecks</artifactId>
             <version>${project.version}</version>
             <optional>true</optional>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -18,7 +18,7 @@
 
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/metrics-log4j2/pom.xml
+++ b/metrics-log4j2/pom.xml
@@ -34,7 +34,7 @@
 
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -21,7 +21,7 @@
 
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -17,7 +17,7 @@
 
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -18,22 +18,22 @@
 
     <dependencies>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-healthchecks</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-json</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-jvm</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -74,7 +74,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-           <groupId>io.dropwizard.metrics4</groupId>
+            <groupId>${project.groupId}</groupId>
             <artifactId>metrics-jetty9</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>


### PR DESCRIPTION
It was already done like that for some; do it for all, to make it
consistent.
