### PR TITLE
Javadoc clarification: initialDelay time unit

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -159,7 +159,7 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
      *
      * @param initialDelay the time to delay the first execution
      * @param period       the amount of time between polls
-     * @param unit         the unit for {@code period}
+     * @param unit         the unit for {@code period} and {@code initialDelay}
      */
     synchronized public void start(long initialDelay, long period, TimeUnit unit) {
         if (this.scheduledFuture != null) {


### PR DESCRIPTION
If you use the method start on ScheduledReporter with an initialDelay, it is not clear which time unit is used for this initial delay. I added a clarification in the JavaDoc.