### PR TITLE
Add missing @Override annotations

### DIFF
--- a/metrics-adapter/src/main/java/com/codahale/metrics/health/HealthCheck.java
+++ b/metrics-adapter/src/main/java/com/codahale/metrics/health/HealthCheck.java
@@ -57,8 +57,10 @@ public abstract class HealthCheck extends io.dropwizard.metrics.health.HealthChe
 		}
 	}
 
+	@Override
 	protected abstract Result check() throws Exception;
 
+	@Override
 	public Result execute() {
 		try {
 			return check();

--- a/metrics-core/src/test/java/io/dropwizard/metrics/InstrumentedExecutorServiceTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/InstrumentedExecutorServiceTest.java
@@ -37,6 +37,7 @@ public class InstrumentedExecutorServiceTest {
         assertThat(rejected.getCount()).isEqualTo(0);
 
         Future<?> theFuture = instrumentedExecutorService.submit(new Runnable() {
+            @Override
             public void run() {
                 assertThat(submitted.getCount()).isEqualTo(1);
                 assertThat(running.getCount()).isEqualTo(1);

--- a/metrics-core/src/test/java/io/dropwizard/metrics/InstrumentedScheduledExecutorServiceTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/InstrumentedScheduledExecutorServiceTest.java
@@ -44,6 +44,7 @@ public class InstrumentedScheduledExecutorServiceTest {
         assertThat(percentOfPeriod.getCount()).isZero();
 
         Future<?> theFuture = instrumentedScheduledExecutor.submit(new Runnable() {
+            @Override
             public void run() {
                 assertThat(submitted.getCount()).isEqualTo(1);
 
@@ -87,6 +88,7 @@ public class InstrumentedScheduledExecutorServiceTest {
         assertThat(percentOfPeriod.getCount()).isZero();
 
         ScheduledFuture<?> theFuture = instrumentedScheduledExecutor.schedule(new Runnable() {
+            @Override
             public void run() {
                 assertThat(submitted.getCount()).isZero();
 
@@ -132,6 +134,7 @@ public class InstrumentedScheduledExecutorServiceTest {
         final Object obj = new Object();
 
         Future<Object> theFuture = instrumentedScheduledExecutor.submit(new Callable<Object>() {
+            @Override
             public Object call() {
                 assertThat(submitted.getCount()).isEqualTo(1);
 
@@ -179,6 +182,7 @@ public class InstrumentedScheduledExecutorServiceTest {
         final Object obj = new Object();
 
         ScheduledFuture<Object> theFuture = instrumentedScheduledExecutor.schedule(new Callable<Object>() {
+            @Override
             public Object call() {
                 assertThat(submitted.getCount()).isZero();
 
@@ -224,6 +228,7 @@ public class InstrumentedScheduledExecutorServiceTest {
         assertThat(percentOfPeriod.getCount()).isZero();
 
         ScheduledFuture<?> theFuture = instrumentedScheduledExecutor.scheduleAtFixedRate(new Runnable() {
+            @Override
             public void run() {
                 assertThat(submitted.getCount()).isZero();
 

--- a/metrics-jvm/src/test/java/io/dropwizard/metrics/jvm/FileDescriptorRatioGaugeTest.java
+++ b/metrics-jvm/src/test/java/io/dropwizard/metrics/jvm/FileDescriptorRatioGaugeTest.java
@@ -52,6 +52,7 @@ public class FileDescriptorRatioGaugeTest {
         }
 
         // overridden on Java 1.7; random crap on Java 1.6
+        @Override
         public ObjectName getObjectName() {
             return null;
         }

--- a/metrics-servlet/src/main/java/io/dropwizard/metrics/servlet/AbstractInstrumentedFilter.java
+++ b/metrics-servlet/src/main/java/io/dropwizard/metrics/servlet/AbstractInstrumentedFilter.java
@@ -175,6 +175,7 @@ public abstract class AbstractInstrumentedFilter implements Filter {
             super.setStatus(sc, sm);
         }
 
+        @Override
         public int getStatus() {
             return httpStatus;
         }


### PR DESCRIPTION
Methods that override the implementation from a superclass or
interface should be annotated with @Override as described in:

  http://stackoverflow.com/a/94411/381622
