### PR TITLE
Add ResponseMetered annotation for Jersey Resources

### DIFF
--- a/metrics-annotation/src/main/java/io/dropwizard/metrics/annotation/ResponseMetered.java
+++ b/metrics-annotation/src/main/java/io/dropwizard/metrics/annotation/ResponseMetered.java
@@ -1,0 +1,46 @@
+package io.dropwizard.metrics.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation for marking a method of an annotated object as metered.
+ * <p/>
+ * Given a method like this:
+ * <pre><code>
+ *     {@literal @}ResponseMetered(name = "fancyName")
+ *     public String fancyName(String name) {
+ *         return "Sir Captain " + name;
+ *     }
+ * </code></pre>
+ * <p/>
+ * A meter for the defining class with the name {@code fancyName} will be created for 1xx/2xx/3xx/4xx/5xx responses
+ * and each time the {@code #fancyName(String)} method is invoked, the appropriate response meter will be marked.
+ */
+@Inherited
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+public @interface ResponseMetered {
+
+    /**
+     * @return The meter's name.
+     */
+    String name() default "";
+
+    /**
+     * @return The meter's tags.
+     */
+    String[] tags() default {};
+
+    /**
+     * @return If {@code true}, use the given name as an absolute name. If {@code false}, use the given name
+     * relative to the annotated class. When annotating a class, this must be {@code false}.
+     */
+    boolean absolute() default false;
+
+}

--- a/metrics-jersey2/src/main/java/io/dropwizard/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
+++ b/metrics-jersey2/src/main/java/io/dropwizard/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
@@ -2,6 +2,8 @@ package io.dropwizard.metrics.jersey2;
 
 import static io.dropwizard.metrics.MetricRegistry.name;
 
+import io.dropwizard.metrics.annotation.ResponseMetered;
+import org.glassfish.jersey.server.ContainerResponse;
 import org.glassfish.jersey.server.model.ModelProcessor;
 import org.glassfish.jersey.server.model.Resource;
 import org.glassfish.jersey.server.model.ResourceMethod;
@@ -43,6 +45,7 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
     private ConcurrentMap<Method, Timer> timers = new ConcurrentHashMap<>();
     private ConcurrentMap<Method, Meter> meters = new ConcurrentHashMap<>();
     private ConcurrentMap<Method, ExceptionMeterMetric> exceptionMeters = new ConcurrentHashMap<>();
+    private ConcurrentMap<Method, ResponseMeterMetric> responseMeters = new ConcurrentHashMap<>();
 
     /**
      * Construct an application event listener using the given metrics registry.
@@ -73,6 +76,27 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
                     exceptionMetered.absolute(), method, ExceptionMetered.DEFAULT_NAME_SUFFIX);
             this.meter = registry.meter(name);
             this.cause = exceptionMetered.cause();
+        }
+    }
+
+    /**
+     * A private class to maintain the metrics for a method annotated with the
+     * {@link ResponseMetered} annotation, which needs to maintain meters for
+     * different response codes
+     */
+    private static class ResponseMeterMetric {
+        public final Meter[] meters;
+        public ResponseMeterMetric(final MetricRegistry registry,
+                                    final ResourceMethod method,
+                                    final ResponseMetered responseMetered) {
+            final MetricName name = chooseName(responseMetered.name(), responseMetered.absolute(), method);
+            this.meters = new Meter[]{
+                    registry.meter(name.resolve("1xx-responses")), // 1xx
+                    registry.meter(name.resolve("2xx-responses")), // 2xx
+                    registry.meter(name.resolve("3xx-responses")), // 3xx
+                    registry.meter(name.resolve("4xx-responses")), // 4xx
+                    registry.meter(name.resolve("5xx-responses"))  // 5xx
+            };
         }
     }
 
@@ -144,6 +168,37 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         }
     }
 
+    private static class ResponseMeterRequestEventListener implements RequestEventListener {
+        private final ConcurrentMap<Method, ResponseMeterMetric> responseMeters;
+
+        public ResponseMeterRequestEventListener(final ConcurrentMap<Method, ResponseMeterMetric> responseMeters) {
+            this.responseMeters = responseMeters;
+        }
+
+        @Override
+        public void onEvent(RequestEvent event) {
+            if (event.getType() == RequestEvent.Type.FINISHED) {
+                final ResourceMethod method = event.getUriInfo().getMatchedResourceMethod();
+                final ResponseMeterMetric metric = (method != null) ?
+                        this.responseMeters.get(method.getInvocable().getDefinitionMethod()) : null;
+
+                if (metric != null) {
+                    ContainerResponse containerResponse = event.getContainerResponse();
+                    if (containerResponse == null) {
+                        if (event.getException() != null) {
+                            metric.meters[4].mark();
+                        }
+                    } else {
+                        final int responseStatus = containerResponse.getStatus() / 100;
+                        if (responseStatus >= 1 && responseStatus <= 5) {
+                            metric.meters[responseStatus - 1].mark();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private static class ChainedRequestEventListener implements RequestEventListener {
         private final RequestEventListener[] listeners;
 
@@ -183,11 +238,13 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
             final Timed classLevelTimed = getClassLevelAnnotation(resource, Timed.class);
             final Metered classLevelMetered = getClassLevelAnnotation(resource, Metered.class);
             final ExceptionMetered classLevelExceptionMetered = getClassLevelAnnotation(resource, ExceptionMetered.class);
+            final ResponseMetered classLevelResponseMetered = getClassLevelAnnotation(resource, ResponseMetered.class);
 
             for (final ResourceMethod method : resource.getAllMethods()) {
                 registerTimedAnnotations(method, classLevelTimed);
                 registerMeteredAnnotations(method, classLevelMetered);
                 registerExceptionMeteredAnnotations(method, classLevelExceptionMetered);
+                registerResponseMeteredAnnotations(method, classLevelResponseMetered);
             }
 
             for (final Resource childResource : resource.getChildResources()) {
@@ -195,15 +252,16 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
                 final Timed classLevelTimedChild = getClassLevelAnnotation(childResource, Timed.class);
                 final Metered classLevelMeteredChild = getClassLevelAnnotation(childResource, Metered.class);
                 final ExceptionMetered classLevelExceptionMeteredChild = getClassLevelAnnotation(childResource, ExceptionMetered.class);
+                final ResponseMetered classLevelResponseMeteredChild = getClassLevelAnnotation(childResource, ResponseMetered.class);
 
                 for (final ResourceMethod method : childResource.getAllMethods()) {
                     registerTimedAnnotations(method, classLevelTimedChild);
                     registerMeteredAnnotations(method, classLevelMeteredChild);
                     registerExceptionMeteredAnnotations(method, classLevelExceptionMeteredChild);
+                    registerResponseMeteredAnnotations(method, classLevelResponseMeteredChild);
                 }
             }
         }
-
     }
 
     @Override
@@ -211,7 +269,8 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         final RequestEventListener listener = new ChainedRequestEventListener(
                 new TimerRequestEventListener(timers),
                 new MeterRequestEventListener(meters),
-                new ExceptionMeterRequestEventListener(exceptionMeters));
+                new ExceptionMeterRequestEventListener(exceptionMeters),
+                new ResponseMeterRequestEventListener(responseMeters));
 
         return listener;
     }
@@ -268,6 +327,20 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
 
         if (annotation != null) {
             exceptionMeters.putIfAbsent(definitionMethod, new ExceptionMeterMetric(metrics, method, annotation));
+        }
+    }
+
+    private void registerResponseMeteredAnnotations(final ResourceMethod method, final ResponseMetered classLevelResponseMetered) {
+        final Method definitionMethod = method.getInvocable().getDefinitionMethod();
+
+        if (classLevelResponseMetered != null) {
+            responseMeters.putIfAbsent(definitionMethod, new ResponseMeterMetric(metrics, method, classLevelResponseMetered));
+            return;
+        }
+        final ResponseMetered annotation = definitionMethod.getAnnotation(ResponseMetered.class);
+
+        if (annotation != null) {
+            responseMeters.putIfAbsent(definitionMethod, new ResponseMeterMetric(metrics, method, annotation));
         }
     }
 

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/SingletonMetricsJerseyTest.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/SingletonMetricsJerseyTest.java
@@ -96,6 +96,41 @@ public class SingletonMetricsJerseyTest extends JerseyTest {
     }
 
     @Test
+    public void responseMeteredMethodsAreMetered() {
+        final Meter meter2xx = registry.meter(name(InstrumentedResource.class,
+                "response2xxMetered",
+                "2xx-responses"));
+        final Meter meter4xx = registry.meter(name(InstrumentedResource.class,
+                "response4xxMetered",
+                "4xx-responses"));
+        final Meter meter5xx = registry.meter(name(InstrumentedResource.class,
+                "response5xxMetered",
+                "5xx-responses"));
+
+        assertThat(meter2xx.getCount()).isZero();
+        assertThat(target("response-2xx-metered")
+                .request()
+                .get().getStatus())
+                .isEqualTo(200);
+
+        assertThat(meter4xx.getCount()).isZero();
+        assertThat(target("response-4xx-metered")
+                .request()
+                .get().getStatus())
+                .isEqualTo(400);
+
+        assertThat(meter5xx.getCount()).isZero();
+        assertThat(target("response-5xx-metered")
+                .request()
+                .get().getStatus())
+                .isEqualTo(500);
+
+        assertThat(meter2xx.getCount()).isEqualTo(1);
+        assertThat(meter4xx.getCount()).isEqualTo(1);
+        assertThat(meter5xx.getCount()).isEqualTo(1);
+    }
+
+    @Test
     public void testResourceNotFound() {
         final Response response = target().path("not-found").request().get();
         assertThat(response.getStatus()).isEqualTo(404);

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/SingletonMetricsResponseMeteredPerClassJerseyTest.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/SingletonMetricsResponseMeteredPerClassJerseyTest.java
@@ -1,0 +1,138 @@
+package io.dropwizard.metrics.jersey2;
+
+import io.dropwizard.metrics.Meter;
+import io.dropwizard.metrics.MetricRegistry;
+import io.dropwizard.metrics.jersey2.exception.mapper.TestExceptionMapper;
+import io.dropwizard.metrics.jersey2.resources.InstrumentedResourceResponseMeteredPerClass;
+import io.dropwizard.metrics.jersey2.resources.InstrumentedSubResourceResponseMeteredPerClass;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
+
+import javax.ws.rs.core.Application;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static io.dropwizard.metrics.MetricRegistry.name;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests registering {@link InstrumentedResourceMethodApplicationListener} as a singleton
+ * in a Jersey {@link ResourceConfig}
+ */
+
+public class SingletonMetricsResponseMeteredPerClassJerseyTest extends JerseyTest {
+    static {
+        Logger.getLogger("org.glassfish.jersey").setLevel(Level.OFF);
+    }
+
+    private MetricRegistry registry;
+
+    @Override
+    protected Application configure() {
+        this.registry = new MetricRegistry();
+
+
+        ResourceConfig config = new ResourceConfig();
+
+        config = config.register(new MetricsFeature(this.registry));
+        config = config.register(InstrumentedResourceResponseMeteredPerClass.class);
+        config = config.register(new TestExceptionMapper());
+
+        return config;
+    }
+
+    @Test
+    public void responseMetered2xxPerClassMethodsAreMetered() {
+        assertThat(target("responseMetered2xxPerClass")
+                .request()
+                .get().getStatus())
+                .isEqualTo(200);
+
+        final Meter meter2xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
+                "responseMetered2xxPerClass",
+                "2xx-responses"));
+
+        assertThat(meter2xx.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void responseMetered4xxPerClassMethodsAreMetered() {
+        assertThat(target("responseMetered4xxPerClass")
+                .request()
+                .get().getStatus())
+                .isEqualTo(400);
+        assertThat(target("responseMeteredBadRequestPerClass")
+                .request()
+                .get().getStatus())
+                .isEqualTo(400);
+
+        final Meter meter4xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
+                "responseMetered4xxPerClass",
+                "4xx-responses"));
+        final Meter meterException4xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
+                "responseMeteredBadRequestPerClass",
+                "4xx-responses"));
+
+        assertThat(meter4xx.getCount()).isEqualTo(1);
+        assertThat(meterException4xx.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void responseMetered5xxPerClassMethodsAreMetered() {
+        assertThat(target("responseMetered5xxPerClass")
+                .request()
+                .get().getStatus())
+                .isEqualTo(500);
+
+        final Meter meter5xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
+                "responseMetered5xxPerClass",
+                "5xx-responses"));
+
+        assertThat(meter5xx.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void responseMeteredMappedExceptionPerClassMethodsAreMetered() {
+        assertThat(target("responseMeteredTestExceptionPerClass")
+                .request()
+                .get().getStatus())
+                .isEqualTo(500);
+
+        final Meter meterTestException = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
+                "responseMeteredTestExceptionPerClass",
+                "5xx-responses"));
+
+        assertThat(meterTestException.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void responseMeteredUnmappedExceptionPerClassMethodsAreMetered() {
+        try {
+            target("responseMeteredRuntimeExceptionPerClass")
+                    .request()
+                    .get();
+        } catch (Exception e) {
+            assertThat(e.getCause()).isInstanceOf(RuntimeException.class);
+        }
+
+        final Meter meterException5xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
+                "responseMeteredRuntimeExceptionPerClass",
+                "5xx-responses"));
+
+        assertThat(meterException5xx.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void subresourcesFromLocatorsRegisterMetrics() {
+        assertThat(target("subresource/responseMeteredPerClass")
+                .request()
+                .get().getStatus())
+                .isEqualTo(200);
+
+        final Meter meter = registry.meter(name(InstrumentedSubResourceResponseMeteredPerClass.class,
+                "responseMeteredPerClass",
+                "2xx-responses"));
+        assertThat(meter.getCount()).isEqualTo(1);
+    }
+}

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/exception/TestException.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/exception/TestException.java
@@ -1,0 +1,7 @@
+package io.dropwizard.metrics.jersey2.exception;
+
+public class TestException extends RuntimeException {
+    public TestException(String message) {
+        super(message);
+    }
+}

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/exception/mapper/TestExceptionMapper.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/exception/mapper/TestExceptionMapper.java
@@ -1,0 +1,14 @@
+package io.dropwizard.metrics.jersey2.exception.mapper;
+
+import io.dropwizard.metrics.jersey2.exception.TestException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class TestExceptionMapper implements ExceptionMapper<TestException> {
+    public Response toResponse(TestException exception) {
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    }
+}

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedResource.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedResource.java
@@ -2,10 +2,12 @@ package io.dropwizard.metrics.jersey2.resources;
 
 import io.dropwizard.metrics.annotation.ExceptionMetered;
 import io.dropwizard.metrics.annotation.Metered;
+import io.dropwizard.metrics.annotation.ResponseMetered;
 import io.dropwizard.metrics.annotation.Timed;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import java.io.IOException;
 
@@ -34,6 +36,27 @@ public class InstrumentedResource {
             throw new IOException("AUGH");
         }
         return "fuh";
+    }
+
+    @GET
+    @ResponseMetered
+    @Path("/response-2xx-metered")
+    public Response response2xxMetered() {
+        return Response.ok().build();
+    }
+
+    @GET
+    @ResponseMetered
+    @Path("/response-4xx-metered")
+    public Response response4xxMetered() {
+        return Response.status(Response.Status.BAD_REQUEST).build();
+    }
+
+    @GET
+    @ResponseMetered
+    @Path("/response-5xx-metered")
+    public Response response5xxMetered() {
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
     }
 
     @Path("/subresource")

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedResourceResponseMeteredPerClass.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedResourceResponseMeteredPerClass.java
@@ -1,0 +1,58 @@
+package io.dropwizard.metrics.jersey2.resources;
+
+import io.dropwizard.metrics.annotation.ResponseMetered;
+import io.dropwizard.metrics.jersey2.exception.TestException;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@ResponseMetered
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+public class InstrumentedResourceResponseMeteredPerClass {
+
+    @GET
+    @Path("/responseMetered2xxPerClass")
+    public Response responseMetered2xxPerClass() {
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/responseMetered4xxPerClass")
+    public Response responseMetered4xxPerClass() {
+        return Response.status(Response.Status.BAD_REQUEST).build();
+    }
+
+    @GET
+    @Path("/responseMetered5xxPerClass")
+    public Response responseMetered5xxPerClass() {
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    }
+
+    @GET
+    @Path("/responseMeteredBadRequestPerClass")
+    public String responseMeteredBadRequestPerClass() {
+        throw new BadRequestException();
+    }
+
+    @GET
+    @Path("/responseMeteredRuntimeExceptionPerClass")
+    public String responseMeteredRuntimeExceptionPerClass() {
+        throw new RuntimeException();
+    }
+
+    @GET
+    @Path("/responseMeteredTestExceptionPerClass")
+    public String responseMeteredTestExceptionPerClass() {
+        throw new TestException("test");
+    }
+
+    @Path("/subresource")
+    public InstrumentedSubResourceResponseMeteredPerClass locateSubResource() {
+        return new InstrumentedSubResourceResponseMeteredPerClass();
+    }
+
+}

--- a/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedSubResourceResponseMeteredPerClass.java
+++ b/metrics-jersey2/src/test/java/io/dropwizard/metrics/jersey2/resources/InstrumentedSubResourceResponseMeteredPerClass.java
@@ -1,0 +1,19 @@
+package io.dropwizard.metrics.jersey2.resources;
+
+import io.dropwizard.metrics.annotation.ResponseMetered;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@ResponseMetered
+@Produces(MediaType.TEXT_PLAIN)
+public class InstrumentedSubResourceResponseMeteredPerClass {
+    @GET
+    @Path("/responseMeteredPerClass")
+    public Response responseMeteredPerClass() {
+        return Response.status(Response.Status.OK).build();
+    }
+}


### PR DESCRIPTION
For Dropwizard services, we currently have metrics for response rates by HTTP status code (1xx, 2xx, 3xx, 4xx, 5xx) captured at Jetty . There have been use cases where it would be helpful to have it on a Jersey Resource method/class level. To achieve that, I've added ```@ResponseMetered``` annotation which will add meters for 1xx/2xx/3xx/4xx/5xx responses. I've reused the logic from [com.codahale.metrics.jetty9.InstrumentedHandler](https://github.com/dropwizard/metrics/blob/4.0-development/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java#L287-L290) to capture the metrics.

I hope you find this helpful and I'm open to suggestions/feedback. Thanks!

```java
@Path("/")
@Produces(MediaType.TEXT_PLAIN)
public class InstrumentedResource {
    @GET
    @ResponseMetered
    @Path("/responseMeteredEndpoint")
    public Response responseMeteredEndpoint() {
        return Response.ok().build();
    }
}
``` 