### PR TITLE
Add a method for timing non-throwing functions.

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/Timer.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Timer.java
@@ -2,6 +2,7 @@ package com.codahale.metrics;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * A timer metric which aggregates timing durations and provides duration statistics, plus
@@ -101,6 +102,24 @@ public class Timer implements Metered, Sampling {
         final long startTime = clock.getTick();
         try {
             return event.call();
+        } finally {
+            update(clock.getTick() - startTime);
+        }
+    }
+
+    /**
+     * Times and records the duration of event. Should not throw exceptions, for that use the
+     * {@link #time(Callable)} method.
+     *
+     * @param event a {@link Supplier} whose {@link Supplier#get()} method implements a process
+     *              whose duration should be timed
+     * @param <T>   the type of the value returned by {@code event}
+     * @return the value returned by {@code event}
+     */
+    public <T> T timeSupplier(Supplier<T> event) {
+        final long startTime = clock.getTick();
+        try {
+            return event.get();
         } finally {
             update(clock.getTick() - startTime);
         }


### PR DESCRIPTION
Allow methods that does not throw exceptions to use this avoiding a unnecessary try/catch block.