### PR TITLE
extract metrics-jmx

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics/Clock.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/Clock.java
@@ -1,8 +1,5 @@
 package io.dropwizard.metrics;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.ThreadMXBean;
-
 /**
  * An abstraction for how time passes. It is passed to {@link Timer} to track timing.
  */
@@ -34,7 +31,6 @@ public abstract class Clock {
      * The default clock to use.
      *
      * @return the default {@link Clock} instance
-     *
      * @see Clock.UserTimeClock
      */
     public static Clock defaultClock() {
@@ -48,18 +44,6 @@ public abstract class Clock {
         @Override
         public long getTick() {
             return System.nanoTime();
-        }
-    }
-
-    /**
-     * A clock implementation which returns the current thread's CPU time.
-     */
-    public static class CpuTimeClock extends Clock {
-        private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
-
-        @Override
-        public long getTick() {
-            return THREAD_MX_BEAN.getCurrentThreadCpuTime();
         }
     }
 }

--- a/metrics-core/src/test/java/io/dropwizard/metrics/ClockTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/ClockTest.java
@@ -10,18 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
 
 public class ClockTest {
-    @Test
-    public void cpuTimeClock() throws Exception {
-        final Clock.CpuTimeClock clock = new Clock.CpuTimeClock();
-
-        assertThat((double) clock.getTime())
-                .isEqualTo(System.currentTimeMillis(),
-                           offset(100.0));
-
-        assertThat((double) clock.getTick())
-                   .isEqualTo(ManagementFactory.getThreadMXBean().getCurrentThreadCpuTime(),
-                              offset(1000000.0));
-    }
 
     @Test
     public void userTimeClock() throws Exception {

--- a/metrics-jmx/pom.xml
+++ b/metrics-jmx/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+       <groupId>io.dropwizard.metrics4</groupId>
+        <artifactId>metrics-parent</artifactId>
+        <version>4.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>metrics-jmx</artifactId>
+    <name>Metrics Integration with JMX</name>
+    <packaging>bundle</packaging>
+    <description>
+        A set of classes which allow you to report metrics via JMX.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/metrics-jmx/src/main/java/io/dropwizard/metrics/jmx/DefaultObjectNameFactory.java
+++ b/metrics-jmx/src/main/java/io/dropwizard/metrics/jmx/DefaultObjectNameFactory.java
@@ -1,7 +1,9 @@
-package io.dropwizard.metrics;
+package io.dropwizard.metrics.jmx;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
+
+import io.dropwizard.metrics.MetricName;
 
 public class DefaultObjectNameFactory implements ObjectNameFactory {
 

--- a/metrics-jmx/src/main/java/io/dropwizard/metrics/jmx/JmxReporter.java
+++ b/metrics-jmx/src/main/java/io/dropwizard/metrics/jmx/JmxReporter.java
@@ -1,7 +1,19 @@
-package io.dropwizard.metrics;
+package io.dropwizard.metrics.jmx;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.dropwizard.metrics.Counter;
+import io.dropwizard.metrics.Gauge;
+import io.dropwizard.metrics.Histogram;
+import io.dropwizard.metrics.Meter;
+import io.dropwizard.metrics.Metered;
+import io.dropwizard.metrics.MetricFilter;
+import io.dropwizard.metrics.MetricName;
+import io.dropwizard.metrics.MetricRegistry;
+import io.dropwizard.metrics.MetricRegistryListener;
+import io.dropwizard.metrics.Reporter;
+import io.dropwizard.metrics.Timer;
 
 import javax.management.*;
 
@@ -148,12 +160,10 @@ public class JmxReporter implements Reporter, Closeable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JmxReporter.class);
 
-    // CHECKSTYLE:OFF
     @SuppressWarnings("UnusedDeclaration")
     public interface MetricMBean {
         ObjectName objectName();
     }
-    // CHECKSTYLE:ON
 
 
     private abstract static class AbstractBean implements MetricMBean {
@@ -169,12 +179,10 @@ public class JmxReporter implements Reporter, Closeable {
         }
     }
 
-    // CHECKSTYLE:OFF
     @SuppressWarnings("UnusedDeclaration")
     public interface JmxGaugeMBean extends MetricMBean {
         Object getValue();
     }
-    // CHECKSTYLE:ON
 
     private static class JmxGauge extends AbstractBean implements JmxGaugeMBean {
         private final Gauge<?> metric;
@@ -190,12 +198,10 @@ public class JmxReporter implements Reporter, Closeable {
         }
     }
 
-    // CHECKSTYLE:OFF
     @SuppressWarnings("UnusedDeclaration")
     public interface JmxCounterMBean extends MetricMBean {
         long getCount();
     }
-    // CHECKSTYLE:ON
 
     private static class JmxCounter extends AbstractBean implements JmxCounterMBean {
         private final Counter metric;
@@ -211,7 +217,6 @@ public class JmxReporter implements Reporter, Closeable {
         }
     }
 
-    // CHECKSTYLE:OFF
     @SuppressWarnings("UnusedDeclaration")
     public interface JmxHistogramMBean extends MetricMBean {
         long getCount();
@@ -238,7 +243,6 @@ public class JmxReporter implements Reporter, Closeable {
 
         long[] values();
     }
-    // CHECKSTYLE:ON
 
     private static class JmxHistogram implements JmxHistogramMBean {
         private final ObjectName objectName;
@@ -315,7 +319,6 @@ public class JmxReporter implements Reporter, Closeable {
         }
     }
 
-    //CHECKSTYLE:OFF
     @SuppressWarnings("UnusedDeclaration")
     public interface JmxMeterMBean extends MetricMBean {
         long getCount();
@@ -330,7 +333,6 @@ public class JmxReporter implements Reporter, Closeable {
 
         String getRateUnit();
     }
-    //CHECKSTYLE:ON
 
     private static class JmxMeter extends AbstractBean implements JmxMeterMBean {
         private final Metered metric;
@@ -380,7 +382,6 @@ public class JmxReporter implements Reporter, Closeable {
         }
     }
 
-    // CHECKSTYLE:OFF
     @SuppressWarnings("UnusedDeclaration")
     public interface JmxTimerMBean extends JmxMeterMBean {
         double getMin();
@@ -406,7 +407,6 @@ public class JmxReporter implements Reporter, Closeable {
         long[] values();
         String getDurationUnit();
     }
-    // CHECKSTYLE:ON
 
     static class JmxTimer extends JmxMeter implements JmxTimerMBean {
         private final Timer metric;
@@ -687,11 +687,11 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         public TimeUnit durationFor(String name) {
-            return durationOverrides.containsKey(name) ? durationOverrides.get(name) : defaultDuration;
+            return durationOverrides.getOrDefault(name, defaultDuration);
         }
 
         public TimeUnit rateFor(String name) {
-            return rateOverrides.containsKey(name) ? rateOverrides.get(name) : defaultRate;
+            return rateOverrides.getOrDefault(name, defaultRate);
         }
     }
 

--- a/metrics-jmx/src/main/java/io/dropwizard/metrics/jmx/ObjectNameFactory.java
+++ b/metrics-jmx/src/main/java/io/dropwizard/metrics/jmx/ObjectNameFactory.java
@@ -1,7 +1,9 @@
-package io.dropwizard.metrics;
+package io.dropwizard.metrics.jmx;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
+
+import io.dropwizard.metrics.MetricName;
 
 public interface ObjectNameFactory {
 

--- a/metrics-jmx/src/test/java/io/dropwizard/metrics/jmx/DefaultObjectNameFactoryTest.java
+++ b/metrics-jmx/src/test/java/io/dropwizard/metrics/jmx/DefaultObjectNameFactoryTest.java
@@ -1,4 +1,4 @@
-package io.dropwizard.metrics;
+package io.dropwizard.metrics.jmx;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -7,8 +7,8 @@ import javax.management.ObjectName;
 
 import org.junit.Test;
 
-import io.dropwizard.metrics.DefaultObjectNameFactory;
 import io.dropwizard.metrics.MetricName;
+import io.dropwizard.metrics.jmx.DefaultObjectNameFactory;
 
 public class DefaultObjectNameFactoryTest {
 

--- a/metrics-jmx/src/test/java/io/dropwizard/metrics/jmx/JmxReporterTest.java
+++ b/metrics-jmx/src/test/java/io/dropwizard/metrics/jmx/JmxReporterTest.java
@@ -1,4 +1,4 @@
-package io.dropwizard.metrics;
+package io.dropwizard.metrics.jmx;
 
 import org.junit.After;
 import org.junit.Before;
@@ -7,14 +7,13 @@ import org.junit.Test;
 import io.dropwizard.metrics.Counter;
 import io.dropwizard.metrics.Gauge;
 import io.dropwizard.metrics.Histogram;
-import io.dropwizard.metrics.JmxReporter;
 import io.dropwizard.metrics.Meter;
 import io.dropwizard.metrics.MetricFilter;
 import io.dropwizard.metrics.MetricName;
 import io.dropwizard.metrics.MetricRegistry;
-import io.dropwizard.metrics.ObjectNameFactory;
 import io.dropwizard.metrics.Snapshot;
 import io.dropwizard.metrics.Timer;
+import io.dropwizard.metrics.jmx.JmxReporter;
 
 import javax.management.*;
 

--- a/metrics-jvm/src/main/java/io/dropwizard/metrics/jvm/BufferPoolMetricSet.java
+++ b/metrics-jvm/src/main/java/io/dropwizard/metrics/jvm/BufferPoolMetricSet.java
@@ -5,7 +5,6 @@ import static io.dropwizard.metrics.MetricRegistry.name;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.dropwizard.metrics.JmxAttributeGauge;
 import io.dropwizard.metrics.Metric;
 import io.dropwizard.metrics.MetricName;
 import io.dropwizard.metrics.MetricSet;

--- a/metrics-jvm/src/main/java/io/dropwizard/metrics/jvm/CpuTimeClock.java
+++ b/metrics-jvm/src/main/java/io/dropwizard/metrics/jvm/CpuTimeClock.java
@@ -1,0 +1,21 @@
+package io.dropwizard.metrics.jvm;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+
+import io.dropwizard.metrics.Clock;
+
+/**
+ * A clock implementation which returns the current thread's CPU time.
+ */
+public class CpuTimeClock extends Clock
+{
+
+  private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
+
+  @Override
+  public long getTick()
+  {
+    return THREAD_MX_BEAN.getCurrentThreadCpuTime();
+  }
+}

--- a/metrics-jvm/src/main/java/io/dropwizard/metrics/jvm/JmxAttributeGauge.java
+++ b/metrics-jvm/src/main/java/io/dropwizard/metrics/jvm/JmxAttributeGauge.java
@@ -1,10 +1,12 @@
-package io.dropwizard.metrics;
+package io.dropwizard.metrics.jvm;
 
 import java.io.IOException;
 
 import javax.management.JMException;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
+
+import io.dropwizard.metrics.Gauge;
 
 import java.lang.management.ManagementFactory;
 import java.util.Set;

--- a/metrics-jvm/src/test/java/io/dropwizard/metrics/jvm/CpuTimeClockTest.java
+++ b/metrics-jvm/src/test/java/io/dropwizard/metrics/jvm/CpuTimeClockTest.java
@@ -1,0 +1,26 @@
+package io.dropwizard.metrics.jvm;
+
+import org.junit.Test;
+
+import io.dropwizard.metrics.jvm.CpuTimeClock;
+
+import java.lang.management.ManagementFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+public class CpuTimeClockTest {
+
+    @Test
+    public void cpuTimeClock() throws Exception {
+        final CpuTimeClock clock = new CpuTimeClock();
+
+        assertThat((double) clock.getTime())
+                .isEqualTo(System.currentTimeMillis(),
+                        offset(200.0));
+
+        assertThat((double) clock.getTick())
+                .isEqualTo(ManagementFactory.getThreadMXBean().getCurrentThreadCpuTime(),
+                        offset(1000000.0));
+    }
+}

--- a/metrics-jvm/src/test/java/io/dropwizard/metrics/jvm/JmxAttributeGaugeTest.java
+++ b/metrics-jvm/src/test/java/io/dropwizard/metrics/jvm/JmxAttributeGaugeTest.java
@@ -1,4 +1,4 @@
-package io.dropwizard.metrics;
+package io.dropwizard.metrics.jvm;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,6 +14,8 @@ import javax.management.ObjectName;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import io.dropwizard.metrics.jvm.JmxAttributeGauge;
 
 public class JmxAttributeGaugeTest {
 

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <module>metrics-servlet</module>
         <module>metrics-servlets</module>
         <module>metrics-adapter</module>
+        <module>metrics-jmx</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This mimics what was done on 4.0-development branch by extracting a metrics-jvm module, and moving some relevant classes to metrics-jvm as well.  I think I have captured the relevant bits in the [history of this module on that branch](https://github.com/dropwizard/metrics/commits/4.0-development/metrics-jmx).

(I'm still trying to figure out why the tests fail on travis.  They pass locally, and the failure seems unrelated to my change).