### PR TITLE
Update findbugs plugin to latest version

### DIFF
--- a/metrics-adapter/pom.xml
+++ b/metrics-adapter/pom.xml
@@ -28,7 +28,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>findbugs-maven-plugin</artifactId>
-				<version>3.0.0</version>
+				<version>3.0.4</version>
 				<configuration>
 					<excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>
 				</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -349,7 +349,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.0.4</version>
                 <configuration>
                     <effort>Max</effort>
                     <threshold>Default</threshold>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <prerequisites>
-        <maven>3.0.1</maven>
+        <maven>3.0.5</maven>
     </prerequisites>
 
     <groupId>io.dropwizard.metrics4</groupId>


### PR DESCRIPTION
Updates the findbugs plugin to the latest version and fixes the minimum maven version to prevent an error reported by the versions checker.
