### PR TITLE
ChunkedAssociativeLongArray re-use expired nodes

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ChunkedAssociativeLongArray.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ChunkedAssociativeLongArray.java
@@ -3,6 +3,8 @@ package com.codahale.metrics;
 import static java.lang.System.arraycopy;
 import static java.util.Arrays.binarySearch;
 
+import java.lang.ref.SoftReference;
+import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.ListIterator;
@@ -10,8 +12,27 @@ import java.util.ListIterator;
 class ChunkedAssociativeLongArray {
     private static final long[] EMPTY = new long[0];
     private static final int DEFAULT_CHUNK_SIZE = 512;
+    private static final int MAX_CACHE_SIZE = 128;
 
     private final int defaultChunkSize;
+    /*
+    We use this ArrayDeque as cache to store chunks that are expired and removed from main data structure.
+    Then instead of allocating new Chunk immediately we are trying to poll one from this deque.
+    So if you have constant or slowly changing load ChunkedAssociativeLongArray will never
+    throw away old chunks or allocate new ones which makes this data structure almost garbage free.
+     */
+    private final ArrayDeque<SoftReference<Chunk>> chunksCache = new ArrayDeque<SoftReference<Chunk>>();
+
+    /*
+    Why LinkedList if we are creating fast data structure with low GC overhead?
+
+    First of all LinkedList here has relatively small size countOfStoredMeasurements / DEFAULT_CHUNK_SIZE.
+    And we are heavily rely on LinkedList implementation because:
+    1. Now we deleting chunks from both sides of the list  in trim(long startKey, long endKey)
+    2. Deleting from and inserting chunks into the middle in clear(long startKey, long endKey)
+
+    LinkedList gives us O(1) complexity for all this operations and that is not the case with ArrayList.
+     */
     private final LinkedList<Chunk> chunks = new LinkedList<Chunk>();
 
     ChunkedAssociativeLongArray() {
@@ -22,11 +43,34 @@ class ChunkedAssociativeLongArray {
         this.defaultChunkSize = chunkSize;
     }
 
+    private Chunk allocateChunk() {
+        SoftReference<Chunk> chunkRef = chunksCache.pollLast();
+        while (chunkRef != null && chunkRef.get() == null) {
+            chunkRef = chunksCache.pollLast();
+        }
+
+        Chunk chunk = chunkRef == null ? null : chunkRef.get();
+        if (chunk == null) {
+            chunk = new Chunk(this.defaultChunkSize);
+        } else {
+            chunk.cursor = 0;
+            chunk.startIndex = 0;
+            chunk.chunkSize = chunk.keys.length;
+        }
+        return chunk;
+    }
+
+    private void freeChunk(Chunk chunk) {
+        if (chunksCache.size() < MAX_CACHE_SIZE) {
+            chunksCache.add(new SoftReference<Chunk>(chunk));
+        }
+    }
+
     synchronized boolean put(long key, long value) {
         Chunk activeChunk = chunks.peekLast();
 
         if (activeChunk == null) { // lazy chunk creation
-            activeChunk = new Chunk(this.defaultChunkSize);
+            activeChunk = allocateChunk();
             chunks.add(activeChunk);
 
         } else {
@@ -35,7 +79,7 @@ class ChunkedAssociativeLongArray {
             }
             boolean isFull = activeChunk.cursor - activeChunk.startIndex == activeChunk.chunkSize;
             if (isFull) {
-                activeChunk = new Chunk(this.defaultChunkSize);
+                activeChunk = allocateChunk();
                 chunks.add(activeChunk);
             }
         }
@@ -105,6 +149,7 @@ class ChunkedAssociativeLongArray {
         while (fromHeadIterator.hasPrevious()) {
             Chunk currentHead = fromHeadIterator.previous();
             if (isFirstElementIsEmptyOrGreaterEqualThanKey(currentHead, endKey)) {
+                freeChunk(currentHead);
                 fromHeadIterator.remove();
             } else {
                 int newEndIndex = findFirstIndexOfGreaterEqualElements(
@@ -119,6 +164,7 @@ class ChunkedAssociativeLongArray {
         while (fromTailIterator.hasNext()) {
             Chunk currentTail = fromTailIterator.next();
             if (isLastElementIsLessThanKey(currentTail, startKey)) {
+                freeChunk(currentTail);
                 fromTailIterator.remove();
             } else {
                 int newStartIndex = findFirstIndexOfGreaterEqualElements(
@@ -162,6 +208,7 @@ class ChunkedAssociativeLongArray {
         while (fromHeadIterator.hasPrevious()) {
             Chunk afterGapHead = fromHeadIterator.previous();
             if (isFirstElementIsEmptyOrGreaterEqualThanKey(afterGapHead, startKey)) {
+                freeChunk(afterGapHead);
                 fromHeadIterator.remove();
             } else {
                 int newEndIndex = findFirstIndexOfGreaterEqualElements(


### PR DESCRIPTION
This change gives `ChunkedAssociativeLongArray` ability to store chunks that are expired and removed from main data structure.
Then instead of allocating new Chunk immediately we are trying to poll one from this cache.
So if you have constant or slowly changing load ChunkedAssociativeLongArray will never throw away old chunks or allocate new ones which makes this data structure almost garbage free. Also chunks stored in cache as `SoftReference`s so this memory can actually be freed if nesesary.

---
Numbers:
In `ReservoirBenchmark`: updates are **5.9x** faster and **~370x** less time spent in GC than `SlidingTimeWindowReservoir`.
In `SlidingTimeWindowReservoirsBenchmark`: updates are **3.2x** faster, reads - **2.7x** faster, **37x** less time spent in GC. (here we see small difference because most time we spent in cleaning snapshots)

---
Graphs:

_Comparison of implementations under constant load [duration 1h]_
![constant load comparison](https://docs.google.com/drawings/d/1z029VoRm8jnMm8HDJx96EdgCYGn7U8AD2FZ39BbprFw/pub?w=1392&amp;h=891)

---
_Comparison of implementations under changing load [duration 1h]_
![changing load comparison](https://docs.google.com/drawings/d/1WaEPmKXScr-6qj-SdUhxBxuT1ghB2qSVGID88fZXtkQ/pub?w=1370&h=881)