### PR TITLE
Add ResponseMetered annotation for Jersey Resource (3.2-development)

### DIFF
--- a/metrics-annotation/src/main/java/com/codahale/metrics/annotation/ResponseMetered.java
+++ b/metrics-annotation/src/main/java/com/codahale/metrics/annotation/ResponseMetered.java
@@ -1,0 +1,39 @@
+package com.codahale.metrics.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation for marking a method of an annotated object as metered.
+ * <p/>
+ * Given a method like this:
+ * <pre><code>
+ *     {@literal @}ResponseMetered(name = "fancyName")
+ *     public String fancyName(String name) {
+ *         return "Sir Captain " + name;
+ *     }
+ * </code></pre>
+ * <p/>
+ * A meter for the defining class with the name {@code fancyName} will be created for 1xx/2xx/3xx/4xx/5xx responses
+ * and each time the {@code #fancyName(String)} method is invoked, the appropriate response meter will be marked.
+ */
+@Inherited
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+public @interface ResponseMetered {
+    /**
+     * @return The name of the meter.
+     */
+    String name() default "";
+
+    /**
+     * @return If {@code true}, use the given name as an absolute name. If {@code false}, use the given name
+     * relative to the annotated class. When annotating a class, this must be {@code false}.
+     */
+    boolean absolute() default false;
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/InstrumentedExecutorService.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/InstrumentedExecutorService.java
@@ -25,6 +25,7 @@ public class InstrumentedExecutorService implements ExecutorService {
     private final Meter submitted;
     private final Counter running;
     private final Meter completed;
+    private final Timer idle;
     private final Timer duration;
 
     /**
@@ -49,6 +50,7 @@ public class InstrumentedExecutorService implements ExecutorService {
         this.submitted = registry.meter(MetricRegistry.name(name, "submitted"));
         this.running = registry.counter(MetricRegistry.name(name, "running"));
         this.completed = registry.meter(MetricRegistry.name(name, "completed"));
+        this.idle = registry.timer(MetricRegistry.name(name, "idle"));
         this.duration = registry.timer(MetricRegistry.name(name, "duration"));
     }
 
@@ -163,19 +165,22 @@ public class InstrumentedExecutorService implements ExecutorService {
 
     private class InstrumentedRunnable implements Runnable {
         private final Runnable task;
+        private final Timer.Context idleContext;
 
         InstrumentedRunnable(Runnable task) {
             this.task = task;
+            this.idleContext = idle.time();
         }
 
         @Override
         public void run() {
+        	idleContext.stop();
             running.inc();
-            final Timer.Context context = duration.time();
+            final Timer.Context durationContext = duration.time();
             try {
                 task.run();
             } finally {
-                context.stop();
+            	durationContext.stop();
                 running.dec();
                 completed.mark();
             }

--- a/metrics-core/src/test/java/com/codahale/metrics/InstrumentedExecutorServiceTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/InstrumentedExecutorServiceTest.java
@@ -26,11 +26,13 @@ public class InstrumentedExecutorServiceTest {
         final Counter running = registry.counter("xs.running");
         final Meter completed = registry.meter("xs.completed");
         final Timer duration = registry.timer("xs.duration");
+        final Timer idle = registry.timer("xs.idle");
 
         assertThat(submitted.getCount()).isEqualTo(0);
         assertThat(running.getCount()).isEqualTo(0);
         assertThat(completed.getCount()).isEqualTo(0);
         assertThat(duration.getCount()).isEqualTo(0);
+        assertThat(idle.getCount()).isEqualTo(0);
 
         Future<?> theFuture = instrumentedExecutorService.submit(new Runnable() {
             public void run() {
@@ -38,6 +40,7 @@ public class InstrumentedExecutorServiceTest {
                 assertThat(running.getCount()).isEqualTo(1);
                 assertThat(completed.getCount()).isEqualTo(0);
                 assertThat(duration.getCount()).isEqualTo(0);
+                assertThat(idle.getCount()).isEqualTo(1);
 	    }
 	});
 
@@ -48,6 +51,8 @@ public class InstrumentedExecutorServiceTest {
         assertThat(completed.getCount()).isEqualTo(1);
         assertThat(duration.getCount()).isEqualTo(1);
         assertThat(duration.getSnapshot().size()).isEqualTo(1);
+        assertThat(idle.getCount()).isEqualTo(1);
+        assertThat(idle.getSnapshot().size()).isEqualTo(1);
     }
 
     @After

--- a/metrics-jersey/src/test/java/com/codahale/metrics/jersey/resources/InstrumentedResource.java
+++ b/metrics-jersey/src/test/java/com/codahale/metrics/jersey/resources/InstrumentedResource.java
@@ -2,10 +2,12 @@ package com.codahale.metrics.jersey.resources;
 
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.ResponseMetered;
 import com.codahale.metrics.annotation.Timed;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.io.IOException;
 
 @Path("/")
@@ -34,4 +36,34 @@ public class InstrumentedResource {
         }
         return "fuh";
     }
+
+    @GET
+    @ResponseMetered
+    @Path("/response-metered-2xx")
+    public Response responseMetered2xx() {
+        return Response.ok().build();
+    }
+
+    @GET
+    @ResponseMetered
+    @Path("/response-metered-3xx")
+    public Response responseMetered3xx() {
+        return Response.notModified().build();
+    }
+
+    @GET
+    @ResponseMetered
+    @Path("/response-metered-5xx")
+    public Response responseMetered5xx() {
+        return Response.serverError().build();
+    }
+
+    @GET
+    @ResponseMetered
+    @Path("/response-metered-io-exception")
+    public Response responseMeteredIOException() throws IOException {
+        throw new IOException("AUGH");
+    }
+
+
 }

--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
@@ -7,7 +7,9 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.ResponseMetered;
 import com.codahale.metrics.annotation.Timed;
+import org.glassfish.jersey.server.ContainerResponse;
 import org.glassfish.jersey.server.model.ModelProcessor;
 import org.glassfish.jersey.server.model.Resource;
 import org.glassfish.jersey.server.model.ResourceMethod;
@@ -48,6 +50,7 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
     private ConcurrentMap<EventTypeAndMethod, Timer> timers = new ConcurrentHashMap<>();
     private ConcurrentMap<Method, Meter> meters = new ConcurrentHashMap<>();
     private ConcurrentMap<Method, ExceptionMeterMetric> exceptionMeters = new ConcurrentHashMap<>();
+    private ConcurrentMap<Method, ResponseMeterMetric> responseMeters = new ConcurrentHashMap<>();
 
     public interface ClockProvider {
         Clock get();
@@ -94,6 +97,27 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
                     exceptionMetered.absolute(), method, ExceptionMetered.DEFAULT_NAME_SUFFIX);
             this.meter = registry.meter(name);
             this.cause = exceptionMetered.cause();
+        }
+    }
+
+    /**
+     * A private class to maintain the metrics for a method annotated with the
+     * {@link ResponseMetered} annotation, which needs to maintain meters for
+     * different response codes
+     */
+    private static class ResponseMeterMetric {
+        public final Meter[] meters;
+        public ResponseMeterMetric(final MetricRegistry registry,
+                                   final ResourceMethod method,
+                                   final ResponseMetered responseMetered) {
+            final String metricName = chooseName(responseMetered.name(), responseMetered.absolute(), method);
+            this.meters = new Meter[]{
+                    registry.meter(name(metricName, "1xx-responses")), // 1xx
+                    registry.meter(name(metricName, "2xx-responses")), // 2xx
+                    registry.meter(name(metricName, "3xx-responses")), // 3xx
+                    registry.meter(name(metricName, "4xx-responses")), // 4xx
+                    registry.meter(name(metricName, "5xx-responses"))  // 5xx
+            };
         }
     }
 
@@ -203,6 +227,37 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         }
     }
 
+    private static class ResponseMeterRequestEventListener implements RequestEventListener {
+        private final ConcurrentMap<Method, ResponseMeterMetric> responseMeters;
+
+        public ResponseMeterRequestEventListener(final ConcurrentMap<Method, ResponseMeterMetric> responseMeters) {
+            this.responseMeters = responseMeters;
+        }
+
+        @Override
+        public void onEvent(RequestEvent event) {
+            if (event.getType() == RequestEvent.Type.FINISHED) {
+                final ResourceMethod method = event.getUriInfo().getMatchedResourceMethod();
+                final ResponseMeterMetric metric = (method != null) ?
+                        this.responseMeters.get(method.getInvocable().getDefinitionMethod()) : null;
+
+                if (metric != null) {
+                    ContainerResponse containerResponse = event.getContainerResponse();
+                    if (containerResponse == null) {
+                        if (event.getException() != null) {
+                            metric.meters[4].mark();
+                        }
+                    } else {
+                        final int responseStatus = containerResponse.getStatus() / 100;
+                        if (responseStatus >= 1 && responseStatus <= 5) {
+                            metric.meters[responseStatus - 1].mark();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private static class ChainedRequestEventListener implements RequestEventListener {
         private final RequestEventListener[] listeners;
 
@@ -242,11 +297,13 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
             final Timed classLevelTimed = getClassLevelAnnotation(resource, Timed.class);
             final Metered classLevelMetered = getClassLevelAnnotation(resource, Metered.class);
             final ExceptionMetered classLevelExceptionMetered = getClassLevelAnnotation(resource, ExceptionMetered.class);
+            final ResponseMetered classLevelResponseMetered = getClassLevelAnnotation(resource, ResponseMetered.class);
 
             for (final ResourceMethod method : resource.getAllMethods()) {
                 registerTimedAnnotations(method, classLevelTimed);
                 registerMeteredAnnotations(method, classLevelMetered);
                 registerExceptionMeteredAnnotations(method, classLevelExceptionMetered);
+                registerResponseMeteredAnnotations(method, classLevelResponseMetered);
             }
 
             for (final Resource childResource : resource.getChildResources()) {
@@ -254,15 +311,16 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
                 final Timed classLevelTimedChild = getClassLevelAnnotation(childResource, Timed.class);
                 final Metered classLevelMeteredChild = getClassLevelAnnotation(childResource, Metered.class);
                 final ExceptionMetered classLevelExceptionMeteredChild = getClassLevelAnnotation(childResource, ExceptionMetered.class);
+                final ResponseMetered classLevelResponseMeteredChild = getClassLevelAnnotation(childResource, ResponseMetered.class);
 
                 for (final ResourceMethod method : childResource.getAllMethods()) {
                     registerTimedAnnotations(method, classLevelTimedChild);
                     registerMeteredAnnotations(method, classLevelMeteredChild);
                     registerExceptionMeteredAnnotations(method, classLevelExceptionMeteredChild);
+                    registerResponseMeteredAnnotations(method, classLevelResponseMeteredChild);
                 }
             }
         }
-
     }
 
     @Override
@@ -270,7 +328,8 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         final RequestEventListener listener = new ChainedRequestEventListener(
                 new TimerRequestEventListener(timers),
                 new MeterRequestEventListener(meters),
-                new ExceptionMeterRequestEventListener(exceptionMeters));
+                new ExceptionMeterRequestEventListener(exceptionMeters),
+                new ResponseMeterRequestEventListener(responseMeters));
 
         return listener;
     }
@@ -343,6 +402,20 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
 
         if (annotation != null) {
             exceptionMeters.putIfAbsent(definitionMethod, new ExceptionMeterMetric(metrics, method, annotation));
+        }
+    }
+
+    private void registerResponseMeteredAnnotations(final ResourceMethod method, final ResponseMetered classLevelResponseMetered) {
+        final Method definitionMethod = method.getInvocable().getDefinitionMethod();
+
+        if (classLevelResponseMetered != null) {
+            responseMeters.putIfAbsent(definitionMethod, new ResponseMeterMetric(metrics, method, classLevelResponseMetered));
+            return;
+        }
+        final ResponseMetered annotation = definitionMethod.getAnnotation(ResponseMetered.class);
+
+        if (annotation != null) {
+            responseMeters.putIfAbsent(definitionMethod, new ResponseMeterMetric(metrics, method, annotation));
         }
     }
 

--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
@@ -1,5 +1,7 @@
 package com.codahale.metrics.jersey2;
 
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.ExponentiallyDecayingReservoir;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
@@ -16,11 +18,13 @@ import org.glassfish.jersey.server.monitoring.RequestEvent;
 import org.glassfish.jersey.server.monitoring.RequestEventListener;
 
 import javax.ws.rs.core.Configuration;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.ext.Provider;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
@@ -37,10 +41,19 @@ import static com.codahale.metrics.MetricRegistry.name;
 @Provider
 public class InstrumentedResourceMethodApplicationListener implements ApplicationEventListener, ModelProcessor {
 
+    private static final String[] REQUEST_FILTERING = {"request", "filtering"};
+    private static final String[] RESPONSE_FILTERING = {"response", "filtering"};
+    private static final String TOTAL = "total";
     private final MetricRegistry metrics;
-    private ConcurrentMap<Method, Timer> timers = new ConcurrentHashMap<>();
+    private ConcurrentMap<EventTypeAndMethod, Timer> timers = new ConcurrentHashMap<>();
     private ConcurrentMap<Method, Meter> meters = new ConcurrentHashMap<>();
     private ConcurrentMap<Method, ExceptionMeterMetric> exceptionMeters = new ConcurrentHashMap<>();
+
+    public interface ClockProvider {
+        Clock get();
+    }
+
+    private final ClockProvider clockProvider;
 
     /**
      * Construct an application event listener using the given metrics registry.
@@ -52,7 +65,17 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
      * @param metrics a {@link MetricRegistry}
      */
     public InstrumentedResourceMethodApplicationListener(final MetricRegistry metrics) {
+        this(metrics, null);
+    }
+
+    public InstrumentedResourceMethodApplicationListener(final MetricRegistry metrics, ClockProvider clockProvider) {
         this.metrics = metrics;
+        this.clockProvider = clockProvider != null ? clockProvider : new ClockProvider() {
+            @Override
+            public Clock get() {
+                return Clock.defaultClock();
+            }
+        };
     }
 
     /**
@@ -74,27 +97,66 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         }
     }
 
-    private static class TimerRequestEventListener implements RequestEventListener {
-        private final ConcurrentMap<Method, Timer> timers;
-        private Timer.Context context = null;
+    private static EventTypeAndMethod key(RequestEvent event) {
+        final ResourceMethod resourceMethod = event.getUriInfo().getMatchedResourceMethod();
+        if (resourceMethod == null) {
+            return null;
+        }
+        return new EventTypeAndMethod(
+            event.getType(), resourceMethod.getInvocable().getDefinitionMethod()
+        );
+    }
 
-        public TimerRequestEventListener(final ConcurrentMap<Method, Timer> timers) {
+    private class TimerRequestEventListener implements RequestEventListener {
+        private final ConcurrentMap<EventTypeAndMethod, Timer> timers;
+        private Timer.Context context = null;
+        private final long start;
+
+        public TimerRequestEventListener(final ConcurrentMap<EventTypeAndMethod, Timer> timers) {
             this.timers = timers;
+            start = clockProvider.get().getTick();
         }
 
         @Override
         public void onEvent(RequestEvent event) {
-            if (event.getType() == RequestEvent.Type.RESOURCE_METHOD_START) {
-                final Timer timer = this.timers.get(event.getUriInfo()
-                        .getMatchedResourceMethod().getInvocable().getDefinitionMethod());
-                if (timer != null) {
-                    this.context = timer.time();
+            switch (event.getType()) {
+            case RESOURCE_METHOD_START:
+            case REQUEST_MATCHED:
+            case RESP_FILTERS_START:
+                final Timer timer = timer(event);
+                if (timer == null) {
+                    return;
                 }
-            } else if (event.getType() == RequestEvent.Type.RESOURCE_METHOD_FINISHED) {
+                this.context = timer.time();
+                break;
+            case RESOURCE_METHOD_FINISHED:
+            case REQUEST_FILTERED:
+            case RESP_FILTERS_FINISHED:
+            case FINISHED:
                 if (this.context != null) {
                     this.context.close();
+                    this.context = null;
                 }
+                break;
+            default:
+                break;
             }
+            if (event.getType() == RequestEvent.Type.FINISHED) {
+                final Timer timer = timer(event);
+                if (timer == null) {
+                    return;
+                }
+                long end = clockProvider.get().getTick();
+                timer.update(end - start, TimeUnit.NANOSECONDS);
+            }
+        }
+
+        private Timer timer(RequestEvent event) {
+            final EventTypeAndMethod key = key(event);
+            if (key == null) {
+                return null;
+            }
+            return timers.get(key);
         }
     }
 
@@ -108,8 +170,7 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         @Override
         public void onEvent(RequestEvent event) {
             if (event.getType() == RequestEvent.Type.RESOURCE_METHOD_START) {
-                final Meter meter = this.meters.get(event.getUriInfo()
-                        .getMatchedResourceMethod().getInvocable().getDefinitionMethod());
+                final Meter meter = this.meters.get(event.getUriInfo().getMatchedResourceMethod().getInvocable().getDefinitionMethod());
                 if (meter != null) {
                     meter.mark();
                 }
@@ -230,14 +291,30 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
     private void registerTimedAnnotations(final ResourceMethod method, final Timed classLevelTimed) {
         final Method definitionMethod = method.getInvocable().getDefinitionMethod();
         if (classLevelTimed != null) {
-            timers.putIfAbsent(definitionMethod, timerMetric(this.metrics, method, classLevelTimed));
+            timers.putIfAbsent(EventTypeAndMethod.requestMethodStart(definitionMethod), timerMetric(this.metrics, method, classLevelTimed));
+            if (classLevelTimed.name().isEmpty()) {
+                timers.putIfAbsent(EventTypeAndMethod.requestMatched(definitionMethod),
+                    timerMetric(this.metrics, method, classLevelTimed, REQUEST_FILTERING));
+                timers.putIfAbsent(EventTypeAndMethod.respFiltersStart(definitionMethod),
+                    timerMetric(this.metrics, method, classLevelTimed, RESPONSE_FILTERING));
+                timers.putIfAbsent(EventTypeAndMethod.finished(definitionMethod),
+                    timerMetric(this.metrics, method, classLevelTimed, TOTAL));
+            }
             return;
         }
 
         final Timed annotation = definitionMethod.getAnnotation(Timed.class);
 
         if (annotation != null) {
-            timers.putIfAbsent(definitionMethod, timerMetric(this.metrics, method, annotation));
+            timers.putIfAbsent(EventTypeAndMethod.requestMethodStart(definitionMethod), timerMetric(this.metrics, method, annotation));
+            if (annotation.name().isEmpty()) {
+                timers.putIfAbsent(EventTypeAndMethod.requestMatched(definitionMethod),
+                    timerMetric(this.metrics, method, annotation, REQUEST_FILTERING));
+                timers.putIfAbsent(EventTypeAndMethod.respFiltersStart(definitionMethod),
+                    timerMetric(this.metrics, method, annotation, RESPONSE_FILTERING));
+                timers.putIfAbsent(EventTypeAndMethod.finished(definitionMethod),
+                    timerMetric(this.metrics, method, annotation, TOTAL));
+            }
         }
     }
 
@@ -269,11 +346,17 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         }
     }
 
-    private static Timer timerMetric(final MetricRegistry registry,
+    private Timer timerMetric(final MetricRegistry registry,
                                      final ResourceMethod method,
-                                     final Timed timed) {
-        final String name = chooseName(timed.name(), timed.absolute(), method);
-        return registry.timer(name);
+                                     final Timed timed,
+                                     final String... suffixes) {
+        final String name = chooseName(timed.name(), timed.absolute(), method, suffixes);
+        return registry.timer(name, new MetricRegistry.MetricSupplier<Timer>() {
+            @Override
+            public Timer newMetric() {
+                return new Timer(new ExponentiallyDecayingReservoir(), clockProvider.get());
+            }
+        });
     }
 
     private static Meter meterMetric(final MetricRegistry registry,
@@ -294,5 +377,57 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         return name(name(method.getInvocable().getDefinitionMethod().getDeclaringClass(),
                         method.getInvocable().getDefinitionMethod().getName()),
                 suffixes);
+    }
+
+    static final class EventTypeAndMethod {
+        @NotNull
+        private final RequestEvent.Type type;
+        @NotNull
+        private final Method method;
+
+        public EventTypeAndMethod(RequestEvent.Type type, Method method) {
+            this.type = type;
+            this.method = method;
+        }
+
+        public static EventTypeAndMethod requestMethodStart(Method method) {
+            return new EventTypeAndMethod(RequestEvent.Type.RESOURCE_METHOD_START, method);
+        }
+
+        public static EventTypeAndMethod requestMatched(Method method) {
+            return new EventTypeAndMethod(RequestEvent.Type.REQUEST_MATCHED, method);
+        }
+
+        public static EventTypeAndMethod respFiltersStart(Method method) {
+            return new EventTypeAndMethod(RequestEvent.Type.RESP_FILTERS_START, method);
+        }
+
+        public static EventTypeAndMethod finished(Method method) {
+            return new EventTypeAndMethod(RequestEvent.Type.FINISHED, method);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            EventTypeAndMethod that = (EventTypeAndMethod) o;
+
+            if (type != that.type) {
+                return false;
+            }
+            return method.equals(that.method);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = type.hashCode();
+            result = 31 * result + method.hashCode();
+            return result;
+        }
     }
 }

--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/MetricsFeature.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/MetricsFeature.java
@@ -13,9 +13,15 @@ import javax.ws.rs.core.FeatureContext;
 public class MetricsFeature implements Feature {
 
     private final MetricRegistry registry;
+    private final InstrumentedResourceMethodApplicationListener.ClockProvider clockProvider;
 
     public MetricsFeature(MetricRegistry registry) {
+        this(registry, null);
+    }
+
+    public MetricsFeature(MetricRegistry registry, InstrumentedResourceMethodApplicationListener.ClockProvider clockProvider) {
         this.registry = registry;
+        this.clockProvider = clockProvider;
     }
 
     public MetricsFeature(String registryName) {
@@ -43,7 +49,7 @@ public class MetricsFeature implements Feature {
      */
     @Override
     public boolean configure(FeatureContext context) {
-        context.register(new InstrumentedResourceMethodApplicationListener(registry));
+        context.register(new InstrumentedResourceMethodApplicationListener(registry, clockProvider));
         return true;
     }
 }

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
@@ -204,6 +204,41 @@ public class SingletonMetricsJerseyTest extends JerseyTest {
     }
 
     @Test
+    public void responseMeteredMethodsAreMetered() {
+        final Meter meter2xx = registry.meter(name(InstrumentedResource.class,
+                "response2xxMetered",
+                "2xx-responses"));
+        final Meter meter4xx = registry.meter(name(InstrumentedResource.class,
+                "response4xxMetered",
+                "4xx-responses"));
+        final Meter meter5xx = registry.meter(name(InstrumentedResource.class,
+                "response5xxMetered",
+                "5xx-responses"));
+
+        assertThat(meter2xx.getCount()).isZero();
+        assertThat(target("response-2xx-metered")
+                .request()
+                .get().getStatus())
+                .isEqualTo(200);
+
+        assertThat(meter4xx.getCount()).isZero();
+        assertThat(target("response-4xx-metered")
+                .request()
+                .get().getStatus())
+                .isEqualTo(400);
+
+        assertThat(meter5xx.getCount()).isZero();
+        assertThat(target("response-5xx-metered")
+                .request()
+                .get().getStatus())
+                .isEqualTo(500);
+
+        assertThat(meter2xx.getCount()).isEqualTo(1);
+        assertThat(meter4xx.getCount()).isEqualTo(1);
+        assertThat(meter5xx.getCount()).isEqualTo(1);
+    }
+
+    @Test
     public void testResourceNotFound() {
         final Response response = target().path("not-found").request().get();
         assertThat(response.getStatus()).isEqualTo(404);

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsResponseMeteredPerClassJerseyTest.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsResponseMeteredPerClassJerseyTest.java
@@ -1,0 +1,137 @@
+package com.codahale.metrics.jersey2;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jersey2.exception.mapper.TestExceptionMapper;
+import com.codahale.metrics.jersey2.resources.InstrumentedResourceResponseMeteredPerClass;
+import com.codahale.metrics.jersey2.resources.InstrumentedSubResourceResponseMeteredPerClass;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Test;
+
+import javax.ws.rs.core.Application;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests registering {@link InstrumentedResourceMethodApplicationListener} as a singleton
+ * in a Jersey {@link ResourceConfig}
+ */
+public class SingletonMetricsResponseMeteredPerClassJerseyTest extends JerseyTest {
+    static {
+        Logger.getLogger("org.glassfish.jersey").setLevel(Level.OFF);
+    }
+
+    private MetricRegistry registry;
+
+    @Override
+    protected Application configure() {
+        this.registry = new MetricRegistry();
+
+
+        ResourceConfig config = new ResourceConfig();
+
+        config = config.register(new MetricsFeature(this.registry));
+        config = config.register(InstrumentedResourceResponseMeteredPerClass.class);
+        config = config.register(new TestExceptionMapper());
+
+        return config;
+    }
+
+    @Test
+    public void responseMetered2xxPerClassMethodsAreMetered() {
+        assertThat(target("responseMetered2xxPerClass")
+                .request()
+                .get().getStatus())
+                .isEqualTo(200);
+
+        final Meter meter2xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
+                "responseMetered2xxPerClass",
+                "2xx-responses"));
+
+        assertThat(meter2xx.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void responseMetered4xxPerClassMethodsAreMetered() {
+        assertThat(target("responseMetered4xxPerClass")
+                .request()
+                .get().getStatus())
+                .isEqualTo(400);
+        assertThat(target("responseMeteredBadRequestPerClass")
+                .request()
+                .get().getStatus())
+                .isEqualTo(400);
+
+        final Meter meter4xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
+                "responseMetered4xxPerClass",
+                "4xx-responses"));
+        final Meter meterException4xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
+                "responseMeteredBadRequestPerClass",
+                "4xx-responses"));
+
+        assertThat(meter4xx.getCount()).isEqualTo(1);
+        assertThat(meterException4xx.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void responseMetered5xxPerClassMethodsAreMetered() {
+        assertThat(target("responseMetered5xxPerClass")
+                .request()
+                .get().getStatus())
+                .isEqualTo(500);
+
+        final Meter meter5xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
+                "responseMetered5xxPerClass",
+                "5xx-responses"));
+
+        assertThat(meter5xx.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void responseMeteredMappedExceptionPerClassMethodsAreMetered() {
+        assertThat(target("responseMeteredTestExceptionPerClass")
+                .request()
+                .get().getStatus())
+                .isEqualTo(500);
+
+        final Meter meterTestException = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
+                "responseMeteredTestExceptionPerClass",
+                "5xx-responses"));
+
+        assertThat(meterTestException.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void responseMeteredUnmappedExceptionPerClassMethodsAreMetered() {
+        try {
+            target("responseMeteredRuntimeExceptionPerClass")
+                    .request()
+                    .get();
+        } catch (Exception e) {
+            assertThat(e.getCause()).isInstanceOf(RuntimeException.class);
+        }
+
+        final Meter meterException5xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
+                "responseMeteredRuntimeExceptionPerClass",
+                "5xx-responses"));
+
+        assertThat(meterException5xx.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void subresourcesFromLocatorsRegisterMetrics() {
+        assertThat(target("subresource/responseMeteredPerClass")
+                .request()
+                .get().getStatus())
+                .isEqualTo(200);
+
+        final Meter meter = registry.meter(name(InstrumentedSubResourceResponseMeteredPerClass.class,
+                "responseMeteredPerClass",
+                "2xx-responses"));
+        assertThat(meter.getCount()).isEqualTo(1);
+    }
+}

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/TestClock.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/TestClock.java
@@ -1,0 +1,11 @@
+package com.codahale.metrics.jersey2;
+
+import com.codahale.metrics.Clock;
+
+public class TestClock extends Clock {
+    public long tick;
+    @Override
+    public long getTick() {
+        return tick;
+    }
+}

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/exception/TestException.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/exception/TestException.java
@@ -1,0 +1,7 @@
+package com.codahale.metrics.jersey2.exception;
+
+public class TestException extends RuntimeException {
+    public TestException(String message) {
+        super(message);
+    }
+}

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/exception/mapper/TestExceptionMapper.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/exception/mapper/TestExceptionMapper.java
@@ -1,0 +1,14 @@
+package com.codahale.metrics.jersey2.exception.mapper;
+
+import com.codahale.metrics.jersey2.exception.TestException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class TestExceptionMapper implements ExceptionMapper<TestException> {
+    public Response toResponse(TestException exception) {
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    }
+}

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
@@ -3,6 +3,7 @@ package com.codahale.metrics.jersey2.resources;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
+import com.codahale.metrics.jersey2.TestClock;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -11,11 +12,34 @@ import java.io.IOException;
 @Path("/")
 @Produces(MediaType.TEXT_PLAIN)
 public class InstrumentedResource {
+    private final TestClock testClock;
+
+    public InstrumentedResource(TestClock testClock) {
+        this.testClock = testClock;
+    }
+
     @GET
     @Timed
     @Path("/timed")
     public String timed() {
+        testClock.tick++;
         return "yay";
+    }
+
+    @GET
+    @Timed(name="fancyName")
+    @Path("/named")
+    public String named() {
+        testClock.tick++;
+        return "fancy";
+    }
+
+    @GET
+    @Timed(name="absolutelyFancy", absolute = true)
+    @Path("/absolute")
+    public String absolute() {
+        testClock.tick++;
+        return "absolute";
     }
 
     @GET
@@ -37,6 +61,6 @@ public class InstrumentedResource {
 
     @Path("/subresource")
     public InstrumentedSubResource locateSubResource() {
-        return new InstrumentedSubResource();
+        return new InstrumentedSubResource(testClock);
     }
 }

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
@@ -2,11 +2,13 @@ package com.codahale.metrics.jersey2.resources;
 
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Metered;
+import com.codahale.metrics.annotation.ResponseMetered;
 import com.codahale.metrics.annotation.Timed;
 import com.codahale.metrics.jersey2.TestClock;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 import java.io.IOException;
 
 @Path("/")
@@ -57,6 +59,27 @@ public class InstrumentedResource {
             throw new IOException("AUGH");
         }
         return "fuh";
+    }
+
+    @GET
+    @ResponseMetered
+    @Path("/response-2xx-metered")
+    public Response response2xxMetered() {
+        return Response.ok().build();
+    }
+
+    @GET
+    @ResponseMetered
+    @Path("/response-4xx-metered")
+    public Response response4xxMetered() {
+        return Response.status(Response.Status.BAD_REQUEST).build();
+    }
+
+    @GET
+    @ResponseMetered
+    @Path("/response-5xx-metered")
+    public Response response5xxMetered() {
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
     }
 
     @Path("/subresource")

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResourceResponseMeteredPerClass.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResourceResponseMeteredPerClass.java
@@ -1,0 +1,58 @@
+package com.codahale.metrics.jersey2.resources;
+
+import com.codahale.metrics.annotation.ResponseMetered;
+import com.codahale.metrics.jersey2.exception.TestException;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@ResponseMetered
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+public class InstrumentedResourceResponseMeteredPerClass {
+
+    @GET
+    @Path("/responseMetered2xxPerClass")
+    public Response responseMetered2xxPerClass() {
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/responseMetered4xxPerClass")
+    public Response responseMetered4xxPerClass() {
+        return Response.status(Response.Status.BAD_REQUEST).build();
+    }
+
+    @GET
+    @Path("/responseMetered5xxPerClass")
+    public Response responseMetered5xxPerClass() {
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    }
+
+    @GET
+    @Path("/responseMeteredBadRequestPerClass")
+    public String responseMeteredBadRequestPerClass() {
+        throw new BadRequestException();
+    }
+
+    @GET
+    @Path("/responseMeteredRuntimeExceptionPerClass")
+    public String responseMeteredRuntimeExceptionPerClass() {
+        throw new RuntimeException();
+    }
+
+    @GET
+    @Path("/responseMeteredTestExceptionPerClass")
+    public String responseMeteredTestExceptionPerClass() {
+        throw new TestException("test");
+    }
+
+    @Path("/subresource")
+    public InstrumentedSubResourceResponseMeteredPerClass locateSubResource() {
+        return new InstrumentedSubResourceResponseMeteredPerClass();
+    }
+
+}

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedSubResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedSubResource.java
@@ -1,17 +1,27 @@
 package com.codahale.metrics.jersey2.resources;
 
-import com.codahale.metrics.annotation.Timed;
-
-import javax.ws.rs.*;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import java.io.IOException;
+
+import com.codahale.metrics.annotation.Timed;
+import com.codahale.metrics.jersey2.TestClock;
 
 @Produces(MediaType.TEXT_PLAIN)
 public class InstrumentedSubResource {
+    private final TestClock testClock;
+
+    public InstrumentedSubResource(TestClock testClock) {
+
+        this.testClock = testClock;
+    }
+
     @GET
     @Timed
     @Path("/timed")
     public String timed() {
+        testClock.tick += 2;
         return "yay";
     }
 

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedSubResourceResponseMeteredPerClass.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedSubResourceResponseMeteredPerClass.java
@@ -1,0 +1,18 @@
+package com.codahale.metrics.jersey2.resources;
+
+import com.codahale.metrics.annotation.ResponseMetered;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@ResponseMetered
+@Produces(MediaType.TEXT_PLAIN)
+public class InstrumentedSubResourceResponseMeteredPerClass {
+    @GET
+    @Path("/responseMeteredPerClass")
+    public Response responseMeteredPerClass() {
+        return Response.status(Response.Status.OK).build();
+    }
+}

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/TestRequestFilter.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/TestRequestFilter.java
@@ -1,0 +1,21 @@
+package com.codahale.metrics.jersey2.resources;
+
+import java.io.IOException;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+
+import com.codahale.metrics.jersey2.TestClock;
+
+public class TestRequestFilter implements ContainerRequestFilter{
+    private final TestClock testClock;
+
+    public TestRequestFilter(TestClock testClock) {
+        this.testClock = testClock;
+    }
+
+    @Override
+    public void filter(ContainerRequestContext containerRequestContext) throws IOException {
+        testClock.tick += 4;
+    }
+}


### PR DESCRIPTION
For Dropwizard services, we currently have metrics for response rates by HTTP status code (1xx, 2xx, 3xx, 4xx, 5xx) captured at Jetty . There have been use cases where it would be helpful to have it on a Jersey Resource method/class level. To achieve that, I've added ```@ResponseMetered``` annotation which will add meters for 1xx/2xx/3xx/4xx/5xx responses. I've reused the logic from [com.codahale.metrics.jetty9.InstrumentedHandler](https://github.com/dropwizard/metrics/blob/4.0-development/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java#L287-L290) to capture the metrics.

I hope you find this helpful and I'm open to suggestions/feedback. Thanks!

This is based of https://github.com/dropwizard/metrics/pull/1185 for the 3.2-development branch

```java
@Path("/")
@Produces(MediaType.TEXT_PLAIN)
public class InstrumentedResource {
    @GET
    @ResponseMetered
    @Path("/responseMeteredEndpoint")
    public Response responseMeteredEndpoint() {
        return Response.ok().build();
    }
}
``` 