### PR TITLE
Unnecessary `clear` operation removal

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/SlidingTimeWindowArrayReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SlidingTimeWindowArrayReservoir.java
@@ -94,7 +94,8 @@ public class SlidingTimeWindowArrayReservoir implements Reservoir {
         if (windowStart < windowEnd) {
             measurements.trim(windowStart, windowEnd);
         } else {
-            measurements.clear(windowEnd, windowStart);
+            // long overflow handling that can happen only after 1 year after class loading
+            measurements.clear();
         }
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/ChunkedAssociativeLongArrayTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ChunkedAssociativeLongArrayTest.java
@@ -7,37 +7,6 @@ import org.junit.Test;
 public class ChunkedAssociativeLongArrayTest {
 
     @Test
-    public void testClear() {
-        ChunkedAssociativeLongArray array = new ChunkedAssociativeLongArray(3);
-        array.put(-3, 3);
-        array.put(-2, 1);
-        array.put(0, 5);
-        array.put(3, 0);
-        array.put(9, 8);
-        array.put(15, 0);
-        array.put(19, 5);
-        array.put(21, 5);
-        array.put(34, -9);
-        array.put(109, 5);
-
-        then(array.out())
-                .isEqualTo("[(-3: 3) (-2: 1) (0: 5) ]->[(3: 0) (9: 8) (15: 0) ]->[(19: 5) (21: 5) (34: -9) ]->[(109: 5) ]");
-        then(array.values())
-                .isEqualTo(new long[]{3, 1, 5, 0, 8, 0, 5, 5, -9, 5});
-        then(array.size())
-                .isEqualTo(10);
-
-        array.clear(-2, 20);
-        then(array.out())
-                .isEqualTo("[(-3: 3) ]->[(21: 5) (34: -9) ]->[(109: 5) ]");
-        then(array.values())
-                .isEqualTo(new long[]{3, 5, -9, 5});
-        then(array.size())
-                .isEqualTo(4);
-    }
-
-
-    @Test
     public void testTrim() {
         ChunkedAssociativeLongArray array = new ChunkedAssociativeLongArray(3);
         array.put(-3, 3);


### PR DESCRIPTION
Hi
Recently I've discussed `ChunkedAssociativeArray` implementation with my colleague and he had noticed that `ChunkedAssociativeArray` contains whole bunch of complicated code `clear(long startKey, long endKey)` to support one supper rare case of long overflow, that can happen only after 1 year after class loading. And even then, it is not so helpful, we will remove almost all values. 
So I've decided to simplify handling of this case 😄 .