### PR TITLE
Make checks for existence of ThreadLocal more robust

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/LongAdderProxy.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/LongAdderProxy.java
@@ -97,7 +97,7 @@ class LongAdderProxy {
             final JdkProvider jdkProvider = new JdkProvider();
             jdkProvider.get(); // To trigger a possible `NoClassDefFoundError` exception
             return jdkProvider;
-        } catch (NoClassDefFoundError e) {
+        } catch (Throwable e) {
             return new InternalLongAdderProvider();
         }
     }

--- a/metrics-core/src/main/java/com/codahale/metrics/ThreadLocalRandomProxy.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ThreadLocalRandomProxy.java
@@ -35,8 +35,10 @@ class ThreadLocalRandomProxy {
     private static final Provider INSTANCE = getThreadLocalProvider();
     private static Provider getThreadLocalProvider() {
         try {
-            return new JdkProvider();
-        } catch (NoClassDefFoundError e) {
+            final JdkProvider jdkProvider = new JdkProvider();
+            jdkProvider.current(); //  To make sure that ThreadLocalRandom actually exists in the JDK
+            return jdkProvider;
+        } catch (Throwable e) {
             return new InternalProvider();
         }
     }


### PR DESCRIPTION
We should try to load an actual value of a `ThreadLocal`, because in some environments (like WebLogic) a `NoClassDefException` won't be thrown during loading of `JdkProvider`.

We should also catch all possible errors, not only `NoClassDefException` to avoid a situation when the provider becomes a null reference.

Originally reported in #1129 