### PR TITLE
Feature/filter metrics v3.2

### DIFF
--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
@@ -16,6 +16,7 @@ import org.glassfish.jersey.server.monitoring.RequestEvent;
 import org.glassfish.jersey.server.monitoring.RequestEventListener;
 
 import javax.ws.rs.core.Configuration;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.ext.Provider;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -38,7 +39,7 @@ import static com.codahale.metrics.MetricRegistry.name;
 public class InstrumentedResourceMethodApplicationListener implements ApplicationEventListener, ModelProcessor {
 
     private final MetricRegistry metrics;
-    private ConcurrentMap<Method, Timer> timers = new ConcurrentHashMap<>();
+    private ConcurrentMap<EventTypeAndMethod, Timer> timers = new ConcurrentHashMap<>();
     private ConcurrentMap<Method, Meter> meters = new ConcurrentHashMap<>();
     private ConcurrentMap<Method, ExceptionMeterMetric> exceptionMeters = new ConcurrentHashMap<>();
 
@@ -74,26 +75,45 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         }
     }
 
+    private static EventTypeAndMethod key(RequestEvent event) {
+        final ResourceMethod resourceMethod = event.getUriInfo().getMatchedResourceMethod();
+        if (resourceMethod == null) {
+            return null;
+        }
+        return new EventTypeAndMethod(
+            event.getType(), resourceMethod.getInvocable().getDefinitionMethod()
+        );
+    }
+
     private static class TimerRequestEventListener implements RequestEventListener {
-        private final ConcurrentMap<Method, Timer> timers;
+        private final ConcurrentMap<EventTypeAndMethod, Timer> timers;
         private Timer.Context context = null;
 
-        public TimerRequestEventListener(final ConcurrentMap<Method, Timer> timers) {
+        public TimerRequestEventListener(final ConcurrentMap<EventTypeAndMethod, Timer> timers) {
             this.timers = timers;
         }
 
         @Override
         public void onEvent(RequestEvent event) {
-            if (event.getType() == RequestEvent.Type.RESOURCE_METHOD_START) {
-                final Timer timer = this.timers.get(event.getUriInfo()
-                        .getMatchedResourceMethod().getInvocable().getDefinitionMethod());
-                if (timer != null) {
-                    this.context = timer.time();
+            switch (event.getType()) {
+            case RESOURCE_METHOD_START:
+                final EventTypeAndMethod key = key(event);
+                if (key == null) {
+                    return;
                 }
-            } else if (event.getType() == RequestEvent.Type.RESOURCE_METHOD_FINISHED) {
+                final Timer timer = this.timers.get(key);
+                if (timer == null) {
+                    return;
+                }
+                this.context = timer.time();
+                break;
+            case RESOURCE_METHOD_FINISHED:
                 if (this.context != null) {
                     this.context.close();
                 }
+                break;
+            default:
+                break;
             }
         }
     }
@@ -108,8 +128,7 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         @Override
         public void onEvent(RequestEvent event) {
             if (event.getType() == RequestEvent.Type.RESOURCE_METHOD_START) {
-                final Meter meter = this.meters.get(event.getUriInfo()
-                        .getMatchedResourceMethod().getInvocable().getDefinitionMethod());
+                final Meter meter = this.meters.get(event.getUriInfo().getMatchedResourceMethod().getInvocable().getDefinitionMethod());
                 if (meter != null) {
                     meter.mark();
                 }
@@ -230,14 +249,14 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
     private void registerTimedAnnotations(final ResourceMethod method, final Timed classLevelTimed) {
         final Method definitionMethod = method.getInvocable().getDefinitionMethod();
         if (classLevelTimed != null) {
-            timers.putIfAbsent(definitionMethod, timerMetric(this.metrics, method, classLevelTimed));
+            timers.putIfAbsent(EventTypeAndMethod.requestMethodStart(definitionMethod), timerMetric(this.metrics, method, classLevelTimed));
             return;
         }
 
         final Timed annotation = definitionMethod.getAnnotation(Timed.class);
 
         if (annotation != null) {
-            timers.putIfAbsent(definitionMethod, timerMetric(this.metrics, method, annotation));
+            timers.putIfAbsent(EventTypeAndMethod.requestMethodStart(definitionMethod), timerMetric(this.metrics, method, annotation));
         }
     }
 
@@ -294,5 +313,45 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         return name(name(method.getInvocable().getDefinitionMethod().getDeclaringClass(),
                         method.getInvocable().getDefinitionMethod().getName()),
                 suffixes);
+    }
+
+    static final class EventTypeAndMethod {
+        @NotNull
+        private final RequestEvent.Type type;
+        @NotNull
+        private final Method method;
+
+        public EventTypeAndMethod(RequestEvent.Type type, Method method) {
+            this.type = type;
+            this.method = method;
+        }
+
+        public static EventTypeAndMethod requestMethodStart(Method method) {
+            return new EventTypeAndMethod(RequestEvent.Type.RESOURCE_METHOD_START, method);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            EventTypeAndMethod that = (EventTypeAndMethod) o;
+
+            if (type != that.type) {
+                return false;
+            }
+            return method.equals(that.method);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = type.hashCode();
+            result = 31 * result + method.hashCode();
+            return result;
+        }
     }
 }

--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/MetricsFeature.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/MetricsFeature.java
@@ -13,9 +13,15 @@ import javax.ws.rs.core.FeatureContext;
 public class MetricsFeature implements Feature {
 
     private final MetricRegistry registry;
+    private final InstrumentedResourceMethodApplicationListener.ClockProvider clockProvider;
 
     public MetricsFeature(MetricRegistry registry) {
+        this(registry, null);
+    }
+
+    public MetricsFeature(MetricRegistry registry, InstrumentedResourceMethodApplicationListener.ClockProvider clockProvider) {
         this.registry = registry;
+        this.clockProvider = clockProvider;
     }
 
     public MetricsFeature(String registryName) {
@@ -43,7 +49,7 @@ public class MetricsFeature implements Feature {
      */
     @Override
     public boolean configure(FeatureContext context) {
-        context.register(new InstrumentedResourceMethodApplicationListener(registry));
+        context.register(new InstrumentedResourceMethodApplicationListener(registry, clockProvider));
         return true;
     }
 }

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/TestClock.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/TestClock.java
@@ -1,0 +1,11 @@
+package com.codahale.metrics.jersey2;
+
+import com.codahale.metrics.Clock;
+
+public class TestClock extends Clock {
+    public long tick;
+    @Override
+    public long getTick() {
+        return tick;
+    }
+}

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
@@ -3,6 +3,7 @@ package com.codahale.metrics.jersey2.resources;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
+import com.codahale.metrics.jersey2.TestClock;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -11,11 +12,34 @@ import java.io.IOException;
 @Path("/")
 @Produces(MediaType.TEXT_PLAIN)
 public class InstrumentedResource {
+    private final TestClock testClock;
+
+    public InstrumentedResource(TestClock testClock) {
+        this.testClock = testClock;
+    }
+
     @GET
     @Timed
     @Path("/timed")
     public String timed() {
+        testClock.tick++;
         return "yay";
+    }
+
+    @GET
+    @Timed(name="fancyName")
+    @Path("/named")
+    public String named() {
+        testClock.tick++;
+        return "fancy";
+    }
+
+    @GET
+    @Timed(name="absolutelyFancy", absolute = true)
+    @Path("/absolute")
+    public String absolute() {
+        testClock.tick++;
+        return "absolute";
     }
 
     @GET
@@ -37,6 +61,6 @@ public class InstrumentedResource {
 
     @Path("/subresource")
     public InstrumentedSubResource locateSubResource() {
-        return new InstrumentedSubResource();
+        return new InstrumentedSubResource(testClock);
     }
 }

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedSubResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedSubResource.java
@@ -1,17 +1,27 @@
 package com.codahale.metrics.jersey2.resources;
 
-import com.codahale.metrics.annotation.Timed;
-
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.io.IOException;
+
+import com.codahale.metrics.annotation.Timed;
+import com.codahale.metrics.jersey2.TestClock;
 
 @Produces(MediaType.TEXT_PLAIN)
 public class InstrumentedSubResource {
+    private final TestClock testClock;
+
+    public InstrumentedSubResource(TestClock testClock) {
+
+        this.testClock = testClock;
+    }
+
     @GET
     @Timed
     @Path("/timed")
     public String timed() {
+        testClock.tick += 2;
         return "yay";
     }
 

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/TestRequestFilter.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/TestRequestFilter.java
@@ -1,0 +1,21 @@
+package com.codahale.metrics.jersey2.resources;
+
+import java.io.IOException;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+
+import com.codahale.metrics.jersey2.TestClock;
+
+public class TestRequestFilter implements ContainerRequestFilter{
+    private final TestClock testClock;
+
+    public TestRequestFilter(TestClock testClock) {
+        this.testClock = testClock;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+        testClock.tick += 4;
+    }
+}


### PR DESCRIPTION
This adds support for measuring time for the entire request processing, and the request and response filtering steps, in addition to the current measurement of the time used by the request method itself. In addition, support is added for letting users specify the clock to be used.

No extra metrics are added for methods with @Timed annotations that specify an explicit name, as it's not really clear what those extra metrics should be named, and it seems wrong to add attributes to the @Timed annotation for jersey-specific concepts. Ideas for how to add the extra metrics for explicitly named methods welcome!

Corresponding PR for master: #1119