### PR TITLE
Remove unnecessary `throws Exception` declarations from tests

### DIFF
--- a/metrics-core/src/test/java/com/codahale/metrics/ClockTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ClockTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.offset;
 public class ClockTest {
 
     @Test
-    public void userTimeClock() throws Exception {
+    public void userTimeClock() {
         final Clock.UserTimeClock clock = new Clock.UserTimeClock();
 
         assertThat((double) clock.getTime())
@@ -21,7 +21,7 @@ public class ClockTest {
     }
 
     @Test
-    public void defaultsToUserTime() throws Exception {
+    public void defaultsToUserTime() {
         assertThat(Clock.defaultClock())
                 .isInstanceOf(Clock.UserTimeClock.class);
     }

--- a/metrics-core/src/test/java/com/codahale/metrics/CounterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/CounterTest.java
@@ -8,13 +8,13 @@ public class CounterTest {
     private final Counter counter = new Counter();
 
     @Test
-    public void startsAtZero() throws Exception {
+    public void startsAtZero() {
         assertThat(counter.getCount())
                 .isZero();
     }
 
     @Test
-    public void incrementsByOne() throws Exception {
+    public void incrementsByOne() {
         counter.inc();
 
         assertThat(counter.getCount())
@@ -22,7 +22,7 @@ public class CounterTest {
     }
 
     @Test
-    public void incrementsByAnArbitraryDelta() throws Exception {
+    public void incrementsByAnArbitraryDelta() {
         counter.inc(12);
 
         assertThat(counter.getCount())
@@ -30,7 +30,7 @@ public class CounterTest {
     }
 
     @Test
-    public void decrementsByOne() throws Exception {
+    public void decrementsByOne() {
         counter.dec();
 
         assertThat(counter.getCount())
@@ -38,7 +38,7 @@ public class CounterTest {
     }
 
     @Test
-    public void decrementsByAnArbitraryDelta() throws Exception {
+    public void decrementsByAnArbitraryDelta() {
         counter.dec(12);
 
         assertThat(counter.getCount())
@@ -46,7 +46,7 @@ public class CounterTest {
     }
 
     @Test
-    public void incrementByNegativeDelta() throws Exception {
+    public void incrementByNegativeDelta() {
         counter.inc(-12);
 
         assertThat(counter.getCount())
@@ -54,7 +54,7 @@ public class CounterTest {
     }
 
     @Test
-    public void decrementByNegativeDelta() throws Exception {
+    public void decrementByNegativeDelta() {
         counter.dec(-12);
 
         assertThat(counter.getCount())

--- a/metrics-core/src/test/java/com/codahale/metrics/DerivativeGaugeTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/DerivativeGaugeTest.java
@@ -14,7 +14,7 @@ public class DerivativeGaugeTest {
     };
 
     @Test
-    public void returnsATransformedValue() throws Exception {
+    public void returnsATransformedValue() {
         assertThat(gauge2.getValue())
                 .isEqualTo(3);
     }

--- a/metrics-core/src/test/java/com/codahale/metrics/EWMATest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/EWMATest.java
@@ -9,7 +9,7 @@ import static org.assertj.core.api.Assertions.offset;
 
 public class EWMATest {
     @Test
-    public void aOneMinuteEWMAWithAValueOfThree() throws Exception {
+    public void aOneMinuteEWMAWithAValueOfThree() {
         final EWMA ewma = EWMA.oneMinuteEWMA();
         ewma.update(3);
         ewma.tick();
@@ -78,7 +78,7 @@ public class EWMATest {
     }
 
     @Test
-    public void aFiveMinuteEWMAWithAValueOfThree() throws Exception {
+    public void aFiveMinuteEWMAWithAValueOfThree() {
         final EWMA ewma = EWMA.fiveMinuteEWMA();
         ewma.update(3);
         ewma.tick();
@@ -147,7 +147,7 @@ public class EWMATest {
     }
 
     @Test
-    public void aFifteenMinuteEWMAWithAValueOfThree() throws Exception {
+    public void aFifteenMinuteEWMAWithAValueOfThree() {
         final EWMA ewma = EWMA.fifteenMinuteEWMA();
         ewma.update(3);
         ewma.tick();

--- a/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExponentiallyDecayingReservoirTest {
     @Test
-    public void aReservoirOf100OutOf1000Elements() throws Exception {
+    public void aReservoirOf100OutOf1000Elements() {
         final ExponentiallyDecayingReservoir reservoir = new ExponentiallyDecayingReservoir(100, 0.99);
         for (int i = 0; i < 1000; i++) {
             reservoir.update(i);
@@ -29,7 +29,7 @@ public class ExponentiallyDecayingReservoirTest {
     }
 
     @Test
-    public void aReservoirOf100OutOf10Elements() throws Exception {
+    public void aReservoirOf100OutOf10Elements() {
         final ExponentiallyDecayingReservoir reservoir = new ExponentiallyDecayingReservoir(100, 0.99);
         for (int i = 0; i < 10; i++) {
             reservoir.update(i);

--- a/metrics-core/src/test/java/com/codahale/metrics/HistogramTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/HistogramTest.java
@@ -12,7 +12,7 @@ public class HistogramTest {
     private final Histogram histogram = new Histogram(reservoir);
 
     @Test
-    public void updatesTheCountOnUpdates() throws Exception {
+    public void updatesTheCountOnUpdates() {
         assertThat(histogram.getCount())
                 .isZero();
 
@@ -23,7 +23,7 @@ public class HistogramTest {
     }
 
     @Test
-    public void returnsTheSnapshotFromTheReservoir() throws Exception {
+    public void returnsTheSnapshotFromTheReservoir() {
         final Snapshot snapshot = mock(Snapshot.class);
         when(reservoir.getSnapshot()).thenReturn(snapshot);
 

--- a/metrics-core/src/test/java/com/codahale/metrics/MeterApproximationTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MeterApproximationTest.java
@@ -30,7 +30,7 @@ public class MeterApproximationTest {
     }
 
     @Test
-    public void controlMeter1MinuteMeanApproximation() throws Exception {
+    public void controlMeter1MinuteMeanApproximation() {
         final Meter meter = simulateMetronome(
                 62934, TimeUnit.MILLISECONDS,
                 3, TimeUnit.MINUTES);
@@ -40,7 +40,7 @@ public class MeterApproximationTest {
     }
 
     @Test
-    public void controlMeter5MinuteMeanApproximation() throws Exception {
+    public void controlMeter5MinuteMeanApproximation() {
         final Meter meter = simulateMetronome(
                 62934, TimeUnit.MILLISECONDS,
                 13, TimeUnit.MINUTES);
@@ -50,7 +50,7 @@ public class MeterApproximationTest {
     }
 
     @Test
-    public void controlMeter15MinuteMeanApproximation() throws Exception {
+    public void controlMeter15MinuteMeanApproximation() {
         final Meter meter = simulateMetronome(
                 62934, TimeUnit.MILLISECONDS,
                 38, TimeUnit.MINUTES);

--- a/metrics-core/src/test/java/com/codahale/metrics/MeterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MeterTest.java
@@ -21,7 +21,7 @@ public class MeterTest {
     }
 
     @Test
-    public void startsOutWithNoRatesOrCount() throws Exception {
+    public void startsOutWithNoRatesOrCount() {
         assertThat(meter.getCount())
                 .isZero();
 
@@ -39,7 +39,7 @@ public class MeterTest {
     }
 
     @Test
-    public void marksEventsAndUpdatesRatesAndCount() throws Exception {
+    public void marksEventsAndUpdatesRatesAndCount() {
         meter.mark();
         meter.mark(2);
 

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricFilterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricFilterTest.java
@@ -7,13 +7,13 @@ import static org.mockito.Mockito.mock;
 
 public class MetricFilterTest {
     @Test
-    public void theAllFilterMatchesAllMetrics() throws Exception {
+    public void theAllFilterMatchesAllMetrics() {
         assertThat(MetricFilter.ALL.matches("", mock(Metric.class)))
                 .isTrue();
     }
 
     @Test
-    public void theStartsWithFilterMatches() throws Exception {
+    public void theStartsWithFilterMatches() {
         assertThat(MetricFilter.startsWith("foo").matches("foo.bar", mock(Metric.class)))
                 .isTrue();
         assertThat(MetricFilter.startsWith("foo").matches("bar.foo", mock(Metric.class)))
@@ -21,7 +21,7 @@ public class MetricFilterTest {
     }
 
     @Test
-    public void theEndsWithFilterMatches() throws Exception {
+    public void theEndsWithFilterMatches() {
         assertThat(MetricFilter.endsWith("foo").matches("foo.bar", mock(Metric.class)))
                 .isFalse();
         assertThat(MetricFilter.endsWith("foo").matches("bar.foo", mock(Metric.class)))
@@ -29,7 +29,7 @@ public class MetricFilterTest {
     }
 
     @Test
-    public void theContainsFilterMatches() throws Exception {
+    public void theContainsFilterMatches() {
         assertThat(MetricFilter.contains("foo").matches("bar.foo.bar", mock(Metric.class)))
                 .isTrue();
         assertThat(MetricFilter.contains("foo").matches("bar.bar", mock(Metric.class)))

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryListenerTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryListenerTest.java
@@ -15,42 +15,42 @@ public class MetricRegistryListenerTest {
     };
 
     @Test
-    public void noOpsOnGaugeAdded() throws Exception {
+    public void noOpsOnGaugeAdded() {
         listener.onGaugeAdded("blah", () -> {
             throw new RuntimeException("Should not be called");
         });
     }
 
     @Test
-    public void noOpsOnCounterAdded() throws Exception {
+    public void noOpsOnCounterAdded() {
         listener.onCounterAdded("blah", counter);
 
         verifyZeroInteractions(counter);
     }
 
     @Test
-    public void noOpsOnHistogramAdded() throws Exception {
+    public void noOpsOnHistogramAdded() {
         listener.onHistogramAdded("blah", histogram);
 
         verifyZeroInteractions(histogram);
     }
 
     @Test
-    public void noOpsOnMeterAdded() throws Exception {
+    public void noOpsOnMeterAdded() {
         listener.onMeterAdded("blah", meter);
 
         verifyZeroInteractions(meter);
     }
 
     @Test
-    public void noOpsOnTimerAdded() throws Exception {
+    public void noOpsOnTimerAdded() {
         listener.onTimerAdded("blah", timer);
 
         verifyZeroInteractions(timer);
     }
 
     @Test
-    public void doesNotExplodeWhenMetricsAreRemoved() throws Exception {
+    public void doesNotExplodeWhenMetricsAreRemoved() {
         listener.onGaugeRemoved("blah");
         listener.onCounterRemoved("blah");
         listener.onHistogramRemoved("blah");

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
@@ -23,12 +23,12 @@ public class MetricRegistryTest {
     private final Timer timer = mock(Timer.class);
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         registry.addListener(listener);
     }
 
     @Test
-    public void registeringAGaugeTriggersANotification() throws Exception {
+    public void registeringAGaugeTriggersANotification() {
         assertThat(registry.register("thing", gauge))
                 .isEqualTo(gauge);
 
@@ -36,7 +36,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void removingAGaugeTriggersANotification() throws Exception {
+    public void removingAGaugeTriggersANotification() {
         registry.register("thing", gauge);
 
         assertThat(registry.remove("thing"))
@@ -46,7 +46,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void registeringACounterTriggersANotification() throws Exception {
+    public void registeringACounterTriggersANotification() {
         assertThat(registry.register("thing", counter))
                 .isEqualTo(counter);
 
@@ -54,7 +54,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void accessingACounterRegistersAndReusesTheCounter() throws Exception {
+    public void accessingACounterRegistersAndReusesTheCounter() {
         final Counter counter1 = registry.counter("thing");
         final Counter counter2 = registry.counter("thing");
 
@@ -65,7 +65,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void accessingACustomCounterRegistersAndReusesTheCounter() throws Exception {
+    public void accessingACustomCounterRegistersAndReusesTheCounter() {
         final MetricRegistry.MetricSupplier<Counter> supplier = () -> counter;
         final Counter counter1 = registry.counter("thing", supplier);
         final Counter counter2 = registry.counter("thing", supplier);
@@ -78,7 +78,7 @@ public class MetricRegistryTest {
 
 
     @Test
-    public void removingACounterTriggersANotification() throws Exception {
+    public void removingACounterTriggersANotification() {
         registry.register("thing", counter);
 
         assertThat(registry.remove("thing"))
@@ -88,7 +88,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void registeringAHistogramTriggersANotification() throws Exception {
+    public void registeringAHistogramTriggersANotification() {
         assertThat(registry.register("thing", histogram))
                 .isEqualTo(histogram);
 
@@ -96,7 +96,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void accessingAHistogramRegistersAndReusesIt() throws Exception {
+    public void accessingAHistogramRegistersAndReusesIt() {
         final Histogram histogram1 = registry.histogram("thing");
         final Histogram histogram2 = registry.histogram("thing");
 
@@ -107,7 +107,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void accessingACustomHistogramRegistersAndReusesIt() throws Exception {
+    public void accessingACustomHistogramRegistersAndReusesIt() {
         final MetricRegistry.MetricSupplier<Histogram> supplier = () -> histogram;
         final Histogram histogram1 = registry.histogram("thing", supplier);
         final Histogram histogram2 = registry.histogram("thing", supplier);
@@ -119,7 +119,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void removingAHistogramTriggersANotification() throws Exception {
+    public void removingAHistogramTriggersANotification() {
         registry.register("thing", histogram);
 
         assertThat(registry.remove("thing"))
@@ -129,7 +129,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void registeringAMeterTriggersANotification() throws Exception {
+    public void registeringAMeterTriggersANotification() {
         assertThat(registry.register("thing", meter))
                 .isEqualTo(meter);
 
@@ -137,7 +137,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void accessingAMeterRegistersAndReusesIt() throws Exception {
+    public void accessingAMeterRegistersAndReusesIt() {
         final Meter meter1 = registry.meter("thing");
         final Meter meter2 = registry.meter("thing");
 
@@ -148,7 +148,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void accessingACustomMeterRegistersAndReusesIt() throws Exception {
+    public void accessingACustomMeterRegistersAndReusesIt() {
         final MetricRegistry.MetricSupplier<Meter> supplier = () -> meter;
         final Meter meter1 = registry.meter("thing", supplier);
         final Meter meter2 = registry.meter("thing", supplier);
@@ -160,7 +160,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void removingAMeterTriggersANotification() throws Exception {
+    public void removingAMeterTriggersANotification() {
         registry.register("thing", meter);
 
         assertThat(registry.remove("thing"))
@@ -170,7 +170,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void registeringATimerTriggersANotification() throws Exception {
+    public void registeringATimerTriggersANotification() {
         assertThat(registry.register("thing", timer))
                 .isEqualTo(timer);
 
@@ -178,7 +178,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void accessingATimerRegistersAndReusesIt() throws Exception {
+    public void accessingATimerRegistersAndReusesIt() {
         final Timer timer1 = registry.timer("thing");
         final Timer timer2 = registry.timer("thing");
 
@@ -189,7 +189,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void accessingACustomTimerRegistersAndReusesIt() throws Exception {
+    public void accessingACustomTimerRegistersAndReusesIt() {
         final MetricRegistry.MetricSupplier<Timer> supplier = () -> timer;
         final Timer timer1 = registry.timer("thing", supplier);
         final Timer timer2 = registry.timer("thing", supplier);
@@ -202,7 +202,7 @@ public class MetricRegistryTest {
 
 
     @Test
-    public void removingATimerTriggersANotification() throws Exception {
+    public void removingATimerTriggersANotification() {
         registry.register("thing", timer);
 
         assertThat(registry.remove("thing"))
@@ -213,7 +213,7 @@ public class MetricRegistryTest {
 
     @Test
     @SuppressWarnings("rawtypes")
-    public void accessingACustomGaugeRegistersAndReusesIt() throws Exception {
+    public void accessingACustomGaugeRegistersAndReusesIt() {
         final MetricRegistry.MetricSupplier<Gauge> supplier = () -> gauge;
         final Gauge gauge1 = registry.gauge("thing", supplier);
         final Gauge gauge2 = registry.gauge("thing", supplier);
@@ -226,7 +226,7 @@ public class MetricRegistryTest {
 
 
     @Test
-    public void addingAListenerWithExistingMetricsCatchesItUp() throws Exception {
+    public void addingAListenerWithExistingMetricsCatchesItUp() {
         registry.register("gauge", gauge);
         registry.register("counter", counter);
         registry.register("histogram", histogram);
@@ -244,7 +244,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void aRemovedListenerDoesNotReceiveUpdates() throws Exception {
+    public void aRemovedListenerDoesNotReceiveUpdates() {
         registry.register("gauge", gauge);
         registry.removeListener(listener);
         registry.register("gauge2", gauge);
@@ -253,7 +253,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void hasAMapOfRegisteredGauges() throws Exception {
+    public void hasAMapOfRegisteredGauges() {
         registry.register("gauge", gauge);
 
         assertThat(registry.getGauges())
@@ -261,7 +261,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void hasAMapOfRegisteredCounters() throws Exception {
+    public void hasAMapOfRegisteredCounters() {
         registry.register("counter", counter);
 
         assertThat(registry.getCounters())
@@ -269,7 +269,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void hasAMapOfRegisteredHistograms() throws Exception {
+    public void hasAMapOfRegisteredHistograms() {
         registry.register("histogram", histogram);
 
         assertThat(registry.getHistograms())
@@ -277,7 +277,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void hasAMapOfRegisteredMeters() throws Exception {
+    public void hasAMapOfRegisteredMeters() {
         registry.register("meter", meter);
 
         assertThat(registry.getMeters())
@@ -285,7 +285,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void hasAMapOfRegisteredTimers() throws Exception {
+    public void hasAMapOfRegisteredTimers() {
         registry.register("timer", timer);
 
         assertThat(registry.getTimers())
@@ -293,7 +293,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void hasASetOfRegisteredMetricNames() throws Exception {
+    public void hasASetOfRegisteredMetricNames() {
         registry.register("gauge", gauge);
         registry.register("counter", counter);
         registry.register("histogram", histogram);
@@ -305,7 +305,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void registersMultipleMetrics() throws Exception {
+    public void registersMultipleMetrics() {
         final MetricSet metrics = () -> {
             final Map<String, Metric> m = new HashMap<>();
             m.put("gauge", gauge);
@@ -320,7 +320,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void registersMultipleMetricsWithAPrefix() throws Exception {
+    public void registersMultipleMetricsWithAPrefix() {
         final MetricSet metrics = () -> {
             final Map<String, Metric> m = new HashMap<>();
             m.put("gauge", gauge);
@@ -335,7 +335,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void registersRecursiveMetricSets() throws Exception {
+    public void registersRecursiveMetricSets() {
         final MetricSet inner = () -> {
             final Map<String, Metric> m = new HashMap<>();
             m.put("gauge", gauge);
@@ -356,7 +356,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void registersMetricsFromAnotherRegistry() throws Exception {
+    public void registersMetricsFromAnotherRegistry() {
         MetricRegistry other = new MetricRegistry();
         other.register("gauge", gauge);
         registry.register("nested", other);
@@ -364,44 +364,44 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void concatenatesStringsToFormADottedName() throws Exception {
+    public void concatenatesStringsToFormADottedName() {
         assertThat(name("one", "two", "three"))
                 .isEqualTo("one.two.three");
     }
 
     @Test
     @SuppressWarnings("NullArgumentToVariableArgMethod")
-    public void elidesNullValuesFromNamesWhenOnlyOneNullPassedIn() throws Exception {
+    public void elidesNullValuesFromNamesWhenOnlyOneNullPassedIn() {
         assertThat(name("one", (String) null))
                 .isEqualTo("one");
     }
 
     @Test
-    public void elidesNullValuesFromNamesWhenManyNullsPassedIn() throws Exception {
+    public void elidesNullValuesFromNamesWhenManyNullsPassedIn() {
         assertThat(name("one", null, null))
                 .isEqualTo("one");
     }
 
     @Test
-    public void elidesNullValuesFromNamesWhenNullAndNotNullPassedIn() throws Exception {
+    public void elidesNullValuesFromNamesWhenNullAndNotNullPassedIn() {
         assertThat(name("one", null, "three"))
                 .isEqualTo("one.three");
     }
 
     @Test
-    public void elidesEmptyStringsFromNames() throws Exception {
+    public void elidesEmptyStringsFromNames() {
         assertThat(name("one", "", "three"))
                 .isEqualTo("one.three");
     }
 
     @Test
-    public void concatenatesClassNamesWithStringsToFormADottedName() throws Exception {
+    public void concatenatesClassNamesWithStringsToFormADottedName() {
         assertThat(name(MetricRegistryTest.class, "one", "two"))
                 .isEqualTo("com.codahale.metrics.MetricRegistryTest.one.two");
     }
 
     @Test
-    public void concatenatesClassesWithoutCanonicalNamesWithStrings() throws Exception {
+    public void concatenatesClassesWithoutCanonicalNamesWithStrings() {
         final Gauge<String> g = () -> null;
 
         assertThat(name(g.getClass(), "one", "two"))
@@ -409,7 +409,7 @@ public class MetricRegistryTest {
     }
 
     @Test
-    public void removesMetricsMatchingAFilter() throws Exception {
+    public void removesMetricsMatchingAFilter() {
         registry.timer("timer-1");
         registry.timer("timer-2");
         registry.histogram("histogram-1");

--- a/metrics-core/src/test/java/com/codahale/metrics/RatioGaugeTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/RatioGaugeTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class RatioGaugeTest {
     @Test
-    public void ratiosAreHumanReadable() throws Exception {
+    public void ratiosAreHumanReadable() {
         final RatioGauge.Ratio ratio = RatioGauge.Ratio.of(100, 200);
 
         assertThat(ratio.toString())
@@ -14,7 +14,7 @@ public class RatioGaugeTest {
     }
 
     @Test
-    public void calculatesTheRatioOfTheNumeratorToTheDenominator() throws Exception {
+    public void calculatesTheRatioOfTheNumeratorToTheDenominator() {
         final RatioGauge regular = new RatioGauge() {
             @Override
             protected Ratio getRatio() {
@@ -27,7 +27,7 @@ public class RatioGaugeTest {
     }
 
     @Test
-    public void handlesDivideByZeroIssues() throws Exception {
+    public void handlesDivideByZeroIssues() {
         final RatioGauge divByZero = new RatioGauge() {
             @Override
             protected Ratio getRatio() {
@@ -40,7 +40,7 @@ public class RatioGaugeTest {
     }
 
     @Test
-    public void handlesInfiniteDenominators() throws Exception {
+    public void handlesInfiniteDenominators() {
         final RatioGauge infinite = new RatioGauge() {
             @Override
             protected Ratio getRatio() {
@@ -53,7 +53,7 @@ public class RatioGaugeTest {
     }
 
     @Test
-    public void handlesNaNDenominators() throws Exception {
+    public void handlesNaNDenominators() {
         final RatioGauge nan = new RatioGauge() {
             @Override
             protected Ratio getRatio() {

--- a/metrics-core/src/test/java/com/codahale/metrics/SharedMetricRegistriesTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SharedMetricRegistriesTest.java
@@ -14,13 +14,13 @@ public class SharedMetricRegistriesTest {
     public ExpectedException exception = ExpectedException.none();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         SharedMetricRegistries.setDefaultRegistryName(new AtomicReference<>());
         SharedMetricRegistries.clear();
     }
 
     @Test
-    public void memorizesRegistriesByName() throws Exception {
+    public void memorizesRegistriesByName() {
         final MetricRegistry one = SharedMetricRegistries.getOrCreate("one");
         final MetricRegistry two = SharedMetricRegistries.getOrCreate("one");
 
@@ -29,7 +29,7 @@ public class SharedMetricRegistriesTest {
     }
 
     @Test
-    public void hasASetOfNames() throws Exception {
+    public void hasASetOfNames() {
         SharedMetricRegistries.getOrCreate("one");
 
         assertThat(SharedMetricRegistries.names())
@@ -37,7 +37,7 @@ public class SharedMetricRegistriesTest {
     }
 
     @Test
-    public void removesRegistries() throws Exception {
+    public void removesRegistries() {
         final MetricRegistry one = SharedMetricRegistries.getOrCreate("one");
         SharedMetricRegistries.remove("one");
 
@@ -50,7 +50,7 @@ public class SharedMetricRegistriesTest {
     }
 
     @Test
-    public void clearsRegistries() throws Exception {
+    public void clearsRegistries() {
         SharedMetricRegistries.getOrCreate("one");
         SharedMetricRegistries.getOrCreate("two");
 
@@ -61,14 +61,14 @@ public class SharedMetricRegistriesTest {
     }
 
     @Test
-    public void errorsWhenDefaultUnset() throws Exception {
+    public void errorsWhenDefaultUnset() {
         exception.expect(IllegalStateException.class);
         exception.expectMessage("Default registry name has not been set.");
         SharedMetricRegistries.getDefault();
     }
 
     @Test
-    public void createsDefaultRegistries() throws Exception {
+    public void createsDefaultRegistries() {
         final String defaultName = "default";
         final MetricRegistry registry = SharedMetricRegistries.setDefault(defaultName);
         assertThat(registry).isNotNull();
@@ -77,7 +77,7 @@ public class SharedMetricRegistriesTest {
     }
 
     @Test
-    public void errorsWhenDefaultAlreadySet() throws Exception {
+    public void errorsWhenDefaultAlreadySet() {
         SharedMetricRegistries.setDefault("foobah");
         exception.expect(IllegalStateException.class);
         exception.expectMessage("Default metric registry name is already set.");
@@ -85,7 +85,7 @@ public class SharedMetricRegistriesTest {
     }
 
     @Test
-    public void setsDefaultExistingRegistries() throws Exception {
+    public void setsDefaultExistingRegistries() {
         final String defaultName = "default";
         final MetricRegistry registry = new MetricRegistry();
         assertThat(SharedMetricRegistries.setDefault(defaultName, registry)).isEqualTo(registry);

--- a/metrics-core/src/test/java/com/codahale/metrics/Slf4jReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/Slf4jReporterTest.java
@@ -36,7 +36,7 @@ public class Slf4jReporterTest {
             .build();
 
     @Test
-    public void reportsGaugeValuesAtError() throws Exception {
+    public void reportsGaugeValuesAtError() {
         when(logger.isErrorEnabled(marker)).thenReturn(true);
         errorReporter.report(map("gauge", () -> "value"),
                 map(),
@@ -48,7 +48,7 @@ public class Slf4jReporterTest {
     }
 
     @Test
-    public void reportsCounterValuesAtError() throws Exception {
+    public void reportsCounterValuesAtError() {
         final Counter counter = mock(Counter.class);
         when(counter.getCount()).thenReturn(100L);
         when(logger.isErrorEnabled(marker)).thenReturn(true);
@@ -63,7 +63,7 @@ public class Slf4jReporterTest {
     }
 
     @Test
-    public void reportsHistogramValuesAtError() throws Exception {
+    public void reportsHistogramValuesAtError() {
         final Histogram histogram = mock(Histogram.class);
         when(histogram.getCount()).thenReturn(1L);
 
@@ -106,7 +106,7 @@ public class Slf4jReporterTest {
     }
 
     @Test
-    public void reportsMeterValuesAtError() throws Exception {
+    public void reportsMeterValuesAtError() {
         final Meter meter = mock(Meter.class);
         when(meter.getCount()).thenReturn(1L);
         when(meter.getMeanRate()).thenReturn(2.0);
@@ -134,7 +134,7 @@ public class Slf4jReporterTest {
     }
 
     @Test
-    public void reportsTimerValuesAtError() throws Exception {
+    public void reportsTimerValuesAtError() {
         final Timer timer = mock(Timer.class);
         when(timer.getCount()).thenReturn(1L);
 
@@ -190,7 +190,7 @@ public class Slf4jReporterTest {
     }
 
     @Test
-    public void reportsGaugeValues() throws Exception {
+    public void reportsGaugeValues() {
         when(logger.isInfoEnabled(marker)).thenReturn(true);
         infoReporter.report(map("gauge", () -> "value"),
                 map(),
@@ -202,7 +202,7 @@ public class Slf4jReporterTest {
     }
 
     @Test
-    public void reportsCounterValues() throws Exception {
+    public void reportsCounterValues() {
         final Counter counter = mock(Counter.class);
         when(counter.getCount()).thenReturn(100L);
         when(logger.isInfoEnabled(marker)).thenReturn(true);
@@ -217,7 +217,7 @@ public class Slf4jReporterTest {
     }
 
     @Test
-    public void reportsHistogramValues() throws Exception {
+    public void reportsHistogramValues() {
         final Histogram histogram = mock(Histogram.class);
         when(histogram.getCount()).thenReturn(1L);
 
@@ -260,7 +260,7 @@ public class Slf4jReporterTest {
     }
 
     @Test
-    public void reportsMeterValues() throws Exception {
+    public void reportsMeterValues() {
         final Meter meter = mock(Meter.class);
         when(meter.getCount()).thenReturn(1L);
         when(meter.getMeanRate()).thenReturn(2.0);
@@ -288,7 +288,7 @@ public class Slf4jReporterTest {
     }
 
     @Test
-    public void reportsTimerValues() throws Exception {
+    public void reportsTimerValues() {
         final Timer timer = mock(Timer.class);
         when(timer.getCount()).thenReturn(1L);
 

--- a/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowArrayReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowArrayReservoirTest.java
@@ -16,7 +16,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class SlidingTimeWindowArrayReservoirTest {
 
     @Test
-    public void storesMeasurementsWithDuplicateTicks() throws Exception {
+    public void storesMeasurementsWithDuplicateTicks() {
         final Clock clock = mock(Clock.class);
         final SlidingTimeWindowArrayReservoir reservoir = new SlidingTimeWindowArrayReservoir(10, NANOSECONDS, clock);
 
@@ -30,7 +30,7 @@ public class SlidingTimeWindowArrayReservoirTest {
     }
 
     @Test
-    public void boundsMeasurementsToATimeWindow() throws Exception {
+    public void boundsMeasurementsToATimeWindow() {
         final Clock clock = mock(Clock.class);
         final SlidingTimeWindowArrayReservoir reservoir = new SlidingTimeWindowArrayReservoir(10, NANOSECONDS, clock);
 

--- a/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowReservoirTest.java
@@ -12,7 +12,7 @@ import static org.mockito.Mockito.when;
 
 public class SlidingTimeWindowReservoirTest {
     @Test
-    public void storesMeasurementsWithDuplicateTicks() throws Exception {
+    public void storesMeasurementsWithDuplicateTicks() {
         final Clock clock = mock(Clock.class);
         final SlidingTimeWindowReservoir reservoir = new SlidingTimeWindowReservoir(10, NANOSECONDS, clock);
 
@@ -26,7 +26,7 @@ public class SlidingTimeWindowReservoirTest {
     }
 
     @Test
-    public void boundsMeasurementsToATimeWindow() throws Exception {
+    public void boundsMeasurementsToATimeWindow() {
         final Clock clock = mock(Clock.class);
         final SlidingTimeWindowReservoir reservoir = new SlidingTimeWindowReservoir(10, NANOSECONDS, clock);
 

--- a/metrics-core/src/test/java/com/codahale/metrics/SlidingWindowReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SlidingWindowReservoirTest.java
@@ -8,7 +8,7 @@ public class SlidingWindowReservoirTest {
     private final SlidingWindowReservoir reservoir = new SlidingWindowReservoir(3);
 
     @Test
-    public void handlesSmallDataStreams() throws Exception {
+    public void handlesSmallDataStreams() {
         reservoir.update(1);
         reservoir.update(2);
 
@@ -17,7 +17,7 @@ public class SlidingWindowReservoirTest {
     }
 
     @Test
-    public void onlyKeepsTheMostRecentFromBigDataStreams() throws Exception {
+    public void onlyKeepsTheMostRecentFromBigDataStreams() {
         reservoir.update(1);
         reservoir.update(2);
         reservoir.update(3);

--- a/metrics-core/src/test/java/com/codahale/metrics/TimerTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/TimerTest.java
@@ -26,7 +26,7 @@ public class TimerTest {
     private final Timer timer = new Timer(reservoir, clock);
 
     @Test
-    public void hasRates() throws Exception {
+    public void hasRates() {
         assertThat(timer.getCount())
                 .isZero();
 
@@ -44,7 +44,7 @@ public class TimerTest {
     }
 
     @Test
-    public void updatesTheCountOnUpdates() throws Exception {
+    public void updatesTheCountOnUpdates() {
         assertThat(timer.getCount())
                 .isZero();
 
@@ -81,7 +81,7 @@ public class TimerTest {
     }
 
     @Test
-    public void timesRunnableInstances() throws Exception {
+    public void timesRunnableInstances() {
         final AtomicBoolean called = new AtomicBoolean();
         timer.time(() -> called.set(true));
 
@@ -95,7 +95,7 @@ public class TimerTest {
     }
 
     @Test
-    public void timesContexts() throws Exception {
+    public void timesContexts() {
         timer.time().stop();
 
         assertThat(timer.getCount())
@@ -105,7 +105,7 @@ public class TimerTest {
     }
 
     @Test
-    public void returnsTheSnapshotFromTheReservoir() throws Exception {
+    public void returnsTheSnapshotFromTheReservoir() {
         final Snapshot snapshot = mock(Snapshot.class);
         when(reservoir.getSnapshot()).thenReturn(snapshot);
 
@@ -114,7 +114,7 @@ public class TimerTest {
     }
 
     @Test
-    public void ignoresNegativeValues() throws Exception {
+    public void ignoresNegativeValues() {
         timer.update(-1, TimeUnit.SECONDS);
 
         assertThat(timer.getCount())

--- a/metrics-core/src/test/java/com/codahale/metrics/UniformReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/UniformReservoirTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class UniformReservoirTest {
     @Test
     @SuppressWarnings("unchecked")
-    public void aReservoirOf100OutOf1000Elements() throws Exception {
+    public void aReservoirOf100OutOf1000Elements() {
         final UniformReservoir reservoir = new UniformReservoir(100);
         for (int i = 0; i < 1000; i++) {
             reservoir.update(i);

--- a/metrics-core/src/test/java/com/codahale/metrics/UniformSnapshotTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/UniformSnapshotTest.java
@@ -16,13 +16,13 @@ public class UniformSnapshotTest {
     private final Snapshot snapshot = new UniformSnapshot(new long[]{5, 1, 2, 3, 4});
 
     @Test
-    public void smallQuantilesAreTheFirstValue() throws Exception {
+    public void smallQuantilesAreTheFirstValue() {
         assertThat(snapshot.getValue(0.0))
                 .isEqualTo(1, offset(0.1));
     }
 
     @Test
-    public void bigQuantilesAreTheLastValue() throws Exception {
+    public void bigQuantilesAreTheLastValue() {
         assertThat(snapshot.getValue(1.0))
                 .isEqualTo(5, offset(0.1));
     }
@@ -43,49 +43,49 @@ public class UniformSnapshotTest {
     }
 
     @Test
-    public void hasAMedian() throws Exception {
+    public void hasAMedian() {
         assertThat(snapshot.getMedian()).isEqualTo(3, offset(0.1));
     }
 
     @Test
-    public void hasAp75() throws Exception {
+    public void hasAp75() {
         assertThat(snapshot.get75thPercentile()).isEqualTo(4.5, offset(0.1));
     }
 
     @Test
-    public void hasAp95() throws Exception {
+    public void hasAp95() {
         assertThat(snapshot.get95thPercentile()).isEqualTo(5.0, offset(0.1));
     }
 
     @Test
-    public void hasAp98() throws Exception {
+    public void hasAp98() {
         assertThat(snapshot.get98thPercentile()).isEqualTo(5.0, offset(0.1));
     }
 
     @Test
-    public void hasAp99() throws Exception {
+    public void hasAp99() {
         assertThat(snapshot.get99thPercentile()).isEqualTo(5.0, offset(0.1));
     }
 
     @Test
-    public void hasAp999() throws Exception {
+    public void hasAp999() {
         assertThat(snapshot.get999thPercentile()).isEqualTo(5.0, offset(0.1));
     }
 
     @Test
-    public void hasValues() throws Exception {
+    public void hasValues() {
         assertThat(snapshot.getValues())
                 .containsOnly(1, 2, 3, 4, 5);
     }
 
     @Test
-    public void hasASize() throws Exception {
+    public void hasASize() {
         assertThat(snapshot.size())
                 .isEqualTo(5);
     }
 
     @Test
-    public void canAlsoBeCreatedFromACollectionOfLongs() throws Exception {
+    public void canAlsoBeCreatedFromACollectionOfLongs() {
         final Snapshot other = new UniformSnapshot(asList(5L, 1L, 2L, 3L, 4L));
 
         assertThat(other.getValues())
@@ -123,7 +123,7 @@ public class UniformSnapshotTest {
     }
 
     @Test
-    public void dumpsToAStream() throws Exception {
+    public void dumpsToAStream() {
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
 
         snapshot.dump(output);
@@ -133,31 +133,31 @@ public class UniformSnapshotTest {
     }
 
     @Test
-    public void calculatesTheMinimumValue() throws Exception {
+    public void calculatesTheMinimumValue() {
         assertThat(snapshot.getMin())
                 .isEqualTo(1);
     }
 
     @Test
-    public void calculatesTheMaximumValue() throws Exception {
+    public void calculatesTheMaximumValue() {
         assertThat(snapshot.getMax())
                 .isEqualTo(5);
     }
 
     @Test
-    public void calculatesTheMeanValue() throws Exception {
+    public void calculatesTheMeanValue() {
         assertThat(snapshot.getMean())
                 .isEqualTo(3.0);
     }
 
     @Test
-    public void calculatesTheStdDev() throws Exception {
+    public void calculatesTheStdDev() {
         assertThat(snapshot.getStdDev())
                 .isEqualTo(1.5811, offset(0.0001));
     }
 
     @Test
-    public void calculatesAMinOfZeroForAnEmptySnapshot() throws Exception {
+    public void calculatesAMinOfZeroForAnEmptySnapshot() {
         final Snapshot emptySnapshot = new UniformSnapshot(new long[]{});
 
         assertThat(emptySnapshot.getMin())
@@ -165,7 +165,7 @@ public class UniformSnapshotTest {
     }
 
     @Test
-    public void calculatesAMaxOfZeroForAnEmptySnapshot() throws Exception {
+    public void calculatesAMaxOfZeroForAnEmptySnapshot() {
         final Snapshot emptySnapshot = new UniformSnapshot(new long[]{});
 
         assertThat(emptySnapshot.getMax())
@@ -173,7 +173,7 @@ public class UniformSnapshotTest {
     }
 
     @Test
-    public void calculatesAMeanOfZeroForAnEmptySnapshot() throws Exception {
+    public void calculatesAMeanOfZeroForAnEmptySnapshot() {
         final Snapshot emptySnapshot = new UniformSnapshot(new long[]{});
 
         assertThat(emptySnapshot.getMean())
@@ -181,7 +181,7 @@ public class UniformSnapshotTest {
     }
 
     @Test
-    public void calculatesAStdDevOfZeroForAnEmptySnapshot() throws Exception {
+    public void calculatesAStdDevOfZeroForAnEmptySnapshot() {
         final Snapshot emptySnapshot = new UniformSnapshot(new long[]{});
 
         assertThat(emptySnapshot.getStdDev())
@@ -189,7 +189,7 @@ public class UniformSnapshotTest {
     }
 
     @Test
-    public void calculatesAStdDevOfZeroForASingletonSnapshot() throws Exception {
+    public void calculatesAStdDevOfZeroForASingletonSnapshot() {
         final Snapshot singleItemSnapshot = new UniformSnapshot(new long[]{1});
 
         assertThat(singleItemSnapshot.getStdDev())

--- a/metrics-core/src/test/java/com/codahale/metrics/WeightedSnapshotTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/WeightedSnapshotTest.java
@@ -32,13 +32,13 @@ public class WeightedSnapshotTest {
             weightedArray(new long[]{5, 1, 2, 3, 4}, new double[]{1, 2, 3, 2, 2}));
 
     @Test
-    public void smallQuantilesAreTheFirstValue() throws Exception {
+    public void smallQuantilesAreTheFirstValue() {
         assertThat(snapshot.getValue(0.0))
                 .isEqualTo(1.0, offset(0.1));
     }
 
     @Test
-    public void bigQuantilesAreTheLastValue() throws Exception {
+    public void bigQuantilesAreTheLastValue() {
         assertThat(snapshot.getValue(1.0))
                 .isEqualTo(5.0, offset(0.1));
     }
@@ -59,49 +59,49 @@ public class WeightedSnapshotTest {
     }
 
     @Test
-    public void hasAMedian() throws Exception {
+    public void hasAMedian() {
         assertThat(snapshot.getMedian()).isEqualTo(3.0, offset(0.1));
     }
 
     @Test
-    public void hasAp75() throws Exception {
+    public void hasAp75() {
         assertThat(snapshot.get75thPercentile()).isEqualTo(4.0, offset(0.1));
     }
 
     @Test
-    public void hasAp95() throws Exception {
+    public void hasAp95() {
         assertThat(snapshot.get95thPercentile()).isEqualTo(5.0, offset(0.1));
     }
 
     @Test
-    public void hasAp98() throws Exception {
+    public void hasAp98() {
         assertThat(snapshot.get98thPercentile()).isEqualTo(5.0, offset(0.1));
     }
 
     @Test
-    public void hasAp99() throws Exception {
+    public void hasAp99() {
         assertThat(snapshot.get99thPercentile()).isEqualTo(5.0, offset(0.1));
     }
 
     @Test
-    public void hasAp999() throws Exception {
+    public void hasAp999() {
         assertThat(snapshot.get999thPercentile()).isEqualTo(5.0, offset(0.1));
     }
 
     @Test
-    public void hasValues() throws Exception {
+    public void hasValues() {
         assertThat(snapshot.getValues())
                 .containsOnly(1, 2, 3, 4, 5);
     }
 
     @Test
-    public void hasASize() throws Exception {
+    public void hasASize() {
         assertThat(snapshot.size())
                 .isEqualTo(5);
     }
 
     @Test
-    public void worksWithUnderestimatedCollections() throws Exception {
+    public void worksWithUnderestimatedCollections() {
         final List<WeightedSample> items = spy(weightedArray(new long[]{5, 1, 2, 3, 4}, new double[]{1, 2, 3, 2, 2}));
         when(items.size()).thenReturn(4, 5);
 
@@ -112,7 +112,7 @@ public class WeightedSnapshotTest {
     }
 
     @Test
-    public void worksWithOverestimatedCollections() throws Exception {
+    public void worksWithOverestimatedCollections() {
         final List<WeightedSample> items = spy(weightedArray(new long[]{5, 1, 2, 3, 4}, new double[]{1, 2, 3, 2, 2}));
         when(items.size()).thenReturn(6, 5);
 
@@ -123,7 +123,7 @@ public class WeightedSnapshotTest {
     }
 
     @Test
-    public void dumpsToAStream() throws Exception {
+    public void dumpsToAStream() {
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
 
         snapshot.dump(output);
@@ -133,31 +133,31 @@ public class WeightedSnapshotTest {
     }
 
     @Test
-    public void calculatesTheMinimumValue() throws Exception {
+    public void calculatesTheMinimumValue() {
         assertThat(snapshot.getMin())
                 .isEqualTo(1);
     }
 
     @Test
-    public void calculatesTheMaximumValue() throws Exception {
+    public void calculatesTheMaximumValue() {
         assertThat(snapshot.getMax())
                 .isEqualTo(5);
     }
 
     @Test
-    public void calculatesTheMeanValue() throws Exception {
+    public void calculatesTheMeanValue() {
         assertThat(snapshot.getMean())
                 .isEqualTo(2.7);
     }
 
     @Test
-    public void calculatesTheStdDev() throws Exception {
+    public void calculatesTheStdDev() {
         assertThat(snapshot.getStdDev())
                 .isEqualTo(1.2688, offset(0.0001));
     }
 
     @Test
-    public void calculatesAMinOfZeroForAnEmptySnapshot() throws Exception {
+    public void calculatesAMinOfZeroForAnEmptySnapshot() {
         final Snapshot emptySnapshot = new WeightedSnapshot(
                 weightedArray(new long[]{}, new double[]{}));
 
@@ -166,7 +166,7 @@ public class WeightedSnapshotTest {
     }
 
     @Test
-    public void calculatesAMaxOfZeroForAnEmptySnapshot() throws Exception {
+    public void calculatesAMaxOfZeroForAnEmptySnapshot() {
         final Snapshot emptySnapshot = new WeightedSnapshot(
                 weightedArray(new long[]{}, new double[]{}));
 
@@ -175,7 +175,7 @@ public class WeightedSnapshotTest {
     }
 
     @Test
-    public void calculatesAMeanOfZeroForAnEmptySnapshot() throws Exception {
+    public void calculatesAMeanOfZeroForAnEmptySnapshot() {
         final Snapshot emptySnapshot = new WeightedSnapshot(
                 weightedArray(new long[]{}, new double[]{}));
 
@@ -184,7 +184,7 @@ public class WeightedSnapshotTest {
     }
 
     @Test
-    public void calculatesAStdDevOfZeroForAnEmptySnapshot() throws Exception {
+    public void calculatesAStdDevOfZeroForAnEmptySnapshot() {
         final Snapshot emptySnapshot = new WeightedSnapshot(
                 weightedArray(new long[]{}, new double[]{}));
 
@@ -193,7 +193,7 @@ public class WeightedSnapshotTest {
     }
 
     @Test
-    public void calculatesAStdDevOfZeroForASingletonSnapshot() throws Exception {
+    public void calculatesAStdDevOfZeroForASingletonSnapshot() {
         final Snapshot singleItemSnapshot = new WeightedSnapshot(
                 weightedArray(new long[]{1}, new double[]{1.0}));
 
@@ -202,7 +202,7 @@ public class WeightedSnapshotTest {
     }
 
     @Test
-    public void expectNoOverflowForLowWeights() throws Exception {
+    public void expectNoOverflowForLowWeights() {
         final Snapshot scatteredSnapshot = new WeightedSnapshot(
                 weightedArray(
                         new long[]{1, 2, 3},

--- a/metrics-ehcache/src/test/java/com/codahale/metrics/ehcache/InstrumentedCacheDecoratorFactoryTest.java
+++ b/metrics-ehcache/src/test/java/com/codahale/metrics/ehcache/InstrumentedCacheDecoratorFactoryTest.java
@@ -22,7 +22,7 @@ public class InstrumentedCacheDecoratorFactoryTest {
     private Ehcache cache;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         this.cache = MANAGER.getEhcache("test-config");
         assumeThat(cache, is(CoreMatchers.notNullValue()));
 
@@ -30,7 +30,7 @@ public class InstrumentedCacheDecoratorFactoryTest {
     }
 
     @Test
-    public void measuresGets() throws Exception {
+    public void measuresGets() {
         cache.get("woo");
 
         assertThat(registry.timer(name(Cache.class, "test-config", "gets")).getCount())
@@ -39,7 +39,7 @@ public class InstrumentedCacheDecoratorFactoryTest {
     }
 
     @Test
-    public void measuresPuts() throws Exception {
+    public void measuresPuts() {
         cache.put(new Element("woo", "whee"));
 
         assertThat(registry.timer(name(Cache.class, "test-config", "puts")).getCount())

--- a/metrics-ehcache/src/test/java/com/codahale/metrics/ehcache/InstrumentedEhcacheTest.java
+++ b/metrics-ehcache/src/test/java/com/codahale/metrics/ehcache/InstrumentedEhcacheTest.java
@@ -20,14 +20,14 @@ public class InstrumentedEhcacheTest {
     private Ehcache cache;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         final Cache c = new Cache(new CacheConfiguration("test", 100));
         MANAGER.addCache(c);
         this.cache = InstrumentedEhcache.instrument(registry, c);
     }
 
     @Test
-    public void measuresGetsAndPuts() throws Exception {
+    public void measuresGetsAndPuts() {
         cache.get("woo");
 
         cache.put(new Element("woo", "whee"));

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteRabbitMQTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteRabbitMQTest.java
@@ -113,7 +113,7 @@ public class GraphiteRabbitMQTest {
     }
 
     @Test
-    public void shouldFailWhenGraphiteHostUnavailable() throws Exception {
+    public void shouldFailWhenGraphiteHostUnavailable() {
         ConnectionFactory connectionFactory = new ConnectionFactory();
         connectionFactory.setHost("some-unknown-host");
 

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -56,7 +56,7 @@ public class GraphiteReporterTest {
         .build(graphite);
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         when(clock.getTime()).thenReturn(timestamp * 1000);
     }
 

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteTest.java
@@ -78,7 +78,7 @@ public class GraphiteTest {
     }
 
     @Test
-    public void measuresFailures() throws Exception {
+    public void measuresFailures() {
         graphite = new Graphite(address, socketFactory);
         assertThat(graphite.getFailures())
                 .isZero();
@@ -140,7 +140,7 @@ public class GraphiteTest {
     }
 
     @Test
-    public void notifiesIfGraphiteIsUnavailable() throws Exception {
+    public void notifiesIfGraphiteIsUnavailable() {
         final String unavailableHost = "unknown-host-10el6m7yg56ge7dmcom";
         InetSocketAddress unavailableAddress = new InetSocketAddress(unavailableHost, 1234);
 

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/AsyncHealthCheckDecoratorTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/AsyncHealthCheckDecoratorTest.java
@@ -149,7 +149,7 @@ public class AsyncHealthCheckDecoratorTest {
     private static class NegativePeriodAsyncHealthCheck extends HealthCheck {
 
         @Override
-        protected Result check() throws Exception {
+        protected Result check() {
             return null;
         }
     }
@@ -158,7 +158,7 @@ public class AsyncHealthCheckDecoratorTest {
     private static class ZeroPeriodAsyncHealthCheck extends HealthCheck {
 
         @Override
-        protected Result check() throws Exception {
+        protected Result check() {
             return null;
         }
     }
@@ -167,7 +167,7 @@ public class AsyncHealthCheckDecoratorTest {
     private static class NegativeInitialDelayAsyncHealthCheck extends HealthCheck {
 
         @Override
-        protected Result check() throws Exception {
+        protected Result check() {
             return null;
         }
     }
@@ -176,7 +176,7 @@ public class AsyncHealthCheckDecoratorTest {
     private static class DefaultAsyncHealthCheck extends HealthCheck {
 
         @Override
-        protected Result check() throws Exception {
+        protected Result check() {
             return null;
         }
     }
@@ -185,7 +185,7 @@ public class AsyncHealthCheckDecoratorTest {
     private static class FixedDelayAsyncHealthCheck extends HealthCheck {
 
         @Override
-        protected Result check() throws Exception {
+        protected Result check() {
             return null;
         }
     }
@@ -194,7 +194,7 @@ public class AsyncHealthCheckDecoratorTest {
     private static class UnhealthyAsyncHealthCheck extends HealthCheck {
 
         @Override
-        protected Result check() throws Exception {
+        protected Result check() {
             return null;
         }
     }

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckFilterTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckFilterTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 public class HealthCheckFilterTest {
 
     @Test
-    public void theAllFilterMatchesAllHealthChecks() throws Exception {
+    public void theAllFilterMatchesAllHealthChecks() {
         assertThat(HealthCheckFilter.ALL.matches("", mock(HealthCheck.class))).isTrue();
     }
 }

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckRegistryTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckRegistryTest.java
@@ -43,7 +43,7 @@ public class HealthCheckRegistryTest {
 
     @Before
     @SuppressWarnings("unchecked")
-    public void setUp() throws Exception {
+    public void setUp() {
         registry.addListener(listener);
 
         when(hc1.execute()).thenReturn(r1);
@@ -115,7 +115,7 @@ public class HealthCheckRegistryTest {
     }
 
     @Test
-    public void runsRegisteredHealthChecks() throws Exception {
+    public void runsRegisteredHealthChecks() {
         final Map<String, HealthCheck.Result> results = registry.runHealthChecks();
 
         assertThat(results).contains(entry("hc1", r1));
@@ -124,14 +124,14 @@ public class HealthCheckRegistryTest {
     }
 
     @Test
-    public void runsRegisteredHealthChecksWithFilter() throws Exception {
+    public void runsRegisteredHealthChecksWithFilter() {
         final Map<String, HealthCheck.Result> results = registry.runHealthChecks((name, healthCheck) -> "hc1".equals(name));
 
         assertThat(results).containsOnly(entry("hc1", r1));
     }
 
     @Test
-    public void runsRegisteredHealthChecksWithNonMatchingFilter() throws Exception {
+    public void runsRegisteredHealthChecksWithNonMatchingFilter() {
         final Map<String, HealthCheck.Result> results = registry.runHealthChecks((name, healthCheck) -> false);
 
         assertThat(results).isEmpty();
@@ -174,7 +174,7 @@ public class HealthCheckRegistryTest {
     }
 
     @Test
-    public void removesRegisteredHealthChecks() throws Exception {
+    public void removesRegisteredHealthChecks() {
         registry.unregister("hc1");
 
         final Map<String, HealthCheck.Result> results = registry.runHealthChecks();
@@ -185,17 +185,17 @@ public class HealthCheckRegistryTest {
     }
 
     @Test
-    public void hasASetOfHealthCheckNames() throws Exception {
+    public void hasASetOfHealthCheckNames() {
         assertThat(registry.getNames()).containsOnly("hc1", "hc2", "ahc");
     }
 
     @Test
-    public void runsHealthChecksByName() throws Exception {
+    public void runsHealthChecksByName() {
         assertThat(registry.runHealthCheck("hc1")).isEqualTo(r1);
     }
 
     @Test
-    public void doesNotRunNonexistentHealthChecks() throws Exception {
+    public void doesNotRunNonexistentHealthChecks()  {
         try {
             registry.runHealthCheck("what");
             failBecauseExceptionWasNotThrown(NoSuchElementException.class);
@@ -215,7 +215,7 @@ public class HealthCheckRegistryTest {
         }
 
         @Override
-        protected Result check() throws Exception {
+        protected Result check() {
             return result;
         }
     }

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
@@ -15,7 +15,7 @@ public class HealthCheckTest {
         }
 
         @Override
-        protected Result check() throws Exception {
+        protected Result check() {
             return underlying.execute();
         }
     }
@@ -24,7 +24,7 @@ public class HealthCheckTest {
     private final HealthCheck healthCheck = new ExampleHealthCheck(underlying);
 
     @Test
-    public void canHaveHealthyResults() throws Exception {
+    public void canHaveHealthyResults() {
         final HealthCheck.Result result = HealthCheck.Result.healthy();
 
         assertThat(result.isHealthy())
@@ -38,7 +38,7 @@ public class HealthCheckTest {
     }
 
     @Test
-    public void canHaveHealthyResultsWithMessages() throws Exception {
+    public void canHaveHealthyResultsWithMessages() {
         final HealthCheck.Result result = HealthCheck.Result.healthy("woo");
 
         assertThat(result.isHealthy())
@@ -52,7 +52,7 @@ public class HealthCheckTest {
     }
 
     @Test
-    public void canHaveHealthyResultsWithFormattedMessages() throws Exception {
+    public void canHaveHealthyResultsWithFormattedMessages() {
         final HealthCheck.Result result = HealthCheck.Result.healthy("foo %s", "bar");
 
         assertThat(result.isHealthy())
@@ -66,7 +66,7 @@ public class HealthCheckTest {
     }
 
     @Test
-    public void canHaveUnhealthyResults() throws Exception {
+    public void canHaveUnhealthyResults() {
         final HealthCheck.Result result = HealthCheck.Result.unhealthy("bad");
 
         assertThat(result.isHealthy())
@@ -80,7 +80,7 @@ public class HealthCheckTest {
     }
 
     @Test
-    public void canHaveUnhealthyResultsWithFormattedMessages() throws Exception {
+    public void canHaveUnhealthyResultsWithFormattedMessages() {
         final HealthCheck.Result result = HealthCheck.Result.unhealthy("foo %s %d", "bar", 123);
 
         assertThat(result.isHealthy())
@@ -94,7 +94,7 @@ public class HealthCheckTest {
     }
 
     @Test
-    public void canHaveUnhealthyResultsWithExceptions() throws Exception {
+    public void canHaveUnhealthyResultsWithExceptions() {
         final RuntimeException e = mock(RuntimeException.class);
         when(e.getMessage()).thenReturn("oh noes");
 
@@ -111,7 +111,7 @@ public class HealthCheckTest {
     }
 
     @Test
-    public void canHaveHealthyBuilderWithDetail() throws Exception {
+    public void canHaveHealthyBuilderWithDetail() {
         final HealthCheck.Result result = HealthCheck.Result.builder()
                 .healthy()
                 .withDetail("detail", "value")
@@ -131,7 +131,7 @@ public class HealthCheckTest {
     }
 
     @Test
-    public void canHaveUnHealthyBuilderWithDetail() throws Exception {
+    public void canHaveUnHealthyBuilderWithDetail() {
         final HealthCheck.Result result = HealthCheck.Result.builder()
                 .unhealthy()
                 .withDetail("detail", "value")
@@ -151,7 +151,7 @@ public class HealthCheckTest {
     }
 
     @Test
-    public void canHaveUnHealthyBuilderWithDetailAndError() throws Exception {
+    public void canHaveUnHealthyBuilderWithDetailAndError() {
         final RuntimeException e = mock(RuntimeException.class);
         when(e.getMessage()).thenReturn("oh noes");
 
@@ -175,7 +175,7 @@ public class HealthCheckTest {
     }
 
     @Test
-    public void returnsResultsWhenExecuted() throws Exception {
+    public void returnsResultsWhenExecuted() {
         final HealthCheck.Result result = mock(HealthCheck.Result.class);
         when(underlying.execute()).thenReturn(result);
 
@@ -184,7 +184,7 @@ public class HealthCheckTest {
     }
 
     @Test
-    public void wrapsExceptionsWhenExecuted() throws Exception {
+    public void wrapsExceptionsWhenExecuted() {
         final RuntimeException e = mock(RuntimeException.class);
         when(e.getMessage()).thenReturn("oh noes");
 
@@ -202,7 +202,7 @@ public class HealthCheckTest {
     }
 
     @Test
-    public void toStringWorksEvenForNullAttributes() throws Exception {
+    public void toStringWorksEvenForNullAttributes() {
         final HealthCheck.Result resultWithNullDetailValue = HealthCheck.Result.builder()
                 .unhealthy()
                 .withDetail("aNullDetail", null)

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/jvm/ThreadDeadlockHealthCheckTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/jvm/ThreadDeadlockHealthCheckTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 
 public class ThreadDeadlockHealthCheckTest {
     @Test
-    public void isHealthyIfNoThreadsAreDeadlocked() throws Exception {
+    public void isHealthyIfNoThreadsAreDeadlocked() {
         final ThreadDeadlockDetector detector = mock(ThreadDeadlockDetector.class);
         final ThreadDeadlockHealthCheck healthCheck = new ThreadDeadlockHealthCheck(detector);
 
@@ -25,7 +25,7 @@ public class ThreadDeadlockHealthCheckTest {
     }
 
     @Test
-    public void isUnhealthyIfThreadsAreDeadlocked() throws Exception {
+    public void isUnhealthyIfThreadsAreDeadlocked() {
         final Set<String> threads = new TreeSet<>();
         threads.add("one");
         threads.add("two");
@@ -45,7 +45,7 @@ public class ThreadDeadlockHealthCheckTest {
     }
 
     @Test
-    public void automaticallyUsesThePlatformThreadBeans() throws Exception {
+    public void automaticallyUsesThePlatformThreadBeans() {
         final ThreadDeadlockHealthCheck healthCheck = new ThreadDeadlockHealthCheck();
         assertThat(healthCheck.execute().isHealthy())
                 .isTrue();

--- a/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/InstrumentedHttpClientsTest.java
+++ b/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/InstrumentedHttpClientsTest.java
@@ -32,7 +32,7 @@ public class InstrumentedHttpClientsTest {
             InstrumentedHttpClients.custom(metricRegistry, metricNameStrategy).disableAutomaticRetries().build();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         metricRegistry.addListener(registryListener);
     }
 

--- a/metrics-jmx/src/test/java/com/codahale/metrics/jmx/JmxReporterTest.java
+++ b/metrics-jmx/src/test/java/com/codahale/metrics/jmx/JmxReporterTest.java
@@ -116,7 +116,7 @@ public class JmxReporterTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         reporter.stop();
     }
 

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/BufferPoolMetricSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/BufferPoolMetricSetTest.java
@@ -28,7 +28,7 @@ public class BufferPoolMetricSetTest {
     }
 
     @Test
-    public void includesGaugesForDirectAndMappedPools() throws Exception {
+    public void includesGaugesForDirectAndMappedPools() {
         assertThat(buffers.getMetrics().keySet())
                 .containsOnly("direct.count",
                         "mapped.used",

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ClassLoadingGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ClassLoadingGaugeSetTest.java
@@ -17,19 +17,19 @@ public class ClassLoadingGaugeSetTest {
     private final ClassLoadingGaugeSet gauges = new ClassLoadingGaugeSet(cl);
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         when(cl.getTotalLoadedClassCount()).thenReturn(2L);
         when(cl.getUnloadedClassCount()).thenReturn(1L);
     }
 
     @Test
-    public void loadedGauge() throws Exception {
+    public void loadedGauge() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("loaded");
         assertThat(gauge.getValue()).isEqualTo(2L);
     }
 
     @Test
-    public void unLoadedGauge() throws Exception {
+    public void unLoadedGauge() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("unloaded");
         assertThat(gauge.getValue()).isEqualTo(1L);
     }

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/CpuTimeClockTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/CpuTimeClockTest.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.offset;
 public class CpuTimeClockTest {
 
     @Test
-    public void cpuTimeClock() throws Exception {
+    public void cpuTimeClock() {
         final CpuTimeClock clock = new CpuTimeClock();
 
         assertThat((double) clock.getTime())

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/FileDescriptorRatioGaugeTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/FileDescriptorRatioGaugeTest.java
@@ -99,13 +99,13 @@ public class FileDescriptorRatioGaugeTest {
     private final FileDescriptorRatioGauge gauge = new FileDescriptorRatioGauge(os);
 
     @Test
-    public void calculatesTheRatioOfUsedToTotalFileDescriptors() throws Exception {
+    public void calculatesTheRatioOfUsedToTotalFileDescriptors() {
         assertThat(gauge.getValue())
                 .isEqualTo(0.1);
     }
 
     @Test
-    public void validateFileDescriptorRatioPresenceOnNixPlatforms() throws Exception {
+    public void validateFileDescriptorRatioPresenceOnNixPlatforms() {
         OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
         assumeTrue(osBean instanceof com.sun.management.UnixOperatingSystemMXBean);
 
@@ -115,7 +115,7 @@ public class FileDescriptorRatioGaugeTest {
     }
 
     @Test
-    public void returnsNaNWhenTheInformationIsUnavailable() throws Exception {
+    public void returnsNaNWhenTheInformationIsUnavailable() {
         assertThat(new FileDescriptorRatioGauge(mock(OperatingSystemMXBean.class)).getValue())
                 .isNaN();
     }

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/GarbageCollectorMetricSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/GarbageCollectorMetricSetTest.java
@@ -17,34 +17,34 @@ public class GarbageCollectorMetricSetTest {
     private final GarbageCollectorMetricSet metrics = new GarbageCollectorMetricSet(Collections.singletonList(gc));
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         when(gc.getName()).thenReturn("PS OldGen");
         when(gc.getCollectionCount()).thenReturn(1L);
         when(gc.getCollectionTime()).thenReturn(2L);
     }
 
     @Test
-    public void hasGaugesForGcCountsAndElapsedTimes() throws Exception {
+    public void hasGaugesForGcCountsAndElapsedTimes() {
         assertThat(metrics.getMetrics().keySet())
                 .containsOnly("PS-OldGen.time", "PS-OldGen.count");
     }
 
     @Test
-    public void hasAGaugeForGcCounts() throws Exception {
+    public void hasAGaugeForGcCounts() {
         final Gauge<Long> gauge = (Gauge<Long>) metrics.getMetrics().get("PS-OldGen.count");
         assertThat(gauge.getValue())
                 .isEqualTo(1L);
     }
 
     @Test
-    public void hasAGaugeForGcTimes() throws Exception {
+    public void hasAGaugeForGcTimes() {
         final Gauge<Long> gauge = (Gauge<Long>) metrics.getMetrics().get("PS-OldGen.time");
         assertThat(gauge.getValue())
                 .isEqualTo(2L);
     }
 
     @Test
-    public void autoDiscoversGCs() throws Exception {
+    public void autoDiscoversGCs() {
         assertThat(new GarbageCollectorMetricSet().getMetrics().keySet())
                 .isNotEmpty();
     }

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/JvmAttributeGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/JvmAttributeGaugeSetTest.java
@@ -16,7 +16,7 @@ public class JvmAttributeGaugeSetTest {
     private final JvmAttributeGaugeSet gauges = new JvmAttributeGaugeSet(runtime);
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         when(runtime.getName()).thenReturn("9928@example.com");
 
         when(runtime.getVmVendor()).thenReturn("Oracle Corporation");
@@ -27,13 +27,13 @@ public class JvmAttributeGaugeSetTest {
     }
 
     @Test
-    public void hasASetOfGauges() throws Exception {
+    public void hasASetOfGauges() {
         assertThat(gauges.getMetrics().keySet())
                 .containsOnly("vendor", "name", "uptime");
     }
 
     @Test
-    public void hasAGaugeForTheJVMName() throws Exception {
+    public void hasAGaugeForTheJVMName() {
         final Gauge<String> gauge = (Gauge<String>) gauges.getMetrics().get("name");
 
         assertThat(gauge.getValue())
@@ -41,7 +41,7 @@ public class JvmAttributeGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForTheJVMVendor() throws Exception {
+    public void hasAGaugeForTheJVMVendor() {
         final Gauge<String> gauge = (Gauge<String>) gauges.getMetrics().get("vendor");
 
         assertThat(gauge.getValue())
@@ -49,7 +49,7 @@ public class JvmAttributeGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForTheJVMUptime() throws Exception {
+    public void hasAGaugeForTheJVMUptime() {
         final Gauge<Long> gauge = (Gauge<Long>) gauges.getMetrics().get("uptime");
 
         assertThat(gauge.getValue())
@@ -57,7 +57,7 @@ public class JvmAttributeGaugeSetTest {
     }
 
     @Test
-    public void autoDiscoversTheRuntimeBean() throws Exception {
+    public void autoDiscoversTheRuntimeBean() {
         final Gauge<Long> gauge = (Gauge<Long>) new JvmAttributeGaugeSet().getMetrics().get("uptime");
 
         assertThat(gauge.getValue()).isPositive();

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/MemoryUsageGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/MemoryUsageGaugeSetTest.java
@@ -29,7 +29,7 @@ public class MemoryUsageGaugeSetTest {
                     weirdMemoryPool));
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         when(heap.getCommitted()).thenReturn(10L);
         when(heap.getInit()).thenReturn(20L);
         when(heap.getUsed()).thenReturn(30L);
@@ -67,7 +67,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasASetOfGauges() throws Exception {
+    public void hasASetOfGauges() {
         assertThat(gauges.getMetrics().keySet())
                 .containsOnly(
                         "heap.init",
@@ -99,7 +99,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForTotalCommitted() throws Exception {
+    public void hasAGaugeForTotalCommitted() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("total.committed");
 
         assertThat(gauge.getValue())
@@ -107,7 +107,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForTotalInit() throws Exception {
+    public void hasAGaugeForTotalInit() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("total.init");
 
         assertThat(gauge.getValue())
@@ -115,7 +115,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForTotalUsed() throws Exception {
+    public void hasAGaugeForTotalUsed() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("total.used");
 
         assertThat(gauge.getValue())
@@ -123,7 +123,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForTotalMax() throws Exception {
+    public void hasAGaugeForTotalMax() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("total.max");
 
         assertThat(gauge.getValue())
@@ -131,7 +131,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForHeapCommitted() throws Exception {
+    public void hasAGaugeForHeapCommitted() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.committed");
 
         assertThat(gauge.getValue())
@@ -139,7 +139,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForHeapInit() throws Exception {
+    public void hasAGaugeForHeapInit() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.init");
 
         assertThat(gauge.getValue())
@@ -147,7 +147,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForHeapUsed() throws Exception {
+    public void hasAGaugeForHeapUsed() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.used");
 
         assertThat(gauge.getValue())
@@ -155,7 +155,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForHeapMax() throws Exception {
+    public void hasAGaugeForHeapMax() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.max");
 
         assertThat(gauge.getValue())
@@ -163,7 +163,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForHeapUsage() throws Exception {
+    public void hasAGaugeForHeapUsage() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.usage");
 
         assertThat(gauge.getValue())
@@ -171,7 +171,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForNonHeapCommitted() throws Exception {
+    public void hasAGaugeForNonHeapCommitted() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.committed");
 
         assertThat(gauge.getValue())
@@ -179,7 +179,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForNonHeapInit() throws Exception {
+    public void hasAGaugeForNonHeapInit() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.init");
 
         assertThat(gauge.getValue())
@@ -187,7 +187,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForNonHeapUsed() throws Exception {
+    public void hasAGaugeForNonHeapUsed() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.used");
 
         assertThat(gauge.getValue())
@@ -195,7 +195,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForNonHeapMax() throws Exception {
+    public void hasAGaugeForNonHeapMax() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.max");
 
         assertThat(gauge.getValue())
@@ -203,7 +203,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForNonHeapUsage() throws Exception {
+    public void hasAGaugeForNonHeapUsage() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.usage");
 
         assertThat(gauge.getValue())
@@ -211,7 +211,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForMemoryPoolUsage() throws Exception {
+    public void hasAGaugeForMemoryPoolUsage() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Big-Pool.usage");
 
         assertThat(gauge.getValue())
@@ -219,7 +219,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForWeirdMemoryPoolInit() throws Exception {
+    public void hasAGaugeForWeirdMemoryPoolInit() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Weird-Pool.init");
 
         assertThat(gauge.getValue())
@@ -227,7 +227,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForWeirdMemoryPoolCommitted() throws Exception {
+    public void hasAGaugeForWeirdMemoryPoolCommitted() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Weird-Pool.committed");
 
         assertThat(gauge.getValue())
@@ -235,7 +235,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForWeirdMemoryPoolUsed() throws Exception {
+    public void hasAGaugeForWeirdMemoryPoolUsed() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Weird-Pool.used");
 
         assertThat(gauge.getValue())
@@ -243,7 +243,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForWeirdMemoryPoolUsage() throws Exception {
+    public void hasAGaugeForWeirdMemoryPoolUsage() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Weird-Pool.usage");
 
         assertThat(gauge.getValue())
@@ -251,7 +251,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForWeirdMemoryPoolMax() throws Exception {
+    public void hasAGaugeForWeirdMemoryPoolMax() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Weird-Pool.max");
 
         assertThat(gauge.getValue())
@@ -259,7 +259,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForWeirdCollectionPoolUsed() throws Exception {
+    public void hasAGaugeForWeirdCollectionPoolUsed() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Weird-Pool.used-after-gc");
 
         assertThat(gauge.getValue())
@@ -267,7 +267,7 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
-    public void autoDetectsMemoryUsageBeanAndMemoryPools() throws Exception {
+    public void autoDetectsMemoryUsageBeanAndMemoryPools() {
         assertThat(new MemoryUsageGaugeSet().getMetrics().keySet())
                 .isNotEmpty();
     }

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadDeadlockDetectorTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadDeadlockDetectorTest.java
@@ -17,7 +17,7 @@ public class ThreadDeadlockDetectorTest {
     private final ThreadDeadlockDetector detector = new ThreadDeadlockDetector(threads);
 
     @Test
-    public void returnsAnEmptySetIfNoThreadsAreDeadlocked() throws Exception {
+    public void returnsAnEmptySetIfNoThreadsAreDeadlocked() {
         when(threads.findDeadlockedThreads()).thenReturn(null);
 
         assertThat(detector.getDeadlockedThreads())
@@ -25,7 +25,7 @@ public class ThreadDeadlockDetectorTest {
     }
 
     @Test
-    public void returnsASetOfThreadsIfAnyAreDeadlocked() throws Exception {
+    public void returnsASetOfThreadsIfAnyAreDeadlocked() {
         final ThreadInfo thread1 = mock(ThreadInfo.class);
         when(thread1.getThreadName()).thenReturn("thread1");
         when(thread1.getLockName()).thenReturn("lock2");
@@ -61,7 +61,7 @@ public class ThreadDeadlockDetectorTest {
     }
 
     @Test
-    public void autoDiscoversTheThreadMXBean() throws Exception {
+    public void autoDiscoversTheThreadMXBean() {
         assertThat(new ThreadDeadlockDetector().getDeadlockedThreads())
             .isNotNull();
     }

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadDumpTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadDumpTest.java
@@ -22,7 +22,7 @@ public class ThreadDumpTest {
     private final ThreadInfo runnable = mock(ThreadInfo.class);
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         final StackTraceElement rLine1 = new StackTraceElement("Blah", "blee", "Blah.java", 100);
 
         when(runnable.getThreadName()).thenReturn("runnable");
@@ -38,7 +38,7 @@ public class ThreadDumpTest {
     }
 
     @Test
-    public void dumpsAllThreads() throws Exception {
+    public void dumpsAllThreads() {
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
         threadDump.dump(output);
 

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadStatesGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadStatesGaugeSetTest.java
@@ -29,7 +29,7 @@ public class ThreadStatesGaugeSetTest {
     private final Set<String> deadlocks = new HashSet<>();
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         deadlocks.add("yay");
 
         when(newThread.getThreadState()).thenReturn(Thread.State.NEW);
@@ -52,7 +52,7 @@ public class ThreadStatesGaugeSetTest {
     }
 
     @Test
-    public void hasASetOfGauges() throws Exception {
+    public void hasASetOfGauges() {
         assertThat(gauges.getMetrics().keySet())
             .containsOnly("terminated.count",
                 "new.count",
@@ -67,7 +67,7 @@ public class ThreadStatesGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForEachThreadState() throws Exception {
+    public void hasAGaugeForEachThreadState() {
         assertThat(((Gauge<?>) gauges.getMetrics().get("new.count")).getValue())
             .isEqualTo(1);
 
@@ -88,31 +88,31 @@ public class ThreadStatesGaugeSetTest {
     }
 
     @Test
-    public void hasAGaugeForTheNumberOfThreads() throws Exception {
+    public void hasAGaugeForTheNumberOfThreads() {
         assertThat(((Gauge<?>) gauges.getMetrics().get("count")).getValue())
             .isEqualTo(12);
     }
 
     @Test
-    public void hasAGaugeForTheNumberOfDaemonThreads() throws Exception {
+    public void hasAGaugeForTheNumberOfDaemonThreads() {
         assertThat(((Gauge<?>) gauges.getMetrics().get("daemon.count")).getValue())
             .isEqualTo(13);
     }
 
     @Test
-    public void hasAGaugeForAnyDeadlocks() throws Exception {
+    public void hasAGaugeForAnyDeadlocks() {
         assertThat(((Gauge<?>) gauges.getMetrics().get("deadlocks")).getValue())
             .isEqualTo(deadlocks);
     }
 
     @Test
-    public void hasAGaugeForAnyDeadlockCount() throws Exception {
+    public void hasAGaugeForAnyDeadlockCount() {
         assertThat(((Gauge<?>) gauges.getMetrics().get("deadlock.count")).getValue())
             .isEqualTo(1);
     }
 
     @Test
-    public void autoDiscoversTheMXBeans() throws Exception {
+    public void autoDiscoversTheMXBeans() {
         final ThreadStatesGaugeSet set = new ThreadStatesGaugeSet();
         assertThat(((Gauge<?>) set.getMetrics().get("count")).getValue())
             .isNotNull();

--- a/metrics-log4j2/src/test/java/com/codahale/metrics/log4j2/InstrumentedAppenderConfigTest.java
+++ b/metrics-log4j2/src/test/java/com/codahale/metrics/log4j2/InstrumentedAppenderConfigTest.java
@@ -27,14 +27,14 @@ public class InstrumentedAppenderConfigTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         context.stop();
     }
 
     // The biggest test is that we can initialize the log4j2 config at all.
 
     @Test
-    public void canRecordAll() throws Exception {
+    public void canRecordAll() {
         Logger logger = context.getLogger(this.getClass().getName());
 
         long initialAllCount = registry.meter(METRIC_NAME_PREFIX + ".all").getCount();
@@ -44,7 +44,7 @@ public class InstrumentedAppenderConfigTest {
     }
 
     @Test
-    public void canRecordError() throws Exception {
+    public void canRecordError() {
         Logger logger = context.getLogger(this.getClass().getName());
 
         long initialErrorCount = registry.meter(METRIC_NAME_PREFIX + ".error").getCount();
@@ -54,7 +54,7 @@ public class InstrumentedAppenderConfigTest {
     }
 
     @Test
-    public void noInvalidRecording() throws Exception {
+    public void noInvalidRecording() {
         Logger logger = context.getLogger(this.getClass().getName());
 
         long initialInfoCount = registry.meter(METRIC_NAME_PREFIX + ".info").getCount();

--- a/metrics-log4j2/src/test/java/com/codahale/metrics/log4j2/InstrumentedAppenderTest.java
+++ b/metrics-log4j2/src/test/java/com/codahale/metrics/log4j2/InstrumentedAppenderTest.java
@@ -22,17 +22,17 @@ public class InstrumentedAppenderTest {
     private final LogEvent event = mock(LogEvent.class);
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         appender.start();
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         SharedMetricRegistries.clear();
     }
 
     @Test
-    public void metersTraceEvents() throws Exception {
+    public void metersTraceEvents() {
         when(event.getLevel()).thenReturn(Level.TRACE);
 
         appender.append(event);
@@ -45,7 +45,7 @@ public class InstrumentedAppenderTest {
     }
 
     @Test
-    public void metersDebugEvents() throws Exception {
+    public void metersDebugEvents() {
         when(event.getLevel()).thenReturn(Level.DEBUG);
 
         appender.append(event);
@@ -58,7 +58,7 @@ public class InstrumentedAppenderTest {
     }
 
     @Test
-    public void metersInfoEvents() throws Exception {
+    public void metersInfoEvents() {
         when(event.getLevel()).thenReturn(Level.INFO);
 
         appender.append(event);
@@ -71,7 +71,7 @@ public class InstrumentedAppenderTest {
     }
 
     @Test
-    public void metersWarnEvents() throws Exception {
+    public void metersWarnEvents() {
         when(event.getLevel()).thenReturn(Level.WARN);
 
         appender.append(event);
@@ -84,7 +84,7 @@ public class InstrumentedAppenderTest {
     }
 
     @Test
-    public void metersErrorEvents() throws Exception {
+    public void metersErrorEvents() {
         when(event.getLevel()).thenReturn(Level.ERROR);
 
         appender.append(event);
@@ -97,7 +97,7 @@ public class InstrumentedAppenderTest {
     }
 
     @Test
-    public void metersFatalEvents() throws Exception {
+    public void metersFatalEvents() {
         when(event.getLevel()).thenReturn(Level.FATAL);
 
         appender.append(event);
@@ -110,7 +110,7 @@ public class InstrumentedAppenderTest {
     }
 
     @Test
-    public void usesSharedRegistries() throws Exception {
+    public void usesSharedRegistries() {
 
         String registryName = "registry";
 

--- a/metrics-logback/src/test/java/com/codahale/metrics/logback/InstrumentedAppenderTest.java
+++ b/metrics-logback/src/test/java/com/codahale/metrics/logback/InstrumentedAppenderTest.java
@@ -22,17 +22,17 @@ public class InstrumentedAppenderTest {
     private final ILoggingEvent event = mock(ILoggingEvent.class);
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         appender.start();
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         SharedMetricRegistries.clear();
     }
 
     @Test
-    public void metersTraceEvents() throws Exception {
+    public void metersTraceEvents() {
         when(event.getLevel()).thenReturn(Level.TRACE);
 
         appender.doAppend(event);
@@ -45,7 +45,7 @@ public class InstrumentedAppenderTest {
     }
 
     @Test
-    public void metersDebugEvents() throws Exception {
+    public void metersDebugEvents() {
         when(event.getLevel()).thenReturn(Level.DEBUG);
 
         appender.doAppend(event);
@@ -58,7 +58,7 @@ public class InstrumentedAppenderTest {
     }
 
     @Test
-    public void metersInfoEvents() throws Exception {
+    public void metersInfoEvents() {
         when(event.getLevel()).thenReturn(Level.INFO);
 
         appender.doAppend(event);
@@ -71,7 +71,7 @@ public class InstrumentedAppenderTest {
     }
 
     @Test
-    public void metersWarnEvents() throws Exception {
+    public void metersWarnEvents() {
         when(event.getLevel()).thenReturn(Level.WARN);
 
         appender.doAppend(event);
@@ -84,7 +84,7 @@ public class InstrumentedAppenderTest {
     }
 
     @Test
-    public void metersErrorEvents() throws Exception {
+    public void metersErrorEvents() {
         when(event.getLevel()).thenReturn(Level.ERROR);
 
         appender.doAppend(event);
@@ -97,7 +97,7 @@ public class InstrumentedAppenderTest {
     }
 
     @Test
-    public void usesSharedRegistries() throws Exception {
+    public void usesSharedRegistries() {
 
         String registryName = "registry";
 
@@ -114,7 +114,7 @@ public class InstrumentedAppenderTest {
     }
 
     @Test
-    public void usesDefaultRegistry() throws Exception {
+    public void usesDefaultRegistry() {
         SharedMetricRegistries.add(InstrumentedAppender.DEFAULT_REGISTRY, registry);
         final InstrumentedAppender shared = new InstrumentedAppender();
         shared.start();
@@ -127,7 +127,7 @@ public class InstrumentedAppenderTest {
     }
 
     @Test
-    public void usesRegistryFromProperty() throws Exception {
+    public void usesRegistryFromProperty() {
         SharedMetricRegistries.add("something_else", registry);
         System.setProperty(InstrumentedAppender.REGISTRY_PROPERTY_NAME, "something_else");
         final InstrumentedAppender shared = new InstrumentedAppender();

--- a/metrics-servlet/src/test/java/com/codahale/metrics/servlet/InstrumentedFilterContextListenerTest.java
+++ b/metrics-servlet/src/test/java/com/codahale/metrics/servlet/InstrumentedFilterContextListenerTest.java
@@ -20,7 +20,7 @@ public class InstrumentedFilterContextListenerTest {
     };
 
     @Test
-    public void injectsTheMetricRegistryIntoTheServletContext() throws Exception {
+    public void injectsTheMetricRegistryIntoTheServletContext() {
         final ServletContext context = mock(ServletContext.class);
 
         final ServletContextEvent event = mock(ServletContextEvent.class);

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/AdminServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/AdminServletTest.java
@@ -23,7 +23,7 @@ public class AdminServletTest extends AbstractServletTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         request.setMethod("GET");
         request.setURI("/context/admin");
         request.setVersion("HTTP/1.0");

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/CpuProfileServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/CpuProfileServletTest.java
@@ -24,19 +24,19 @@ public class CpuProfileServletTest extends AbstractServletTest {
     }
 
     @Test
-    public void returns200OK() throws Exception {
+    public void returns200OK() {
         assertThat(response.getStatus())
                 .isEqualTo(200);
     }
 
     @Test
-    public void returnsPprofRaw() throws Exception {
+    public void returnsPprofRaw() {
         assertThat(response.get(HttpHeader.CONTENT_TYPE))
                 .isEqualTo("pprof/raw");
     }
 
     @Test
-    public void returnsUncacheable() throws Exception {
+    public void returnsUncacheable() {
         assertThat(response.get(HttpHeader.CACHE_CONTROL))
                 .isEqualTo("must-revalidate,no-cache,no-store");
 

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
@@ -39,14 +39,14 @@ public class HealthCheckServletTest extends AbstractServletTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         request.setMethod("GET");
         request.setURI("/healthchecks");
         request.setVersion("HTTP/1.0");
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         threadPool.shutdown();
     }
 

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletContextListenerTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletContextListenerTest.java
@@ -50,7 +50,7 @@ public class MetricsServletContextListenerTest extends AbstractServletTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         when(clock.getTick()).thenReturn(100L, 200L, 300L, 400L);
 
         registry.register("g1", (Gauge<Long>) () -> 100L);

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/MetricsServletTest.java
@@ -38,7 +38,7 @@ public class MetricsServletTest extends AbstractServletTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         when(clock.getTick()).thenReturn(100L, 200L, 300L, 400L);
 
         registry.register("g1", (Gauge<Long>) () -> 100L);

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/PingServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/PingServletTest.java
@@ -14,7 +14,7 @@ public class PingServletTest extends AbstractServletTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() throws Exception  {
         request.setMethod("GET");
         request.setURI("/ping");
         request.setVersion("HTTP/1.0");
@@ -23,25 +23,25 @@ public class PingServletTest extends AbstractServletTest {
     }
 
     @Test
-    public void returns200OK() throws Exception {
+    public void returns200OK()  {
         assertThat(response.getStatus())
                 .isEqualTo(200);
     }
 
     @Test
-    public void returnsPong() throws Exception {
+    public void returnsPong()  {
         assertThat(response.getContent())
                 .isEqualTo(String.format("pong%n"));
     }
 
     @Test
-    public void returnsTextPlain() throws Exception {
+    public void returnsTextPlain()  {
         assertThat(response.get(HttpHeader.CONTENT_TYPE))
                 .isEqualTo("text/plain;charset=ISO-8859-1");
     }
 
     @Test
-    public void returnsUncacheable() throws Exception {
+    public void returnsUncacheable()  {
         assertThat(response.get(HttpHeader.CACHE_CONTROL))
                 .isEqualTo("must-revalidate,no-cache,no-store");
 

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/ThreadDumpServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/ThreadDumpServletTest.java
@@ -23,25 +23,25 @@ public class ThreadDumpServletTest extends AbstractServletTest {
     }
 
     @Test
-    public void returns200OK() throws Exception {
+    public void returns200OK() {
         assertThat(response.getStatus())
                 .isEqualTo(200);
     }
 
     @Test
-    public void returnsAThreadDump() throws Exception {
+    public void returnsAThreadDump() {
         assertThat(response.getContent())
                 .contains("Finalizer");
     }
 
     @Test
-    public void returnsTextPlain() throws Exception {
+    public void returnsTextPlain() {
         assertThat(response.get(HttpHeader.CONTENT_TYPE))
                 .isEqualTo("text/plain");
     }
 
     @Test
-    public void returnsUncacheable() throws Exception {
+    public void returnsUncacheable() {
         assertThat(response.get(HttpHeader.CACHE_CONTROL))
                 .isEqualTo("must-revalidate,no-cache,no-store");
 


### PR DESCRIPTION
Make the test code more terse and clear