### PR TITLE
Fixing GraphiteReporter rate reporting

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -300,10 +300,10 @@ public class GraphiteReporter extends ScheduledReporter {
 
     private void reportMetered(String name, Metered meter, long timestamp) throws IOException {
         sendIfEnabled(COUNT, name, meter.getCount(), timestamp);
-        sendIfEnabled(M1_RATE, name, meter.getOneMinuteRate(), timestamp);
-        sendIfEnabled(M5_RATE, name, meter.getFiveMinuteRate(), timestamp);
-        sendIfEnabled(M15_RATE, name, meter.getFifteenMinuteRate(), timestamp);
-        sendIfEnabled(MEAN_RATE, name, meter.getMeanRate(), timestamp);
+        sendIfEnabled(M1_RATE, name, convertRate(meter.getOneMinuteRate()), timestamp);
+        sendIfEnabled(M5_RATE, name, convertRate(meter.getFiveMinuteRate()), timestamp);
+        sendIfEnabled(M15_RATE, name, convertRate(meter.getFifteenMinuteRate()), timestamp);
+        sendIfEnabled(MEAN_RATE, name, convertRate(meter.getMeanRate()), timestamp);
     }
 
     private void reportHistogram(String name, Histogram histogram, long timestamp) throws IOException {

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -31,6 +31,16 @@ public class GraphiteReporterTest {
                                                               .disabledMetricAttributes(Collections.<MetricAttribute>emptySet())
                                                               .build(graphite);
 
+    private final GraphiteReporter minuteRateReporter = GraphiteReporter
+            .forRegistry(registry)
+            .withClock(clock)
+            .prefixedWith("prefix")
+            .convertRatesTo(TimeUnit.MINUTES)
+            .convertDurationsTo(TimeUnit.MILLISECONDS)
+            .filter(MetricFilter.ALL)
+            .disabledMetricAttributes(Collections.<MetricAttribute>emptySet())
+            .build(graphite);
+
     @Before
     public void setUp() throws Exception {
         when(clock.getTime()).thenReturn(timestamp * 1000);
@@ -292,6 +302,34 @@ public class GraphiteReporterTest {
         inOrder.verify(graphite).send("prefix.meter.m5_rate", "3.00", timestamp);
         inOrder.verify(graphite).send("prefix.meter.m15_rate", "4.00", timestamp);
         inOrder.verify(graphite).send("prefix.meter.mean_rate", "5.00", timestamp);
+        inOrder.verify(graphite).flush();
+        inOrder.verify(graphite).close();
+
+        verifyNoMoreInteractions(graphite);
+    }
+
+    @Test
+    public void reportsMetersInMinutes() throws Exception {
+        final Meter meter = mock(Meter.class);
+        when(meter.getCount()).thenReturn(1L);
+        when(meter.getOneMinuteRate()).thenReturn(2.0);
+        when(meter.getFiveMinuteRate()).thenReturn(3.0);
+        when(meter.getFifteenMinuteRate()).thenReturn(4.0);
+        when(meter.getMeanRate()).thenReturn(5.0);
+
+        minuteRateReporter.report(this.<Gauge>map(),
+                this.<Counter>map(),
+                this.<Histogram>map(),
+                this.<Meter>map("meter", meter),
+                this.<Timer>map());
+
+        final InOrder inOrder = inOrder(graphite);
+        inOrder.verify(graphite).connect();
+        inOrder.verify(graphite).send("prefix.meter.count", "1", timestamp);
+        inOrder.verify(graphite).send("prefix.meter.m1_rate", "120.00", timestamp);
+        inOrder.verify(graphite).send("prefix.meter.m5_rate", "180.00", timestamp);
+        inOrder.verify(graphite).send("prefix.meter.m15_rate", "240.00", timestamp);
+        inOrder.verify(graphite).send("prefix.meter.mean_rate", "300.00", timestamp);
         inOrder.verify(graphite).flush();
         inOrder.verify(graphite).close();
 


### PR DESCRIPTION
Fixing rate reporting when rates are converted to a different TimeUnit. Proper integration can be seen here: https://github.com/dropwizard/metrics/blob/d170988536d07beb68431cecca2a468e51ae4581/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java#L277

Added unit test for verifying rate conversion.