### PR TITLE
Add ability to get default health check registry without an exception

### DIFF
--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/SharedHealthCheckRegistries.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/SharedHealthCheckRegistries.java
@@ -84,10 +84,23 @@ public class SharedHealthCheckRegistries {
      * @throws IllegalStateException if the default has not been set
      */
     public static HealthCheckRegistry getDefault() {
+        final HealthCheckRegistry healthCheckRegistry = tryGetDefault();
+        if (healthCheckRegistry != null) {
+            return healthCheckRegistry;
+        }
+        throw new IllegalStateException("Default registry name has not been set.");
+    }
+
+    /**
+     * Same as {@link #getDefault()} except returns null when the default registry has not been set.
+     *
+     * @return the default registry or null
+     */
+    public static HealthCheckRegistry tryGetDefault() {
         final String name = defaultRegistryName.get();
         if (name != null) {
             return getOrCreate(name);
         }
-        throw new IllegalStateException("Default registry name has not been set.");
+        return null;
     }
 }


### PR DESCRIPTION
Currently, there exists only one method for getting the default health
check registry - `getDefault`. Unfortunately, it throws an
`IllegalStateException` if the registry is not set. End users need to
check for this condition. Some users would like avoid using
exceptions for the control flow and would prefer to make a null check
instead catching an exception. For them we provide the `tryGetDefault`
method which does exactly that.