### PR TITLE
Check presence of JDK Class before instanciating JdkProvider

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ThreadLocalRandomProxy.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ThreadLocalRandomProxy.java
@@ -35,8 +35,9 @@ class ThreadLocalRandomProxy {
     private static final Provider INSTANCE = getThreadLocalProvider();
     private static Provider getThreadLocalProvider() {
         try {
+            Class.forName("java.util.concurrent.ThreadLocalRandom");
             return new JdkProvider();
-        } catch (NoClassDefFoundError e) {
+        } catch (ClassNotFoundException e) {
             return new InternalProvider();
         }
     }

--- a/metrics-core/src/main/java/com/codahale/metrics/ThreadLocalRandomProxy.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ThreadLocalRandomProxy.java
@@ -35,7 +35,7 @@ class ThreadLocalRandomProxy {
     private static final Provider INSTANCE = getThreadLocalProvider();
     private static Provider getThreadLocalProvider() {
         try {
-            Class.forName("java.util.concurrent.ThreadLocalRandom");
+            Class.forName("java.util.concurrent.ThreadLocalRandom");
             return new JdkProvider();
         } catch (ClassNotFoundException e) {
             return new InternalProvider();


### PR DESCRIPTION
Security needed, as Under Weblogic 10.3 Oracle Jdk 6, ClassNotFoundException is thrown only when current() is called, not at instanciation.