### PR TITLE
Exponentially decaying reservoir update

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
@@ -166,12 +166,15 @@ public class ExponentiallyDecayingReservoir implements Reservoir {
                 final long oldStartTime = startTime;
                 this.startTime = currentTimeInSeconds();
                 final double scalingFactor = exp(-alpha * (startTime - oldStartTime));
-
-                final ArrayList<Double> keys = new ArrayList<Double>(values.keySet());
-                for (Double key : keys) {
-                    final WeightedSample sample = values.remove(key);
-                    final WeightedSample newSample = new WeightedSample(sample.value, sample.weight * scalingFactor);
-                    values.put(key * scalingFactor, newSample);
+                if (Double.compare(scalingFactor, 0) == 0) {
+                    values.clear();
+                } else {
+                    final ArrayList<Double> keys = new ArrayList<Double>(values.keySet());
+                    for (Double key : keys) {
+                        final WeightedSample sample = values.remove(key);
+                        final WeightedSample newSample = new WeightedSample(sample.value, sample.weight * scalingFactor);
+                        values.put(key * scalingFactor, newSample);
+                    }
                 }
 
                 // make sure the counter is in sync with the number of stored samples.

--- a/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
@@ -96,7 +96,7 @@ public class ExponentiallyDecayingReservoir implements Reservoir {
             final double itemWeight = weight(timestamp - startTime);
             final WeightedSample sample = new WeightedSample(value, itemWeight);
             final double priority = itemWeight / ThreadLocalRandomProxy.current().nextDouble();
-
+            
             final long newCount = count.incrementAndGet();
             if (newCount <= size) {
                 values.put(priority, sample);

--- a/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
@@ -96,7 +96,7 @@ public class ExponentiallyDecayingReservoir implements Reservoir {
             final double itemWeight = weight(timestamp - startTime);
             final WeightedSample sample = new WeightedSample(value, itemWeight);
             final double priority = itemWeight / ThreadLocalRandomProxy.current().nextDouble();
-            
+
             final long newCount = count.incrementAndGet();
             if (newCount <= size) {
                 values.put(priority, sample);
@@ -124,6 +124,7 @@ public class ExponentiallyDecayingReservoir implements Reservoir {
 
     @Override
     public Snapshot getSnapshot() {
+        rescaleIfNeeded();
         lockForRegularUsage();
         try {
             return new WeightedSnapshot(values.values());

--- a/metrics-core/src/main/java/com/codahale/metrics/WeightedSnapshot.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/WeightedSnapshot.java
@@ -38,14 +38,13 @@ public class WeightedSnapshot extends Snapshot {
      * @param values    an unordered set of values in the reservoir
      */
     public WeightedSnapshot(Collection<WeightedSample> values) {
-        final WeightedSample[] copy = values.toArray( new WeightedSample[]{} );
-
         if (values.size()==1 && Double.compare(values.iterator().next().weight,0D)==0) {
             this.values = new long[0];
             this.normWeights = new double[0];
             this.quantiles = new double[0];
             return;
         }
+        final WeightedSample[] copy = values.toArray( new WeightedSample[]{} );
 
         Arrays.sort(copy, new Comparator<WeightedSample>() {
             @Override

--- a/metrics-core/src/main/java/com/codahale/metrics/WeightedSnapshot.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/WeightedSnapshot.java
@@ -45,7 +45,7 @@ public class WeightedSnapshot extends Snapshot {
             return;
         }
         final WeightedSample[] copy = values.toArray( new WeightedSample[]{} );
-        
+    
         Arrays.sort(copy, new Comparator<WeightedSample>() {
             @Override
             public int compare(WeightedSample o1, WeightedSample o2) {

--- a/metrics-core/src/main/java/com/codahale/metrics/WeightedSnapshot.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/WeightedSnapshot.java
@@ -12,7 +12,7 @@ import java.util.Comparator;
  * A statistical snapshot of a {@link WeightedSnapshot}.
  */
 public class WeightedSnapshot extends Snapshot {
-
+    
     /**
      * A single sample item with value and its weights for {@link WeightedSnapshot}.
      */
@@ -25,7 +25,7 @@ public class WeightedSnapshot extends Snapshot {
             this.weight = weight;
         }
     }
-
+    
     private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     private final long[] values;
@@ -45,7 +45,7 @@ public class WeightedSnapshot extends Snapshot {
             return;
         }
         final WeightedSample[] copy = values.toArray( new WeightedSample[]{} );
-
+        
         Arrays.sort(copy, new Comparator<WeightedSample>() {
             @Override
             public int compare(WeightedSample o1, WeightedSample o2) {
@@ -61,7 +61,7 @@ public class WeightedSnapshot extends Snapshot {
         this.values = new long[copy.length];
         this.normWeights = new double[copy.length];
         this.quantiles = new double[copy.length];
-
+        
         double sumWeight = 0;
         for (WeightedSample sample : copy) {
             sumWeight += sample.weight;

--- a/metrics-core/src/main/java/com/codahale/metrics/WeightedSnapshot.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/WeightedSnapshot.java
@@ -12,7 +12,7 @@ import java.util.Comparator;
  * A statistical snapshot of a {@link WeightedSnapshot}.
  */
 public class WeightedSnapshot extends Snapshot {
-    
+
     /**
      * A single sample item with value and its weights for {@link WeightedSnapshot}.
      */
@@ -25,7 +25,7 @@ public class WeightedSnapshot extends Snapshot {
             this.weight = weight;
         }
     }
-    
+
     private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     private final long[] values;
@@ -39,7 +39,14 @@ public class WeightedSnapshot extends Snapshot {
      */
     public WeightedSnapshot(Collection<WeightedSample> values) {
         final WeightedSample[] copy = values.toArray( new WeightedSample[]{} );
-    
+
+        if (values.size()==1 && Double.compare(values.iterator().next().weight,0D)==0) {
+            this.values = new long[0];
+            this.normWeights = new double[0];
+            this.quantiles = new double[0];
+            return;
+        }
+
         Arrays.sort(copy, new Comparator<WeightedSample>() {
             @Override
             public int compare(WeightedSample o1, WeightedSample o2) {
@@ -55,7 +62,7 @@ public class WeightedSnapshot extends Snapshot {
         this.values = new long[copy.length];
         this.normWeights = new double[copy.length];
         this.quantiles = new double[copy.length];
-        
+
         double sumWeight = 0;
         for (WeightedSample sample : copy) {
             sumWeight += sample.weight;

--- a/metrics-core/src/main/java/com/codahale/metrics/WeightedSnapshot.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/WeightedSnapshot.java
@@ -38,12 +38,6 @@ public class WeightedSnapshot extends Snapshot {
      * @param values    an unordered set of values in the reservoir
      */
     public WeightedSnapshot(Collection<WeightedSample> values) {
-        if (values.size()==1 && Double.compare(values.iterator().next().weight,0D)==0) {
-            this.values = new long[0];
-            this.normWeights = new double[0];
-            this.quantiles = new double[0];
-            return;
-        }
         final WeightedSample[] copy = values.toArray( new WeightedSample[]{} );
     
         Arrays.sort(copy, new Comparator<WeightedSample>() {

--- a/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
@@ -87,7 +87,7 @@ public class ExponentiallyDecayingReservoirTest {
         clock.addHours(15);
         reservoir.update(2000);
         assertThat(reservoir.getSnapshot().size())
-                .isEqualTo(2);
+                .isEqualTo(1);
         assertAllValuesBetween(reservoir, 1000, 3000);
 
 

--- a/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
@@ -127,7 +127,19 @@ public class ExponentiallyDecayingReservoirTest {
         assertThat(snapshot.getMax()).isEqualTo(0);
         assertThat(snapshot.getMean()).isEqualTo(0);
         assertThat(snapshot.getMedian()).isEqualTo(0);
-        assertThat(snapshot.size()).isEqualTo(1);
+        assertThat(snapshot.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void emptyReservoirSnapshot_shouldReturnZeroForAllValues() {
+        final ExponentiallyDecayingReservoir reservoir = new ExponentiallyDecayingReservoir(100, 0.015,
+                new ManualClock());
+
+        Snapshot snapshot = reservoir.getSnapshot();
+        assertThat(snapshot.getMax()).isEqualTo(0);
+        assertThat(snapshot.getMean()).isEqualTo(0);
+        assertThat(snapshot.getMedian()).isEqualTo(0);
+        assertThat(snapshot.size()).isEqualTo(0);
     }
 
     @Test

--- a/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
@@ -251,13 +251,13 @@ public class ExponentiallyDecayingReservoirTest {
             reservoir.update(177);
             clock.addMillis(valuesIntervalMillis);
         }
-
+        
         // switching to mode 2: 10 minutes more with the same rate, but larger value
         for (int i = 0; i < 10*valuesRatePerMinute; i++) {
             reservoir.update(9999);
             clock.addMillis(valuesIntervalMillis);
         }
-
+        
         // expect that quantiles should be more about mode 2 after 10 minutes
         assertThat(reservoir.getSnapshot().getMedian())
                 .isEqualTo(9999);
@@ -269,7 +269,7 @@ public class ExponentiallyDecayingReservoirTest {
         final ExponentiallyDecayingReservoir reservoir = new ExponentiallyDecayingReservoir(1000,
                                                                                             0.015,
                                                                                             clock);
-
+        
         final int valuesRatePerMinute = 10;
         final int valuesIntervalMillis = (int) (TimeUnit.MINUTES.toMillis(1) / valuesRatePerMinute);
         // mode 1: steady regime for 120 minutes
@@ -277,18 +277,18 @@ public class ExponentiallyDecayingReservoirTest {
             reservoir.update(9998);
             clock.addMillis(valuesIntervalMillis);
         }
-
+        
         // switching to mode 2: 10 minutes more with the same rate, but smaller value
         for (int i = 0; i < 10*valuesRatePerMinute; i++) {
             reservoir.update(178);
             clock.addMillis(valuesIntervalMillis);
         }
-
+        
         // expect that quantiles should be more about mode 2 after 10 minutes
         assertThat(reservoir.getSnapshot().get95thPercentile())
                 .isEqualTo(178);
     }
-
+    
     @Test
     public void quantiliesShouldBeBasedOnWeights() {
         final ManualClock clock = new ManualClock();
@@ -300,7 +300,7 @@ public class ExponentiallyDecayingReservoirTest {
         }
 
         clock.addSeconds(120);
-
+        
         for (int i = 0; i < 10; i++) {
             reservoir.update(9999);
         }
@@ -316,7 +316,7 @@ public class ExponentiallyDecayingReservoirTest {
         assertThat(reservoir.getSnapshot().get75thPercentile())
                 .isEqualTo(9999);
     }
-
+    
     private static void assertAllValuesBetween(ExponentiallyDecayingReservoir reservoir,
                                                double min,
                                                double max) {


### PR DESCRIPTION
Exponentially Decaying Reservoir was giving incorrect values in the snapshot if the inactive period was too long. This could result in wrong metrics aggregation.