### PR TITLE
Implement doOptions for CORS in MetricServlet

### DIFF
--- a/docs/source/about/release-notes.rst
+++ b/docs/source/about/release-notes.rst
@@ -4,12 +4,20 @@
 Release Notes
 #############
 
+.. _rel-3.2.2:
+
+v3.2.2: Mar 20 2017
+===================
+
+* Fix creating a uniform snapshot from a collection `#1111 <https://github.com/dropwizard/metrics/pull/1111>`_
+* Register metrics defined at Resource level `#1105 <https://github.com/dropwizard/metrics/pull/1105>`_
+
 .. _rel-3.2.1:
 
 v3.2.1: Mar 10 2017
 ===================
 
-* Suppot for shutting down the health check registry. `#1084 <https://github.com/dropwizard/metrics/pull/1084>`_
+* Support for shutting down the health check registry. `#1084 <https://github.com/dropwizard/metrics/pull/1084>`_
 * Added support for the default shared health check registry name #1095 `#1095 <https://github.com/dropwizard/metrics/pull/1095>`_
 * SharedMetricRegistries are now thread-safe. `#1094 <https://github.com/dropwizard/metrics/pull/1095>`_
 * The size of the snapshot of a histogram is reported via JMX. `#1102 <https://github.com/dropwizard/metrics/pull/1102>`_

--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/MetricsServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/MetricsServlet.java
@@ -179,7 +179,7 @@ public class MetricsServlet extends HttpServlet {
             output.close();
         }
     }
-    
+
     @Override
     protected void doOptions(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         // Send Response

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletTest.java
@@ -260,4 +260,19 @@ public class MetricsServletTest extends AbstractServletTest {
         final MetricsServlet metricsServlet = new MetricsServlet(null);
         metricsServlet.init(servletConfig);
     }
+    
+    @Test
+    public void optionsHasAccessControlAllowedOrigin() throws Exception{
+    	request.setMethod("OPTIONS");
+        request.setURI("/metrics");
+        request.setVersion("HTTP/1.0");
+        request.setHeader("Origin", "http://localhost");
+        
+        processRequest();
+
+        assertThat(response.getStatus())
+                .isEqualTo(200);
+        assertThat(response.get("Access-Control-Allow-Origin"))
+                .isEqualTo("*");
+    }
 }

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletTest.java
@@ -260,14 +260,14 @@ public class MetricsServletTest extends AbstractServletTest {
         final MetricsServlet metricsServlet = new MetricsServlet(null);
         metricsServlet.init(servletConfig);
     }
-    
+
     @Test
-    public void optionsHasAccessControlAllowedOrigin() throws Exception{
-    	request.setMethod("OPTIONS");
+    public void optionsHasAccessControlAllowedOrigin() throws Exception {
+        request.setMethod("OPTIONS");
         request.setURI("/metrics");
         request.setVersion("HTTP/1.0");
         request.setHeader("Origin", "http://localhost");
-        
+
         processRequest();
 
         assertThat(response.getStatus())


### PR DESCRIPTION
Set Access-Control-Allow-Origin on Options response headers if allowedOrigin is specified by a ContextListener.

Related to #1120