### PR TITLE
Exposed Healthcheck objects from the registry based on name

### DIFF
--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistry.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistry.java
@@ -140,6 +140,15 @@ public class HealthCheckRegistry {
     }
 
     /**
+     * Returns the {@link HealthCheck} instance with a given name
+     *
+     * @param name the name of the {@link HealthCheck} instance
+     */
+    public HealthCheck getHealthCheck(String name) {
+        return healthChecks.get(name);
+    }
+
+    /**
      * Runs the health check with the given name.
      *
      * @param name the health check's name


### PR DESCRIPTION
We would like to get access to the HealthCheck object that has been added by (for example extending InjectableHealthcheck) to do some tests on the Healthcheck object. 

The particular use case we have is checking for the existence of an annotation on the HealthCheck object, so we can treat some healthchecks differently. 

I can't see any reason why these aren't exposed currently so this would be a big help.