### PR TITLE
Add tracking for idle time in instrumentedExecutorService

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/InstrumentedExecutorService.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/InstrumentedExecutorService.java
@@ -25,6 +25,7 @@ public class InstrumentedExecutorService implements ExecutorService {
     private final Meter submitted;
     private final Counter running;
     private final Meter completed;
+    private final Timer idle;
     private final Timer duration;
 
     /**
@@ -49,6 +50,7 @@ public class InstrumentedExecutorService implements ExecutorService {
         this.submitted = registry.meter(MetricRegistry.name(name, "submitted"));
         this.running = registry.counter(MetricRegistry.name(name, "running"));
         this.completed = registry.meter(MetricRegistry.name(name, "completed"));
+        this.idle = registry.timer(MetricRegistry.name(name, "idle"));
         this.duration = registry.timer(MetricRegistry.name(name, "duration"));
     }
 
@@ -163,19 +165,22 @@ public class InstrumentedExecutorService implements ExecutorService {
 
     private class InstrumentedRunnable implements Runnable {
         private final Runnable task;
+        private final Timer.Context idleContext;
 
         InstrumentedRunnable(Runnable task) {
             this.task = task;
+            this.idleContext = idle.time();
         }
 
         @Override
         public void run() {
+        	idleContext.stop();
             running.inc();
-            final Timer.Context context = duration.time();
+            final Timer.Context durationContext = duration.time();
             try {
                 task.run();
             } finally {
-                context.stop();
+            	durationContext.stop();
                 running.dec();
                 completed.mark();
             }

--- a/metrics-core/src/test/java/com/codahale/metrics/InstrumentedExecutorServiceTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/InstrumentedExecutorServiceTest.java
@@ -26,11 +26,13 @@ public class InstrumentedExecutorServiceTest {
         final Counter running = registry.counter("xs.running");
         final Meter completed = registry.meter("xs.completed");
         final Timer duration = registry.timer("xs.duration");
+        final Timer idle = registry.timer("xs.idle");
 
         assertThat(submitted.getCount()).isEqualTo(0);
         assertThat(running.getCount()).isEqualTo(0);
         assertThat(completed.getCount()).isEqualTo(0);
         assertThat(duration.getCount()).isEqualTo(0);
+        assertThat(idle.getCount()).isEqualTo(0);
 
         Future<?> theFuture = instrumentedExecutorService.submit(new Runnable() {
             public void run() {
@@ -38,6 +40,7 @@ public class InstrumentedExecutorServiceTest {
                 assertThat(running.getCount()).isEqualTo(1);
                 assertThat(completed.getCount()).isEqualTo(0);
                 assertThat(duration.getCount()).isEqualTo(0);
+                assertThat(idle.getCount()).isEqualTo(1);
 	    }
 	});
 
@@ -48,6 +51,8 @@ public class InstrumentedExecutorServiceTest {
         assertThat(completed.getCount()).isEqualTo(1);
         assertThat(duration.getCount()).isEqualTo(1);
         assertThat(duration.getSnapshot().size()).isEqualTo(1);
+        assertThat(idle.getCount()).isEqualTo(1);
+        assertThat(idle.getSnapshot().size()).isEqualTo(1);
     }
 
     @After


### PR DESCRIPTION
At this point I can't know how much time did it take for task to be executed. I can only know how much time is spent on execution, but I don't know how long task was in queue. So I have added new Timer metric called idle which starts when task is created and stop when execution starts.