### PR TITLE
Adds a module for instrumentation of Jdbi 3

### DIFF
--- a/metrics-jdbi3/pom.xml
+++ b/metrics-jdbi3/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-parent</artifactId>
+        <version>4.0.0-alpha5-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>metrics-jdbi3</artifactId>
+    <name>Metrics Integration for JDBI3</name>
+    <packaging>bundle</packaging>
+    <description>Provides instrumentation of Jdbi3 data access objects</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-annotation</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/InstrumentedTimingCollector.java
+++ b/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/InstrumentedTimingCollector.java
@@ -1,0 +1,37 @@
+package com.codahale.metrics.jdbi3;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jdbi3.strategies.SmartNameStrategy;
+import com.codahale.metrics.jdbi3.strategies.StatementNameStrategy;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.statement.TimingCollector;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link TimingCollector} implementation for JDBI which uses the SQL objects' class names and
+ * method names for millisecond-precision timers.
+ */
+public class InstrumentedTimingCollector implements TimingCollector {
+
+    private final MetricRegistry registry;
+    private final StatementNameStrategy statementNameStrategy;
+
+    public InstrumentedTimingCollector(MetricRegistry registry) {
+        this(registry, new SmartNameStrategy());
+    }
+
+    public InstrumentedTimingCollector(MetricRegistry registry,
+                                       StatementNameStrategy statementNameStrategy) {
+        this.registry = registry;
+        this.statementNameStrategy = statementNameStrategy;
+    }
+
+    @Override
+    public void collect(long elapsedTime, StatementContext ctx) {
+        String statementName = statementNameStrategy.getStatementName(ctx);
+        if (statementName != null) {
+            registry.timer(statementName).update(elapsedTime, TimeUnit.NANOSECONDS);
+        }
+    }
+}

--- a/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/BasicSqlNameStrategy.java
+++ b/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/BasicSqlNameStrategy.java
@@ -1,0 +1,12 @@
+package com.codahale.metrics.jdbi3.strategies;
+
+/**
+ * Collects metrics by respective SQLObject methods.
+ */
+public class BasicSqlNameStrategy extends DelegatingStatementNameStrategy {
+
+    public BasicSqlNameStrategy() {
+        super(DefaultNameStrategy.CHECK_EMPTY,
+                DefaultNameStrategy.SQL_OBJECT);
+    }
+}

--- a/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/DefaultNameStrategy.java
+++ b/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/DefaultNameStrategy.java
@@ -1,0 +1,59 @@
+package com.codahale.metrics.jdbi3.strategies;
+
+import com.codahale.metrics.MetricRegistry;
+import org.jdbi.v3.core.extension.ExtensionMethod;
+import org.jdbi.v3.core.statement.StatementContext;
+
+/**
+ * Default strategies which build a basis of more complex strategies
+ */
+public enum DefaultNameStrategy implements StatementNameStrategy {
+
+    /**
+     * If no SQL in the context, returns `sql.empty`, otherwise falls through
+     */
+    CHECK_EMPTY {
+        @Override
+        public String getStatementName(StatementContext statementContext) {
+            final String rawSql = statementContext.getRawSql();
+            return rawSql == null || rawSql.isEmpty() ? "sql.empty" : null;
+        }
+    },
+
+    /**
+     * If there is an SQL object attached to the context, returns the name package,
+     * the class and the method on which SQL is declared. If not SQL object is attached,
+     * falls through
+     */
+    SQL_OBJECT {
+        @Override
+        public String getStatementName(StatementContext statementContext) {
+            ExtensionMethod extensionMethod = statementContext.getExtensionMethod();
+            if (extensionMethod != null) {
+                return MetricRegistry.name(extensionMethod.getType(), extensionMethod.getMethod().getName());
+            }
+            return null;
+        }
+    },
+
+    /**
+     * Returns a raw SQL in the context (even if it's not exist)
+     */
+    NAIVE_NAME {
+        @Override
+        public String getStatementName(StatementContext statementContext) {
+            return statementContext.getRawSql();
+        }
+    },
+
+    /**
+     * Returns the `sql.raw` constant
+     */
+    CONSTANT_SQL_RAW {
+        @Override
+        public String getStatementName(StatementContext statementContext) {
+            return "sql.raw";
+        }
+    }
+
+}

--- a/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/DelegatingStatementNameStrategy.java
+++ b/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/DelegatingStatementNameStrategy.java
@@ -1,0 +1,32 @@
+package com.codahale.metrics.jdbi3.strategies;
+
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class DelegatingStatementNameStrategy implements StatementNameStrategy {
+
+    /**
+     * Unknown SQL.
+     */
+    private static final String UNKNOWN_SQL = "sql.unknown";
+
+    private final List<StatementNameStrategy> strategies;
+
+    protected DelegatingStatementNameStrategy(StatementNameStrategy... strategies) {
+        this.strategies = Arrays.asList(strategies);
+    }
+
+    @Override
+    public String getStatementName(StatementContext statementContext) {
+        for (StatementNameStrategy strategy : strategies) {
+            final String statementName = strategy.getStatementName(statementContext);
+            if (statementName != null) {
+                return statementName;
+            }
+        }
+
+        return UNKNOWN_SQL;
+    }
+}

--- a/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/NaiveNameStrategy.java
+++ b/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/NaiveNameStrategy.java
@@ -1,0 +1,12 @@
+package com.codahale.metrics.jdbi3.strategies;
+
+/**
+ * Very simple strategy, can be used with any JDBI loader to build basic statistics.
+ */
+public class NaiveNameStrategy extends DelegatingStatementNameStrategy {
+
+    public NaiveNameStrategy() {
+        super(DefaultNameStrategy.CHECK_EMPTY,
+              DefaultNameStrategy.NAIVE_NAME);
+    }
+}

--- a/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/SmartNameStrategy.java
+++ b/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/SmartNameStrategy.java
@@ -1,0 +1,13 @@
+package com.codahale.metrics.jdbi3.strategies;
+
+/**
+ * Uses a {@link BasicSqlNameStrategy} and fallbacks to {@link DefaultNameStrategy#CONSTANT_SQL_RAW}
+ */
+public class SmartNameStrategy extends DelegatingStatementNameStrategy {
+
+    public SmartNameStrategy() {
+        super(DefaultNameStrategy.CHECK_EMPTY,
+                DefaultNameStrategy.SQL_OBJECT,
+                DefaultNameStrategy.CONSTANT_SQL_RAW);
+    }
+}

--- a/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/StatementNameStrategy.java
+++ b/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/StatementNameStrategy.java
@@ -1,0 +1,12 @@
+package com.codahale.metrics.jdbi3.strategies;
+
+import org.jdbi.v3.core.statement.StatementContext;
+
+/**
+ * Interface for strategies to statement contexts to metric names.
+ */
+@FunctionalInterface
+public interface StatementNameStrategy {
+
+    String getStatementName(StatementContext statementContext);
+}

--- a/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/TimedAnnotationNameStrategy.java
+++ b/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/TimedAnnotationNameStrategy.java
@@ -1,0 +1,47 @@
+package com.codahale.metrics.jdbi3.strategies;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.annotation.Timed;
+import org.jdbi.v3.core.extension.ExtensionMethod;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.lang.reflect.Method;
+
+/**
+ * Takes into account the {@link Timed} annotation on extension methods
+ */
+public class TimedAnnotationNameStrategy implements StatementNameStrategy {
+
+    @Override
+    public String getStatementName(StatementContext statementContext) {
+        final ExtensionMethod extensionMethod = statementContext.getExtensionMethod();
+        if (extensionMethod == null) {
+            return null;
+        }
+
+        final Class<?> clazz = extensionMethod.getType();
+        final Timed classTimed = clazz.getAnnotation(Timed.class);
+        final Method method = extensionMethod.getMethod();
+        final Timed methodTimed = method.getAnnotation(Timed.class);
+
+        // If the method is timed, figure out the name
+        if (methodTimed != null) {
+            String methodName = methodTimed.name().isEmpty() ? method.getName() : methodTimed.name();
+            if (methodTimed.absolute()) {
+                return methodName;
+            } else {
+                // We need to check if the class has a custom timer name
+                return classTimed == null || classTimed.name().isEmpty() ?
+                        MetricRegistry.name(clazz, methodName) :
+                        MetricRegistry.name(classTimed.name(), methodName);
+            }
+        } else if (classTimed != null) {
+            // Maybe the class is timed?
+            return classTimed.name().isEmpty() ? MetricRegistry.name(clazz, method.getName()) :
+                    MetricRegistry.name(classTimed.name(), method.getName());
+        } else {
+            // No timers neither on the method or the class
+            return null;
+        }
+    }
+}

--- a/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/AbstractStrategyTest.java
+++ b/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/AbstractStrategyTest.java
@@ -1,0 +1,23 @@
+package com.codahale.metrics.jdbi3.strategies;
+
+import com.codahale.metrics.MetricRegistry;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.junit.Before;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AbstractStrategyTest {
+
+    MetricRegistry registry = new MetricRegistry();
+    StatementContext ctx = mock(StatementContext.class);
+
+    @Before
+    public void setUp() throws Exception {
+        when(ctx.getRawSql()).thenReturn("SELECT 1");
+    }
+
+    long getTimerMaxValue(String name) {
+        return registry.timer(name).getSnapshot().getMax();
+    }
+}

--- a/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/BasicSqlNameStrategyTest.java
+++ b/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/BasicSqlNameStrategyTest.java
@@ -1,0 +1,21 @@
+package com.codahale.metrics.jdbi3.strategies;
+
+import org.jdbi.v3.core.extension.ExtensionMethod;
+import org.junit.Test;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class BasicSqlNameStrategyTest extends AbstractStrategyTest {
+
+    private BasicSqlNameStrategy basicSqlNameStrategy = new BasicSqlNameStrategy();
+
+    @Test
+    public void producesMethodNameAsMetric() throws Exception {
+        when(ctx.getExtensionMethod()).thenReturn(new ExtensionMethod(getClass(), getClass().getMethod("producesMethodNameAsMetric")));
+        String name = basicSqlNameStrategy.getStatementName(ctx);
+        assertThat(name).isEqualTo(name(getClass(), "producesMethodNameAsMetric"));
+    }
+
+}

--- a/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/NaiveNameStrategyTest.java
+++ b/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/NaiveNameStrategyTest.java
@@ -1,0 +1,17 @@
+package com.codahale.metrics.jdbi3.strategies;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NaiveNameStrategyTest extends AbstractStrategyTest {
+
+    private NaiveNameStrategy naiveNameStrategy = new NaiveNameStrategy();
+
+    @Test
+    public void producesSqlRawMetrics() throws Exception {
+        String name = naiveNameStrategy.getStatementName(ctx);
+        assertThat(name).isEqualToIgnoringCase("SELECT 1");
+    }
+
+}

--- a/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/SmartNameStrategyTest.java
+++ b/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/SmartNameStrategyTest.java
@@ -1,0 +1,68 @@
+package com.codahale.metrics.jdbi3.strategies;
+
+import com.codahale.metrics.jdbi3.InstrumentedTimingCollector;
+import org.jdbi.v3.core.extension.ExtensionMethod;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+public class SmartNameStrategyTest extends AbstractStrategyTest {
+
+    private StatementNameStrategy smartNameStrategy = new SmartNameStrategy();
+    private InstrumentedTimingCollector collector;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        collector = new InstrumentedTimingCollector(registry, smartNameStrategy);
+    }
+
+    @Test
+    public void updatesTimerForSqlObjects() throws Exception {
+        when(ctx.getExtensionMethod()).thenReturn(
+                new ExtensionMethod(getClass(), getClass().getMethod("updatesTimerForSqlObjects")));
+
+        collector.collect(TimeUnit.SECONDS.toNanos(1), ctx);
+
+        String name = smartNameStrategy.getStatementName(ctx);
+        assertThat(name).isEqualTo(name(getClass(), "updatesTimerForSqlObjects"));
+        assertThat(getTimerMaxValue(name)).isEqualTo(1000000000);
+    }
+
+    @Test
+    public void updatesTimerForRawSql() throws Exception {
+        collector.collect(TimeUnit.SECONDS.toNanos(2), ctx);
+
+        String name = smartNameStrategy.getStatementName(ctx);
+        assertThat(name).isEqualTo(name("sql", "raw"));
+        assertThat(getTimerMaxValue(name)).isEqualTo(2000000000);
+    }
+
+    @Test
+    public void updatesTimerForNoRawSql() throws Exception {
+        reset(ctx);
+
+        collector.collect(TimeUnit.SECONDS.toNanos(2), ctx);
+
+        String name = smartNameStrategy.getStatementName(ctx);
+        assertThat(name).isEqualTo(name("sql", "empty"));
+        assertThat(getTimerMaxValue(name)).isEqualTo(2000000000);
+    }
+
+    @Test
+    public void updatesTimerForContextClass() throws Exception {
+        when(ctx.getExtensionMethod()).thenReturn(new ExtensionMethod(getClass(),
+                getClass().getMethod("updatesTimerForContextClass")));
+        collector.collect(TimeUnit.SECONDS.toNanos(3), ctx);
+
+        String name = smartNameStrategy.getStatementName(ctx);
+        assertThat(name).isEqualTo(name(getClass(), "updatesTimerForContextClass"));
+        assertThat(getTimerMaxValue(name)).isEqualTo(3000000000L);
+    }
+}

--- a/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/TimedAnnotationNameStrategyTest.java
+++ b/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/TimedAnnotationNameStrategyTest.java
@@ -1,0 +1,88 @@
+package com.codahale.metrics.jdbi3.strategies;
+
+import com.codahale.metrics.annotation.Timed;
+import org.jdbi.v3.core.extension.ExtensionMethod;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class TimedAnnotationNameStrategyTest extends AbstractStrategyTest {
+
+    private TimedAnnotationNameStrategy timedAnnotationNameStrategy = new TimedAnnotationNameStrategy();
+
+    public interface Foo {
+
+        @Timed
+        void update();
+
+        @Timed(name = "custom-update")
+        void customUpdate();
+
+        @Timed(name = "absolute-update", absolute = true)
+        void absoluteUpdate();
+    }
+
+
+    @Timed
+    public interface Bar {
+
+        void update();
+    }
+
+    @Timed(name = "custom-bar")
+    public interface CustomBar {
+
+        @Timed(name = "find-by-id")
+        int find(String name);
+    }
+
+    public interface Dummy {
+
+        void show();
+    }
+
+    @Test
+    public void testAnnotationOnMethod() throws Exception {
+        when(ctx.getExtensionMethod()).thenReturn(new ExtensionMethod(Foo.class, Foo.class.getMethod("update")));
+        assertThat(timedAnnotationNameStrategy.getStatementName(ctx))
+                .isEqualTo("com.codahale.metrics.jdbi3.strategies.TimedAnnotationNameStrategyTest$Foo.update");
+    }
+
+    @Test
+    public void testAnnotationOnMethodWithCustomName() throws Exception {
+        when(ctx.getExtensionMethod()).thenReturn(new ExtensionMethod(Foo.class, Foo.class.getMethod("customUpdate")));
+        assertThat(timedAnnotationNameStrategy.getStatementName(ctx))
+                .isEqualTo("com.codahale.metrics.jdbi3.strategies.TimedAnnotationNameStrategyTest$Foo.custom-update");
+    }
+
+    @Test
+    public void testAnnotationOnMethodWithCustomAbsoluteName() throws Exception {
+        when(ctx.getExtensionMethod()).thenReturn(new ExtensionMethod(Foo.class, Foo.class.getMethod("absoluteUpdate")));
+        assertThat(timedAnnotationNameStrategy.getStatementName(ctx)).isEqualTo("absolute-update");
+    }
+
+    @Test
+    public void testAnnotationOnClass() throws Exception {
+        when(ctx.getExtensionMethod()).thenReturn(new ExtensionMethod(Bar.class, Bar.class.getMethod("update")));
+        assertThat(timedAnnotationNameStrategy.getStatementName(ctx))
+                .isEqualTo("com.codahale.metrics.jdbi3.strategies.TimedAnnotationNameStrategyTest$Bar.update");
+    }
+
+    @Test
+    public void testAnnotationOnMethodAndClassWithCustomNames() throws Exception {
+        when(ctx.getExtensionMethod()).thenReturn(new ExtensionMethod(CustomBar.class, CustomBar.class.getMethod("find", String.class)));
+        assertThat(timedAnnotationNameStrategy.getStatementName(ctx)).isEqualTo("custom-bar.find-by-id");
+    }
+
+    @Test
+    public void testNoAnnotations() throws Exception {
+        when(ctx.getExtensionMethod()).thenReturn(new ExtensionMethod(Dummy.class, Dummy.class.getMethod("show")));
+        assertThat(timedAnnotationNameStrategy.getStatementName(ctx)).isNull();
+    }
+
+    @Test
+    public void testNoMethod() {
+        assertThat(timedAnnotationNameStrategy.getStatementName(ctx)).isNull();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <module>metrics-httpasyncclient</module>
         <module>metrics-jcache</module>
         <module>metrics-jdbi</module>
+        <module>metrics-jdbi3</module>
         <module>metrics-jersey2</module>
         <module>metrics-jetty9</module>
         <module>metrics-json</module>


### PR DESCRIPTION
jdbi3 has been released a couple weeks ago (https://groups.google.com/forum/#!topic/jdbi/zS4p0p83sOM) and they use a new model for instrumentation. This change adds support for setting strategies for instrumenting Jdbi apps.

Implementation-wise this is a port of the `metrics-jdbi` module, improved, upgraded to Java8, and with added support for the `@Timed` annotation (previously it was not possible to set a custom metric name for an SqlObject class and method).