### PR TITLE
Avoid NaN values in WeightedSnapshot

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/WeightedSnapshot.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/WeightedSnapshot.java
@@ -52,7 +52,7 @@ public class WeightedSnapshot extends Snapshot {
 
         for (int i = 0; i < copy.length; i++) {
             this.values[i] = copy[i].value;
-            this.normWeights[i] = copy[i].weight / sumWeight;
+            this.normWeights[i] = sumWeight != 0 ? copy[i].weight / sumWeight : 0;
         }
 
         for (int i = 1; i < copy.length; i++) {

--- a/metrics-core/src/test/java/com/codahale/metrics/WeightedSnapshotTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/WeightedSnapshotTest.java
@@ -214,4 +214,11 @@ public class WeightedSnapshotTest {
                 .isEqualTo(2);
     }
 
+    @Test
+    public void doesNotProduceNaNValues() {
+        WeightedSnapshot weightedSnapshot = new WeightedSnapshot(
+                weightedArray(new long[]{1, 2, 3}, new double[]{0, 0, 0}));
+        assertThat(weightedSnapshot.getMean()).isEqualTo(0);
+    }
+
 }


### PR DESCRIPTION
Theoretically, we could have a snapshot with the values which have zero weights. In this case a normalized weight will have a NaN value, because 0/0 = NaN. We should avoid it and in case a weight is zero, make the normalized weight zero too.

See #1230 and #1173