### PR TITLE
common metric filters

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics/MetricFilter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/MetricFilter.java
@@ -7,12 +7,31 @@ public interface MetricFilter {
     /**
      * Matches all metrics, regardless of type or name.
      */
-    MetricFilter ALL = new MetricFilter() {
-        @Override
-        public boolean matches(MetricName name, Metric metric) {
-            return true;
-        }
-    };
+    MetricFilter ALL = (name, metric) -> true;
+
+    static MetricFilter startsWith(String prefix) {
+        return (name, metric) -> name.startsWith(prefix);
+    }
+
+    static MetricFilter endsWith(String suffix) {
+        return (name, metric) -> name.endsWith(suffix);
+    }
+
+    static MetricFilter contains(String substring) {
+        return (name, metric) -> name.contains(substring);
+    }
+
+    static MetricFilter startsWith(MetricName prefix) {
+        return (name, metric) -> name.startsWith(prefix);
+    }
+
+    static MetricFilter endsWith(MetricName suffix) {
+        return (name, metric) -> name.endsWith(suffix);
+    }
+
+    static MetricFilter contains(MetricName substring) {
+        return (name, metric) -> name.contains(substring);
+    }
 
     /**
      * Returns {@code true} if the metric matches the filter; {@code false} otherwise.

--- a/metrics-core/src/main/java/io/dropwizard/metrics/MetricName.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics/MetricName.java
@@ -230,6 +230,30 @@ public class MetricName implements Comparable<MetricName> {
         return true;
     }
 
+    public boolean startsWith(MetricName prefix) {
+        return key.startsWith(prefix.getKey());
+    }
+
+    public boolean endsWith(MetricName suffix) {
+      return key.endsWith(suffix.getKey());
+    }
+
+    public boolean contains(MetricName sub) {
+      return key.contains(sub.getKey());
+    }
+
+    public boolean startsWith(String prefix) {
+        return key.startsWith(prefix);
+    }
+
+    public boolean endsWith(String suffix) {
+        return key.endsWith(suffix);
+    }
+
+    public boolean contains(String sub) {
+        return key.contains(sub);
+    }
+
     @Override
     public int compareTo(MetricName o) {
         if (o == null)

--- a/metrics-core/src/test/java/io/dropwizard/metrics/MetricFilterTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics/MetricFilterTest.java
@@ -15,4 +15,28 @@ public class MetricFilterTest {
         assertThat(MetricFilter.ALL.matches(MetricName.build(""), mock(Metric.class)))
                 .isTrue();
     }
+
+    @Test
+    public void theStartsWithFilterMatches() throws Exception {
+        assertThat(MetricFilter.startsWith("foo").matches(MetricName.build("foo.bar"), mock(Metric.class)))
+                .isTrue();
+        assertThat(MetricFilter.startsWith("foo").matches(MetricName.build("bar.foo"), mock(Metric.class)))
+                .isFalse();
+    }
+
+    @Test
+    public void theEndsWithFilterMatches() throws Exception {
+        assertThat(MetricFilter.endsWith("foo").matches(MetricName.build("foo.bar"), mock(Metric.class)))
+                .isFalse();
+        assertThat(MetricFilter.endsWith("foo").matches(MetricName.build("bar.foo"), mock(Metric.class)))
+                .isTrue();
+    }
+
+    @Test
+    public void theContainsFilterMatches() throws Exception {
+        assertThat(MetricFilter.contains("foo").matches(MetricName.build("bar.foo.bar"), mock(Metric.class)))
+                .isTrue();
+        assertThat(MetricFilter.contains("foo").matches(MetricName.build("bar.bar"), mock(Metric.class)))
+                .isFalse();
+    }
 }


### PR DESCRIPTION
This adds some common filters to the suite, besides just ``ALL``. Seems like these would be useful to many.  

I've left ``MetricName`` and ``String`` versions, because it seems many modules still use ``String`` rather than the new typed version.
