### PR TITLE
Prevent NaN values when calculating mean

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
@@ -174,6 +174,9 @@ public class ExponentiallyDecayingReservoir implements Reservoir {
                     for (Double key : keys) {
                         final WeightedSample sample = values.remove(key);
                         final WeightedSample newSample = new WeightedSample(sample.value, sample.weight * scalingFactor);
+                        if (Double.compare(newSample.weight, 0) == 0) {
+                            continue;
+                        }
                         values.put(key * scalingFactor, newSample);
                     }
                 }

--- a/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
@@ -142,7 +142,7 @@ public class ExponentiallyDecayingReservoirTest {
     }
 
     @Test
-    public void removeZeroWeightsInSamplesToPreventNaNInMeanValues() throws Exception {
+    public void removeZeroWeightsInSamplesToPreventNaNInMeanValues() {
         final ManualClock clock = new ManualClock();
         final ExponentiallyDecayingReservoir reservoir = new ExponentiallyDecayingReservoir(1028, 0.015, clock);
         Timer timer = new Timer(reservoir, clock);

--- a/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
@@ -151,7 +151,7 @@ public class ExponentiallyDecayingReservoirTest {
         clock.addMillis(100);
         context.stop();
 
-        for(int i = 1; i < 48; i++) {
+        for (int i = 1; i < 48; i++) {
             clock.addHours(1);
             assertThat(reservoir.getSnapshot().getMean()).isBetween(0.0, Double.MAX_VALUE);
         }

--- a/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics;
 
+import com.codahale.metrics.Timer.Context;
 import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
@@ -138,6 +139,22 @@ public class ExponentiallyDecayingReservoirTest {
         assertThat(snapshot.getMean()).isEqualTo(0);
         assertThat(snapshot.getMedian()).isEqualTo(0);
         assertThat(snapshot.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void removeZeroWeightsInSamplesToPreventNaNInMeanValues() throws Exception {
+        final ManualClock clock = new ManualClock();
+        final ExponentiallyDecayingReservoir reservoir = new ExponentiallyDecayingReservoir(1028, 0.015, clock);
+        Timer timer = new Timer(reservoir, clock);
+
+        Context context = timer.time();
+        clock.addMillis(100);
+        context.stop();
+
+        for(int i = 1; i < 48; i++) {
+            clock.addHours(1);
+            assertThat(reservoir.getSnapshot().getMean()).isBetween(0.0, Double.MAX_VALUE);
+        }
     }
 
     @Test


### PR DESCRIPTION
This addresses the issue raised in #1173. 

Credits go to @altery for providing this example to reproduce the issue (which I used to write the unit test): https://gist.github.com/altery/0efd06c4f8d0c83a44bd718e8170a49e