### PR TITLE
Jetty9: unhandled response should be counted as 404 and not 200

### DIFF
--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -205,7 +205,7 @@ public class InstrumentedHandler extends HandlerWrapper {
                 final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
                 final HttpServletRequest request = (HttpServletRequest) state.getRequest();
                 final HttpServletResponse response = (HttpServletResponse) state.getResponse();
-                updateResponses(request, response, startTime);
+                updateResponses(request, response, startTime, true);
                 if (state.getHttpChannelState().getState() != HttpChannelState.State.DISPATCHED) {
                     activeSuspended.dec();
                 }
@@ -249,7 +249,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             if (state.isSuspended()) {
                 activeSuspended.inc();
             } else if (state.isInitial()) {
-                updateResponses(httpRequest, httpResponse, start);
+                updateResponses(httpRequest, httpResponse, start, request.isHandled());
             }
             // else onCompletion will handle it.
         }
@@ -285,8 +285,13 @@ public class InstrumentedHandler extends HandlerWrapper {
         }
     }
 
-    private void updateResponses(HttpServletRequest request, HttpServletResponse response, long start) {
-        final int responseStatus = response.getStatus() / 100;
+    private void updateResponses(HttpServletRequest request, HttpServletResponse response, long start, boolean isHandled) {
+        final int responseStatus;
+        if (isHandled) {
+            responseStatus = response.getStatus() / 100;
+        } else {
+            responseStatus = 4; // will end up with a 404 response sent by HttpChannel.handle
+        }
         if (responseStatus >= 1 && responseStatus <= 5) {
             responses[responseStatus - 1].mark();
         }


### PR DESCRIPTION
In Jetty, a request that has not been handled by the handler chain keeps the default status code 200, and a 404 response is produced by `HttpChannel`. The Jetty9 `InstrumentedHandler` therefore has to count unhandled request as 404 and not 200.

To reveal the issue, this PR removes the 404 response from `InstrumentedHandlerTest.TestHandler` so that a request to `/hello` ends up not being handled.

This PR is against branch `3.2-development`. Should I open another PR for branch `4.0-development`?