### PR TITLE
Support metrics on JDK9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,20 @@ install: echo "I trust Maven."
 # don't just run the tests, also run error-prone
 script: mvn verify
 
-jdk:
-  - oraclejdk8
+matrix:
+  include:
+    - os: linux
+      jdk: oraclejdk8
+      addons:
+        apt:
+          packages:
+            - oracle-java8-installer
+    - os: linux
+      jdk: oraclejdk9
+      addons:
+        apt:
+          packages:
+            - oracle-java9-installer
 
 notifications:
   email:

--- a/metrics-core/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
@@ -35,10 +35,16 @@ public class ConsoleReporterTest {
             .convertDurationsTo(TimeUnit.MILLISECONDS)
             .filter(MetricFilter.ALL)
             .build();
+    private String dateHeader;
 
     @Before
     public void setUp() throws Exception {
         when(clock.getTime()).thenReturn(1363568676000L);
+        // JDK9 has changed the java.text.DateFormat API implementation according to Unicode.
+        // See http://mail.openjdk.java.net/pipermail/jdk9-dev/2017-April/005732.html
+        dateHeader = System.getProperty("java.version").startsWith("1.8") ?
+                "3/17/13 6:04:36 PM =============================================================" :
+                "3/17/13, 6:04:36 PM ============================================================";
     }
 
     @Test
@@ -53,7 +59,7 @@ public class ConsoleReporterTest {
 
         assertThat(consoleOutput())
                 .isEqualTo(lines(
-                        "3/17/13 6:04:36 PM =============================================================",
+                        dateHeader,
                         "",
                         "-- Gauges ----------------------------------------------------------------------",
                         "gauge",
@@ -76,7 +82,7 @@ public class ConsoleReporterTest {
 
         assertThat(consoleOutput())
                 .isEqualTo(lines(
-                        "3/17/13 6:04:36 PM =============================================================",
+                        dateHeader,
                         "",
                         "-- Counters --------------------------------------------------------------------",
                         "test.counter",
@@ -113,7 +119,7 @@ public class ConsoleReporterTest {
 
         assertThat(consoleOutput())
                 .isEqualTo(lines(
-                        "3/17/13 6:04:36 PM =============================================================",
+                        dateHeader,
                         "",
                         "-- Histograms ------------------------------------------------------------------",
                         "test.histogram",
@@ -150,7 +156,7 @@ public class ConsoleReporterTest {
 
         assertThat(consoleOutput())
                 .isEqualTo(lines(
-                        "3/17/13 6:04:36 PM =============================================================",
+                        dateHeader,
                         "",
                         "-- Meters ----------------------------------------------------------------------",
                         "test.meter",
@@ -196,7 +202,7 @@ public class ConsoleReporterTest {
 
         assertThat(consoleOutput())
                 .isEqualTo(lines(
-                        "3/17/13 6:04:36 PM =============================================================",
+                        dateHeader,
                         "",
                         "-- Timers ----------------------------------------------------------------------",
                         "test.another.timer",
@@ -250,7 +256,7 @@ public class ConsoleReporterTest {
 
         assertThat(consoleOutput())
                 .isEqualTo(lines(
-                        "3/17/13 6:04:36 PM =============================================================",
+                        dateHeader,
                         "",
                         "-- Meters ----------------------------------------------------------------------",
                         "test.meter",
@@ -306,7 +312,7 @@ public class ConsoleReporterTest {
 
         assertThat(consoleOutput())
                 .isEqualTo(lines(
-                        "3/17/13 6:04:36 PM =============================================================",
+                        dateHeader,
                         "",
                         "-- Timers ----------------------------------------------------------------------",
                         "test.another.timer",
@@ -366,7 +372,7 @@ public class ConsoleReporterTest {
 
         assertThat(consoleOutput())
                 .isEqualTo(lines(
-                        "3/17/13 6:04:36 PM =============================================================",
+                        dateHeader,
                         "",
                         "-- Histograms ------------------------------------------------------------------",
                         "test.histogram",

--- a/metrics-jcache/pom.xml
+++ b/metrics-jcache/pom.xml
@@ -16,6 +16,26 @@
         Uses the CacheStatisticsMXBean provided statistics.
     </description>
 
+    <profiles>
+        <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-modules java.xml.bind</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>

--- a/metrics-jcache/pom.xml
+++ b/metrics-jcache/pom.xml
@@ -26,6 +26,17 @@
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.7.0</version>
+                        <configuration>
+                            <source>9</source>
+                            <target>9</target>
+                            <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                            <showWarnings>true</showWarnings>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <argLine>--add-modules java.xml.bind</argLine>

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/FileDescriptorRatioGaugeTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/FileDescriptorRatioGaugeTest.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.jvm;
 
+import com.sun.management.UnixOperatingSystemMXBean;
 import org.junit.Test;
 
 import javax.management.ObjectName;
@@ -12,7 +13,7 @@ import static org.mockito.Mockito.mock;
 
 @SuppressWarnings("UnusedDeclaration")
 public class FileDescriptorRatioGaugeTest {
-    private final OperatingSystemMXBean os = new OperatingSystemMXBean() {
+    private final OperatingSystemMXBean os = new UnixOperatingSystemMXBean() {
         @Override
         public String getName() {
             return null;
@@ -38,14 +39,54 @@ public class FileDescriptorRatioGaugeTest {
             return 0;
         }
 
-        // these duplicate methods from UnixOperatingSystem
-
-        private long getOpenFileDescriptorCount() {
+        @Override
+        public long getOpenFileDescriptorCount() {
             return 10;
         }
 
-        private long getMaxFileDescriptorCount() {
+        @Override
+        public long getMaxFileDescriptorCount() {
             return 100;
+        }
+
+        @Override
+        public long getCommittedVirtualMemorySize() {
+            return 0;
+        }
+
+        @Override
+        public long getTotalSwapSpaceSize() {
+            return 0;
+        }
+
+        @Override
+        public long getFreeSwapSpaceSize() {
+            return 0;
+        }
+
+        @Override
+        public long getProcessCpuTime() {
+            return 0;
+        }
+
+        @Override
+        public long getFreePhysicalMemorySize() {
+            return 0;
+        }
+
+        @Override
+        public long getTotalPhysicalMemorySize() {
+            return 0;
+        }
+
+        @Override
+        public double getSystemCpuLoad() {
+            return 0;
+        }
+
+        @Override
+        public double getProcessCpuLoad() {
+            return 0;
         }
 
         // overridden on Java 1.7; random crap on Java 1.6

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,27 @@
 
     <profiles>
         <profile>
+            <id>jdk9</id>
+            <activation>
+                <jdk>9</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.7.0</version>
+                        <configuration>
+                            <source>9</source>
+                            <target>9</target>
+                            <forceJavacCompilerUse>true</forceJavacCompilerUse>
+                            <showWarnings>true</showWarnings>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>release-sign-artifacts</id>
             <activation>
                 <property>


### PR DESCRIPTION
This fixes the issues with running metrics on JDK8 and JDK9: 
* Fix date formatting differences between JDK8 and JDK9 in `ConsoleReporter`
* Fix `FileDescriptorRatioGauge`, so it doesn't use reflection
* Add the `java.xml.bind` module to the JCache tests, so it can access JAXB on JDK9
* Add a JDK9 profile, so we check that we can compile metrics in JDK9
* Finally, it adds JDK9 to the test matrix on Travis CI.