### PR TITLE
Feature/filter metrics

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/MetricRegistry.java
@@ -141,6 +141,39 @@ public class MetricRegistry implements MetricSet {
     }
 
     /**
+     * Return the {@link Counter} registered under this name; or create and register
+     * a new {@link Counter} using the provided MetricSupplier if none is registered.
+     *
+     * @param name the name of the metric
+     * @param supplier a MetricSupplier that can be used to manufacture a counter.
+     * @return a new or pre-existing {@link Counter}
+     */
+    public Counter counter(String name, final MetricSupplier<Counter> supplier) {
+        return counter(MetricName.build(name), supplier);
+    }
+
+    /**
+         * Return the {@link Counter} registered under this name; or create and register
+         * a new {@link Counter} using the provided MetricSupplier if none is registered.
+         *
+         * @param name the name of the metric
+         * @param supplier a MetricSupplier that can be used to manufacture a counter.
+         * @return a new or pre-existing {@link Counter}
+         */
+    public Counter counter(MetricName name, final MetricSupplier<Counter> supplier) {
+        return getOrAdd(name, new MetricBuilder<Counter>() {
+            @Override
+            public Counter newMetric() {
+                return supplier.newMetric();
+            }
+            @Override
+            public boolean isInstance(Metric metric) {
+                return Counter.class.isInstance(metric);
+            }
+        });
+    }
+
+    /**
      * @see #histogram(MetricName)
      */
     public Histogram histogram(String name) {
@@ -156,6 +189,40 @@ public class MetricRegistry implements MetricSet {
      */
     public Histogram histogram(MetricName name) {
         return getOrAdd(name, MetricBuilder.HISTOGRAMS);
+    }
+
+
+    /**
+     * Return the {@link Histogram} registered under this name; or create and register
+     * a new {@link Histogram} using the provided MetricSupplier if none is registered.
+     *
+     * @param name the name of the metric
+     * @param supplier a MetricSupplier that can be used to manufacture a histogram
+     * @return a new or pre-existing {@link Histogram}
+     */
+    public Histogram histogram(String name, final MetricSupplier<Histogram> supplier) {
+        return histogram(MetricName.build(name), supplier);
+    }
+
+    /**
+         * Return the {@link Histogram} registered under this name; or create and register
+         * a new {@link Histogram} using the provided MetricSupplier if none is registered.
+         *
+         * @param name the name of the metric
+         * @param supplier a MetricSupplier that can be used to manufacture a histogram
+         * @return a new or pre-existing {@link Histogram}
+         */
+    public Histogram histogram(MetricName name, final MetricSupplier<Histogram> supplier) {
+      return getOrAdd(name, new MetricBuilder<Histogram>() {
+        @Override
+        public Histogram newMetric() {
+          return supplier.newMetric();
+        }
+        @Override
+        public boolean isInstance(Metric metric) {
+          return Histogram.class.isInstance(metric);
+        }
+      });
     }
 
     /**
@@ -177,6 +244,39 @@ public class MetricRegistry implements MetricSet {
     }
 
     /**
+     * Return the {@link Meter} registered under this name; or create and register
+     * a new {@link Meter} using the provided MetricSupplier if none is registered.
+     *
+     * @param name the name of the metric
+     * @param supplier a MetricSupplier that can be used to manufacture a Meter
+     * @return a new or pre-existing {@link Meter}
+     */
+    public Meter meter(String name, final MetricSupplier<Meter> supplier) {
+        return meter(MetricName.build(name), supplier);
+    }
+
+    /**
+         * Return the {@link Meter} registered under this name; or create and register
+         * a new {@link Meter} using the provided MetricSupplier if none is registered.
+         *
+         * @param name the name of the metric
+         * @param supplier a MetricSupplier that can be used to manufacture a Meter
+         * @return a new or pre-existing {@link Meter}
+         */
+    public Meter meter(MetricName name, final MetricSupplier<Meter> supplier) {
+        return getOrAdd(name, new MetricBuilder<Meter>() {
+            @Override
+            public Meter newMetric() {
+                return supplier.newMetric();
+            }
+            @Override
+            public boolean isInstance(Metric metric) {
+                return Meter.class.isInstance(metric);
+            }
+        });
+    }
+
+    /**
      * @see #timer(MetricName)
      */
     public Timer timer(String name) {
@@ -195,11 +295,78 @@ public class MetricRegistry implements MetricSet {
     }
 
     /**
-     * Removes the metric with the given name.
+     * Return the {@link Timer} registered under this name; or create and register
+     * a new {@link Timer} using the provided MetricSupplier if none is registered.
      *
      * @param name the name of the metric
-     * @return whether or not the metric was removed
+     * @param supplier a MetricSupplier that can be used to manufacture a Timer
+     * @return a new or pre-existing {@link Timer}
      */
+    public Timer timer(String name, final MetricSupplier<Timer> supplier) {
+        return timer(MetricName.build(name), supplier);
+    }
+
+    /**
+     * Return the {@link Timer} registered under this name; or create and register
+     * a new {@link Timer} using the provided MetricSupplier if none is registered.
+     *
+     * @param name the name of the metric
+     * @param supplier a MetricSupplier that can be used to manufacture a Timer
+     * @return a new or pre-existing {@link Timer}
+     */
+    public Timer timer(MetricName name, final MetricSupplier<Timer> supplier) {
+        return getOrAdd(name, new MetricBuilder<Timer>() {
+            @Override
+            public Timer newMetric() {
+                return supplier.newMetric();
+            }
+            @Override
+            public boolean isInstance(Metric metric) {
+                return Timer.class.isInstance(metric);
+            }
+        });
+    }
+
+    /**
+     * Return the {@link Gauge} registered under this name; or create and register
+     * a new {@link Gauge} using the provided MetricSupplier if none is registered.
+     *
+     * @param name the name of the metric
+     * @param supplier a MetricSupplier that can be used to manufacture a Gauge
+     * @return a new or pre-existing {@link Gauge}
+     */
+    public Gauge gauge(String name, final MetricSupplier<Gauge> supplier) {
+        return gauge(MetricName.build(name), supplier);
+    }
+
+    /**
+         * Return the {@link Gauge} registered under this name; or create and register
+         * a new {@link Gauge} using the provided MetricSupplier if none is registered.
+         *
+         * @param name the name of the metric
+         * @param supplier a MetricSupplier that can be used to manufacture a Gauge
+         * @return a new or pre-existing {@link Gauge}
+         */
+    public Gauge gauge(MetricName name, final MetricSupplier<Gauge> supplier) {
+        return getOrAdd(name, new MetricBuilder<Gauge>() {
+            @Override
+            public Gauge newMetric() {
+                return supplier.newMetric();
+            }
+            @Override
+            public boolean isInstance(Metric metric) {
+                return Gauge.class.isInstance(metric);
+            }
+        });
+    }
+
+
+        /**
+         * Removes the metric with the given name.
+         *
+         * @param name the name of the metric
+         * @return whether or not the metric was removed
+         */
     public boolean remove(MetricName name) {
         final Metric metric = metrics.remove(name);
         if (metric != null) {
@@ -446,6 +613,10 @@ public class MetricRegistry implements MetricSet {
     @Override
     public Map<MetricName, Metric> getMetrics() {
         return Collections.unmodifiableMap(metrics);
+    }
+
+    public interface MetricSupplier<T extends Metric> {
+      T newMetric();
     }
 
     /**

--- a/metrics-core/src/test/java/io/dropwizard/metrics/MetricRegistryTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/MetricRegistryTest.java
@@ -5,18 +5,6 @@ import static io.dropwizard.metrics.MetricRegistry.name;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.dropwizard.metrics.Counter;
-import io.dropwizard.metrics.Gauge;
-import io.dropwizard.metrics.Histogram;
-import io.dropwizard.metrics.Meter;
-import io.dropwizard.metrics.Metric;
-import io.dropwizard.metrics.MetricFilter;
-import io.dropwizard.metrics.MetricName;
-import io.dropwizard.metrics.MetricRegistry;
-import io.dropwizard.metrics.MetricRegistryListener;
-import io.dropwizard.metrics.MetricSet;
-import io.dropwizard.metrics.Timer;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -85,6 +73,23 @@ public class MetricRegistryTest {
     }
 
     @Test
+    public void accessingACustomCounterRegistersAndReusesTheCounter() throws Exception {
+        final MetricRegistry.MetricSupplier<Counter> supplier = new MetricRegistry.MetricSupplier<Counter>() {
+            @Override
+            public Counter newMetric() {
+                return counter;
+            }
+        };
+        final Counter counter1 = registry.counter("thing", supplier);
+        final Counter counter2 = registry.counter("thing", supplier);
+
+        assertThat(counter1)
+                .isSameAs(counter2);
+
+        verify(listener).onCounterAdded(THING, counter1);
+    }
+
+    @Test
     public void removingACounterTriggersANotification() throws Exception {
         registry.register(THING, counter);
 
@@ -114,6 +119,23 @@ public class MetricRegistryTest {
     }
 
     @Test
+    public void accessingACustomHistogramRegistersAndReusesIt() throws Exception {
+        final MetricRegistry.MetricSupplier<Histogram> supplier = new MetricRegistry.MetricSupplier<Histogram>() {
+            @Override
+            public Histogram newMetric() {
+                return histogram;
+            }
+        };
+        final Histogram histogram1 = registry.histogram("thing", supplier);
+        final Histogram histogram2 = registry.histogram("thing", supplier);
+
+        assertThat(histogram1)
+            .isSameAs(histogram2);
+
+        verify(listener).onHistogramAdded(THING, histogram1);
+    }
+
+    @Test
     public void removingAHistogramTriggersANotification() throws Exception {
         registry.register(THING, histogram);
 
@@ -135,6 +157,23 @@ public class MetricRegistryTest {
     public void accessingAMeterRegistersAndReusesIt() throws Exception {
         final Meter meter1 = registry.meter(THING);
         final Meter meter2 = registry.meter(THING);
+
+        assertThat(meter1)
+                .isSameAs(meter2);
+
+        verify(listener).onMeterAdded(THING, meter1);
+    }
+
+    @Test
+    public void accessingACustomMeterRegistersAndReusesIt() throws Exception {
+        final MetricRegistry.MetricSupplier<Meter> supplier = new MetricRegistry.MetricSupplier<Meter>() {
+            @Override
+            public Meter newMetric() {
+                return meter;
+            }
+        };
+        final Meter meter1 = registry.meter("thing", supplier);
+        final Meter meter2 = registry.meter("thing", supplier);
 
         assertThat(meter1)
                 .isSameAs(meter2);
@@ -171,6 +210,23 @@ public class MetricRegistryTest {
         verify(listener).onTimerAdded(THING, timer1);
     }
 
+     @Test
+    public void accessingACustomTimerRegistersAndReusesIt() throws Exception {
+        final MetricRegistry.MetricSupplier<Timer> supplier = new MetricRegistry.MetricSupplier<Timer>() {
+            @Override
+            public Timer newMetric() {
+                return timer;
+            }
+        };
+        final Timer timer1 = registry.timer("thing", supplier);
+        final Timer timer2 = registry.timer("thing", supplier);
+
+        assertThat(timer1)
+                .isSameAs(timer2);
+
+        verify(listener).onTimerAdded(THING, timer1);
+    }
+
     @Test
     public void removingATimerTriggersANotification() throws Exception {
         registry.register(THING, timer);
@@ -179,6 +235,23 @@ public class MetricRegistryTest {
                 .isTrue();
 
         verify(listener).onTimerRemoved(THING);
+    }
+
+     @Test
+    public void accessingACustomGaugeRegistersAndReusesIt() throws Exception {
+        final MetricRegistry.MetricSupplier<Gauge> supplier = new MetricRegistry.MetricSupplier<Gauge>() {
+            @Override
+            public Gauge newMetric() {
+                return gauge;
+            }
+        };
+        final Gauge gauge1 = registry.gauge("thing", supplier);
+        final Gauge gauge2 = registry.gauge("thing", supplier);
+
+        assertThat(gauge1)
+                .isSameAs(gauge2);
+
+        verify(listener).onGaugeAdded(THING, gauge1);
     }
 
     @Test

--- a/metrics-jersey2/src/main/java/io/dropwizard/metrics/jersey2/MetricsFeature.java
+++ b/metrics-jersey2/src/main/java/io/dropwizard/metrics/jersey2/MetricsFeature.java
@@ -13,9 +13,15 @@ import javax.ws.rs.core.FeatureContext;
 public class MetricsFeature implements Feature {
 
     private final MetricRegistry registry;
+    private final InstrumentedResourceMethodApplicationListener.ClockProvider clockProvider;
 
     public MetricsFeature(MetricRegistry registry) {
+        this(registry, null);
+    }
+
+    public MetricsFeature(MetricRegistry registry, InstrumentedResourceMethodApplicationListener.ClockProvider clockProvider) {
         this.registry = registry;
+        this.clockProvider = clockProvider;
     }
 
     public MetricsFeature(String registryName) {
@@ -43,7 +49,7 @@ public class MetricsFeature implements Feature {
      */
     @Override
     public boolean configure(FeatureContext context) {
-        context.register(new InstrumentedResourceMethodApplicationListener(registry));
+        context.register(new InstrumentedResourceMethodApplicationListener(registry, clockProvider));
         return true;
     }
 }

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/TestClock.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/TestClock.java
@@ -1,0 +1,11 @@
+package io.dropwizard.metrics.jersey2;
+
+import io.dropwizard.metrics.Clock;
+
+public class TestClock extends Clock {
+    public long tick;
+    @Override
+    public long getTick() {
+        return tick;
+    }
+}

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedResource.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedResource.java
@@ -3,6 +3,7 @@ package io.dropwizard.metrics.jersey2.resources;
 import io.dropwizard.metrics.annotation.ExceptionMetered;
 import io.dropwizard.metrics.annotation.Metered;
 import io.dropwizard.metrics.annotation.Timed;
+import io.dropwizard.metrics.jersey2.TestClock;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -12,11 +13,34 @@ import java.io.IOException;
 @Path("/")
 @Produces(MediaType.TEXT_PLAIN)
 public class InstrumentedResource {
+    private final TestClock testClock;
+
+    public InstrumentedResource(TestClock testClock) {
+        this.testClock = testClock;
+    }
+
     @GET
     @Timed
     @Path("/timed")
     public String timed() {
+        testClock.tick++;
         return "yay";
+    }
+
+      @GET
+    @Timed(name="fancyName")
+    @Path("/named")
+    public String named() {
+        testClock.tick++;
+        return "fancy";
+    }
+
+    @GET
+    @Timed(name="absolutelyFancy", absolute = true)
+    @Path("/absolute")
+    public String absolute() {
+        testClock.tick++;
+        return "absolute";
     }
 
     @GET
@@ -38,6 +62,6 @@ public class InstrumentedResource {
 
     @Path("/subresource")
     public InstrumentedSubResource locateSubResource() {
-        return new InstrumentedSubResource();
+        return new InstrumentedSubResource(testClock);
     }
 }

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedSubResource.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedSubResource.java
@@ -4,13 +4,21 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 
 import io.dropwizard.metrics.annotation.Timed;
+import io.dropwizard.metrics.jersey2.TestClock;
 
 @Produces(MediaType.TEXT_PLAIN)
 public class InstrumentedSubResource {
+    private final TestClock testClock;
+
+    public InstrumentedSubResource(TestClock testClock) {
+        this.testClock = testClock;
+    }
+
     @GET
     @Timed
     @Path("/timed")
     public String timed() {
+        testClock.tick += 2;
         return "yay";
     }
 

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/TestRequestFilter.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/TestRequestFilter.java
@@ -1,0 +1,21 @@
+package io.dropwizard.metrics.jersey2.resources;
+
+import java.io.IOException;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+
+import io.dropwizard.metrics.jersey2.TestClock;
+
+public class TestRequestFilter implements ContainerRequestFilter{
+    private final TestClock testClock;
+
+    public TestRequestFilter(TestClock testClock) {
+        this.testClock = testClock;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+        testClock.tick += 4;
+    }
+}


### PR DESCRIPTION
This adds support for measuring time for the entire request processing, and the request and response filtering steps, in addition to the current measurement of the time used by the request method itself. In addition, support is added for letting users specify the clock to be used. This PR also includes a cherry-pick of randomstatic's thread-safe getters for metrics with custom instantiations from the 3.2 branch.

No extra metrics are added for methods with @Timed annotations that specify an explicit name, as it's not really clear what those extra metrics should be named, and it seems wrong to add attributes to the @Timed annotation for jersey-specific concepts. Ideas for how to add the extra metrics for explicitly named methods welcome!

Corresponding PR for 3.2: #1118 