### PR TITLE
Throw on existing healt check name, fixes #1245

### DIFF
--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistry.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistry.java
@@ -95,21 +95,18 @@ public class HealthCheckRegistry {
      * @param healthCheck the {@link HealthCheck} instance
      */
     public void register(String name, HealthCheck healthCheck) {
-        HealthCheck registered = null;
+        HealthCheck registered;
         synchronized (lock) {
-            if (!healthChecks.containsKey(name)) {
-                registered = healthCheck;
-                if (healthCheck.getClass().isAnnotationPresent(Async.class)) {
-                    registered = new AsyncHealthCheckDecorator(healthCheck, asyncExecutorService);
-                }
-                healthChecks.put(name, registered);
+            if (healthChecks.containsKey(name)) {
+                throw new IllegalArgumentException("A health check named " + name + " already exists");
             }
+            registered = healthCheck;
+            if (healthCheck.getClass().isAnnotationPresent(Async.class)) {
+                registered = new AsyncHealthCheckDecorator(healthCheck, asyncExecutorService);
+            }
+            healthChecks.put(name, registered);
         }
-        if (registered == null) {
-            throw new IllegalArgumentException("A health check named " + name + " already exists");
-        } else {
-            onHealthCheckAdded(name, registered);
-        }
+        onHealthCheckAdded(name, registered);
     }
 
     /**

--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistry.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistry.java
@@ -105,7 +105,9 @@ public class HealthCheckRegistry {
                 healthChecks.put(name, registered);
             }
         }
-        if (registered != null) {
+        if (registered == null) {
+            throw new IllegalArgumentException("A health check named " + name + " already exists");
+        } else {
             onHealthCheckAdded(name, registered);
         }
     }

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckRegistryTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckRegistryTest.java
@@ -70,6 +70,11 @@ public class HealthCheckRegistryTest {
         verify(af).cancel(true);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void registeringHealthCheckTwiceThrowsException() {
+        registry.register("hc1", hc1);
+    }
+
     @Test
     public void registeringHealthCheckTriggersNotification() {
         verify(listener).onHealthCheckAdded("hc1", hc1);


### PR DESCRIPTION
Throw an exception when registering a health check under an already existing name. This fixes #1245.