### PR TITLE
Fix creating a uniform snapshot from a collection

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/UniformSnapshot.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/UniformSnapshot.java
@@ -23,14 +23,14 @@ public class UniformSnapshot extends Snapshot {
      * @param values    an unordered set of values in the reservoir
      */
     public UniformSnapshot(Collection<Long> values) {
-        this.values = new long[values.size()];
-        int i = 0;
-        for (Long value : values) {
-            this.values[i++] = value;
+        final Object[] copy = values.toArray();
+        this.values = new long[copy.length];
+        for (int i = 0; i < copy.length; i++) {
+            this.values[i] = (Long) copy[i];
         }
         Arrays.sort(this.values);
     }
-    
+
     /**
      * Create a new {@link Snapshot} with the given values.
      *


### PR DESCRIPTION
The current code for creating a snapshot from the collection is unfortunately broken. The code fails if the provided collection is modified during creating of the snapshot and it has a weak iterator (precisely what `ConcurrentSkipListMap` provides). The iterator doesn't guarantee that it has exactly the same amount iteration as the size of the collection. As a result, the code throws an `ArrayIndexOutOfBoundException`.
The correct behaviour is too dump the collection to a resizable array on the fly and then convert it the array of long primitives.

The behaviour was correct in the 3.1 branch, but was broken in 3.2 by the optimization in #972.

Fixes #1104 