### PR TITLE
Improve metrics filter

### DIFF
--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
@@ -86,14 +86,6 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         }
     }
 
-    private static EventTypeAndMethod key(RequestEvent event) {
-        final ResourceMethod resourceMethod = event.getUriInfo().getMatchedResourceMethod();
-        if (resourceMethod == null) {
-            return null;
-        }
-        return new EventTypeAndMethod(event.getType(), resourceMethod.getInvocable().getDefinitionMethod());
-    }
-
     private static class TimerRequestEventListener implements RequestEventListener {
 
         private final ConcurrentMap<EventTypeAndMethod, Timer> timers;
@@ -142,11 +134,11 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         }
 
         private Timer timer(RequestEvent event) {
-            final EventTypeAndMethod key = key(event);
-            if (key == null) {
+            final ResourceMethod resourceMethod = event.getUriInfo().getMatchedResourceMethod();
+            if (resourceMethod == null) {
                 return null;
             }
-            return timers.get(key);
+            return timers.get(new EventTypeAndMethod(event.getType(), resourceMethod.getInvocable().getDefinitionMethod()));
         }
     }
 

--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
@@ -94,13 +94,16 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         return new EventTypeAndMethod(event.getType(), resourceMethod.getInvocable().getDefinitionMethod());
     }
 
-    private class TimerRequestEventListener implements RequestEventListener {
+    private static class TimerRequestEventListener implements RequestEventListener {
+
         private final ConcurrentMap<EventTypeAndMethod, Timer> timers;
+        private final Clock clock;
         private Timer.Context context = null;
         private final long start;
 
-        public TimerRequestEventListener(final ConcurrentMap<EventTypeAndMethod, Timer> timers) {
+        public TimerRequestEventListener(final ConcurrentMap<EventTypeAndMethod, Timer> timers, Clock clock) {
             this.timers = timers;
+            this.clock = clock;
             start = clock.getTick();
         }
 
@@ -255,7 +258,7 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
     @Override
     public RequestEventListener onRequest(final RequestEvent event) {
         final RequestEventListener listener = new ChainedRequestEventListener(
-                new TimerRequestEventListener(timers),
+                new TimerRequestEventListener(timers, clock),
                 new MeterRequestEventListener(meters),
                 new ExceptionMeterRequestEventListener(exceptionMeters));
 

--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/MetricsFeature.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/MetricsFeature.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.jersey2;
 
+import com.codahale.metrics.Clock;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
 
@@ -13,15 +14,15 @@ import javax.ws.rs.core.FeatureContext;
 public class MetricsFeature implements Feature {
 
     private final MetricRegistry registry;
-    private final InstrumentedResourceMethodApplicationListener.ClockProvider clockProvider;
+    private final Clock clock;
 
     public MetricsFeature(MetricRegistry registry) {
         this(registry, null);
     }
 
-    public MetricsFeature(MetricRegistry registry, InstrumentedResourceMethodApplicationListener.ClockProvider clockProvider) {
+    public MetricsFeature(MetricRegistry registry, Clock clock) {
         this.registry = registry;
-        this.clockProvider = clockProvider;
+        this.clock = clock;
     }
 
     public MetricsFeature(String registryName) {
@@ -49,7 +50,7 @@ public class MetricsFeature implements Feature {
      */
     @Override
     public boolean configure(FeatureContext context) {
-        context.register(new InstrumentedResourceMethodApplicationListener(registry, clockProvider));
+        context.register(new InstrumentedResourceMethodApplicationListener(registry, clock));
         return true;
     }
 }

--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/MetricsFeature.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/MetricsFeature.java
@@ -15,14 +15,20 @@ public class MetricsFeature implements Feature {
 
     private final MetricRegistry registry;
     private final Clock clock;
+    private final boolean trackFilters;
 
     public MetricsFeature(MetricRegistry registry) {
-        this(registry, null);
+        this(registry, Clock.defaultClock());
     }
 
     public MetricsFeature(MetricRegistry registry, Clock clock) {
+        this(registry, clock, false);
+    }
+
+    public MetricsFeature(MetricRegistry registry, Clock clock, boolean trackFilters) {
         this.registry = registry;
         this.clock = clock;
+        this.trackFilters = trackFilters;
     }
 
     public MetricsFeature(String registryName) {
@@ -50,7 +56,7 @@ public class MetricsFeature implements Feature {
      */
     @Override
     public boolean configure(FeatureContext context) {
-        context.register(new InstrumentedResourceMethodApplicationListener(registry, clock));
+        context.register(new InstrumentedResourceMethodApplicationListener(registry, clock, trackFilters));
         return true;
     }
 }

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonFilterMetricsJerseyTest.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonFilterMetricsJerseyTest.java
@@ -1,0 +1,162 @@
+package com.codahale.metrics.jersey2;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.jersey2.resources.InstrumentedFilteredResource;
+import com.codahale.metrics.jersey2.resources.TestRequestFilter;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.test.JerseyTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.Application;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests registering {@link InstrumentedResourceMethodApplicationListener} as a singleton
+ * in a Jersey {@link ResourceConfig} with filter tracking
+ */
+public class SingletonFilterMetricsJerseyTest extends JerseyTest {
+    static {
+        Logger.getLogger("org.glassfish.jersey").setLevel(Level.OFF);
+    }
+
+    private MetricRegistry registry;
+
+    private TestClock testClock;
+
+    @Override
+    protected Application configure() {
+        registry = new MetricRegistry();
+        testClock = new TestClock();
+        ResourceConfig config = new ResourceConfig();
+        config = config.register(new MetricsFeature(this.registry, testClock, true));
+        config = config.register(new TestRequestFilter(testClock));
+        config = config.register(new InstrumentedFilteredResource(testClock));
+        return config;
+    }
+
+    @Before
+    public void resetClock() {
+        testClock.tick = 0;
+    }
+
+    @Test
+    public void timedMethodsAreTimed() {
+        assertThat(target("timed")
+                .request()
+                .get(String.class))
+                .isEqualTo("yay");
+
+        final Timer timer = registry.timer(name(InstrumentedFilteredResource.class, "timed"));
+
+        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(timer.getSnapshot().getValues()[0]).isEqualTo(1);
+    }
+
+    @Test
+    public void explicitNamesAreTimed() {
+        assertThat(target("named")
+                .request()
+                .get(String.class))
+                .isEqualTo("fancy");
+
+        final Timer timer = registry.timer(name(InstrumentedFilteredResource.class, "fancyName"));
+
+        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(timer.getSnapshot().getValues()[0]).isEqualTo(1);
+    }
+
+    @Test
+    public void absoluteNamesAreTimed() {
+        assertThat(target("absolute")
+                .request()
+                .get(String.class))
+                .isEqualTo("absolute");
+
+        final Timer timer = registry.timer("absolutelyFancy");
+
+        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(timer.getSnapshot().getValues()[0]).isEqualTo(1);
+    }
+
+    @Test
+    public void requestFiltersOfTimedMethodsAreTimed() {
+        assertThat(target("timed")
+                .request()
+                .get(String.class))
+                .isEqualTo("yay");
+
+        final Timer timer = registry.timer(name(InstrumentedFilteredResource.class, "timed", "request", "filtering"));
+
+        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(timer.getSnapshot().getValues()[0]).isEqualTo(4);
+    }
+
+    @Test
+    public void responseFiltersOfTimedMethodsAreTimed() {
+        assertThat(target("timed")
+                .request()
+                .get(String.class))
+                .isEqualTo("yay");
+
+        final Timer timer = registry.timer(name(InstrumentedFilteredResource.class, "timed", "response", "filtering"));
+
+        assertThat(timer.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void totalTimeOfTimedMethodsIsTimed() {
+        assertThat(target("timed")
+                .request()
+                .get(String.class))
+                .isEqualTo("yay");
+
+        final Timer timer = registry.timer(name(InstrumentedFilteredResource.class, "timed", "total"));
+
+        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(timer.getSnapshot().getValues()[0]).isEqualTo(5);
+    }
+
+    @Test
+    public void requestFiltersOfNamedMethodsAreTimed() {
+        assertThat(target("named")
+                .request()
+                .get(String.class))
+                .isEqualTo("fancy");
+
+        final Timer timer = registry.timer(name(InstrumentedFilteredResource.class, "fancyName", "request", "filtering"));
+
+        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(timer.getSnapshot().getValues()[0]).isEqualTo(4);
+    }
+
+    @Test
+    public void requestFiltersOfAbsoluteMethodsAreTimed() {
+        assertThat(target("absolute")
+                .request()
+                .get(String.class))
+                .isEqualTo("absolute");
+
+        final Timer timer = registry.timer(name("absolutelyFancy", "request", "filtering"));
+        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(timer.getSnapshot().getValues()[0]).isEqualTo(4);
+    }
+
+    @Test
+    public void subResourcesFromLocatorsRegisterMetrics() {
+        assertThat(target("subresource/timed")
+                .request()
+                .get(String.class))
+                .isEqualTo("yay");
+
+        final Timer timer = registry.timer(name(InstrumentedFilteredResource.InstrumentedFilteredSubResource.class,
+                "timed"));
+        assertThat(timer.getCount()).isEqualTo(1);
+
+    }
+}

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
@@ -5,12 +5,9 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.jersey2.resources.InstrumentedResource;
 import com.codahale.metrics.jersey2.resources.InstrumentedSubResource;
-import com.codahale.metrics.jersey2.resources.TestRequestFilter;
-
 import org.glassfish.jersey.client.ClientResponse;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
-import org.junit.Before;
 import org.junit.Test;
 
 import javax.ws.rs.NotFoundException;
@@ -36,23 +33,15 @@ public class SingletonMetricsJerseyTest extends JerseyTest {
 
     private MetricRegistry registry;
 
-    private TestClock testClock;
-
     @Override
     protected Application configure() {
-        registry = new MetricRegistry();
-        testClock = new TestClock();
+        this.registry = new MetricRegistry();
+
         ResourceConfig config = new ResourceConfig();
-        config = config.register(new MetricsFeature(this.registry, testClock));
-        config = config.register(new TestRequestFilter(testClock));
-        config = config.register(new InstrumentedResource(testClock));
+        config = config.register(new MetricsFeature(this.registry));
+        config = config.register(InstrumentedResource.class);
 
         return config;
-    }
-
-    @Before
-    public void resetClock() {
-        testClock.tick = 0;
     }
 
     @Test
@@ -65,97 +54,7 @@ public class SingletonMetricsJerseyTest extends JerseyTest {
         final Timer timer = registry.timer(name(InstrumentedResource.class, "timed"));
 
         assertThat(timer.getCount()).isEqualTo(1);
-        assertThat(timer.getSnapshot().getValues()[0]).isEqualTo(1);
     }
-
-    @Test
-    public void explicitNamesAreUsed() {
-        assertThat(target("named")
-            .request()
-            .get(String.class))
-            .isEqualTo("fancy");
-
-        final Timer timer = registry.timer(name(InstrumentedResource.class, "fancyName"));
-
-        assertThat(timer.getCount()).isEqualTo(1);
-        assertThat(timer.getSnapshot().getValues()[0]).isEqualTo(1);
-    }
-
-    @Test
-    public void absoluteNamesAreNotPrefixed() {
-        assertThat(target("absolute")
-            .request()
-            .get(String.class))
-            .isEqualTo("absolute");
-
-        final Timer timer = registry.timer("absolutelyFancy");
-
-        assertThat(timer.getCount()).isEqualTo(1);
-        assertThat(timer.getSnapshot().getValues()[0]).isEqualTo(1);
-    }
-
-    @Test
-    public void requestFiltersOfTimedMethodsAreTimed() {
-        assertThat(target("timed")
-            .request()
-            .get(String.class))
-            .isEqualTo("yay");
-
-        final Timer timer = registry.timer(name(InstrumentedResource.class, "timed", "request", "filtering"));
-
-        assertThat(timer.getCount()).isEqualTo(1);
-        assertThat(timer.getSnapshot().getValues()[0]).isEqualTo(4);
-    }
-
-    @Test
-    public void requestTimedMethodsGetTotalTimer() {
-        assertThat(target("timed")
-            .request()
-            .get(String.class))
-            .isEqualTo("yay");
-
-        final Timer timer = registry.timer(name(InstrumentedResource.class, "timed", "total"));
-
-        assertThat(timer.getCount()).isEqualTo(1);
-        assertThat(timer.getSnapshot().getValues()[0]).isEqualTo(5);
-    }
-
-    @Test
-    public void implicitlyNamedMethodsDoGetFilterMetrics() {
-        assertThat(target("timed")
-            .request()
-            .get(String.class))
-            .isEqualTo("yay");
-
-        assertThat(registry.getMeters()).doesNotContainKey(
-            name(InstrumentedResource.class, "timed", "request", "filtering")
-        );
-    }
-
-    @Test
-    public void explicitlyNamedMethodsDontGetFilterMetrics() {
-        assertThat(target("named")
-            .request()
-            .get(String.class))
-            .isEqualTo("fancy");
-
-        assertThat(registry.getMeters()).doesNotContainKey(
-            name(InstrumentedResource.class, "fancyName", "request", "filtering")
-        );
-    }
-
-    @Test
-    public void responseFiltersOfTimedMethodsAreTimed() {
-        assertThat(target("timed")
-            .request()
-            .get(String.class))
-            .isEqualTo("yay");
-
-        final Timer timer = registry.timer(name(InstrumentedResource.class, "timed", "response", "filtering"));
-
-        assertThat(timer.getCount()).isEqualTo(1);
-    }
-
 
     @Test
     public void meteredMethodsAreMetered() {

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
@@ -39,19 +39,12 @@ public class SingletonMetricsJerseyTest extends JerseyTest {
 
     private TestClock testClock;
 
-    public class TestClockProvider implements InstrumentedResourceMethodApplicationListener.ClockProvider {
-        @Override
-        public Clock get() {
-            return testClock;
-        }
-    }
-
     @Override
     protected Application configure() {
-        this.registry = new MetricRegistry();
+        registry = new MetricRegistry();
         testClock = new TestClock();
         ResourceConfig config = new ResourceConfig();
-        config = config.register(new MetricsFeature(this.registry, new TestClockProvider()));
+        config = config.register(new MetricsFeature(this.registry, testClock));
         config = config.register(new TestRequestFilter(testClock));
         config = config.register(new InstrumentedResource(testClock));
 

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
@@ -1,6 +1,5 @@
 package com.codahale.metrics.jersey2;
 
-import com.codahale.metrics.Clock;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/TestClock.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/TestClock.java
@@ -3,7 +3,9 @@ package com.codahale.metrics.jersey2;
 import com.codahale.metrics.Clock;
 
 public class TestClock extends Clock {
+
     public long tick;
+
     @Override
     public long getTick() {
         return tick;

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedFilteredResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedFilteredResource.java
@@ -1,0 +1,62 @@
+package com.codahale.metrics.jersey2.resources;
+
+import com.codahale.metrics.annotation.Timed;
+import com.codahale.metrics.jersey2.TestClock;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Path("/")
+@Produces(MediaType.TEXT_PLAIN)
+public class InstrumentedFilteredResource {
+
+    private final TestClock testClock;
+
+    public InstrumentedFilteredResource(TestClock testClock) {
+        this.testClock = testClock;
+    }
+
+    @GET
+    @Timed
+    @Path("/timed")
+    public String timed() {
+        testClock.tick++;
+        return "yay";
+    }
+
+    @GET
+    @Timed(name = "fancyName")
+    @Path("/named")
+    public String named() {
+        testClock.tick++;
+        return "fancy";
+    }
+
+    @GET
+    @Timed(name = "absolutelyFancy", absolute = true)
+    @Path("/absolute")
+    public String absolute() {
+        testClock.tick++;
+        return "absolute";
+    }
+
+    @Path("/subresource")
+    public InstrumentedFilteredSubResource locateSubResource() {
+        return new InstrumentedFilteredSubResource();
+    }
+
+    @Produces(MediaType.TEXT_PLAIN)
+    public class InstrumentedFilteredSubResource {
+
+        @GET
+        @Timed
+        @Path("/timed")
+        public String timed() {
+            testClock.tick += 2;
+            return "yay";
+        }
+
+    }
+}

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 @Path("/")
 @Produces(MediaType.TEXT_PLAIN)
 public class InstrumentedResource {
+
     private final TestClock testClock;
 
     public InstrumentedResource(TestClock testClock) {

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
@@ -3,7 +3,6 @@ package com.codahale.metrics.jersey2.resources;
 import com.codahale.metrics.annotation.ExceptionMetered;
 import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
-import com.codahale.metrics.jersey2.TestClock;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
@@ -12,35 +11,11 @@ import java.io.IOException;
 @Path("/")
 @Produces(MediaType.TEXT_PLAIN)
 public class InstrumentedResource {
-
-    private final TestClock testClock;
-
-    public InstrumentedResource(TestClock testClock) {
-        this.testClock = testClock;
-    }
-
     @GET
     @Timed
     @Path("/timed")
     public String timed() {
-        testClock.tick++;
         return "yay";
-    }
-
-    @GET
-    @Timed(name="fancyName")
-    @Path("/named")
-    public String named() {
-        testClock.tick++;
-        return "fancy";
-    }
-
-    @GET
-    @Timed(name="absolutelyFancy", absolute = true)
-    @Path("/absolute")
-    public String absolute() {
-        testClock.tick++;
-        return "absolute";
     }
 
     @GET
@@ -62,6 +37,6 @@ public class InstrumentedResource {
 
     @Path("/subresource")
     public InstrumentedSubResource locateSubResource() {
-        return new InstrumentedSubResource(testClock);
+        return new InstrumentedSubResource();
     }
 }

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedSubResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedSubResource.java
@@ -1,27 +1,19 @@
 package com.codahale.metrics.jersey2.resources;
 
+import com.codahale.metrics.annotation.Timed;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import com.codahale.metrics.annotation.Timed;
-import com.codahale.metrics.jersey2.TestClock;
-
 @Produces(MediaType.TEXT_PLAIN)
 public class InstrumentedSubResource {
-    private final TestClock testClock;
-
-    public InstrumentedSubResource(TestClock testClock) {
-
-        this.testClock = testClock;
-    }
 
     @GET
     @Timed
     @Path("/timed")
     public String timed() {
-        testClock.tick += 2;
         return "yay";
     }
 

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/TestRequestFilter.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/TestRequestFilter.java
@@ -1,13 +1,13 @@
 package com.codahale.metrics.jersey2.resources;
 
-import java.io.IOException;
+import com.codahale.metrics.jersey2.TestClock;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
+import java.io.IOException;
 
-import com.codahale.metrics.jersey2.TestClock;
+public class TestRequestFilter implements ContainerRequestFilter {
 
-public class TestRequestFilter implements ContainerRequestFilter{
     private final TestClock testClock;
 
     public TestRequestFilter(TestClock testClock) {


### PR DESCRIPTION
Improvement to #1118.

* Add explicit flag to control tracking filters

We should not guess whether to include filter metrics based on the
metric name. Since tracking of filter times is a new feature, it
should be enabled explicitly for users who want it. For other users,
the process of migrating to the new instrumented listener should be
backward-compatible.

*  Split contexts to several variables

To be more much more clear what event handlers do. Otherwise, they
reuse the common variable and the correct behaviour depends on the
sequence in which Jersey produces events.

*  Remove the superfluous method "key" 
*  Make TimerRequestEventListener a static inner class
So we its creation doesn't carry all fields of
`InstrumentedResourceMethodApplicationListener` and we explicitly
set fields its state.

* Don't use a ClockProvider

`Clock` is already an abstraction over a tick represented by a long value,
so it seem superfluous to use a provided for a class which doesn't have
any state and doesn't change.
