### PR TITLE
#1168 Fix uncaught CancellationException when stopping reporter with …

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -215,22 +215,6 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
                 }
                 // just cancel the scheduledFuture and exit
                 this.scheduledFuture.cancel(false);
-                try {
-                    // Wait a while for existing tasks to terminate
-                    scheduledFuture.get(1, TimeUnit.SECONDS);
-                } catch (ExecutionException e) {
-                    // well, we should get this error when future is cancelled normally, just ignore it
-                } catch (InterruptedException e) {
-                    // The thread was interrupted while waiting future to complete
-                    // Preserve interrupt status
-                    Thread.currentThread().interrupt();
-                    if (!this.scheduledFuture.isDone()) {
-                        LOG.warn("The reporting schedulingFuture is not cancelled yet");
-                    }
-                } catch (TimeoutException e) {
-                    // The last reporting cycle is still in progress, nothing wrong, just add log record
-                    LOG.warn("The reporting schedulingFuture is not cancelled yet");
-                }
             }
         }
     }

--- a/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
@@ -7,8 +7,10 @@ import org.junit.Test;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.*;
 
@@ -18,8 +20,10 @@ public class ScheduledReporterTest {
     private final Histogram histogram = mock(Histogram.class);
     private final Meter meter = mock(Meter.class);
     private final Timer timer = mock(Timer.class);
-    private final ScheduledFuture scheduledFuture = mock(ScheduledFuture.class);
-    private final ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+
+    private final ScheduledExecutorService mockExecutor = mock(ScheduledExecutorService.class);
+    private final ScheduledExecutorService customExecutor = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService externalExecutor = Executors.newSingleThreadScheduledExecutor();
 
     private final MetricRegistry registry = new MetricRegistry();
     private final ScheduledReporter reporter = spy(
@@ -28,8 +32,9 @@ public class ScheduledReporterTest {
     private final ScheduledReporter reporterWithNullExecutor = spy(
             new DummyReporter(registry, "example", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, null)
     );
-    private final ScheduledReporter reporterWithCustomExecutor = new DummyReporter(registry, "example", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, executor);
-    private final ScheduledReporter reporterWithExternallyManagedExecutor = new DummyReporter(registry, "example", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, executor, false);
+    private final ScheduledReporter reporterWithCustomMockExecutor = new DummyReporter(registry, "example", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, mockExecutor);
+    private final ScheduledReporter reporterWithCustomExecutor = new DummyReporter(registry, "example", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, customExecutor);
+    private final DummyReporter reporterWithExternallyManagedExecutor = new DummyReporter(registry, "example", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, externalExecutor, false);
     private final ScheduledReporter[] reporters = new ScheduledReporter[] {reporter, reporterWithCustomExecutor, reporterWithExternallyManagedExecutor};
 
     @Before
@@ -39,13 +44,12 @@ public class ScheduledReporterTest {
         registry.register("histogram", histogram);
         registry.register("meter", meter);
         registry.register("timer", timer);
-
-        when(executor.scheduleAtFixedRate(any(Runnable.class), any(Long.class), any(Long.class), eq(TimeUnit.MILLISECONDS)))
-                .thenReturn(scheduledFuture);
     }
 
     @After
     public void tearDown() throws Exception {
+        customExecutor.shutdown();
+        externalExecutor.shutdown();
         reporter.stop();
         reporterWithNullExecutor.stop();
     }
@@ -66,18 +70,18 @@ public class ScheduledReporterTest {
 
     @Test
     public void shouldUsePeriodAsInitialDelayIfNotSpecifiedOtherwise() throws Exception {
-        reporterWithCustomExecutor.start(200, TimeUnit.MILLISECONDS);
+        reporterWithCustomMockExecutor.start(200, TimeUnit.MILLISECONDS);
 
-        verify(executor, times(1)).scheduleAtFixedRate(
+        verify(mockExecutor, times(1)).scheduleAtFixedRate(
             any(Runnable.class), eq(200L), eq(200L), eq(TimeUnit.MILLISECONDS)
         );
     }
 
     @Test
     public void shouldStartWithSpecifiedInitialDelay() throws Exception {
-        reporterWithCustomExecutor.start(350, 100, TimeUnit.MILLISECONDS);
+        reporterWithCustomMockExecutor.start(350, 100, TimeUnit.MILLISECONDS);
 
-        verify(executor).scheduleAtFixedRate(
+        verify(mockExecutor).scheduleAtFixedRate(
             any(Runnable.class), eq(350L), eq(100L), eq(TimeUnit.MILLISECONDS)
         );
     }
@@ -135,48 +139,28 @@ public class ScheduledReporterTest {
     public void shouldShutdownExecutorOnStopByDefault() {
         reporterWithCustomExecutor.start(200, TimeUnit.MILLISECONDS);
         reporterWithCustomExecutor.stop();
-        verify(executor).shutdown();
-        verify(executor).shutdownNow();
+        assertTrue(customExecutor.isTerminated());
     }
 
     @Test
     public void shouldNotShutdownExternallyManagedExecutorOnStop() {
         reporterWithExternallyManagedExecutor.start(200, TimeUnit.MILLISECONDS);
         reporterWithExternallyManagedExecutor.stop();
-        verify(executor, never()).shutdown();
-        verify(executor, never()).shutdownNow();
+        assertFalse(mockExecutor.isTerminated());
+        assertFalse(mockExecutor.isShutdown());
     }
 
     @Test
     public void shouldCancelScheduledFutureWhenStoppingWithExternallyManagedExecutor() throws InterruptedException, ExecutionException, TimeoutException {
-        reporterWithExternallyManagedExecutor.start(200, TimeUnit.MILLISECONDS);
+        // configure very frequency rate of execution
+        reporterWithExternallyManagedExecutor.start(1, TimeUnit.MILLISECONDS);
         reporterWithExternallyManagedExecutor.stop();
-        // should cancel future
-        verify(scheduledFuture).cancel(false);
-        // should wait 1 second to future complete
-        verify(scheduledFuture).get(1, TimeUnit.SECONDS);
-    }
+        Thread.sleep(100);
 
-    @Test
-    public void shouldIgnoreExecutionExceptionByDesign() throws InterruptedException, ExecutionException, TimeoutException {
-        when(scheduledFuture.get(1, TimeUnit.SECONDS)).thenThrow(ExecutionException.class);
-        reporterWithExternallyManagedExecutor.start(200, TimeUnit.MILLISECONDS);
-        reporterWithExternallyManagedExecutor.stop(); // TimeoutException should be ignored
-    }
-
-    @Test
-    public void shouldRestoreInterruptionFlagWhenStoppingWithExternallyManagedExecutor() throws InterruptedException, ExecutionException, TimeoutException {
-        when(scheduledFuture.get(1, TimeUnit.SECONDS)).thenThrow(new InterruptedException());
-        reporterWithExternallyManagedExecutor.start(200, TimeUnit.MILLISECONDS);
-        reporterWithExternallyManagedExecutor.stop();
-        assertTrue(Thread.interrupted());
-    }
-
-    @Test
-    public void shouldIgnoreTimeoutExceptionWhenFutureIsNotCancelledInOneSecond() throws InterruptedException, ExecutionException, TimeoutException {
-        when(scheduledFuture.get(1, TimeUnit.SECONDS)).thenThrow(new TimeoutException());
-        reporterWithExternallyManagedExecutor.start(200, TimeUnit.MILLISECONDS);
-        reporterWithExternallyManagedExecutor.stop(); // TimeoutException should be ignored
+        // executionCount should not increase when scheduled future is canceled properly
+        int executionCount = reporterWithExternallyManagedExecutor.executionCount.get();
+        Thread.sleep(500);
+        assertEquals(executionCount, reporterWithExternallyManagedExecutor.executionCount.get());
     }
 
     @Test
@@ -192,6 +176,8 @@ public class ScheduledReporterTest {
 
     private static class DummyReporter extends ScheduledReporter {
 
+        private AtomicInteger executionCount = new AtomicInteger();
+
         public DummyReporter(MetricRegistry registry, String name, MetricFilter filter, TimeUnit rateUnit, TimeUnit durationUnit) {
             super(registry, name, filter, rateUnit, durationUnit);
         }
@@ -206,6 +192,7 @@ public class ScheduledReporterTest {
 
         @Override
         public void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters, SortedMap<String, Histogram> histograms, SortedMap<String, Meter> meters, SortedMap<String, Timer> timers) {
+            executionCount.incrementAndGet();
             // nothing doing!
         }
     }


### PR DESCRIPTION
Fix uncaught CancellationException when stopping reporter with externally managed executor:

- Do not try to wait the end of current reporting phase, when stopping reporter with externally managed executor, because JDK ScheduledExecutorService does not provide this feature, and [handy implementation of this feature](https://stackoverflow.com/a/45418900) requires big amount of complex concurrent code.
- Do not mock executors(where sensible) in order to make tests more realistic.