### PR TITLE
Fix "Missing Fail" warnings reported by error-prone

### DIFF
--- a/metrics-core/src/test/java/com/codahale/metrics/SharedMetricRegistriesTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SharedMetricRegistriesTest.java
@@ -2,12 +2,17 @@ package com.codahale.metrics;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicReference;
 
 public class SharedMetricRegistriesTest {
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
     @Before
     public void setUp() throws Exception {
         SharedMetricRegistries.setDefaultRegistryName(new AtomicReference<>());
@@ -57,12 +62,9 @@ public class SharedMetricRegistriesTest {
 
     @Test
     public void errorsWhenDefaultUnset() throws Exception {
-        try {
-            SharedMetricRegistries.getDefault();
-        } catch (final Exception e) {
-            assertThat(e).isInstanceOf(IllegalStateException.class);
-            assertThat(e.getMessage()).isEqualTo("Default registry name has not been set.");
-        }
+        exception.expect(IllegalStateException.class);
+        exception.expectMessage("Default registry name has not been set.");
+        SharedMetricRegistries.getDefault();
     }
 
     @Test
@@ -76,13 +78,10 @@ public class SharedMetricRegistriesTest {
 
     @Test
     public void errorsWhenDefaultAlreadySet() throws Exception {
-        try {
-            SharedMetricRegistries.setDefault("foobah");
-            SharedMetricRegistries.setDefault("borg");
-        } catch (final Exception e) {
-            assertThat(e).isInstanceOf(IllegalStateException.class);
-            assertThat(e.getMessage()).isEqualTo("Default metric registry name is already set.");
-        }
+        SharedMetricRegistries.setDefault("foobah");
+        exception.expect(IllegalStateException.class);
+        exception.expectMessage("Default metric registry name is already set.");
+        SharedMetricRegistries.setDefault("borg");
     }
 
     @Test

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsResponseMeteredPerClassJerseyTest.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsResponseMeteredPerClassJerseyTest.java
@@ -15,6 +15,7 @@ import java.util.logging.Logger;
 
 import static com.codahale.metrics.MetricRegistry.name;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Tests registering {@link InstrumentedResourceMethodApplicationListener} as a singleton
@@ -111,6 +112,7 @@ public class SingletonMetricsResponseMeteredPerClassJerseyTest extends JerseyTes
             target("responseMeteredRuntimeExceptionPerClass")
                     .request()
                     .get();
+            fail("expected RuntimeException");
         } catch (Exception e) {
             assertThat(e.getCause()).isInstanceOf(RuntimeException.class);
         }


### PR DESCRIPTION
As described in [1] the test is broken if fail() is not called because
it will still pass if the exception didn't get thrown.

In some of the cases this can be fixed by using JUnit's ExpectedException
rule. The limitation of this is that it can only be used when there are
no more statements in the test method following the statement that is
expected to throw. Those subsequent statements will never get executed
because the framework exits the test.

For tests where it's not possible to use ExpectedException due to the
reason mentioned above, add a call to fail().

[1] http://errorprone.info/bugpattern/MissingFail

Change-Id: I75eabf0bcb325fe385742f48aedee2938439b9da