### PR TITLE
Introducing a health check filter

### DIFF
--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckFilter.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckFilter.java
@@ -1,0 +1,25 @@
+package com.codahale.metrics.health;
+
+/**
+ * A filter used to determine whether or not a health check should be reported.
+ */
+public interface HealthCheckFilter {
+    /**
+     * Matches all health checks, regardless of type or name.
+     */
+    HealthCheckFilter ALL = new HealthCheckFilter() {
+        @Override
+        public boolean matches(String name, HealthCheck healthCheck) {
+            return true;
+        }
+    };
+
+    /**
+     * Returns {@code true} if the health check matches the filter; {@code false} otherwise.
+     *
+     * @param name        the health check's name
+     * @param healthCheck the health check
+     * @return {@code true} if the health check matches the filter
+     */
+    boolean matches(String name, HealthCheck healthCheck);
+}

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckFilterTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckFilterTest.java
@@ -1,0 +1,14 @@
+package com.codahale.metrics.health;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+public class HealthCheckFilterTest {
+
+    @Test
+    public void theAllFilterMatchesAllHealthChecks() throws Exception {
+        assertThat(HealthCheckFilter.ALL.matches("", mock(HealthCheck.class))).isTrue();
+    }
+}

--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
@@ -1,20 +1,26 @@
 package com.codahale.metrics.servlets;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import com.codahale.metrics.health.HealthCheck;
-import com.codahale.metrics.health.HealthCheckRegistry;
-import com.codahale.metrics.json.HealthCheckModule;
-
-import javax.servlet.*;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.concurrent.ExecutorService;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckFilter;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.codahale.metrics.json.HealthCheckModule;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 
 public class HealthCheckServlet extends HttpServlet {
     public static abstract class ContextListener implements ServletContextListener {
@@ -32,6 +38,14 @@ public class HealthCheckServlet extends HttpServlet {
             return null;
         }
 
+        /**
+         * @return the {@link HealthCheckFilter} that shall be used to filter health checks,
+         * or {@link HealthCheckFilter#ALL} if the default should be used.
+         */
+        protected HealthCheckFilter getHealthCheckFilter() {
+            return HealthCheckFilter.ALL;
+        }
+
         @Override
         public void contextInitialized(ServletContextEvent event) {
             final ServletContext context = event.getServletContext();
@@ -47,12 +61,14 @@ public class HealthCheckServlet extends HttpServlet {
 
     public static final String HEALTH_CHECK_REGISTRY = HealthCheckServlet.class.getCanonicalName() + ".registry";
     public static final String HEALTH_CHECK_EXECUTOR = HealthCheckServlet.class.getCanonicalName() + ".executor";
+    public static final String HEALTH_CHECK_FILTER = HealthCheckServlet.class.getCanonicalName() + ".healthCheckFilter";
 
     private static final long serialVersionUID = -8432996484889177321L;
     private static final String CONTENT_TYPE = "application/json";
 
     private transient HealthCheckRegistry registry;
     private transient ExecutorService executorService;
+    private transient HealthCheckFilter filter;
     private transient ObjectMapper mapper;
 
     public HealthCheckServlet() {
@@ -61,13 +77,14 @@ public class HealthCheckServlet extends HttpServlet {
     public HealthCheckServlet(HealthCheckRegistry registry) {
         this.registry = registry;
     }
-    
+
     @Override
     public void init(ServletConfig config) throws ServletException {
         super.init(config);
 
+        final ServletContext context = config.getServletContext();
         if (null == registry) {
-            final Object registryAttr = config.getServletContext().getAttribute(HEALTH_CHECK_REGISTRY);
+            final Object registryAttr = context.getAttribute(HEALTH_CHECK_REGISTRY);
             if (registryAttr instanceof HealthCheckRegistry) {
                 this.registry = (HealthCheckRegistry) registryAttr;
             } else {
@@ -75,9 +92,18 @@ public class HealthCheckServlet extends HttpServlet {
             }
         }
 
-        final Object executorAttr = config.getServletContext().getAttribute(HEALTH_CHECK_EXECUTOR);
+        final Object executorAttr = context.getAttribute(HEALTH_CHECK_EXECUTOR);
         if (executorAttr instanceof ExecutorService) {
             this.executorService = (ExecutorService) executorAttr;
+        }
+
+
+        final Object filterAttr = context.getAttribute(HEALTH_CHECK_FILTER);
+        if (filterAttr instanceof HealthCheckFilter) {
+            filter = (HealthCheckFilter) filterAttr;
+        }
+        if (filter == null) {
+            filter = HealthCheckFilter.ALL;
         }
 
         this.mapper = new ObjectMapper().registerModule(new HealthCheckModule());
@@ -123,9 +149,9 @@ public class HealthCheckServlet extends HttpServlet {
 
     private SortedMap<String, HealthCheck.Result> runHealthChecks() {
         if (executorService == null) {
-            return registry.runHealthChecks();
+            return registry.runHealthChecks(filter);
         }
-        return registry.runHealthChecks(executorService);
+        return registry.runHealthChecks(executorService, filter);
     }
 
     private static boolean isAllHealthy(Map<String, HealthCheck.Result> results) {

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
@@ -1,14 +1,12 @@
 package com.codahale.metrics.servlets;
 
-import com.codahale.metrics.health.HealthCheck;
-import com.codahale.metrics.health.HealthCheckRegistry;
-import org.eclipse.jetty.http.HttpHeader;
-import org.eclipse.jetty.servlet.ServletTester;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -17,7 +15,15 @@ import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.servlet.ServletTester;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckFilter;
+import com.codahale.metrics.health.HealthCheckRegistry;
 
 public class HealthCheckServletTest extends AbstractServletTest {
     private final HealthCheckRegistry registry = new HealthCheckRegistry();
@@ -28,6 +34,12 @@ public class HealthCheckServletTest extends AbstractServletTest {
         tester.addServlet(HealthCheckServlet.class, "/healthchecks");
         tester.setAttribute("com.codahale.metrics.servlets.HealthCheckServlet.registry", registry);
         tester.setAttribute("com.codahale.metrics.servlets.HealthCheckServlet.executor", threadPool);
+        tester.setAttribute("com.codahale.metrics.servlets.HealthCheckServlet.healthCheckFilter", new HealthCheckFilter() {
+            @Override
+            public boolean matches(String name, HealthCheck healthCheck) {
+                return !"filtered".equals(name);
+            }
+        });
     }
 
     @Before
@@ -60,6 +72,32 @@ public class HealthCheckServletTest extends AbstractServletTest {
             @Override
             protected Result check() throws Exception {
                 return Result.healthy("whee");
+            }
+        });
+
+        processRequest();
+
+        assertThat(response.getStatus())
+                .isEqualTo(200);
+        assertThat(response.getContent())
+                .isEqualTo("{\"fun\":{\"healthy\":true,\"message\":\"whee\"}}");
+        assertThat(response.get(HttpHeader.CONTENT_TYPE))
+                .isEqualTo("application/json");
+    }
+
+    @Test
+    public void returnsASubsetOfHealthChecksIfFiltered() throws Exception {
+        registry.register("fun", new HealthCheck() {
+            @Override
+            protected Result check() throws Exception {
+                return Result.healthy("whee");
+            }
+        });
+
+        registry.register("filtered", new HealthCheck() {
+            @Override
+            protected Result check() throws Exception {
+                return Result.unhealthy("whee");
             }
         });
 
@@ -151,7 +189,7 @@ public class HealthCheckServletTest extends AbstractServletTest {
         final HealthCheckServlet healthCheckServlet = new HealthCheckServlet(null);
         healthCheckServlet.init(servletConfig);
  
-        verify(servletConfig, times(2)).getServletContext();
+        verify(servletConfig, times(1)).getServletContext();
         verify(servletContext, times(1)).getAttribute(eq(HealthCheckServlet.HEALTH_CHECK_REGISTRY));
     }
 


### PR DESCRIPTION
Adding a health check filter similar to metric filter. This will allow registering multiple health check servlets on different endpoints exposing different checks from a single registry. It could be useful when someone wants to distinguish critical checks  - that would signal the application is non-functional - from the less important ones.