### PR TITLE
Avoid npe in toString of HealthCheck.Result

### DIFF
--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
@@ -197,10 +197,11 @@ public abstract class HealthCheck {
             if (details != null) {
                 Iterator<Map.Entry<String, Object>> it = details.entrySet().iterator();
                 while (it.hasNext()) {
+                    builder.append(", ");
                     Map.Entry<String, Object> e = it.next();
                     builder.append(e.getKey())
                             .append("=")
-                            .append(e.getValue().toString());
+                            .append(String.valueOf(e.getValue()));
                 }
             }
             builder.append('}');

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
@@ -200,4 +200,16 @@ public class HealthCheckTest {
         assertThat(actual.getDetails())
                 .isNull();
     }
+
+    @Test
+    public void toStringWorksEvenForNullAttributes() throws Exception {
+        final HealthCheck.Result resultWithNullDetailValue = HealthCheck.Result.builder()
+           .unhealthy()
+           .withDetail("aNullDetail", null)
+           .build();
+        assertThat(resultWithNullDetailValue.toString())
+           .contains(
+              "Result{isHealthy=false, timestamp=", // Skip the timestamp part of the String.
+              ", aNullDetail=null}");
+    }
 }


### PR DESCRIPTION
Use String.valueOf in toString of HealthCheck.Result to avoid NullPointerException when it has a detail with null value.
Prepend ", " to any details, to make the resulting String more readable.