### PR TITLE
Make tests more stable

### DIFF
--- a/metrics-core/src/test/java/com/codahale/metrics/InstrumentedScheduledExecutorServiceTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/InstrumentedScheduledExecutorServiceTest.java
@@ -5,7 +5,12 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.*;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -259,6 +264,7 @@ public class InstrumentedScheduledExecutorServiceTest {
         assertThat(scheduledOverrun.getCount()).isZero();
         assertThat(percentOfPeriod.getCount()).isZero();
 
+        CountDownLatch countDownLatch = new CountDownLatch(1);
         ScheduledFuture<?> theFuture = instrumentedScheduledExecutor.scheduleWithFixedDelay(() -> {
             assertThat(submitted.getCount()).isZero();
 
@@ -272,11 +278,11 @@ public class InstrumentedScheduledExecutorServiceTest {
             } catch (InterruptedException ex) {
                 Thread.currentThread().interrupt();
             }
-
-            return;
+            countDownLatch.countDown();
         }, 10L, 10L, TimeUnit.MILLISECONDS);
 
         TimeUnit.MILLISECONDS.sleep(100);
+        countDownLatch.await(5, TimeUnit.SECONDS);
         theFuture.cancel(true);
         TimeUnit.MILLISECONDS.sleep(100);
 

--- a/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -66,9 +67,15 @@ public class ScheduledReporterTest {
 
     @Test
     public void pollsPeriodically() throws Exception {
-        reporter.start(200, TimeUnit.MILLISECONDS);
+        CountDownLatch latch = new CountDownLatch(2);
+        reporter.start(100, 100, TimeUnit.MILLISECONDS, () -> {
+            if (latch.getCount() > 0) {
+                reporter.report();
+                latch.countDown();
+            }
+        });
+        latch.await(5, TimeUnit.SECONDS);
 
-        Thread.sleep(500);
         verify(reporter, times(2)).report(
                 map("gauge", gauge),
                 map("counter", counter),
@@ -98,9 +105,14 @@ public class ScheduledReporterTest {
 
     @Test
     public void shouldAutoCreateExecutorWhenItNull() throws Exception {
-        reporterWithNullExecutor.start(200, TimeUnit.MILLISECONDS);
-
-        Thread.sleep(500);
+        CountDownLatch latch = new CountDownLatch(2);
+        reporterWithNullExecutor.start(100, 100, TimeUnit.MILLISECONDS, () -> {
+            if (latch.getCount() > 0) {
+                reporterWithNullExecutor.report();
+                latch.countDown();
+            }
+        });
+        latch.await(5, TimeUnit.SECONDS);
         verify(reporterWithNullExecutor, times(2)).report(
                 map("gauge", gauge),
                 map("counter", counter),


### PR DESCRIPTION
After I added running tests on AppVeyour, I have seen test failures. Mostly they are caused by unpredictable unit tests which rely that `Thread.sleep(n)` actually hibernates a thread for n milliseconds. 
I guess, in Windows environments the behavior can different in the Linux ones.

Anyway, we should use synchronization primitives to guarantee correct multithreading coordination and avoid flaky tests. 