### PR TITLE
Improve ScheduledReporter convertDurations precision

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -63,9 +63,9 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
     private final Set<MetricAttribute> disabledMetricAttributes;
     private ScheduledFuture<?> scheduledFuture;
     private final MetricFilter filter;
-    private final double durationFactor;
+    private final long durationFactor;
     private final String durationUnit;
-    private final double rateFactor;
+    private final long rateFactor;
     private final String rateUnit;
 
     /**
@@ -139,7 +139,7 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
         this.shutdownExecutorOnStop = shutdownExecutorOnStop;
         this.rateFactor = rateUnit.toSeconds(1);
         this.rateUnit = calculateRateUnit(rateUnit);
-        this.durationFactor = 1.0 / durationUnit.toNanos(1);
+        this.durationFactor = durationUnit.toNanos(1);
         this.durationUnit = durationUnit.toString().toLowerCase(Locale.US);
         this.disabledMetricAttributes = disabledMetricAttributes != null ? disabledMetricAttributes :
                 Collections.<MetricAttribute>emptySet();
@@ -280,7 +280,7 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
     }
 
     protected double convertDuration(double duration) {
-        return duration * durationFactor;
+        return duration / durationFactor;
     }
 
     protected double convertRate(double rate) {

--- a/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
@@ -8,6 +8,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.*;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
@@ -176,6 +177,11 @@ public class ScheduledReporterTest {
         when(scheduledFuture.get(1, TimeUnit.SECONDS)).thenThrow(new TimeoutException());
         reporterWithExternallyManagedExecutor.start(200, TimeUnit.MILLISECONDS);
         reporterWithExternallyManagedExecutor.stop(); // TimeoutException should be ignored
+    }
+
+    @Test
+    public void shouldConvertDurationToMillisecondsPrecisely() {
+        assertEquals(2.0E-5, reporter.convertDuration(20), 0.0);
     }
 
     private <T> SortedMap<String, T> map(String name, T value) {


### PR DESCRIPTION
Hello! This was something I noticed while testing metric conversions recently.

For a precision test like this:

```java
@Test
public void shouldConvertDurationToMillisecondsPrecisely() {
  assertEquals(2.0E-5, reporter.convertDuration(20), 0.0);
}
```

The current implementation will fail:

```
java.lang.AssertionError: 
Expected :2.0E-5
Actual   :1.9999999999999998E-5
```

However, if we perform the division directly on given durations, the test will pass.

I don't believe this change degrades the precision for other inputs, but happy to hear otherwise and backpedal :)