### PR TITLE
Fix class name in example in "Getting Started" documentation

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -138,7 +138,7 @@ To run
 
 .. code-block:: sh
 
-  mvn package exec:java -Dexec.mainClass=sample.First
+  mvn package exec:java -Dexec.mainClass=sample.GetStarted
 
 
 .. _gs-registry:


### PR DESCRIPTION
Fixes #1177
