### PR TITLE
Introduce MetricName to encapsulate more info about metrics

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
@@ -223,18 +223,18 @@ public class ConsoleReporter extends ScheduledReporter {
 
     @Override
     @SuppressWarnings("rawtypes")
-    public void report(SortedMap<String, Gauge> gauges,
-                       SortedMap<String, Counter> counters,
-                       SortedMap<String, Histogram> histograms,
-                       SortedMap<String, Meter> meters,
-                       SortedMap<String, Timer> timers) {
+    public void report(SortedMap<MetricName, Gauge> gauges,
+                       SortedMap<MetricName, Counter> counters,
+                       SortedMap<MetricName, Histogram> histograms,
+                       SortedMap<MetricName, Meter> meters,
+                       SortedMap<MetricName, Timer> timers) {
         final String dateTime = dateFormat.format(new Date(clock.getTime()));
         printWithBanner(dateTime, '=');
         output.println();
 
         if (!gauges.isEmpty()) {
             printWithBanner("-- Gauges", '-');
-            for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+            for (Map.Entry<MetricName, Gauge> entry : gauges.entrySet()) {
                 output.println(entry.getKey());
                 printGauge(entry.getValue());
             }
@@ -243,7 +243,7 @@ public class ConsoleReporter extends ScheduledReporter {
 
         if (!counters.isEmpty()) {
             printWithBanner("-- Counters", '-');
-            for (Map.Entry<String, Counter> entry : counters.entrySet()) {
+            for (Map.Entry<MetricName, Counter> entry : counters.entrySet()) {
                 output.println(entry.getKey());
                 printCounter(entry);
             }
@@ -252,7 +252,7 @@ public class ConsoleReporter extends ScheduledReporter {
 
         if (!histograms.isEmpty()) {
             printWithBanner("-- Histograms", '-');
-            for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
+            for (Map.Entry<MetricName, Histogram> entry : histograms.entrySet()) {
                 output.println(entry.getKey());
                 printHistogram(entry.getValue());
             }
@@ -261,7 +261,7 @@ public class ConsoleReporter extends ScheduledReporter {
 
         if (!meters.isEmpty()) {
             printWithBanner("-- Meters", '-');
-            for (Map.Entry<String, Meter> entry : meters.entrySet()) {
+            for (Map.Entry<MetricName, Meter> entry : meters.entrySet()) {
                 output.println(entry.getKey());
                 printMeter(entry.getValue());
             }
@@ -270,7 +270,7 @@ public class ConsoleReporter extends ScheduledReporter {
 
         if (!timers.isEmpty()) {
             printWithBanner("-- Timers", '-');
-            for (Map.Entry<String, Timer> entry : timers.entrySet()) {
+            for (Map.Entry<MetricName, Timer> entry : timers.entrySet()) {
                 output.println(entry.getKey());
                 printTimer(entry.getValue());
             }
@@ -289,7 +289,7 @@ public class ConsoleReporter extends ScheduledReporter {
         printIfEnabled(MetricAttribute.M15_RATE, String.format(locale, "    15-minute rate = %2.2f events/%s", convertRate(meter.getFifteenMinuteRate()), getRateUnit()));
     }
 
-    private void printCounter(Map.Entry<String, Counter> entry) {
+    private void printCounter(Map.Entry<MetricName, Counter> entry) {
         output.printf(locale, "             count = %d%n", entry.getValue().getCount());
     }
 

--- a/metrics-core/src/main/java/com/codahale/metrics/CsvReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/CsvReporter.java
@@ -217,35 +217,35 @@ public class CsvReporter extends ScheduledReporter {
 
     @Override
     @SuppressWarnings("rawtypes")
-    public void report(SortedMap<String, Gauge> gauges,
-                       SortedMap<String, Counter> counters,
-                       SortedMap<String, Histogram> histograms,
-                       SortedMap<String, Meter> meters,
-                       SortedMap<String, Timer> timers) {
+    public void report(SortedMap<MetricName, Gauge> gauges,
+                       SortedMap<MetricName, Counter> counters,
+                       SortedMap<MetricName, Histogram> histograms,
+                       SortedMap<MetricName, Meter> meters,
+                       SortedMap<MetricName, Timer> timers) {
         final long timestamp = TimeUnit.MILLISECONDS.toSeconds(clock.getTime());
 
-        for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+        for (Map.Entry<MetricName, Gauge> entry : gauges.entrySet()) {
             reportGauge(timestamp, entry.getKey(), entry.getValue());
         }
 
-        for (Map.Entry<String, Counter> entry : counters.entrySet()) {
+        for (Map.Entry<MetricName, Counter> entry : counters.entrySet()) {
             reportCounter(timestamp, entry.getKey(), entry.getValue());
         }
 
-        for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
+        for (Map.Entry<MetricName, Histogram> entry : histograms.entrySet()) {
             reportHistogram(timestamp, entry.getKey(), entry.getValue());
         }
 
-        for (Map.Entry<String, Meter> entry : meters.entrySet()) {
+        for (Map.Entry<MetricName, Meter> entry : meters.entrySet()) {
             reportMeter(timestamp, entry.getKey(), entry.getValue());
         }
 
-        for (Map.Entry<String, Timer> entry : timers.entrySet()) {
+        for (Map.Entry<MetricName, Timer> entry : timers.entrySet()) {
             reportTimer(timestamp, entry.getKey(), entry.getValue());
         }
     }
 
-    private void reportTimer(long timestamp, String name, Timer timer) {
+    private void reportTimer(long timestamp, MetricName name, Timer timer) {
         final Snapshot snapshot = timer.getSnapshot();
 
         report(timestamp,
@@ -271,7 +271,7 @@ public class CsvReporter extends ScheduledReporter {
                 getDurationUnit());
     }
 
-    private void reportMeter(long timestamp, String name, Meter meter) {
+    private void reportMeter(long timestamp, MetricName name, Meter meter) {
         report(timestamp,
                 name,
                 "count,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit",
@@ -284,7 +284,7 @@ public class CsvReporter extends ScheduledReporter {
                 getRateUnit());
     }
 
-    private void reportHistogram(long timestamp, String name, Histogram histogram) {
+    private void reportHistogram(long timestamp, MetricName name, Histogram histogram) {
         final Snapshot snapshot = histogram.getSnapshot();
 
         report(timestamp,
@@ -304,17 +304,17 @@ public class CsvReporter extends ScheduledReporter {
                 snapshot.get999thPercentile());
     }
 
-    private void reportCounter(long timestamp, String name, Counter counter) {
+    private void reportCounter(long timestamp, MetricName name, Counter counter) {
         report(timestamp, name, "count", "%d", counter.getCount());
     }
 
-    private void reportGauge(long timestamp, String name, Gauge<?> gauge) {
+    private void reportGauge(long timestamp, MetricName name, Gauge<?> gauge) {
         report(timestamp, name, "value", "%s", gauge.getValue());
     }
 
-    private void report(long timestamp, String name, String header, String line, Object... values) {
+    private void report(long timestamp, MetricName name, String header, String line, Object... values) {
         try {
-            final File file = csvFileProvider.getFile(directory, name);
+            final File file = csvFileProvider.getFile(directory, name.getKey());
             final boolean fileAlreadyExists = file.exists();
             if (fileAlreadyExists || file.createNewFile()) {
                 try (PrintWriter out = new PrintWriter(new OutputStreamWriter(
@@ -330,7 +330,7 @@ public class CsvReporter extends ScheduledReporter {
         }
     }
 
-    protected String sanitize(String name) {
-        return name;
+    protected String sanitize(MetricName name) {
+        return name.getKey();
     }
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricFilter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricFilter.java
@@ -10,15 +10,15 @@ public interface MetricFilter {
     MetricFilter ALL = (name, metric) -> true;
 
     static MetricFilter startsWith(String prefix) {
-        return (name, metric) -> name.startsWith(prefix);
+        return (name, metric) -> name.getKey().startsWith(prefix);
     }
 
     static MetricFilter endsWith(String suffix) {
-        return (name, metric) -> name.endsWith(suffix);
+        return (name, metric) -> name.getKey().endsWith(suffix);
     }
 
     static MetricFilter contains(String substring) {
-        return (name, metric) -> name.contains(substring);
+        return (name, metric) -> name.getKey().contains(substring);
     }
 
     /**
@@ -28,5 +28,5 @@ public interface MetricFilter {
      * @param metric the metric
      * @return {@code true} if the metric matches the filter
      */
-    boolean matches(String name, Metric metric);
+    boolean matches(MetricName name, Metric metric);
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricName.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricName.java
@@ -1,0 +1,246 @@
+package com.codahale.metrics;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * A metric name with the ability to include semantic tags.
+ * This replaces the previous style where metric names where strictly dot-separated strings.
+ */
+public class MetricName implements Comparable<MetricName> {
+
+    private static final String SEPARATOR = ".";
+    private static final Map<String, String> EMPTY_TAGS = Collections.unmodifiableMap(new HashMap<String, String>());
+    static final MetricName EMPTY = new MetricName("");
+
+    private final String key;
+    private final Map<String, String> tags;
+
+    private MetricName(String key) {
+        this(key, EMPTY_TAGS);
+    }
+
+    public MetricName(String key, Map<String, String> tags) {
+        this.key = Objects.requireNonNull(key);
+        this.tags = tags.isEmpty() ? EMPTY_TAGS : Collections.unmodifiableMap(tags);
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
+    /**
+     * Build the MetricName that is this with another path appended to it.
+     * The new MetricName inherits the tags of this one.
+     *
+     * @param p The extra path element to add to the new metric.
+     * @return A new metric name relative to the original by the path specified
+     * in p.
+     */
+    public MetricName resolve(String p) {
+        final String next;
+        if (p != null && !p.isEmpty()) {
+            if (!key.isEmpty()) {
+                next = key + SEPARATOR + p;
+            } else {
+                next = p;
+            }
+        } else {
+            next = key;
+        }
+
+        return new MetricName(next, tags);
+    }
+
+    /**
+     * Add tags to a metric name and return the newly created MetricName.
+     *
+     * @param add Tags to add.
+     * @return A newly created metric name with the specified tags associated with it.
+     */
+    public MetricName tagged(Map<String, String> add) {
+        final Map<String, String> newTags = new HashMap<>(add);
+        newTags.putAll(tags);
+        return new MetricName(key, newTags);
+    }
+
+    /**
+     * Same as {@link #tagged(Map)}, but takes a variadic list of arguments.
+     *
+     * @param pairs An even list of strings acting as key-value pairs.
+     * @return A newly created metric name with the specified tags associated with it.
+     * @see #tagged(Map)
+     */
+    public MetricName tagged(String... pairs) {
+        if (pairs == null || pairs.length == 0) {
+            return this;
+        }
+
+        if (pairs.length % 2 != 0) {
+            throw new IllegalArgumentException("Argument count must be even");
+        }
+
+        final Map<String, String> add = new HashMap<>();
+        for (int i = 0; i < pairs.length; i += 2) {
+            add.put(pairs[i], pairs[i + 1]);
+        }
+
+        return tagged(add);
+    }
+
+    /**
+     * Join the specified set of metric names.
+     *
+     * @param parts Multiple metric names to join using the separator.
+     * @return A newly created metric name which has the name of the specified
+     * parts and includes all tags of all child metric names.
+     **/
+    public static MetricName join(MetricName... parts) {
+        final StringBuilder nameBuilder = new StringBuilder();
+        final Map<String, String> tags = new HashMap<>();
+
+        boolean first = true;
+
+        for (MetricName part : parts) {
+            final String name = part.getKey();
+            if (name != null && !name.isEmpty()) {
+                if (first) {
+                    first = false;
+                } else {
+                    nameBuilder.append(SEPARATOR);
+                }
+
+                nameBuilder.append(name);
+            }
+
+            if (!part.getTags().isEmpty()) {
+                tags.putAll(part.getTags());
+            }
+        }
+
+        return new MetricName(nameBuilder.toString(), tags);
+    }
+
+    /**
+     * Build a new metric name using the specific path components.
+     *
+     * @param parts Path of the new metric name.
+     * @return A newly created metric name with the specified path.
+     **/
+    public static MetricName build(String... parts) {
+        if (parts == null || parts.length == 0) {
+            return MetricName.EMPTY;
+        } else if (parts.length == 1) {
+            return new MetricName(parts[0], EMPTY_TAGS);
+        }
+        return new MetricName(buildName(parts), EMPTY_TAGS);
+    }
+
+    private static String buildName(String... names) {
+        final StringBuilder builder = new StringBuilder();
+        boolean first = true;
+
+        for (String name : names) {
+            if (name == null || name.isEmpty()) {
+                continue;
+            }
+
+            if (first) {
+                first = false;
+            } else {
+                builder.append(SEPARATOR);
+            }
+
+            builder.append(name);
+        }
+
+        return builder.toString();
+    }
+
+    @Override
+    public String toString() {
+        return tags.isEmpty() ? key : key + tags;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MetricName that = (MetricName) o;
+        return Objects.equals(key, that.key) &&
+                Objects.equals(tags, that.tags);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(key, tags);
+    }
+
+    @Override
+    public int compareTo(MetricName o) {
+        if (o == null) {
+            return -1;
+        }
+
+        int c = compareName(key, o.getKey());
+        if (c != 0) {
+            return c;
+        }
+
+        return compareTags(tags, o.getTags());
+    }
+
+    private int compareName(String left, String right) {
+        if (left.isEmpty() && right.isEmpty()) {
+            return 0;
+        } else if (left.isEmpty()) {
+            return 1;
+        } else if (right.isEmpty()) {
+            return -1;
+        }
+
+        return left.compareTo(right);
+    }
+
+    private int compareTags(Map<String, String> left, Map<String, String> right) {
+        if (left.isEmpty() && right.isEmpty()) {
+            return 0;
+        } else if (left.isEmpty()) {
+            return 1;
+        } else if (right.isEmpty()) {
+            return -1;
+        }
+        final Iterable<String> keys = uniqueSortedKeys(left, right);
+        for (final String key : keys) {
+            final String a = left.get(key);
+            final String b = right.get(key);
+            if (a == null && b == null) {
+                continue;
+            } else if (a == null) {
+                return -1;
+            } else if (b == null) {
+                return 1;
+            }
+            int c = a.compareTo(b);
+            if (c != 0) {
+                return c;
+            }
+        }
+
+        return 0;
+    }
+
+    private Iterable<String> uniqueSortedKeys(Map<String, String> left, Map<String, String> right) {
+        final Set<String> set = new TreeSet<>(left.keySet());
+        set.addAll(right.keySet());
+        return set;
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistryListener.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistryListener.java
@@ -11,43 +11,43 @@ public interface MetricRegistryListener extends EventListener {
      */
     abstract class Base implements MetricRegistryListener {
         @Override
-        public void onGaugeAdded(String name, Gauge<?> gauge) {
+        public void onGaugeAdded(MetricName name, Gauge<?> gauge) {
         }
 
         @Override
-        public void onGaugeRemoved(String name) {
+        public void onGaugeRemoved(MetricName name) {
         }
 
         @Override
-        public void onCounterAdded(String name, Counter counter) {
+        public void onCounterAdded(MetricName name, Counter counter) {
         }
 
         @Override
-        public void onCounterRemoved(String name) {
+        public void onCounterRemoved(MetricName name) {
         }
 
         @Override
-        public void onHistogramAdded(String name, Histogram histogram) {
+        public void onHistogramAdded(MetricName name, Histogram histogram) {
         }
 
         @Override
-        public void onHistogramRemoved(String name) {
+        public void onHistogramRemoved(MetricName name) {
         }
 
         @Override
-        public void onMeterAdded(String name, Meter meter) {
+        public void onMeterAdded(MetricName name, Meter meter) {
         }
 
         @Override
-        public void onMeterRemoved(String name) {
+        public void onMeterRemoved(MetricName name) {
         }
 
         @Override
-        public void onTimerAdded(String name, Timer timer) {
+        public void onTimerAdded(MetricName name, Timer timer) {
         }
 
         @Override
-        public void onTimerRemoved(String name) {
+        public void onTimerRemoved(MetricName name) {
         }
     }
 
@@ -57,14 +57,14 @@ public interface MetricRegistryListener extends EventListener {
      * @param name  the gauge's name
      * @param gauge the gauge
      */
-    void onGaugeAdded(String name, Gauge<?> gauge);
+    void onGaugeAdded(MetricName name, Gauge<?> gauge);
 
     /**
      * Called when a {@link Gauge} is removed from the registry.
      *
      * @param name the gauge's name
      */
-    void onGaugeRemoved(String name);
+    void onGaugeRemoved(MetricName name);
 
     /**
      * Called when a {@link Counter} is added to the registry.
@@ -72,14 +72,14 @@ public interface MetricRegistryListener extends EventListener {
      * @param name    the counter's name
      * @param counter the counter
      */
-    void onCounterAdded(String name, Counter counter);
+    void onCounterAdded(MetricName name, Counter counter);
 
     /**
      * Called when a {@link Counter} is removed from the registry.
      *
      * @param name the counter's name
      */
-    void onCounterRemoved(String name);
+    void onCounterRemoved(MetricName name);
 
     /**
      * Called when a {@link Histogram} is added to the registry.
@@ -87,14 +87,14 @@ public interface MetricRegistryListener extends EventListener {
      * @param name      the histogram's name
      * @param histogram the histogram
      */
-    void onHistogramAdded(String name, Histogram histogram);
+    void onHistogramAdded(MetricName name, Histogram histogram);
 
     /**
      * Called when a {@link Histogram} is removed from the registry.
      *
      * @param name the histogram's name
      */
-    void onHistogramRemoved(String name);
+    void onHistogramRemoved(MetricName name);
 
     /**
      * Called when a {@link Meter} is added to the registry.
@@ -102,14 +102,14 @@ public interface MetricRegistryListener extends EventListener {
      * @param name  the meter's name
      * @param meter the meter
      */
-    void onMeterAdded(String name, Meter meter);
+    void onMeterAdded(MetricName name, Meter meter);
 
     /**
      * Called when a {@link Meter} is removed from the registry.
      *
      * @param name the meter's name
      */
-    void onMeterRemoved(String name);
+    void onMeterRemoved(MetricName name);
 
     /**
      * Called when a {@link Timer} is added to the registry.
@@ -117,12 +117,12 @@ public interface MetricRegistryListener extends EventListener {
      * @param name  the timer's name
      * @param timer the timer
      */
-    void onTimerAdded(String name, Timer timer);
+    void onTimerAdded(MetricName name, Timer timer);
 
     /**
      * Called when a {@link Timer} is removed from the registry.
      *
      * @param name the timer's name
      */
-    void onTimerRemoved(String name);
+    void onTimerRemoved(MetricName name);
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricSet.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricSet.java
@@ -13,5 +13,5 @@ public interface MetricSet extends Metric {
      *
      * @return the metrics
      */
-    Map<String, Metric> getMetrics();
+    Map<MetricName, Metric> getMetrics();
 }

--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -252,11 +252,11 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
      * @param timers     all of the timers in the registry
      */
     @SuppressWarnings("rawtypes")
-    public abstract void report(SortedMap<String, Gauge> gauges,
-                                SortedMap<String, Counter> counters,
-                                SortedMap<String, Histogram> histograms,
-                                SortedMap<String, Meter> meters,
-                                SortedMap<String, Timer> timers);
+    public abstract void report(SortedMap<MetricName, Gauge> gauges,
+                                SortedMap<MetricName, Counter> counters,
+                                SortedMap<MetricName, Histogram> histograms,
+                                SortedMap<MetricName, Meter> meters,
+                                SortedMap<MetricName, Timer> timers);
 
     protected String getRateUnit() {
         return rateUnit;

--- a/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
@@ -192,7 +192,7 @@ public class Slf4jReporter extends ScheduledReporter {
 
     private final LoggerProxy loggerProxy;
     private final Marker marker;
-    private final String prefix;
+    private final MetricName prefix;
 
     private Slf4jReporter(MetricRegistry registry,
                           LoggerProxy loggerProxy,
@@ -206,40 +206,40 @@ public class Slf4jReporter extends ScheduledReporter {
         super(registry, "logger-reporter", filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop);
         this.loggerProxy = loggerProxy;
         this.marker = marker;
-        this.prefix = prefix;
+        this.prefix = MetricName.build(prefix);
     }
 
     @Override
     @SuppressWarnings("rawtypes")
-    public void report(SortedMap<String, Gauge> gauges,
-                       SortedMap<String, Counter> counters,
-                       SortedMap<String, Histogram> histograms,
-                       SortedMap<String, Meter> meters,
-                       SortedMap<String, Timer> timers) {
+    public void report(SortedMap<MetricName, Gauge> gauges,
+                       SortedMap<MetricName, Counter> counters,
+                       SortedMap<MetricName, Histogram> histograms,
+                       SortedMap<MetricName, Meter> meters,
+                       SortedMap<MetricName, Timer> timers) {
         if (loggerProxy.isEnabled(marker)) {
-            for (Entry<String, Gauge> entry : gauges.entrySet()) {
+            for (Entry<MetricName, Gauge> entry : gauges.entrySet()) {
                 logGauge(entry.getKey(), entry.getValue());
             }
 
-            for (Entry<String, Counter> entry : counters.entrySet()) {
+            for (Entry<MetricName, Counter> entry : counters.entrySet()) {
                 logCounter(entry.getKey(), entry.getValue());
             }
 
-            for (Entry<String, Histogram> entry : histograms.entrySet()) {
+            for (Entry<MetricName, Histogram> entry : histograms.entrySet()) {
                 logHistogram(entry.getKey(), entry.getValue());
             }
 
-            for (Entry<String, Meter> entry : meters.entrySet()) {
+            for (Entry<MetricName, Meter> entry : meters.entrySet()) {
                 logMeter(entry.getKey(), entry.getValue());
             }
 
-            for (Entry<String, Timer> entry : timers.entrySet()) {
+            for (Entry<MetricName, Timer> entry : timers.entrySet()) {
                 logTimer(entry.getKey(), entry.getValue());
             }
         }
     }
 
-    private void logTimer(String name, Timer timer) {
+    private void logTimer(MetricName name, Timer timer) {
         final Snapshot snapshot = timer.getSnapshot();
         loggerProxy.log(marker,
                 "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, " +
@@ -266,7 +266,7 @@ public class Slf4jReporter extends ScheduledReporter {
                 getDurationUnit());
     }
 
-    private void logMeter(String name, Meter meter) {
+    private void logMeter(MetricName name, Meter meter) {
         loggerProxy.log(marker,
                 "type={}, name={}, count={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}",
                 "METER",
@@ -279,7 +279,7 @@ public class Slf4jReporter extends ScheduledReporter {
                 getRateUnit());
     }
 
-    private void logHistogram(String name, Histogram histogram) {
+    private void logHistogram(MetricName name, Histogram histogram) {
         final Snapshot snapshot = histogram.getSnapshot();
         loggerProxy.log(marker,
                 "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, " +
@@ -299,11 +299,11 @@ public class Slf4jReporter extends ScheduledReporter {
                 snapshot.get999thPercentile());
     }
 
-    private void logCounter(String name, Counter counter) {
+    private void logCounter(MetricName name, Counter counter) {
         loggerProxy.log(marker, "type={}, name={}, count={}", "COUNTER", prefix(name), counter.getCount());
     }
 
-    private void logGauge(String name, Gauge<?> gauge) {
+    private void logGauge(MetricName name, Gauge<?> gauge) {
         loggerProxy.log(marker, "type={}, name={}, value={}", "GAUGE", prefix(name), gauge.getValue());
     }
 
@@ -312,8 +312,8 @@ public class Slf4jReporter extends ScheduledReporter {
         return "events/" + super.getRateUnit();
     }
 
-    private String prefix(String... components) {
-        return MetricRegistry.name(prefix, components);
+    private MetricName prefix(MetricName metricName) {
+        return MetricName.join(prefix, metricName);
     }
 
     /* private class to allow logger configuration */

--- a/metrics-core/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
@@ -51,7 +51,7 @@ public class ConsoleReporterTest {
     public void reportsGaugeValues() throws Exception {
         final Gauge<Integer> gauge = () -> 1;
 
-        reporter.report(map("gauge", gauge),
+        reporter.report(map(MetricName.build("gauge"), gauge),
                 map(),
                 map(),
                 map(),
@@ -75,7 +75,7 @@ public class ConsoleReporterTest {
         when(counter.getCount()).thenReturn(100L);
 
         reporter.report(map(),
-                map("test.counter", counter),
+                map(MetricName.build("test.counter"), counter),
                 map(),
                 map(),
                 map());
@@ -113,7 +113,7 @@ public class ConsoleReporterTest {
 
         reporter.report(map(),
                 map(),
-                map("test.histogram", histogram),
+                map(MetricName.build("test.histogram"), histogram),
                 map(),
                 map());
 
@@ -151,7 +151,7 @@ public class ConsoleReporterTest {
         reporter.report(map(),
                 map(),
                 map(),
-                map("test.meter", meter),
+                map(MetricName.build("test.meter"), meter),
                 map());
 
         assertThat(consoleOutput())
@@ -198,7 +198,7 @@ public class ConsoleReporterTest {
                 map(),
                 map(),
                 map(),
-                map("test.another.timer", timer));
+                map(MetricName.build("test.another.timer"), timer));
 
         assertThat(consoleOutput())
                 .isEqualTo(lines(
@@ -251,7 +251,7 @@ public class ConsoleReporterTest {
         customReporter.report(map(),
                 map(),
                 map(),
-                map("test.meter", meter),
+                map(MetricName.build("test.meter"), meter),
                 map());
 
         assertThat(consoleOutput())
@@ -308,7 +308,7 @@ public class ConsoleReporterTest {
                 map(),
                 map(),
                 map(),
-                map("test.another.timer", timer));
+                map(MetricName.build("test.another.timer"), timer));
 
         assertThat(consoleOutput())
                 .isEqualTo(lines(
@@ -366,7 +366,7 @@ public class ConsoleReporterTest {
 
         customReporter.report(map(),
                 map(),
-                map("test.histogram", histogram),
+                map(MetricName.build("test.histogram"), histogram),
                 map(),
                 map());
 
@@ -400,12 +400,12 @@ public class ConsoleReporterTest {
         return bytes.toString("UTF-8");
     }
 
-    private <T> SortedMap<String, T> map() {
+    private <T> SortedMap<MetricName, T> map() {
         return new TreeMap<>();
     }
 
-    private <T> SortedMap<String, T> map(String name, T metric) {
-        final TreeMap<String, T> map = new TreeMap<>();
+    private <T> SortedMap<MetricName, T> map(MetricName name, T metric) {
+        final TreeMap<MetricName, T> map = new TreeMap<>();
         map.put(name, metric);
         return map;
     }

--- a/metrics-core/src/test/java/com/codahale/metrics/CsvReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/CsvReporterTest.java
@@ -48,7 +48,7 @@ public class CsvReporterTest {
     public void reportsGaugeValues() throws Exception {
         final Gauge<Integer> gauge = () -> 1;
 
-        reporter.report(map("gauge", gauge),
+        reporter.report(map(MetricName.build("gauge"), gauge),
                 map(),
                 map(),
                 map(),
@@ -67,7 +67,7 @@ public class CsvReporterTest {
         when(counter.getCount()).thenReturn(100L);
 
         reporter.report(map(),
-                map("test.counter", counter),
+                map(MetricName.build("test.counter"), counter),
                 map(),
                 map(),
                 map());
@@ -100,7 +100,7 @@ public class CsvReporterTest {
 
         reporter.report(map(),
                 map(),
-                map("test.histogram", histogram),
+                map(MetricName.build("test.histogram"), histogram),
                 map(),
                 map());
 
@@ -118,7 +118,7 @@ public class CsvReporterTest {
         reporter.report(map(),
                 map(),
                 map(),
-                map("test.meter", meter),
+                map(MetricName.build("test.meter"), meter),
                 map());
 
         assertThat(fileContents("test.meter.csv"))
@@ -155,7 +155,7 @@ public class CsvReporterTest {
                 map(),
                 map(),
                 map(),
-                map("test.another.timer", timer));
+                map(MetricName.build("test.another.timer"), timer));
 
         assertThat(fileContents("test.another.timer.csv"))
                 .isEqualTo(csv(
@@ -175,7 +175,7 @@ public class CsvReporterTest {
 
         final Gauge<Integer> gauge = () -> 1;
 
-        reporter.report(map("gauge", gauge),
+        reporter.report(map(MetricName.build("gauge"), gauge),
                 map(),
                 map(),
                 map(),
@@ -200,7 +200,7 @@ public class CsvReporterTest {
         customSeparatorReporter.report(map(),
                 map(),
                 map(),
-                map("test.meter", meter),
+                map(MetricName.build("test.meter"), meter),
                 map());
 
         assertThat(fileContents("test.meter.csv"))
@@ -233,12 +233,12 @@ public class CsvReporterTest {
         return new String(Files.readAllBytes(new File(dataDirectory, filename).toPath()), StandardCharsets.UTF_8);
     }
 
-    private <T> SortedMap<String, T> map() {
+    private <T> SortedMap<MetricName, T> map() {
         return new TreeMap<>();
     }
 
-    private <T> SortedMap<String, T> map(String name, T metric) {
-        final TreeMap<String, T> map = new TreeMap<>();
+    private <T> SortedMap<MetricName, T> map(MetricName name, T metric) {
+        final TreeMap<MetricName, T> map = new TreeMap<>();
         map.put(name, metric);
         return map;
     }

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricFilterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricFilterTest.java
@@ -8,31 +8,31 @@ import static org.mockito.Mockito.mock;
 public class MetricFilterTest {
     @Test
     public void theAllFilterMatchesAllMetrics() {
-        assertThat(MetricFilter.ALL.matches("", mock(Metric.class)))
+        assertThat(MetricFilter.ALL.matches(MetricName.build(""), mock(Metric.class)))
                 .isTrue();
     }
 
     @Test
     public void theStartsWithFilterMatches() {
-        assertThat(MetricFilter.startsWith("foo").matches("foo.bar", mock(Metric.class)))
+        assertThat(MetricFilter.startsWith("foo").matches(MetricName.build("foo.bar"), mock(Metric.class)))
                 .isTrue();
-        assertThat(MetricFilter.startsWith("foo").matches("bar.foo", mock(Metric.class)))
+        assertThat(MetricFilter.startsWith("foo").matches(MetricName.build("bar.foo"), mock(Metric.class)))
                 .isFalse();
     }
 
     @Test
     public void theEndsWithFilterMatches() {
-        assertThat(MetricFilter.endsWith("foo").matches("foo.bar", mock(Metric.class)))
+        assertThat(MetricFilter.endsWith("foo").matches(MetricName.build("foo.bar"), mock(Metric.class)))
                 .isFalse();
-        assertThat(MetricFilter.endsWith("foo").matches("bar.foo", mock(Metric.class)))
+        assertThat(MetricFilter.endsWith("foo").matches(MetricName.build("bar.foo"), mock(Metric.class)))
                 .isTrue();
     }
 
     @Test
     public void theContainsFilterMatches() {
-        assertThat(MetricFilter.contains("foo").matches("bar.foo.bar", mock(Metric.class)))
+        assertThat(MetricFilter.contains("foo").matches(MetricName.build("bar.foo.bar"), mock(Metric.class)))
                 .isTrue();
-        assertThat(MetricFilter.contains("foo").matches("bar.bar", mock(Metric.class)))
+        assertThat(MetricFilter.contains("foo").matches(MetricName.build("bar.bar"), mock(Metric.class)))
                 .isFalse();
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricNameTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricNameTest.java
@@ -1,0 +1,86 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MetricNameTest {
+    @Test
+    public void testEmpty() {
+        assertThat(MetricName.EMPTY.getTags()).isEmpty();
+        assertThat(MetricName.EMPTY.getKey()).isEqualTo("");
+
+        assertThat(MetricName.build()).isEqualTo(MetricName.EMPTY);
+        assertThat(MetricName.EMPTY.resolve(null)).isEqualTo(MetricName.EMPTY);
+    }
+
+    @Test
+    public void testEmptyResolve() {
+        final MetricName name = MetricName.build();
+        assertThat(name.resolve("foo")).isEqualTo(MetricName.build("foo"));
+    }
+
+    @Test
+    public void testResolveToEmpty() {
+        final MetricName name = MetricName.build("foo");
+        assertThat(name.resolve(null)).isEqualTo(MetricName.build("foo"));
+    }
+
+    @Test
+    public void testResolve() {
+        final MetricName name = MetricName.build("foo");
+        assertThat(name.resolve("bar")).isEqualTo(MetricName.build("foo.bar"));
+    }
+
+    @Test
+    public void testResolveBothEmpty() {
+        final MetricName name = MetricName.build();
+        assertThat(name.resolve(null)).isEqualTo(MetricName.EMPTY);
+    }
+
+    @Test
+    public void testAddTagsVarious() {
+        final Map<String, String> refTags = new HashMap<String, String>();
+        refTags.put("foo", "bar");
+        final MetricName test = MetricName.EMPTY.tagged("foo", "bar");
+        final MetricName test2 = MetricName.EMPTY.tagged(refTags);
+
+        assertThat(test).isEqualTo(new MetricName("", refTags));
+        assertThat(test.getTags()).isEqualTo(refTags);
+
+        assertThat(test2).isEqualTo(new MetricName("", refTags));
+        assertThat(test2.getTags()).isEqualTo(refTags);
+    }
+
+    @Test
+    public void testTaggedMoreArguments() {
+        final Map<String, String> refTags = new HashMap<String, String>();
+        refTags.put("foo", "bar");
+        refTags.put("baz", "biz");
+        assertThat(MetricName.EMPTY.tagged("foo", "bar", "baz", "biz").getTags()).isEqualTo(refTags);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTaggedNotPairs() {
+        MetricName.EMPTY.tagged("foo");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTaggedNotPairs2() {
+        MetricName.EMPTY.tagged("foo", "bar", "baz");
+    }
+
+    @Test
+    public void testCompareTo() {
+        final MetricName a = MetricName.EMPTY.tagged("foo", "bar");
+        final MetricName b = MetricName.EMPTY.tagged("foo", "baz");
+
+        assertThat(a.compareTo(b)).isLessThan(0);
+        assertThat(b.compareTo(a)).isGreaterThan(0);
+        assertThat(b.resolve("key").compareTo(b)).isLessThan(0);
+        assertThat(b.compareTo(b.resolve("key"))).isGreaterThan(0);
+    }
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryListenerTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryListenerTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class MetricRegistryListenerTest {
+    private static final MetricName BLAH = MetricName.build("blah");
+
     private final Counter counter = mock(Counter.class);
     private final Histogram histogram = mock(Histogram.class);
     private final Meter meter = mock(Meter.class);
@@ -16,45 +18,45 @@ public class MetricRegistryListenerTest {
 
     @Test
     public void noOpsOnGaugeAdded() {
-        listener.onGaugeAdded("blah", () -> {
+        listener.onGaugeAdded(BLAH, () -> {
             throw new RuntimeException("Should not be called");
         });
     }
 
     @Test
     public void noOpsOnCounterAdded() {
-        listener.onCounterAdded("blah", counter);
+        listener.onCounterAdded(BLAH, counter);
 
         verifyZeroInteractions(counter);
     }
 
     @Test
     public void noOpsOnHistogramAdded() {
-        listener.onHistogramAdded("blah", histogram);
+        listener.onHistogramAdded(BLAH, histogram);
 
         verifyZeroInteractions(histogram);
     }
 
     @Test
     public void noOpsOnMeterAdded() {
-        listener.onMeterAdded("blah", meter);
+        listener.onMeterAdded(BLAH, meter);
 
         verifyZeroInteractions(meter);
     }
 
     @Test
     public void noOpsOnTimerAdded() {
-        listener.onTimerAdded("blah", timer);
+        listener.onTimerAdded(BLAH, timer);
 
         verifyZeroInteractions(timer);
     }
 
     @Test
     public void doesNotExplodeWhenMetricsAreRemoved() {
-        listener.onGaugeRemoved("blah");
-        listener.onCounterRemoved("blah");
-        listener.onHistogramRemoved("blah");
-        listener.onMeterRemoved("blah");
-        listener.onTimerRemoved("blah");
+        listener.onGaugeRemoved(BLAH);
+        listener.onCounterRemoved(BLAH);
+        listener.onHistogramRemoved(BLAH);
+        listener.onMeterRemoved(BLAH);
+        listener.onTimerRemoved(BLAH);
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
@@ -14,6 +14,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 public class MetricRegistryTest {
+    private static final MetricName TIMER2 = MetricName.build("timer");
+    private static final MetricName METER2 = MetricName.build("meter");
+    private static final MetricName HISTOGRAM2 = MetricName.build("histogram");
+    private static final MetricName COUNTER = MetricName.build("counter");
+    private static final MetricName COUNTER2 = MetricName.build("counter2");
+    private static final MetricName GAUGE = MetricName.build("gauge");
+    private static final MetricName GAUGE2 = MetricName.build("gauge2");
+    private static final MetricName THING = MetricName.build("thing");
     private final MetricRegistryListener listener = mock(MetricRegistryListener.class);
     private final MetricRegistry registry = new MetricRegistry();
     private final Gauge<String> gauge = () -> "";
@@ -29,375 +37,381 @@ public class MetricRegistryTest {
 
     @Test
     public void registeringAGaugeTriggersANotification() {
-        assertThat(registry.register("thing", gauge))
+        assertThat(registry.register(THING, gauge))
                 .isEqualTo(gauge);
 
-        verify(listener).onGaugeAdded("thing", gauge);
+        verify(listener).onGaugeAdded(THING, gauge);
     }
 
     @Test
     public void removingAGaugeTriggersANotification() {
-        registry.register("thing", gauge);
+        registry.register(THING, gauge);
 
-        assertThat(registry.remove("thing"))
+        assertThat(registry.remove(THING))
                 .isTrue();
 
-        verify(listener).onGaugeRemoved("thing");
+        verify(listener).onGaugeRemoved(THING);
     }
 
     @Test
     public void registeringACounterTriggersANotification() {
-        assertThat(registry.register("thing", counter))
+        assertThat(registry.register(THING, counter))
                 .isEqualTo(counter);
 
-        verify(listener).onCounterAdded("thing", counter);
+        verify(listener).onCounterAdded(THING, counter);
     }
 
     @Test
     public void accessingACounterRegistersAndReusesTheCounter() {
-        final Counter counter1 = registry.counter("thing");
-        final Counter counter2 = registry.counter("thing");
+        final Counter counter1 = registry.counter(THING);
+        final Counter counter2 = registry.counter(THING);
 
         assertThat(counter1)
                 .isSameAs(counter2);
 
-        verify(listener).onCounterAdded("thing", counter1);
+        verify(listener).onCounterAdded(THING, counter1);
     }
 
     @Test
     public void accessingACustomCounterRegistersAndReusesTheCounter() {
         final MetricRegistry.MetricSupplier<Counter> supplier = () -> counter;
-        final Counter counter1 = registry.counter("thing", supplier);
-        final Counter counter2 = registry.counter("thing", supplier);
+        final Counter counter1 = registry.counter(THING, supplier);
+        final Counter counter2 = registry.counter(THING, supplier);
 
         assertThat(counter1)
                 .isSameAs(counter2);
 
-        verify(listener).onCounterAdded("thing", counter1);
+        verify(listener).onCounterAdded(THING, counter1);
     }
 
 
     @Test
     public void removingACounterTriggersANotification() {
-        registry.register("thing", counter);
+        registry.register(THING, counter);
 
-        assertThat(registry.remove("thing"))
+        assertThat(registry.remove(THING))
                 .isTrue();
 
-        verify(listener).onCounterRemoved("thing");
+        verify(listener).onCounterRemoved(THING);
     }
 
     @Test
     public void registeringAHistogramTriggersANotification() {
-        assertThat(registry.register("thing", histogram))
+        assertThat(registry.register(THING, histogram))
                 .isEqualTo(histogram);
 
-        verify(listener).onHistogramAdded("thing", histogram);
+        verify(listener).onHistogramAdded(THING, histogram);
     }
 
     @Test
     public void accessingAHistogramRegistersAndReusesIt() {
-        final Histogram histogram1 = registry.histogram("thing");
-        final Histogram histogram2 = registry.histogram("thing");
+        final Histogram histogram1 = registry.histogram(THING);
+        final Histogram histogram2 = registry.histogram(THING);
 
         assertThat(histogram1)
                 .isSameAs(histogram2);
 
-        verify(listener).onHistogramAdded("thing", histogram1);
+        verify(listener).onHistogramAdded(THING, histogram1);
     }
 
     @Test
     public void accessingACustomHistogramRegistersAndReusesIt() {
         final MetricRegistry.MetricSupplier<Histogram> supplier = () -> histogram;
-        final Histogram histogram1 = registry.histogram("thing", supplier);
-        final Histogram histogram2 = registry.histogram("thing", supplier);
+        final Histogram histogram1 = registry.histogram(THING, supplier);
+        final Histogram histogram2 = registry.histogram(THING, supplier);
 
         assertThat(histogram1)
                 .isSameAs(histogram2);
 
-        verify(listener).onHistogramAdded("thing", histogram1);
+        verify(listener).onHistogramAdded(THING, histogram1);
     }
 
     @Test
     public void removingAHistogramTriggersANotification() {
-        registry.register("thing", histogram);
+        registry.register(THING, histogram);
 
-        assertThat(registry.remove("thing"))
+        assertThat(registry.remove(THING))
                 .isTrue();
 
-        verify(listener).onHistogramRemoved("thing");
+        verify(listener).onHistogramRemoved(THING);
     }
 
     @Test
     public void registeringAMeterTriggersANotification() {
-        assertThat(registry.register("thing", meter))
+        assertThat(registry.register(THING, meter))
                 .isEqualTo(meter);
 
-        verify(listener).onMeterAdded("thing", meter);
+        verify(listener).onMeterAdded(THING, meter);
     }
 
     @Test
     public void accessingAMeterRegistersAndReusesIt() {
-        final Meter meter1 = registry.meter("thing");
-        final Meter meter2 = registry.meter("thing");
+        final Meter meter1 = registry.meter(THING);
+        final Meter meter2 = registry.meter(THING);
 
         assertThat(meter1)
                 .isSameAs(meter2);
 
-        verify(listener).onMeterAdded("thing", meter1);
+        verify(listener).onMeterAdded(THING, meter1);
     }
 
     @Test
     public void accessingACustomMeterRegistersAndReusesIt() {
         final MetricRegistry.MetricSupplier<Meter> supplier = () -> meter;
-        final Meter meter1 = registry.meter("thing", supplier);
-        final Meter meter2 = registry.meter("thing", supplier);
+        final Meter meter1 = registry.meter(THING, supplier);
+        final Meter meter2 = registry.meter(THING, supplier);
 
         assertThat(meter1)
                 .isSameAs(meter2);
 
-        verify(listener).onMeterAdded("thing", meter1);
+        verify(listener).onMeterAdded(THING, meter1);
     }
 
     @Test
     public void removingAMeterTriggersANotification() {
-        registry.register("thing", meter);
+        registry.register(THING, meter);
 
-        assertThat(registry.remove("thing"))
+        assertThat(registry.remove(THING))
                 .isTrue();
 
-        verify(listener).onMeterRemoved("thing");
+        verify(listener).onMeterRemoved(THING);
     }
 
     @Test
     public void registeringATimerTriggersANotification() {
-        assertThat(registry.register("thing", timer))
+        assertThat(registry.register(THING, timer))
                 .isEqualTo(timer);
 
-        verify(listener).onTimerAdded("thing", timer);
+        verify(listener).onTimerAdded(THING, timer);
     }
 
     @Test
     public void accessingATimerRegistersAndReusesIt() {
-        final Timer timer1 = registry.timer("thing");
-        final Timer timer2 = registry.timer("thing");
+        final Timer timer1 = registry.timer(THING);
+        final Timer timer2 = registry.timer(THING);
 
         assertThat(timer1)
                 .isSameAs(timer2);
 
-        verify(listener).onTimerAdded("thing", timer1);
+        verify(listener).onTimerAdded(THING, timer1);
     }
 
     @Test
     public void accessingACustomTimerRegistersAndReusesIt() {
         final MetricRegistry.MetricSupplier<Timer> supplier = () -> timer;
-        final Timer timer1 = registry.timer("thing", supplier);
-        final Timer timer2 = registry.timer("thing", supplier);
+        final Timer timer1 = registry.timer(THING, supplier);
+        final Timer timer2 = registry.timer(THING, supplier);
 
         assertThat(timer1)
                 .isSameAs(timer2);
 
-        verify(listener).onTimerAdded("thing", timer1);
+        verify(listener).onTimerAdded(THING, timer1);
     }
 
 
     @Test
     public void removingATimerTriggersANotification() {
-        registry.register("thing", timer);
+        registry.register(THING, timer);
 
-        assertThat(registry.remove("thing"))
+        assertThat(registry.remove(THING))
                 .isTrue();
 
-        verify(listener).onTimerRemoved("thing");
+        verify(listener).onTimerRemoved(THING);
     }
 
     @Test
     @SuppressWarnings("rawtypes")
     public void accessingACustomGaugeRegistersAndReusesIt() {
         final MetricRegistry.MetricSupplier<Gauge> supplier = () -> gauge;
-        final Gauge gauge1 = registry.gauge("thing", supplier);
-        final Gauge gauge2 = registry.gauge("thing", supplier);
+        final Gauge gauge1 = registry.gauge(THING, supplier);
+        final Gauge gauge2 = registry.gauge(THING, supplier);
 
         assertThat(gauge1)
                 .isSameAs(gauge2);
 
-        verify(listener).onGaugeAdded("thing", gauge1);
+        verify(listener).onGaugeAdded(THING, gauge1);
     }
 
 
     @Test
     public void addingAListenerWithExistingMetricsCatchesItUp() {
-        registry.register("gauge", gauge);
-        registry.register("counter", counter);
-        registry.register("histogram", histogram);
-        registry.register("meter", meter);
-        registry.register("timer", timer);
+        registry.register(GAUGE2, gauge);
+        registry.register(COUNTER2, counter);
+        registry.register(HISTOGRAM2, histogram);
+        registry.register(METER2, meter);
+        registry.register(TIMER2, timer);
 
         final MetricRegistryListener other = mock(MetricRegistryListener.class);
         registry.addListener(other);
 
-        verify(other).onGaugeAdded("gauge", gauge);
-        verify(other).onCounterAdded("counter", counter);
-        verify(other).onHistogramAdded("histogram", histogram);
-        verify(other).onMeterAdded("meter", meter);
-        verify(other).onTimerAdded("timer", timer);
+        verify(other).onGaugeAdded(GAUGE2, gauge);
+        verify(other).onCounterAdded(COUNTER2, counter);
+        verify(other).onHistogramAdded(HISTOGRAM2, histogram);
+        verify(other).onMeterAdded(METER2, meter);
+        verify(other).onTimerAdded(TIMER2, timer);
     }
 
     @Test
     public void aRemovedListenerDoesNotReceiveUpdates() {
-        registry.register("gauge", gauge);
+        registry.register(GAUGE, gauge);
         registry.removeListener(listener);
-        registry.register("gauge2", gauge);
+        registry.register(GAUGE2, gauge);
 
-        verify(listener, never()).onGaugeAdded("gauge2", gauge);
+        verify(listener, never()).onGaugeAdded(GAUGE2, gauge);
     }
 
     @Test
     public void hasAMapOfRegisteredGauges() {
-        registry.register("gauge", gauge);
+        registry.register(GAUGE2, gauge);
 
         assertThat(registry.getGauges())
-                .contains(entry("gauge", gauge));
+                .contains(entry(GAUGE2, gauge));
     }
 
     @Test
     public void hasAMapOfRegisteredCounters() {
-        registry.register("counter", counter);
+        registry.register(COUNTER2, counter);
 
         assertThat(registry.getCounters())
-                .contains(entry("counter", counter));
+                .contains(entry(COUNTER2, counter));
     }
 
     @Test
     public void hasAMapOfRegisteredHistograms() {
-        registry.register("histogram", histogram);
+        registry.register(HISTOGRAM2, histogram);
 
         assertThat(registry.getHistograms())
-                .contains(entry("histogram", histogram));
+                .contains(entry(HISTOGRAM2, histogram));
     }
 
     @Test
     public void hasAMapOfRegisteredMeters() {
-        registry.register("meter", meter);
+        registry.register(METER2, meter);
 
         assertThat(registry.getMeters())
-                .contains(entry("meter", meter));
+                .contains(entry(METER2, meter));
     }
 
     @Test
     public void hasAMapOfRegisteredTimers() {
-        registry.register("timer", timer);
+        registry.register(TIMER2, timer);
 
         assertThat(registry.getTimers())
-                .contains(entry("timer", timer));
+                .contains(entry(TIMER2, timer));
     }
 
     @Test
     public void hasASetOfRegisteredMetricNames() {
-        registry.register("gauge", gauge);
-        registry.register("counter", counter);
-        registry.register("histogram", histogram);
-        registry.register("meter", meter);
-        registry.register("timer", timer);
+        registry.register(GAUGE2, gauge);
+        registry.register(COUNTER2, counter);
+        registry.register(HISTOGRAM2, histogram);
+        registry.register(METER2, meter);
+        registry.register(TIMER2, timer);
 
         assertThat(registry.getNames())
-                .containsOnly("gauge", "counter", "histogram", "meter", "timer");
+                .containsOnly(GAUGE2, COUNTER2, HISTOGRAM2, METER2, TIMER2);
     }
 
     @Test
     public void registersMultipleMetrics() {
         final MetricSet metrics = () -> {
-            final Map<String, Metric> m = new HashMap<>();
-            m.put("gauge", gauge);
-            m.put("counter", counter);
+            final Map<MetricName, Metric> m = new HashMap<>();
+            m.put(GAUGE2, gauge);
+            m.put(COUNTER2, counter);
             return m;
         };
 
         registry.registerAll(metrics);
 
         assertThat(registry.getNames())
-                .containsOnly("gauge", "counter");
+                .containsOnly(GAUGE2, COUNTER2);
     }
 
     @Test
     public void registersMultipleMetricsWithAPrefix() {
+        final MetricName myCounter = MetricName.build("my.counter");
+        final MetricName myGauge = MetricName.build("my.gauge");
+
         final MetricSet metrics = () -> {
-            final Map<String, Metric> m = new HashMap<>();
-            m.put("gauge", gauge);
-            m.put("counter", counter);
+            final Map<MetricName, Metric> m = new HashMap<>();
+            m.put(GAUGE, gauge);
+            m.put(COUNTER, counter);
             return m;
         };
 
         registry.register("my", metrics);
 
         assertThat(registry.getNames())
-                .containsOnly("my.gauge", "my.counter");
+                .containsOnly(myGauge, myCounter);
     }
 
     @Test
     public void registersRecursiveMetricSets() {
         final MetricSet inner = () -> {
-            final Map<String, Metric> m = new HashMap<>();
-            m.put("gauge", gauge);
+            final Map<MetricName, Metric> m = new HashMap<>();
+            m.put(GAUGE, gauge);
             return m;
         };
 
         final MetricSet outer = () -> {
-            final Map<String, Metric> m = new HashMap<>();
-            m.put("inner", inner);
-            m.put("counter", counter);
+            final Map<MetricName, Metric> m = new HashMap<>();
+            m.put(MetricName.build("inner"), inner);
+            m.put(COUNTER, counter);
             return m;
         };
 
         registry.register("my", outer);
 
+        final MetricName myCounter = MetricName.build("my.counter");
+        final MetricName myInnerGauge = MetricName.build("my.inner.gauge");
+
         assertThat(registry.getNames())
-                .containsOnly("my.inner.gauge", "my.counter");
+                .containsOnly(myInnerGauge, myCounter);
     }
 
     @Test
     public void registersMetricsFromAnotherRegistry() {
         MetricRegistry other = new MetricRegistry();
-        other.register("gauge", gauge);
+        other.register(GAUGE, gauge);
         registry.register("nested", other);
-        assertThat(registry.getNames()).containsOnly("nested.gauge");
+        assertThat(registry.getNames()).containsOnly(MetricName.build("nested.gauge"));
     }
 
     @Test
     public void concatenatesStringsToFormADottedName() {
         assertThat(name("one", "two", "three"))
-                .isEqualTo("one.two.three");
+                .isEqualTo(MetricName.build("one.two.three"));
     }
 
     @Test
     @SuppressWarnings("NullArgumentToVariableArgMethod")
     public void elidesNullValuesFromNamesWhenOnlyOneNullPassedIn() {
         assertThat(name("one", (String) null))
-                .isEqualTo("one");
+                .isEqualTo(MetricName.build("one"));
     }
 
     @Test
     public void elidesNullValuesFromNamesWhenManyNullsPassedIn() {
         assertThat(name("one", null, null))
-                .isEqualTo("one");
+                .isEqualTo(MetricName.build("one"));
     }
 
     @Test
     public void elidesNullValuesFromNamesWhenNullAndNotNullPassedIn() {
         assertThat(name("one", null, "three"))
-                .isEqualTo("one.three");
+                .isEqualTo(MetricName.build("one.three"));
     }
 
     @Test
     public void elidesEmptyStringsFromNames() {
         assertThat(name("one", "", "three"))
-                .isEqualTo("one.three");
+                .isEqualTo(MetricName.build("one.three"));
     }
 
     @Test
     public void concatenatesClassNamesWithStringsToFormADottedName() {
         assertThat(name(MetricRegistryTest.class, "one", "two"))
-                .isEqualTo("com.codahale.metrics.MetricRegistryTest.one.two");
+                .isEqualTo(MetricName.build("com.codahale.metrics.MetricRegistryTest.one.two"));
     }
 
     @Test
@@ -405,26 +419,30 @@ public class MetricRegistryTest {
         final Gauge<String> g = () -> null;
 
         assertThat(name(g.getClass(), "one", "two"))
-                .matches("com\\.codahale\\.metrics\\.MetricRegistryTest.+?\\.one\\.two");
+                .isEqualTo(MetricName.build(g.getClass().getName() + ".one.two"));
     }
 
     @Test
     public void removesMetricsMatchingAFilter() {
-        registry.timer("timer-1");
-        registry.timer("timer-2");
-        registry.histogram("histogram-1");
+        final MetricName timer1 = MetricName.build("timer-1");
+        final MetricName timer2 = MetricName.build("timer-2");
+        final MetricName histogram1 = MetricName.build("histogram-1");
+
+        registry.timer(timer1);
+        registry.timer(timer2);
+        registry.histogram(histogram1);
 
         assertThat(registry.getNames())
-                .contains("timer-1", "timer-2", "histogram-1");
+                .contains(timer1, timer2, histogram1);
 
-        registry.removeMatching((name, metric) -> name.endsWith("1"));
+        registry.removeMatching((name, metric) -> name.getKey().endsWith("1"));
 
         assertThat(registry.getNames())
-                .doesNotContain("timer-1", "histogram-1");
+                .doesNotContain(timer1, histogram1);
         assertThat(registry.getNames())
-                .contains("timer-2");
+                .contains(timer2);
 
-        verify(listener).onTimerRemoved("timer-1");
-        verify(listener).onHistogramRemoved("histogram-1");
+        verify(listener).onTimerRemoved(timer1);
+        verify(listener).onHistogramRemoved(histogram1);
     }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
@@ -77,11 +77,11 @@ public class ScheduledReporterTest {
         latch.await(5, TimeUnit.SECONDS);
 
         verify(reporter, times(2)).report(
-                map("gauge", gauge),
-                map("counter", counter),
-                map("histogram", histogram),
-                map("meter", meter),
-                map("timer", timer)
+                map(MetricName.build("gauge"), gauge),
+                map(MetricName.build("counter"), counter),
+                map(MetricName.build("histogram"), histogram),
+                map(MetricName.build("meter"), meter),
+                map(MetricName.build("timer"), timer)
         );
     }
 
@@ -114,11 +114,11 @@ public class ScheduledReporterTest {
         });
         latch.await(5, TimeUnit.SECONDS);
         verify(reporterWithNullExecutor, times(2)).report(
-                map("gauge", gauge),
-                map("counter", counter),
-                map("histogram", histogram),
-                map("meter", meter),
-                map("timer", timer)
+                map(MetricName.build("gauge"), gauge),
+                map(MetricName.build("counter"), counter),
+                map(MetricName.build("histogram"), histogram),
+                map(MetricName.build("meter"), meter),
+                map(MetricName.build("timer"), timer)
         );
     }
 
@@ -190,8 +190,8 @@ public class ScheduledReporterTest {
         assertEquals(2.0E-5, reporter.convertDuration(20), 0.0);
     }
 
-    private <T> SortedMap<String, T> map(String name, T value) {
-        final SortedMap<String, T> map = new TreeMap<>();
+    private <T> SortedMap<MetricName, T> map(MetricName name, T value) {
+        final SortedMap<MetricName, T> map = new TreeMap<>();
         map.put(name, value);
         return map;
     }
@@ -214,7 +214,7 @@ public class ScheduledReporterTest {
 
         @Override
         @SuppressWarnings("rawtypes")
-        public void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters, SortedMap<String, Histogram> histograms, SortedMap<String, Meter> meters, SortedMap<String, Timer> timers) {
+        public void report(SortedMap<MetricName, Gauge> gauges, SortedMap<MetricName, Counter> counters, SortedMap<MetricName, Histogram> histograms, SortedMap<MetricName, Meter> meters, SortedMap<MetricName, Timer> timers) {
             executionCount.incrementAndGet();
             // nothing doing!
         }

--- a/metrics-core/src/test/java/com/codahale/metrics/Slf4jReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/Slf4jReporterTest.java
@@ -38,13 +38,13 @@ public class Slf4jReporterTest {
     @Test
     public void reportsGaugeValuesAtError() {
         when(logger.isErrorEnabled(marker)).thenReturn(true);
-        errorReporter.report(map("gauge", () -> "value"),
+        errorReporter.report(map(MetricName.build("gauge"), () -> "value"),
                 map(),
                 map(),
                 map(),
                 map());
 
-        verify(logger).error(marker, "type={}, name={}, value={}", "GAUGE", "gauge", "value");
+        verify(logger).error(marker, "type={}, name={}, value={}", "GAUGE", MetricName.build("gauge"), "value");
     }
 
     @Test
@@ -54,12 +54,12 @@ public class Slf4jReporterTest {
         when(logger.isErrorEnabled(marker)).thenReturn(true);
 
         errorReporter.report(map(),
-                map("test.counter", counter),
+                map(MetricName.build("test.counter"), counter),
                 map(),
                 map(),
                 map());
 
-        verify(logger).error(marker, "type={}, name={}, count={}", "COUNTER", "test.counter", 100L);
+        verify(logger).error(marker, "type={}, name={}, count={}", "COUNTER", MetricName.build("test.counter"), 100L);
     }
 
     @Test
@@ -84,14 +84,14 @@ public class Slf4jReporterTest {
 
         errorReporter.report(map(),
                 map(),
-                map("test.histogram", histogram),
+                map(MetricName.build("test.histogram"), histogram),
                 map(),
                 map());
 
         verify(logger).error(marker,
                 "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}",
                 "HISTOGRAM",
-                "test.histogram",
+                MetricName.build( "test.histogram"),
                 1L,
                 4L,
                 2L,
@@ -118,13 +118,13 @@ public class Slf4jReporterTest {
         errorReporter.report(map(),
                 map(),
                 map(),
-                map("test.meter", meter),
+                map(MetricName.build("test.meter"), meter),
                 map());
 
         verify(logger).error(marker,
                 "type={}, name={}, count={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}",
                 "METER",
-                "test.meter",
+                MetricName.build("test.meter"),
                 1L,
                 2.0,
                 3.0,
@@ -164,12 +164,12 @@ public class Slf4jReporterTest {
                 map(),
                 map(),
                 map(),
-                map("test.another.timer", timer));
+                map(MetricName.build("test.another.timer"), timer));
 
         verify(logger).error(marker,
                 "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}, duration_unit={}",
                 "TIMER",
-                "test.another.timer",
+                MetricName.build("test.another.timer"),
                 1L,
                 300.0,
                 100.0,
@@ -192,13 +192,13 @@ public class Slf4jReporterTest {
     @Test
     public void reportsGaugeValues() {
         when(logger.isInfoEnabled(marker)).thenReturn(true);
-        infoReporter.report(map("gauge", () -> "value"),
+        infoReporter.report(map(MetricName.build("gauge"), () -> "value"),
                 map(),
                 map(),
                 map(),
                 map());
 
-        verify(logger).info(marker, "type={}, name={}, value={}", "GAUGE", "prefix.gauge", "value");
+        verify(logger).info(marker, "type={}, name={}, value={}", "GAUGE", MetricName.build("prefix.gauge"), "value");
     }
 
     @Test
@@ -208,12 +208,12 @@ public class Slf4jReporterTest {
         when(logger.isInfoEnabled(marker)).thenReturn(true);
 
         infoReporter.report(map(),
-                map("test.counter", counter),
+                map(MetricName.build("test.counter"), counter),
                 map(),
                 map(),
                 map());
 
-        verify(logger).info(marker, "type={}, name={}, count={}", "COUNTER", "prefix.test.counter", 100L);
+        verify(logger).info(marker, "type={}, name={}, count={}", "COUNTER", MetricName.build("prefix.test.counter"), 100L);
     }
 
     @Test
@@ -238,14 +238,14 @@ public class Slf4jReporterTest {
 
         infoReporter.report(map(),
                 map(),
-                map("test.histogram", histogram),
+                map(MetricName.build("test.histogram"), histogram),
                 map(),
                 map());
 
         verify(logger).info(marker,
                 "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}",
                 "HISTOGRAM",
-                "prefix.test.histogram",
+                MetricName.build("prefix.test.histogram"),
                 1L,
                 4L,
                 2L,
@@ -272,13 +272,13 @@ public class Slf4jReporterTest {
         infoReporter.report(map(),
                 map(),
                 map(),
-                map("test.meter", meter),
+                map(MetricName.build("test.meter"), meter),
                 map());
 
         verify(logger).info(marker,
                 "type={}, name={}, count={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}",
                 "METER",
-                "prefix.test.meter",
+                MetricName.build("prefix.test.meter"),
                 1L,
                 2.0,
                 3.0,
@@ -317,12 +317,12 @@ public class Slf4jReporterTest {
                 map(),
                 map(),
                 map(),
-                map("test.another.timer", timer));
+                map(MetricName.build("test.another.timer"), timer));
 
         verify(logger).info(marker,
                 "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}, duration_unit={}",
                 "TIMER",
-                "prefix.test.another.timer",
+                MetricName.build("prefix.test.another.timer"),
                 1L,
                 300.0,
                 100.0,
@@ -342,12 +342,12 @@ public class Slf4jReporterTest {
                 "milliseconds");
     }
 
-    private <T> SortedMap<String, T> map() {
+    private <T> SortedMap<MetricName, T> map() {
         return new TreeMap<>();
     }
 
-    private <T> SortedMap<String, T> map(String name, T metric) {
-        final TreeMap<String, T> map = new TreeMap<>();
+    private <T> SortedMap<MetricName, T> map(MetricName name, T metric) {
+        final TreeMap<MetricName, T> map = new TreeMap<>();
         map.put(name, metric);
         return map;
     }

--- a/metrics-ehcache/src/main/java/com/codahale/metrics/ehcache/InstrumentedEhcache.java
+++ b/metrics-ehcache/src/main/java/com/codahale/metrics/ehcache/InstrumentedEhcache.java
@@ -1,8 +1,10 @@
 package com.codahale.metrics.ehcache;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+
 import net.sf.ehcache.CacheException;
 import net.sf.ehcache.Ehcache;
 import net.sf.ehcache.Element;
@@ -117,56 +119,56 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
      */
     public static Ehcache instrument(MetricRegistry registry, final Ehcache cache) {
 
-        final String prefix = name(cache.getClass(), cache.getName());
-        registry.register(name(prefix, "hits"),
+        final MetricName prefix = name(cache.getClass(), cache.getName());
+        registry.register(prefix.resolve("hits"),
                 (Gauge<Long>) () -> cache.getStatistics().cacheHitCount());
 
-        registry.register(name(prefix, "in-memory-hits"),
+        registry.register(prefix.resolve("in-memory-hits"),
                 (Gauge<Long>) () -> cache.getStatistics().localHeapHitCount());
 
-        registry.register(name(prefix, "off-heap-hits"),
+        registry.register(prefix.resolve("off-heap-hits"),
                 (Gauge<Long>) () -> cache.getStatistics().localOffHeapHitCount());
 
-        registry.register(name(prefix, "on-disk-hits"),
+        registry.register(prefix.resolve("on-disk-hits"),
                 (Gauge<Long>) () -> cache.getStatistics().localDiskHitCount());
 
-        registry.register(name(prefix, "misses"),
+        registry.register(prefix.resolve("misses"),
                 (Gauge<Long>) () -> cache.getStatistics().cacheMissCount());
 
-        registry.register(name(prefix, "in-memory-misses"),
+        registry.register(prefix.resolve("in-memory-misses"),
                 (Gauge<Long>) () -> cache.getStatistics().localHeapMissCount());
 
-        registry.register(name(prefix, "off-heap-misses"),
+        registry.register(prefix.resolve("off-heap-misses"),
                 (Gauge<Long>) () -> cache.getStatistics().localOffHeapMissCount());
 
-        registry.register(name(prefix, "on-disk-misses"),
+        registry.register(prefix.resolve("on-disk-misses"),
                 (Gauge<Long>) () -> cache.getStatistics().localDiskMissCount());
 
-        registry.register(name(prefix, "objects"),
+        registry.register(prefix.resolve("objects"),
                 (Gauge<Long>) () -> cache.getStatistics().getSize());
 
-        registry.register(name(prefix, "in-memory-objects"),
+        registry.register(prefix.resolve("in-memory-objects"),
                 (Gauge<Long>) () -> cache.getStatistics().getLocalHeapSize());
 
-        registry.register(name(prefix, "off-heap-objects"),
+        registry.register(prefix.resolve("off-heap-objects"),
                 (Gauge<Long>) () -> cache.getStatistics().getLocalOffHeapSize());
 
-        registry.register(name(prefix, "on-disk-objects"),
+        registry.register(prefix.resolve("on-disk-objects"),
                 (Gauge<Long>) () -> cache.getStatistics().getLocalDiskSize());
 
-        registry.register(name(prefix, "mean-get-time"),
+        registry.register(prefix.resolve("mean-get-time"),
                 (Gauge<Double>) () -> cache.getStatistics().cacheGetOperation().latency().average().value());
 
-        registry.register(name(prefix, "mean-search-time"),
+        registry.register(prefix.resolve("mean-search-time"),
                 (Gauge<Double>) () -> cache.getStatistics().cacheSearchOperation().latency().average().value());
 
-        registry.register(name(prefix, "eviction-count"),
+        registry.register(prefix.resolve("eviction-count"),
                 (Gauge<Long>) () -> cache.getStatistics().cacheEvictionOperation().count().value());
 
-        registry.register(name(prefix, "searches-per-second"),
+        registry.register(prefix.resolve("searches-per-second"),
                 (Gauge<Double>) () -> cache.getStatistics().cacheSearchOperation().rate().value());
 
-        registry.register(name(prefix, "writer-queue-size"),
+        registry.register(prefix.resolve("writer-queue-size"),
                 (Gauge<Long>) () -> cache.getStatistics().getWriterQueueLength());
 
         return new InstrumentedEhcache(registry, cache);

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -1,15 +1,6 @@
 package com.codahale.metrics.graphite;
 
-import com.codahale.metrics.Clock;
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricAttribute;
-import com.codahale.metrics.MetricFilter;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Snapshot;
-import com.codahale.metrics.Timer;
+import com.codahale.metrics.*;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InOrder;
@@ -32,6 +23,10 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class GraphiteReporterTest {
+    private static final MetricName GAUGE = MetricName.build("gauge");
+    private static final MetricName METER = MetricName.build("meter");
+    private static final MetricName COUNTER = MetricName.build("counter");
+
     private final long timestamp = 1000198;
     private final Clock clock = mock(Clock.class);
     private final Graphite graphite = mock(Graphite.class);
@@ -62,7 +57,7 @@ public class GraphiteReporterTest {
 
     @Test
     public void doesNotReportStringGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge("value")),
+        reporter.report(map(GAUGE, gauge("value")),
             map(),
             map(),
             map(),
@@ -79,7 +74,7 @@ public class GraphiteReporterTest {
 
     @Test
     public void reportsByteGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge((byte) 1)),
+        reporter.report(map(GAUGE, gauge((byte) 1)),
             map(),
             map(),
             map(),
@@ -96,7 +91,7 @@ public class GraphiteReporterTest {
 
     @Test
     public void reportsShortGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge((short) 1)),
+        reporter.report(map(GAUGE, gauge((short) 1)),
             map(),
             map(),
             map(),
@@ -113,7 +108,7 @@ public class GraphiteReporterTest {
 
     @Test
     public void reportsIntegerGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1)),
+        reporter.report(map(GAUGE, gauge(1)),
             map(),
             map(),
             map(),
@@ -130,7 +125,7 @@ public class GraphiteReporterTest {
 
     @Test
     public void reportsLongGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1L)),
+        reporter.report(map(GAUGE, gauge(1L)),
             map(),
             map(),
             map(),
@@ -147,7 +142,7 @@ public class GraphiteReporterTest {
 
     @Test
     public void reportsFloatGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1.1f)),
+        reporter.report(map(GAUGE, gauge(1.1f)),
             map(),
             map(),
             map(),
@@ -164,7 +159,7 @@ public class GraphiteReporterTest {
 
     @Test
     public void reportsDoubleGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(1.1)),
+        reporter.report(map(GAUGE, gauge(1.1)),
             map(),
             map(),
             map(),
@@ -182,7 +177,7 @@ public class GraphiteReporterTest {
     @Test
     public void reportsDoubleGaugeValuesWithCustomFormat() throws Exception {
         try (final GraphiteReporter graphiteReporter = getReporterWithCustomFormat()) {
-            graphiteReporter.report(map("gauge", gauge(1.13574)),
+            graphiteReporter.report(map(GAUGE, gauge(1.13574)),
                 map(),
                 map(),
                 map(),
@@ -200,13 +195,13 @@ public class GraphiteReporterTest {
 
     @Test
     public void reportsBooleanGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge(true)),
+        reporter.report(map(GAUGE, gauge(true)),
             map(),
             map(),
             map(),
             map());
 
-        reporter.report(map("gauge", gauge(false)),
+        reporter.report(map(GAUGE, gauge(false)),
             map(),
             map(),
             map(),
@@ -230,7 +225,7 @@ public class GraphiteReporterTest {
         when(counter.getCount()).thenReturn(100L);
 
         reporter.report(map(),
-            map("counter", counter),
+            map(COUNTER, counter),
             map(),
             map(),
             map());
@@ -265,7 +260,7 @@ public class GraphiteReporterTest {
 
         reporter.report(map(),
             map(),
-            map("histogram", histogram),
+            map(MetricName.build("histogram"), histogram),
             map(),
             map());
 
@@ -300,7 +295,7 @@ public class GraphiteReporterTest {
         reporter.report(map(),
             map(),
             map(),
-            map("meter", meter),
+            map(METER, meter),
             map());
 
         final InOrder inOrder = inOrder(graphite);
@@ -328,7 +323,7 @@ public class GraphiteReporterTest {
         minuteRateReporter.report(this.map(),
             this.map(),
             this.map(),
-            this.map("meter", meter),
+            this.map(METER, meter),
             this.map());
 
         final InOrder inOrder = inOrder(graphite);
@@ -372,7 +367,7 @@ public class GraphiteReporterTest {
             map(),
             map(),
             map(),
-            map("timer", timer));
+            map(MetricName.build("timer"), timer));
 
         final InOrder inOrder = inOrder(graphite);
         inOrder.verify(graphite).connect();
@@ -402,7 +397,7 @@ public class GraphiteReporterTest {
     @Test
     public void closesConnectionIfGraphiteIsUnavailable() throws Exception {
         doThrow(new UnknownHostException("UNKNOWN-HOST")).when(graphite).connect();
-        reporter.report(map("gauge", gauge(1)),
+        reporter.report(map(GAUGE, gauge(1)),
             map(),
             map(),
             map(),
@@ -447,9 +442,9 @@ public class GraphiteReporterTest {
             .disabledMetricAttributes(disabledMetricAttributes)
             .build(graphite);
         reporterWithdisabledMetricAttributes.report(map(),
-            map("counter", counter),
+            map(COUNTER, counter),
             map(),
-            map("meter", meter),
+            map(METER, meter),
             map());
 
         final InOrder inOrder = inOrder(graphite);
@@ -475,12 +470,12 @@ public class GraphiteReporterTest {
         };
     }
 
-    private <T> SortedMap<String, T> map() {
+    private <T> SortedMap<MetricName, T> map() {
         return new TreeMap<>();
     }
 
-    private <T> SortedMap<String, T> map(String name, T metric) {
-        final TreeMap<String, T> map = new TreeMap<>();
+    private <T> SortedMap<MetricName, T> map(MetricName name, T metric) {
+        final TreeMap<MetricName, T> map = new TreeMap<>();
         map.put(name, metric);
         return map;
     }

--- a/metrics-httpasyncclient/src/main/java/com/codahale/metrics/httpasyncclient/InstrumentedNHttpClientBuilder.java
+++ b/metrics-httpasyncclient/src/main/java/com/codahale/metrics/httpasyncclient/InstrumentedNHttpClientBuilder.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.httpasyncclient;
 
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.httpclient.HttpClientMetricNameStrategies;
@@ -44,7 +45,8 @@ public class InstrumentedNHttpClientBuilder extends HttpAsyncClientBuilder {
     }
 
     private Timer timer(HttpRequest request) {
-        return metricRegistry.timer(metricNameStrategy.getNameFor(name, request));
+        MetricName nameFor = metricNameStrategy.getNameFor(name, request);
+        return metricRegistry.timer(nameFor);
     }
 
     @Override

--- a/metrics-httpasyncclient/src/test/java/com/codahale/metrics/httpasyncclient/InstrumentedHttpClientsTest.java
+++ b/metrics-httpasyncclient/src/test/java/com/codahale/metrics/httpasyncclient/InstrumentedHttpClientsTest.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.httpasyncclient;
 
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricRegistryListener;
 import com.codahale.metrics.Timer;
@@ -37,7 +38,7 @@ public class InstrumentedHttpClientsTest extends HttpClientTestBase {
     public void registersExpectedMetricsGivenNameStrategy() throws Exception {
         HttpHost host = startServerWithGlobalRequestHandler(STATUS_OK);
         final HttpGet get = new HttpGet("/q=anything");
-        final String metricName = MetricRegistry.name("some.made.up.metric.name");
+        final MetricName metricName = MetricName.build("some.made.up.metric.name");
 
         when(metricNameStrategy.getNameFor(any(), any(HttpRequest.class)))
                 .thenReturn(metricName);

--- a/metrics-httpasyncclient/src/test/java/com/codahale/metrics/httpasyncclient/InstrumentedHttpClientsTimerTest.java
+++ b/metrics-httpasyncclient/src/test/java/com/codahale/metrics/httpasyncclient/InstrumentedHttpClientsTimerTest.java
@@ -1,9 +1,11 @@
 package com.codahale.metrics.httpasyncclient;
 
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.httpclient.HttpClientMetricNameStrategy;
 import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.concurrent.FutureCallback;
@@ -21,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
@@ -42,13 +45,13 @@ public class InstrumentedHttpClientsTimerTest extends HttpClientTestBase {
     @Before
     public void setUp() throws Exception {
         CloseableHttpAsyncClient chac = new InstrumentedNHttpClientBuilder(metricRegistry,
-                mock(HttpClientMetricNameStrategy.class)).build();
+                (name, request) -> MetricName.build("test")).build();
         chac.start();
         asyncHttpClient = chac;
 
         Timer timer = mock(Timer.class);
         when(timer.time()).thenReturn(context);
-        when(metricRegistry.timer(any())).thenReturn(timer);
+        when(metricRegistry.timer(MetricName.build("test"))).thenReturn(timer);
     }
 
     @Test

--- a/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategy.java
+++ b/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategy.java
@@ -3,13 +3,14 @@ package com.codahale.metrics.httpclient;
 import com.codahale.metrics.MetricRegistry;
 import org.apache.http.HttpRequest;
 import org.apache.http.client.HttpClient;
+import com.codahale.metrics.MetricName;
 
 @FunctionalInterface
 public interface HttpClientMetricNameStrategy {
 
-    String getNameFor(String name, HttpRequest request);
+    MetricName getNameFor(String name, HttpRequest request);
 
-    default String getNameFor(String name, Exception exception) {
+    default MetricName getNameFor(String name, Exception exception) {
         return MetricRegistry.name(HttpClient.class,
                 name,
                 exception.getClass().getSimpleName());

--- a/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategiesTest.java
+++ b/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/HttpClientMetricNameStrategiesTest.java
@@ -17,30 +17,32 @@ import static com.codahale.metrics.httpclient.HttpClientMetricNameStrategies.QUE
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
+import com.codahale.metrics.MetricName;
+
 public class HttpClientMetricNameStrategiesTest {
 
     @Test
     public void methodOnlyWithName() {
         assertThat(METHOD_ONLY.getNameFor("some-service", new HttpGet("/whatever")),
-                is("org.apache.http.client.HttpClient.some-service.get-requests"));
+                is(MetricName.build("org.apache.http.client.HttpClient.some-service.get-requests")));
     }
 
     @Test
     public void methodOnlyWithoutName() {
         assertThat(METHOD_ONLY.getNameFor(null, new HttpGet("/whatever")),
-                is("org.apache.http.client.HttpClient.get-requests"));
+                is(MetricName.build("org.apache.http.client.HttpClient.get-requests")));
     }
 
     @Test
     public void hostAndMethodWithName() {
         assertThat(HOST_AND_METHOD.getNameFor("some-service", new HttpPost("http://my.host.com/whatever")),
-                is("org.apache.http.client.HttpClient.some-service.my.host.com.post-requests"));
+                is(MetricName.build("org.apache.http.client.HttpClient.some-service.my.host.com.post-requests")));
     }
 
     @Test
     public void hostAndMethodWithoutName() {
         assertThat(HOST_AND_METHOD.getNameFor(null, new HttpPost("http://my.host.com/whatever")),
-                is("org.apache.http.client.HttpClient.my.host.com.post-requests"));
+                is(MetricName.build("org.apache.http.client.HttpClient.my.host.com.post-requests")));
     }
 
     @Test
@@ -48,7 +50,7 @@ public class HttpClientMetricNameStrategiesTest {
         HttpRequest request = rewriteRequestURI(new HttpPost("http://my.host.com/whatever"));
 
         assertThat(HOST_AND_METHOD.getNameFor("some-service", request),
-                is("org.apache.http.client.HttpClient.some-service.my.host.com.post-requests"));
+                is(MetricName.build("org.apache.http.client.HttpClient.some-service.my.host.com.post-requests")));
     }
 
     @Test
@@ -56,7 +58,7 @@ public class HttpClientMetricNameStrategiesTest {
         HttpRequest request = rewriteRequestURI(new HttpPost("http://my.host.com/whatever"));
 
         assertThat(HOST_AND_METHOD.getNameFor(null, request),
-                is("org.apache.http.client.HttpClient.my.host.com.post-requests"));
+                is(MetricName.build("org.apache.http.client.HttpClient.my.host.com.post-requests")));
     }
 
     @Test
@@ -64,7 +66,7 @@ public class HttpClientMetricNameStrategiesTest {
         assertThat(QUERYLESS_URL_AND_METHOD.getNameFor(
                 "some-service",
                 new HttpPut("https://thing.com:8090/my/path?ignore=this&and=this")),
-                is("org.apache.http.client.HttpClient.some-service.https://thing.com:8090/my/path.put-requests"));
+                is(MetricName.build("org.apache.http.client.HttpClient.some-service.https://thing.com:8090/my/path.put-requests")));
     }
 
     @Test
@@ -73,7 +75,7 @@ public class HttpClientMetricNameStrategiesTest {
         assertThat(QUERYLESS_URL_AND_METHOD.getNameFor(
                 "some-service",
                 request),
-                is("org.apache.http.client.HttpClient.some-service.https://thing.com:8090/my/path.put-requests"));
+                is(MetricName.build("org.apache.http.client.HttpClient.some-service.https://thing.com:8090/my/path.put-requests")));
     }
 
     private static HttpRequest rewriteRequestURI(HttpRequest request) throws URISyntaxException {

--- a/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/InstrumentedHttpClientsTest.java
+++ b/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/InstrumentedHttpClientsTest.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.httpclient;
 
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricRegistryListener;
 import com.codahale.metrics.Timer;
@@ -39,7 +40,7 @@ public class InstrumentedHttpClientsTest {
     @Test
     public void registersExpectedMetricsGivenNameStrategy() throws Exception {
         final HttpGet get = new HttpGet("http://example.com?q=anything");
-        final String metricName = "some.made.up.metric.name";
+        final MetricName metricName = MetricName.build("some.made.up.metric.name");
 
         when(metricNameStrategy.getNameFor(any(), any(HttpRequest.class)))
                 .thenReturn(metricName);
@@ -54,8 +55,8 @@ public class InstrumentedHttpClientsTest {
         HttpServer httpServer = HttpServer.create(new InetSocketAddress(0), 0);
 
         final HttpGet get = new HttpGet("http://localhost:" + httpServer.getAddress().getPort() + "/");
-        final String requestMetricName = "request";
-        final String exceptionMetricName = "exception";
+        final MetricName requestMetricName = MetricName.build("request");
+        final MetricName exceptionMetricName = MetricName.build("exception");
 
         httpServer.createContext("/", HttpExchange::close);
         httpServer.start();
@@ -69,7 +70,7 @@ public class InstrumentedHttpClientsTest {
             client.execute(get);
             fail();
         } catch (NoHttpResponseException expected) {
-            assertThat(metricRegistry.getMeters()).containsKey("exception");
+            assertThat(metricRegistry.getMeters()).containsKey(MetricName.build("exception"));
         } finally {
             httpServer.stop(0);
         }

--- a/metrics-jcache/src/main/java/com/codahale/metrics/jcache/JCacheGaugeSet.java
+++ b/metrics-jcache/src/main/java/com/codahale/metrics/jcache/JCacheGaugeSet.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.jcache;
 
+import com.codahale.metrics.MetricName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,11 +38,11 @@ public class JCacheGaugeSet implements MetricSet {
     private static final Logger LOGGER = LoggerFactory.getLogger(JCacheGaugeSet.class);
 
     @Override
-    public Map<String, Metric> getMetrics() {
+    public Map<MetricName, Metric> getMetrics() {
         Set<ObjectInstance> cacheBeans = getCacheBeans();
         List<String> availableStatsNames = retrieveStatsNames();
 
-        Map<String, Metric> gauges = new HashMap<>(cacheBeans.size() * availableStatsNames.size());
+        Map<MetricName, Metric> gauges = new HashMap<>(cacheBeans.size() * availableStatsNames.size());
 
         for (ObjectInstance cacheBean : cacheBeans) {
             ObjectName objectName = cacheBean.getObjectName();

--- a/metrics-jcache/src/test/java/JCacheGaugeSetTest.java
+++ b/metrics-jcache/src/test/java/JCacheGaugeSetTest.java
@@ -1,3 +1,4 @@
+import com.codahale.metrics.MetricName;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,41 +39,43 @@ public class JCacheGaugeSetTest {
     public void measuresGauges() throws Exception {
 
         myOtherCache.get("woo");
-        assertThat(registry.getGauges().get("jcache.statistics.myOtherCache.cache-misses").getValue())
+        assertThat(registry.getGauges().get(MetricName.build("jcache.statistics.myOtherCache.cache-misses"))
+                .getValue())
                 .isEqualTo(1L);
 
         myCache.get("woo");
-        assertThat(registry.getGauges().get("jcache.statistics.myCache.cache-misses").getValue())
+        MetricName myCache = MetricName.build("jcache.statistics.myCache");
+        assertThat(registry.getGauges().get(myCache.resolve("cache-misses")).getValue())
                 .isEqualTo(1L);
-        assertThat(registry.getGauges().get("jcache.statistics.myCache.cache-hits").getValue())
+        assertThat(registry.getGauges().get(myCache.resolve("cache-hits")).getValue())
                 .isEqualTo(0L);
-        assertThat(registry.getGauges().get("jcache.statistics.myCache.cache-gets").getValue())
+        assertThat(registry.getGauges().get(myCache.resolve("cache-gets")).getValue())
                 .isEqualTo(1L);
 
-        myCache.put("woo", "whee");
-        myCache.get("woo");
-        assertThat(registry.getGauges().get("jcache.statistics.myCache.cache-puts").getValue())
+        this.myCache.put("woo", "whee");
+        this.myCache.get("woo");
+        assertThat(registry.getGauges().get(myCache.resolve("cache-puts")).getValue())
                 .isEqualTo(1L);
-        assertThat(registry.getGauges().get("jcache.statistics.myCache.cache-hits").getValue())
+        assertThat(registry.getGauges().get(myCache.resolve("cache-hits")).getValue())
                 .isEqualTo(1L);
-        assertThat(registry.getGauges().get("jcache.statistics.myCache.cache-hit-percentage").getValue())
+        assertThat(registry.getGauges().get(myCache.resolve("cache-hit-percentage")).getValue())
                 .isEqualTo(50.0f);
-        assertThat(registry.getGauges().get("jcache.statistics.myCache.cache-miss-percentage").getValue())
+        assertThat(registry.getGauges().get(myCache.resolve("cache-miss-percentage")).getValue())
                 .isEqualTo(50.0f);
-        assertThat(registry.getGauges().get("jcache.statistics.myCache.cache-gets").getValue())
+        assertThat(registry.getGauges().get(myCache.resolve("cache-gets")).getValue())
                 .isEqualTo(2L);
 
         // cache size being 1, eviction occurs after this line
-        myCache.put("woo2", "whoza");
-        assertThat(registry.getGauges().get("jcache.statistics.myCache.cache-evictions").getValue())
+        this.myCache.put("woo2", "whoza");
+        assertThat(registry.getGauges().get(myCache.resolve("cache-evictions")).getValue())
                 .isEqualTo(1L);
 
-        myCache.remove("woo2");
-        assertThat((Float) registry.getGauges().get("jcache.statistics.myCache.average-get-time").getValue())
+        this.myCache.remove("woo2");
+        assertThat((Float) registry.getGauges().get(myCache.resolve("average-get-time")).getValue())
                 .isGreaterThan(0.0f);
-        assertThat((Float) registry.getGauges().get("jcache.statistics.myCache.average-put-time").getValue())
+        assertThat((Float) registry.getGauges().get(myCache.resolve("average-put-time")).getValue())
                 .isGreaterThan(0.0f);
-        assertThat((Float) registry.getGauges().get("jcache.statistics.myCache.average-remove-time").getValue())
+        assertThat((Float) registry.getGauges().get(myCache.resolve("average-remove-time")).getValue())
                 .isGreaterThan(0.0f);
 
     }

--- a/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/DelegatingStatementNameStrategy.java
+++ b/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/DelegatingStatementNameStrategy.java
@@ -2,6 +2,8 @@ package com.codahale.metrics.jdbi.strategies;
 
 import org.skife.jdbi.v2.StatementContext;
 
+import com.codahale.metrics.MetricName;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -18,9 +20,9 @@ public abstract class DelegatingStatementNameStrategy implements StatementNameSt
     }
 
     @Override
-    public String getStatementName(StatementContext statementContext) {
+    public MetricName getStatementName(StatementContext statementContext) {
         for (StatementNameStrategy strategy : strategies) {
-            final String statementName = strategy.getStatementName(statementContext);
+            final MetricName statementName = strategy.getStatementName(statementContext);
             if (statementName != null) {
                 return statementName;
             }

--- a/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/NameStrategies.java
+++ b/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/NameStrategies.java
@@ -3,6 +3,8 @@ package com.codahale.metrics.jdbi.strategies;
 import org.skife.jdbi.v2.ClasspathStatementLocator;
 import org.skife.jdbi.v2.StatementContext;
 
+import com.codahale.metrics.MetricName;
+
 import java.lang.reflect.Method;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -20,12 +22,12 @@ public final class NameStrategies {
     /**
      * An empty SQL statement.
      */
-    private static final String EMPTY_SQL = "sql.empty";
+    private static final MetricName EMPTY_SQL = MetricName.build("sql.empty");
 
     /**
      * Unknown SQL.
      */
-    static final String UNKNOWN_SQL = "sql.unknown";
+    static final MetricName UNKNOWN_SQL = MetricName.build("sql.unknown");
 
     /**
      * Context attribute name for the metric class.
@@ -47,7 +49,7 @@ public final class NameStrategies {
      */
     public static final String STATEMENT_NAME = "_metric_name";
 
-    private static String forRawSql(String rawSql) {
+    private static MetricName forRawSql(String rawSql) {
         return name("sql", "raw", rawSql);
     }
 
@@ -56,7 +58,7 @@ public final class NameStrategies {
         }
 
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final String rawSql = statementContext.getRawSql();
 
             if (rawSql == null || rawSql.length() == 0) {
@@ -71,7 +73,7 @@ public final class NameStrategies {
         }
 
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final String rawSql = statementContext.getRawSql();
 
             if (ClasspathStatementLocator.looksLikeSql(rawSql)) {
@@ -86,7 +88,7 @@ public final class NameStrategies {
         }
 
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final String rawSql = statementContext.getRawSql();
 
             // Is it using the template loader?
@@ -108,7 +110,7 @@ public final class NameStrategies {
         }
 
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final Class<?> clazz = statementContext.getSqlObjectType();
             final Method method = statementContext.getSqlObjectMethod();
             if (clazz != null) {
@@ -128,7 +130,7 @@ public final class NameStrategies {
         }
 
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final Object classObj = statementContext.getAttribute(STATEMENT_CLASS);
             final Object nameObj = statementContext.getAttribute(STATEMENT_NAME);
 
@@ -160,7 +162,7 @@ public final class NameStrategies {
         }
 
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final Object groupObj = statementContext.getAttribute(STATEMENT_GROUP);
             final Object typeObj = statementContext.getAttribute(STATEMENT_TYPE);
             final Object nameObj = statementContext.getAttribute(STATEMENT_NAME);

--- a/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/ShortNameStrategy.java
+++ b/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/ShortNameStrategy.java
@@ -2,6 +2,8 @@ package com.codahale.metrics.jdbi.strategies;
 
 import org.skife.jdbi.v2.StatementContext;
 
+import com.codahale.metrics.MetricName;
+
 import java.lang.reflect.Method;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -31,7 +33,7 @@ public final class ShortNameStrategy extends DelegatingStatementNameStrategy {
 
     private final class ShortContextClassStrategy implements StatementNameStrategy {
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final Object classObj = statementContext.getAttribute(NameStrategies.STATEMENT_CLASS);
             final Object nameObj = statementContext.getAttribute(NameStrategies.STATEMENT_NAME);
 
@@ -60,7 +62,7 @@ public final class ShortNameStrategy extends DelegatingStatementNameStrategy {
 
     private final class ShortSqlObjectStrategy implements StatementNameStrategy {
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final Class<?> clazz = statementContext.getSqlObjectType();
             final Method method = statementContext.getSqlObjectMethod();
             if (clazz != null && method != null) {

--- a/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/StatementNameStrategy.java
+++ b/metrics-jdbi/src/main/java/com/codahale/metrics/jdbi/strategies/StatementNameStrategy.java
@@ -2,9 +2,11 @@ package com.codahale.metrics.jdbi.strategies;
 
 import org.skife.jdbi.v2.StatementContext;
 
+import com.codahale.metrics.MetricName;
+
 /**
  * Interface for strategies to statement contexts to metric names.
  */
 public interface StatementNameStrategy {
-    String getStatementName(StatementContext statementContext);
+    MetricName getStatementName(StatementContext statementContext);
 }

--- a/metrics-jdbi/src/test/java/com/codahale/metrics/jdbi/InstrumentedTimingCollectorTest.java
+++ b/metrics-jdbi/src/test/java/com/codahale/metrics/jdbi/InstrumentedTimingCollectorTest.java
@@ -1,11 +1,13 @@
 package com.codahale.metrics.jdbi;
 
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.jdbi.strategies.NameStrategies;
 import com.codahale.metrics.jdbi.strategies.ShortNameStrategy;
 import com.codahale.metrics.jdbi.strategies.SmartNameStrategy;
 import com.codahale.metrics.jdbi.strategies.StatementNameStrategy;
+
 import org.junit.Test;
 import org.skife.jdbi.v2.StatementContext;
 
@@ -31,7 +33,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(1), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -51,7 +53,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(1), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -70,7 +72,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(2), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -88,7 +90,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(2), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -107,7 +109,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(3), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -129,7 +131,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(3), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -151,7 +153,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(4), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -173,7 +175,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(4), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -196,7 +198,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(5), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -218,7 +220,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(1), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)
@@ -242,7 +244,7 @@ public class InstrumentedTimingCollectorTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(3), ctx);
 
-        final String name = strategy.getStatementName(ctx);
+        final MetricName name = strategy.getStatementName(ctx);
         final Timer timer = registry.timer(name);
 
         assertThat(name)

--- a/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/InstrumentedTimingCollector.java
+++ b/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/InstrumentedTimingCollector.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.jdbi3;
 
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.jdbi3.strategies.SmartNameStrategy;
 import com.codahale.metrics.jdbi3.strategies.StatementNameStrategy;
@@ -29,7 +30,7 @@ public class InstrumentedTimingCollector implements TimingCollector {
 
     @Override
     public void collect(long elapsedTime, StatementContext ctx) {
-        String statementName = statementNameStrategy.getStatementName(ctx);
+        MetricName statementName = statementNameStrategy.getStatementName(ctx);
         if (statementName != null) {
             registry.timer(statementName).update(elapsedTime, TimeUnit.NANOSECONDS);
         }

--- a/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/DefaultNameStrategy.java
+++ b/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/DefaultNameStrategy.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.jdbi3.strategies;
 
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import org.jdbi.v3.core.extension.ExtensionMethod;
 import org.jdbi.v3.core.statement.StatementContext;
@@ -14,9 +15,9 @@ public enum DefaultNameStrategy implements StatementNameStrategy {
      */
     CHECK_EMPTY {
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             final String rawSql = statementContext.getRawSql();
-            return rawSql == null || rawSql.isEmpty() ? "sql.empty" : null;
+            return rawSql == null || rawSql.isEmpty() ? MetricName.build("sql.empty") : null;
         }
     },
 
@@ -27,7 +28,7 @@ public enum DefaultNameStrategy implements StatementNameStrategy {
      */
     SQL_OBJECT {
         @Override
-        public String getStatementName(StatementContext statementContext) {
+        public MetricName getStatementName(StatementContext statementContext) {
             ExtensionMethod extensionMethod = statementContext.getExtensionMethod();
             if (extensionMethod != null) {
                 return MetricRegistry.name(extensionMethod.getType(), extensionMethod.getMethod().getName());
@@ -41,8 +42,8 @@ public enum DefaultNameStrategy implements StatementNameStrategy {
      */
     NAIVE_NAME {
         @Override
-        public String getStatementName(StatementContext statementContext) {
-            return statementContext.getRawSql();
+        public MetricName getStatementName(StatementContext statementContext) {
+            return MetricName.build(statementContext.getRawSql());
         }
     },
 
@@ -51,8 +52,8 @@ public enum DefaultNameStrategy implements StatementNameStrategy {
      */
     CONSTANT_SQL_RAW {
         @Override
-        public String getStatementName(StatementContext statementContext) {
-            return "sql.raw";
+        public MetricName getStatementName(StatementContext statementContext) {
+            return MetricName.build("sql.raw");
         }
     }
 

--- a/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/DelegatingStatementNameStrategy.java
+++ b/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/DelegatingStatementNameStrategy.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.jdbi3.strategies;
 
+import com.codahale.metrics.MetricName;
 import org.jdbi.v3.core.statement.StatementContext;
 
 import java.util.Arrays;
@@ -10,7 +11,7 @@ public abstract class DelegatingStatementNameStrategy implements StatementNameSt
     /**
      * Unknown SQL.
      */
-    private static final String UNKNOWN_SQL = "sql.unknown";
+    private static final MetricName UNKNOWN_SQL = MetricName.build("sql.unknown");
 
     private final List<StatementNameStrategy> strategies;
 
@@ -19,9 +20,9 @@ public abstract class DelegatingStatementNameStrategy implements StatementNameSt
     }
 
     @Override
-    public String getStatementName(StatementContext statementContext) {
+    public MetricName getStatementName(StatementContext statementContext) {
         for (StatementNameStrategy strategy : strategies) {
-            final String statementName = strategy.getStatementName(statementContext);
+            final MetricName statementName = strategy.getStatementName(statementContext);
             if (statementName != null) {
                 return statementName;
             }

--- a/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/StatementNameStrategy.java
+++ b/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/StatementNameStrategy.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.jdbi3.strategies;
 
+import com.codahale.metrics.MetricName;
 import org.jdbi.v3.core.statement.StatementContext;
 
 /**
@@ -8,5 +9,5 @@ import org.jdbi.v3.core.statement.StatementContext;
 @FunctionalInterface
 public interface StatementNameStrategy {
 
-    String getStatementName(StatementContext statementContext);
+    MetricName getStatementName(StatementContext statementContext);
 }

--- a/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/TimedAnnotationNameStrategy.java
+++ b/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/strategies/TimedAnnotationNameStrategy.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.jdbi3.strategies;
 
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.annotation.Timed;
 import org.jdbi.v3.core.extension.ExtensionMethod;
@@ -13,7 +14,7 @@ import java.lang.reflect.Method;
 public class TimedAnnotationNameStrategy implements StatementNameStrategy {
 
     @Override
-    public String getStatementName(StatementContext statementContext) {
+    public MetricName getStatementName(StatementContext statementContext) {
         final ExtensionMethod extensionMethod = statementContext.getExtensionMethod();
         if (extensionMethod == null) {
             return null;
@@ -28,7 +29,7 @@ public class TimedAnnotationNameStrategy implements StatementNameStrategy {
         if (methodTimed != null) {
             String methodName = methodTimed.name().isEmpty() ? method.getName() : methodTimed.name();
             if (methodTimed.absolute()) {
-                return methodName;
+                return MetricName.build(methodName);
             } else {
                 // We need to check if the class has a custom timer name
                 return classTimed == null || classTimed.name().isEmpty() ?

--- a/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/AbstractStrategyTest.java
+++ b/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/AbstractStrategyTest.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.jdbi3.strategies;
 
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.junit.Before;
@@ -17,7 +18,7 @@ public class AbstractStrategyTest {
         when(ctx.getRawSql()).thenReturn("SELECT 1");
     }
 
-    long getTimerMaxValue(String name) {
+    long getTimerMaxValue(MetricName name) {
         return registry.timer(name).getSnapshot().getMax();
     }
 }

--- a/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/BasicSqlNameStrategyTest.java
+++ b/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/BasicSqlNameStrategyTest.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.jdbi3.strategies;
 
+import com.codahale.metrics.MetricName;
 import org.jdbi.v3.core.extension.ExtensionMethod;
 import org.junit.Test;
 
@@ -14,7 +15,7 @@ public class BasicSqlNameStrategyTest extends AbstractStrategyTest {
     @Test
     public void producesMethodNameAsMetric() throws Exception {
         when(ctx.getExtensionMethod()).thenReturn(new ExtensionMethod(getClass(), getClass().getMethod("producesMethodNameAsMetric")));
-        String name = basicSqlNameStrategy.getStatementName(ctx);
+        MetricName name = basicSqlNameStrategy.getStatementName(ctx);
         assertThat(name).isEqualTo(name(getClass(), "producesMethodNameAsMetric"));
     }
 

--- a/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/NaiveNameStrategyTest.java
+++ b/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/NaiveNameStrategyTest.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.jdbi3.strategies;
 
+import com.codahale.metrics.MetricName;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,8 +11,8 @@ public class NaiveNameStrategyTest extends AbstractStrategyTest {
 
     @Test
     public void producesSqlRawMetrics() throws Exception {
-        String name = naiveNameStrategy.getStatementName(ctx);
-        assertThat(name).isEqualToIgnoringCase("SELECT 1");
+        MetricName name = naiveNameStrategy.getStatementName(ctx);
+        assertThat(name.getKey()).isEqualToIgnoringCase("SELECT 1");
     }
 
 }

--- a/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/SmartNameStrategyTest.java
+++ b/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/SmartNameStrategyTest.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.jdbi3.strategies;
 
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.jdbi3.InstrumentedTimingCollector;
 import org.jdbi.v3.core.extension.ExtensionMethod;
 import org.junit.Before;
@@ -30,7 +31,7 @@ public class SmartNameStrategyTest extends AbstractStrategyTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(1), ctx);
 
-        String name = smartNameStrategy.getStatementName(ctx);
+        MetricName name = smartNameStrategy.getStatementName(ctx);
         assertThat(name).isEqualTo(name(getClass(), "updatesTimerForSqlObjects"));
         assertThat(getTimerMaxValue(name)).isEqualTo(1000000000);
     }
@@ -39,7 +40,7 @@ public class SmartNameStrategyTest extends AbstractStrategyTest {
     public void updatesTimerForRawSql() throws Exception {
         collector.collect(TimeUnit.SECONDS.toNanos(2), ctx);
 
-        String name = smartNameStrategy.getStatementName(ctx);
+        MetricName name = smartNameStrategy.getStatementName(ctx);
         assertThat(name).isEqualTo(name("sql", "raw"));
         assertThat(getTimerMaxValue(name)).isEqualTo(2000000000);
     }
@@ -50,7 +51,7 @@ public class SmartNameStrategyTest extends AbstractStrategyTest {
 
         collector.collect(TimeUnit.SECONDS.toNanos(2), ctx);
 
-        String name = smartNameStrategy.getStatementName(ctx);
+        MetricName name = smartNameStrategy.getStatementName(ctx);
         assertThat(name).isEqualTo(name("sql", "empty"));
         assertThat(getTimerMaxValue(name)).isEqualTo(2000000000);
     }
@@ -61,7 +62,7 @@ public class SmartNameStrategyTest extends AbstractStrategyTest {
                 getClass().getMethod("updatesTimerForContextClass")));
         collector.collect(TimeUnit.SECONDS.toNanos(3), ctx);
 
-        String name = smartNameStrategy.getStatementName(ctx);
+        MetricName name = smartNameStrategy.getStatementName(ctx);
         assertThat(name).isEqualTo(name(getClass(), "updatesTimerForContextClass"));
         assertThat(getTimerMaxValue(name)).isEqualTo(3000000000L);
     }

--- a/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/TimedAnnotationNameStrategyTest.java
+++ b/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/strategies/TimedAnnotationNameStrategyTest.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.jdbi3.strategies;
 
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.annotation.Timed;
 import org.jdbi.v3.core.extension.ExtensionMethod;
 import org.junit.Test;
@@ -46,33 +47,33 @@ public class TimedAnnotationNameStrategyTest extends AbstractStrategyTest {
     public void testAnnotationOnMethod() throws Exception {
         when(ctx.getExtensionMethod()).thenReturn(new ExtensionMethod(Foo.class, Foo.class.getMethod("update")));
         assertThat(timedAnnotationNameStrategy.getStatementName(ctx))
-                .isEqualTo("com.codahale.metrics.jdbi3.strategies.TimedAnnotationNameStrategyTest$Foo.update");
+                .isEqualTo(MetricName.build("com.codahale.metrics.jdbi3.strategies.TimedAnnotationNameStrategyTest$Foo.update"));
     }
 
     @Test
     public void testAnnotationOnMethodWithCustomName() throws Exception {
         when(ctx.getExtensionMethod()).thenReturn(new ExtensionMethod(Foo.class, Foo.class.getMethod("customUpdate")));
         assertThat(timedAnnotationNameStrategy.getStatementName(ctx))
-                .isEqualTo("com.codahale.metrics.jdbi3.strategies.TimedAnnotationNameStrategyTest$Foo.custom-update");
+                .isEqualTo(MetricName.build("com.codahale.metrics.jdbi3.strategies.TimedAnnotationNameStrategyTest$Foo.custom-update"));
     }
 
     @Test
     public void testAnnotationOnMethodWithCustomAbsoluteName() throws Exception {
         when(ctx.getExtensionMethod()).thenReturn(new ExtensionMethod(Foo.class, Foo.class.getMethod("absoluteUpdate")));
-        assertThat(timedAnnotationNameStrategy.getStatementName(ctx)).isEqualTo("absolute-update");
+        assertThat(timedAnnotationNameStrategy.getStatementName(ctx)).isEqualTo(MetricName.build("absolute-update"));
     }
 
     @Test
     public void testAnnotationOnClass() throws Exception {
         when(ctx.getExtensionMethod()).thenReturn(new ExtensionMethod(Bar.class, Bar.class.getMethod("update")));
         assertThat(timedAnnotationNameStrategy.getStatementName(ctx))
-                .isEqualTo("com.codahale.metrics.jdbi3.strategies.TimedAnnotationNameStrategyTest$Bar.update");
+                .isEqualTo(MetricName.build("com.codahale.metrics.jdbi3.strategies.TimedAnnotationNameStrategyTest$Bar.update"));
     }
 
     @Test
     public void testAnnotationOnMethodAndClassWithCustomNames() throws Exception {
         when(ctx.getExtensionMethod()).thenReturn(new ExtensionMethod(CustomBar.class, CustomBar.class.getMethod("find", String.class)));
-        assertThat(timedAnnotationNameStrategy.getStatementName(ctx)).isEqualTo("custom-bar.find-by-id");
+        assertThat(timedAnnotationNameStrategy.getStatementName(ctx)).isEqualTo(MetricName.build("custom-bar.find-by-id"));
     }
 
     @Test

--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -2,9 +2,11 @@ package com.codahale.metrics.jetty9;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.RatioGauge;
 import com.codahale.metrics.Timer;
+
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.server.AsyncContextState;
 import org.eclipse.jetty.server.Handler;
@@ -17,6 +19,7 @@ import javax.servlet.AsyncListener;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
@@ -100,38 +103,38 @@ public class InstrumentedHandler extends HandlerWrapper {
     protected void doStart() throws Exception {
         super.doStart();
 
-        final String prefix = this.prefix == null ? name(getHandler().getClass(), name) : name(this.prefix, name);
+        final MetricName prefix = this.prefix == null ? name(getHandler().getClass(), name) : name(this.prefix, name);
 
-        this.requests = metricRegistry.timer(name(prefix, "requests"));
-        this.dispatches = metricRegistry.timer(name(prefix, "dispatches"));
+        this.requests = metricRegistry.timer(prefix.resolve("requests"));
+        this.dispatches = metricRegistry.timer(prefix.resolve("dispatches"));
 
-        this.activeRequests = metricRegistry.counter(name(prefix, "active-requests"));
-        this.activeDispatches = metricRegistry.counter(name(prefix, "active-dispatches"));
-        this.activeSuspended = metricRegistry.counter(name(prefix, "active-suspended"));
+        this.activeRequests = metricRegistry.counter(prefix.resolve("active-requests"));
+        this.activeDispatches = metricRegistry.counter(prefix.resolve("active-dispatches"));
+        this.activeSuspended = metricRegistry.counter(prefix.resolve("active-suspended"));
 
-        this.asyncDispatches = metricRegistry.meter(name(prefix, "async-dispatches"));
-        this.asyncTimeouts = metricRegistry.meter(name(prefix, "async-timeouts"));
+        this.asyncDispatches = metricRegistry.meter(prefix.resolve("async-dispatches"));
+        this.asyncTimeouts = metricRegistry.meter(prefix.resolve("async-timeouts"));
 
         this.responses = new Meter[]{
-                metricRegistry.meter(name(prefix, "1xx-responses")), // 1xx
-                metricRegistry.meter(name(prefix, "2xx-responses")), // 2xx
-                metricRegistry.meter(name(prefix, "3xx-responses")), // 3xx
-                metricRegistry.meter(name(prefix, "4xx-responses")), // 4xx
-                metricRegistry.meter(name(prefix, "5xx-responses"))  // 5xx
+                metricRegistry.meter(prefix.resolve("1xx-responses")), // 1xx
+                metricRegistry.meter(prefix.resolve("2xx-responses")), // 2xx
+                metricRegistry.meter(prefix.resolve("3xx-responses")), // 3xx
+                metricRegistry.meter(prefix.resolve("4xx-responses")), // 4xx
+                metricRegistry.meter(prefix.resolve("5xx-responses"))  // 5xx
         };
 
-        this.getRequests = metricRegistry.timer(name(prefix, "get-requests"));
-        this.postRequests = metricRegistry.timer(name(prefix, "post-requests"));
-        this.headRequests = metricRegistry.timer(name(prefix, "head-requests"));
-        this.putRequests = metricRegistry.timer(name(prefix, "put-requests"));
-        this.deleteRequests = metricRegistry.timer(name(prefix, "delete-requests"));
-        this.optionsRequests = metricRegistry.timer(name(prefix, "options-requests"));
-        this.traceRequests = metricRegistry.timer(name(prefix, "trace-requests"));
-        this.connectRequests = metricRegistry.timer(name(prefix, "connect-requests"));
-        this.moveRequests = metricRegistry.timer(name(prefix, "move-requests"));
-        this.otherRequests = metricRegistry.timer(name(prefix, "other-requests"));
+        this.getRequests = metricRegistry.timer(prefix.resolve("get-requests"));
+        this.postRequests = metricRegistry.timer(prefix.resolve("post-requests"));
+        this.headRequests = metricRegistry.timer(prefix.resolve("head-requests"));
+        this.putRequests = metricRegistry.timer(prefix.resolve("put-requests"));
+        this.deleteRequests = metricRegistry.timer(prefix.resolve("delete-requests"));
+        this.optionsRequests = metricRegistry.timer(prefix.resolve("options-requests"));
+        this.traceRequests = metricRegistry.timer(prefix.resolve("trace-requests"));
+        this.connectRequests = metricRegistry.timer(prefix.resolve("connect-requests"));
+        this.moveRequests = metricRegistry.timer(prefix.resolve("move-requests"));
+        this.otherRequests = metricRegistry.timer(prefix.resolve("other-requests"));
 
-        metricRegistry.register(name(prefix, "percent-4xx-1m"), new RatioGauge() {
+        metricRegistry.register(prefix.resolve("percent-4xx-1m"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[3].getOneMinuteRate(),
@@ -139,7 +142,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             }
         });
 
-        metricRegistry.register(name(prefix, "percent-4xx-5m"), new RatioGauge() {
+        metricRegistry.register(prefix.resolve("percent-4xx-5m"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[3].getFiveMinuteRate(),
@@ -147,7 +150,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             }
         });
 
-        metricRegistry.register(name(prefix, "percent-4xx-15m"), new RatioGauge() {
+        metricRegistry.register(prefix.resolve("percent-4xx-15m"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[3].getFifteenMinuteRate(),
@@ -155,7 +158,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             }
         });
 
-        metricRegistry.register(name(prefix, "percent-5xx-1m"), new RatioGauge() {
+        metricRegistry.register(prefix.resolve("percent-5xx-1m"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[4].getOneMinuteRate(),
@@ -163,7 +166,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             }
         });
 
-        metricRegistry.register(name(prefix, "percent-5xx-5m"), new RatioGauge() {
+        metricRegistry.register(prefix.resolve("percent-5xx-5m"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[4].getFiveMinuteRate(),
@@ -171,7 +174,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             }
         });
 
-        metricRegistry.register(name(prefix, "percent-5xx-15m"), new RatioGauge() {
+        metricRegistry.register(prefix.resolve("percent-5xx-15m"), new RatioGauge() {
             @Override
             public Ratio getRatio() {
                 return Ratio.of(responses[4].getFifteenMinuteRate(),

--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedQueuedThreadPool.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedQueuedThreadPool.java
@@ -1,6 +1,7 @@
 package com.codahale.metrics.jetty9;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.RatioGauge;
 import org.eclipse.jetty.util.annotation.Name;
@@ -67,22 +68,22 @@ public class InstrumentedQueuedThreadPool extends QueuedThreadPool {
     protected void doStart() throws Exception {
         super.doStart();
 
-        final String prefix = this.prefix == null ? name(QueuedThreadPool.class, getName()) : name(this.prefix, getName());
+        final MetricName prefix = this.prefix == null ? name(QueuedThreadPool.class, getName()) : name(this.prefix, getName());
 
-        metricRegistry.register(name(prefix, "utilization"), new RatioGauge() {
+        metricRegistry.register(prefix.resolve("utilization"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(getThreads() - getIdleThreads(), getThreads());
             }
         });
-        metricRegistry.register(name(prefix, "utilization-max"), new RatioGauge() {
+        metricRegistry.register(prefix.resolve("utilization-max"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(getThreads() - getIdleThreads(), getMaxThreads());
             }
         });
-        metricRegistry.register(name(prefix, "size"), (Gauge<Integer>) this::getThreads);
-        metricRegistry.register(name(prefix, "jobs"), (Gauge<Integer>) () -> {
+        metricRegistry.register(prefix.resolve("size"), (Gauge<Integer>) this::getThreads);
+        metricRegistry.register(prefix.resolve("jobs"), (Gauge<Integer>) () -> {
             // This assumes the QueuedThreadPool is using a BlockingArrayQueue or
             // ArrayBlockingQueue for its queue, and is therefore a constant-time operation.
             return getQueue().size();

--- a/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHandlerTest.java
+++ b/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHandlerTest.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.jetty9;
 
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
@@ -61,37 +62,38 @@ public class InstrumentedHandlerTest {
         assertThat(response.getStatus())
             .isEqualTo(404);
 
+        final MetricName prefix = MetricRegistry.name(TestHandler.class, "handler");
+
         assertThat(registry.getNames())
             .containsOnly(
-                MetricRegistry.name(TestHandler.class, "handler.1xx-responses"),
-                MetricRegistry.name(TestHandler.class, "handler.2xx-responses"),
-                MetricRegistry.name(TestHandler.class, "handler.3xx-responses"),
-                MetricRegistry.name(TestHandler.class, "handler.4xx-responses"),
-                MetricRegistry.name(TestHandler.class, "handler.5xx-responses"),
-                MetricRegistry.name(TestHandler.class, "handler.percent-4xx-1m"),
-                MetricRegistry.name(TestHandler.class, "handler.percent-4xx-5m"),
-                MetricRegistry.name(TestHandler.class, "handler.percent-4xx-15m"),
-                MetricRegistry.name(TestHandler.class, "handler.percent-5xx-1m"),
-                MetricRegistry.name(TestHandler.class, "handler.percent-5xx-5m"),
-                MetricRegistry.name(TestHandler.class, "handler.percent-5xx-15m"),
-                MetricRegistry.name(TestHandler.class, "handler.requests"),
-                MetricRegistry.name(TestHandler.class, "handler.active-suspended"),
-                MetricRegistry.name(TestHandler.class, "handler.async-dispatches"),
-                MetricRegistry.name(TestHandler.class, "handler.async-timeouts"),
-                MetricRegistry.name(TestHandler.class, "handler.get-requests"),
-                MetricRegistry.name(TestHandler.class, "handler.put-requests"),
-                MetricRegistry.name(TestHandler.class, "handler.active-dispatches"),
-                MetricRegistry.name(TestHandler.class, "handler.trace-requests"),
-                MetricRegistry.name(TestHandler.class, "handler.other-requests"),
-                MetricRegistry.name(TestHandler.class, "handler.connect-requests"),
-                MetricRegistry.name(TestHandler.class, "handler.dispatches"),
-                MetricRegistry.name(TestHandler.class, "handler.head-requests"),
-                MetricRegistry.name(TestHandler.class, "handler.post-requests"),
-                MetricRegistry.name(TestHandler.class, "handler.options-requests"),
-                MetricRegistry.name(TestHandler.class, "handler.active-requests"),
-                MetricRegistry.name(TestHandler.class, "handler.delete-requests"),
-                MetricRegistry.name(TestHandler.class, "handler.move-requests")
-            );
+                    prefix.resolve("1xx-responses"),
+                    prefix.resolve("2xx-responses"),
+                    prefix.resolve("3xx-responses"),
+                    prefix.resolve("4xx-responses"),
+                    prefix.resolve("5xx-responses"),
+                    prefix.resolve("percent-4xx-1m"),
+                    prefix.resolve("percent-4xx-5m"),
+                    prefix.resolve("percent-4xx-15m"),
+                    prefix.resolve("percent-5xx-1m"),
+                    prefix.resolve("percent-5xx-5m"),
+                    prefix.resolve("percent-5xx-15m"),
+                    prefix.resolve("requests"),
+                    prefix.resolve("active-suspended"),
+                    prefix.resolve("async-dispatches"),
+                    prefix.resolve("async-timeouts"),
+                    prefix.resolve("get-requests"),
+                    prefix.resolve("put-requests"),
+                    prefix.resolve("active-dispatches"),
+                    prefix.resolve("trace-requests"),
+                    prefix.resolve("other-requests"),
+                    prefix.resolve("connect-requests"),
+                    prefix.resolve("dispatches"),
+                    prefix.resolve("head-requests"),
+                    prefix.resolve("post-requests"),
+                    prefix.resolve("options-requests"),
+                    prefix.resolve("active-requests"),
+                    prefix.resolve("delete-requests"),
+                    prefix.resolve("move-requests"));
     }
 
 
@@ -118,14 +120,14 @@ public class InstrumentedHandlerTest {
     }
 
     private void assertResponseTimesValid() {
-        assertThat(registry.getMeters().get(metricName() + ".2xx-responses")
+        assertThat(registry.getMeters().get(metricName().resolve("2xx-responses"))
             .getCount()).isGreaterThan(0L);
 
 
-        assertThat(registry.getTimers().get(metricName() + ".get-requests")
+        assertThat(registry.getTimers().get(metricName().resolve("get-requests"))
             .getSnapshot().getMedian()).isGreaterThan(0.0).isLessThan(TimeUnit.SECONDS.toNanos(1));
 
-        assertThat(registry.getTimers().get(metricName() + ".requests")
+        assertThat(registry.getTimers().get(metricName().resolve("requests"))
             .getSnapshot().getMedian()).isGreaterThan(0.0).isLessThan(TimeUnit.SECONDS.toNanos(1));
     }
 
@@ -133,7 +135,7 @@ public class InstrumentedHandlerTest {
         return "http://localhost:" + connector.getLocalPort() + path;
     }
 
-    private String metricName() {
+    private MetricName metricName() {
         return MetricRegistry.name(TestHandler.class.getName(), "handler");
     }
 

--- a/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedQueuedThreadPoolTest.java
+++ b/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedQueuedThreadPoolTest.java
@@ -1,6 +1,7 @@
 package com.codahale.metrics.jetty9;
 
 import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricRegistry;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.After;
@@ -18,7 +19,7 @@ public class InstrumentedQueuedThreadPoolTest {
 
     private final MetricRegistry metricRegistry = mock(MetricRegistry.class);
     private final InstrumentedQueuedThreadPool iqtp = new InstrumentedQueuedThreadPool(metricRegistry);
-    private final ArgumentCaptor<String> metricNameCaptor = ArgumentCaptor.forClass(String.class);
+    private final ArgumentCaptor<MetricName> metricNameCaptor = ArgumentCaptor.forClass(MetricName.class);
 
     @After
     public void tearDown() throws Exception {
@@ -31,8 +32,8 @@ public class InstrumentedQueuedThreadPoolTest {
         iqtp.doStart();
 
         verify(metricRegistry, atLeastOnce()).register(metricNameCaptor.capture(), any(Metric.class));
-        String metricName = metricNameCaptor.getValue();
-        assertThat(metricName)
+        MetricName metricName = metricNameCaptor.getValue();
+        assertThat(metricName.getKey())
                 .overridingErrorMessage("Custom metric's prefix doesn't match")
                 .startsWith(PREFIX);
 
@@ -43,8 +44,8 @@ public class InstrumentedQueuedThreadPoolTest {
         iqtp.doStart();
 
         verify(metricRegistry, atLeastOnce()).register(metricNameCaptor.capture(), any(Metric.class));
-        String metricName = metricNameCaptor.getValue();
-        assertThat(metricName)
+        MetricName metricName = metricNameCaptor.getValue();
+        assertThat(metricName.getKey())
                 .overridingErrorMessage("The default metrics prefix was changed")
                 .startsWith(QueuedThreadPool.class.getName());
     }

--- a/metrics-jmx/src/main/java/com/codahale/metrics/jmx/DefaultObjectNameFactory.java
+++ b/metrics-jmx/src/main/java/com/codahale/metrics/jmx/DefaultObjectNameFactory.java
@@ -3,6 +3,7 @@ package com.codahale.metrics.jmx;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
+import com.codahale.metrics.MetricName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,16 +12,16 @@ public class DefaultObjectNameFactory implements ObjectNameFactory {
     private static final Logger LOGGER = LoggerFactory.getLogger(JmxReporter.class);
 
     @Override
-    public ObjectName createName(String type, String domain, String name) {
+    public ObjectName createName(String type, String domain, MetricName name) {
         try {
-            ObjectName objectName = new ObjectName(domain, "name", name);
+            ObjectName objectName = new ObjectName(domain, "name", name.getKey());
             if (objectName.isPattern()) {
-                objectName = new ObjectName(domain, "name", ObjectName.quote(name));
+                objectName = new ObjectName(domain, "name", ObjectName.quote(name.getKey()));
             }
             return objectName;
         } catch (MalformedObjectNameException e) {
             try {
-                return new ObjectName(domain, "name", ObjectName.quote(name));
+                return new ObjectName(domain, "name", ObjectName.quote(name.getKey()));
             } catch (MalformedObjectNameException e1) {
                 LOGGER.warn("Unable to register {} {}", type, name, e1);
                 throw new RuntimeException(e1);

--- a/metrics-jmx/src/main/java/com/codahale/metrics/jmx/JmxReporter.java
+++ b/metrics-jmx/src/main/java/com/codahale/metrics/jmx/JmxReporter.java
@@ -1,15 +1,6 @@
 package com.codahale.metrics.jmx;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.Metered;
-import com.codahale.metrics.MetricFilter;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.MetricRegistryListener;
-import com.codahale.metrics.Reporter;
-import com.codahale.metrics.Timer;
+import com.codahale.metrics.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -533,7 +524,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onGaugeAdded(String name, Gauge<?> gauge) {
+        public void onGaugeAdded(MetricName name, Gauge<?> gauge) {
             try {
                 if (filter.matches(name, gauge)) {
                     final ObjectName objectName = createName("gauges", name);
@@ -547,7 +538,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onGaugeRemoved(String name) {
+        public void onGaugeRemoved(MetricName name) {
             try {
                 final ObjectName objectName = createName("gauges", name);
                 unregisterMBean(objectName);
@@ -559,7 +550,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onCounterAdded(String name, Counter counter) {
+        public void onCounterAdded(MetricName name, Counter counter) {
             try {
                 if (filter.matches(name, counter)) {
                     final ObjectName objectName = createName("counters", name);
@@ -573,7 +564,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onCounterRemoved(String name) {
+        public void onCounterRemoved(MetricName name) {
             try {
                 final ObjectName objectName = createName("counters", name);
                 unregisterMBean(objectName);
@@ -585,7 +576,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onHistogramAdded(String name, Histogram histogram) {
+        public void onHistogramAdded(MetricName name, Histogram histogram) {
             try {
                 if (filter.matches(name, histogram)) {
                     final ObjectName objectName = createName("histograms", name);
@@ -599,7 +590,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onHistogramRemoved(String name) {
+        public void onHistogramRemoved(MetricName name) {
             try {
                 final ObjectName objectName = createName("histograms", name);
                 unregisterMBean(objectName);
@@ -611,11 +602,11 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onMeterAdded(String name, Meter meter) {
+        public void onMeterAdded(MetricName name, Meter meter) {
             try {
                 if (filter.matches(name, meter)) {
                     final ObjectName objectName = createName("meters", name);
-                    registerMBean(new JmxMeter(meter, objectName, timeUnits.rateFor(name)), objectName);
+                    registerMBean(new JmxMeter(meter, objectName, timeUnits.rateFor(name.getKey())), objectName);
                 }
             } catch (InstanceAlreadyExistsException e) {
                 LOGGER.debug("Unable to register meter", e);
@@ -625,7 +616,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onMeterRemoved(String name) {
+        public void onMeterRemoved(MetricName name) {
             try {
                 final ObjectName objectName = createName("meters", name);
                 unregisterMBean(objectName);
@@ -637,11 +628,11 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onTimerAdded(String name, Timer timer) {
+        public void onTimerAdded(MetricName name, Timer timer) {
             try {
                 if (filter.matches(name, timer)) {
                     final ObjectName objectName = createName("timers", name);
-                    registerMBean(new JmxTimer(timer, objectName, timeUnits.rateFor(name), timeUnits.durationFor(name)), objectName);
+                    registerMBean(new JmxTimer(timer, objectName, timeUnits.rateFor(name.getKey()), timeUnits.durationFor(name.getKey())), objectName);
                 }
             } catch (InstanceAlreadyExistsException e) {
                 LOGGER.debug("Unable to register timer", e);
@@ -651,7 +642,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onTimerRemoved(String name) {
+        public void onTimerRemoved(MetricName name) {
             try {
                 final ObjectName objectName = createName("timers", name);
                 unregisterMBean(objectName);
@@ -662,7 +653,7 @@ public class JmxReporter implements Reporter, Closeable {
             }
         }
 
-        private ObjectName createName(String type, String name) {
+        private ObjectName createName(String type, MetricName name) {
             return objectNameFactory.createName(type, this.name, name);
         }
 

--- a/metrics-jmx/src/main/java/com/codahale/metrics/jmx/ObjectNameFactory.java
+++ b/metrics-jmx/src/main/java/com/codahale/metrics/jmx/ObjectNameFactory.java
@@ -1,8 +1,10 @@
 package com.codahale.metrics.jmx;
 
+import com.codahale.metrics.MetricName;
+
 import javax.management.ObjectName;
 
 public interface ObjectNameFactory {
 
-    ObjectName createName(String type, String domain, String name);
+    ObjectName createName(String type, String domain, MetricName name);
 }

--- a/metrics-jmx/src/test/java/com/codahale/metrics/jmx/DefaultObjectNameFactoryTest.java
+++ b/metrics-jmx/src/test/java/com/codahale/metrics/jmx/DefaultObjectNameFactoryTest.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.jmx;
 
+import com.codahale.metrics.MetricName;
 import org.junit.Test;
 
 import javax.management.ObjectName;
@@ -11,14 +12,14 @@ public class DefaultObjectNameFactoryTest {
     @Test
     public void createsObjectNameWithDomainInInput() {
         DefaultObjectNameFactory f = new DefaultObjectNameFactory();
-        ObjectName on = f.createName("type", "com.domain", "something.with.dots");
+        ObjectName on = f.createName("type", "com.domain", MetricName.build("something.with.dots"));
         assertThat(on.getDomain()).isEqualTo("com.domain");
     }
 
     @Test
     public void createsObjectNameWithNameAsKeyPropertyName() {
         DefaultObjectNameFactory f = new DefaultObjectNameFactory();
-        ObjectName on = f.createName("type", "com.domain", "something.with.dots");
+        ObjectName on = f.createName("type", "com.domain", MetricName.build("something.with.dots"));
         assertThat(on.getKeyProperty("name")).isEqualTo("something.with.dots");
     }
 }

--- a/metrics-jmx/src/test/java/com/codahale/metrics/jmx/JmxReporterTest.java
+++ b/metrics-jmx/src/test/java/com/codahale/metrics/jmx/JmxReporterTest.java
@@ -1,13 +1,6 @@
 package com.codahale.metrics.jmx;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricFilter;
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.Snapshot;
-import com.codahale.metrics.Timer;
+import com.codahale.metrics.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -125,7 +118,7 @@ public class JmxReporterTest {
         ObjectName n = new ObjectName(name + ":name=dummy");
         try {
             String widgetName = "something";
-            when(mockObjectNameFactory.createName(any(String.class), any(String.class), any(String.class))).thenReturn(n);
+            when(mockObjectNameFactory.createName(any(String.class), any(String.class), any(MetricName.class))).thenReturn(n);
             Gauge aGauge = mock(Gauge.class);
             when(aGauge.getValue()).thenReturn(1);
 
@@ -136,7 +129,7 @@ public class JmxReporterTest {
                     .build();
             registry.register(widgetName, aGauge);
             reporter.start();
-            verify(mockObjectNameFactory).createName(eq("gauges"), any(String.class), eq("something"));
+            verify(mockObjectNameFactory).createName(eq("gauges"), any(String.class), eq(MetricName.build("something")));
             //verifyNoMoreInteractions(mockObjectNameFactory);
         } finally {
             reporter.stop();
@@ -298,7 +291,7 @@ public class JmxReporterTest {
     }
 
     private AttributeList getAttributes(String name, String... attributeNames) throws JMException {
-        ObjectName n = concreteObjectNameFactory.createName("only-for-logging-error", this.name, name);
+        ObjectName n = concreteObjectNameFactory.createName("only-for-logging-error", this.name, MetricName.build(name));
         return mBeanServer.getAttributes(n, attributeNames);
     }
 

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/BufferPoolMetricSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/BufferPoolMetricSet.java
@@ -2,6 +2,8 @@ package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricSet;
+import com.codahale.metrics.MetricName;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,8 +34,8 @@ public class BufferPoolMetricSet implements MetricSet {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        final Map<String, Metric> gauges = new HashMap<>();
+    public Map<MetricName, Metric> getMetrics() {
+        final Map<MetricName, Metric> gauges = new HashMap<>();
         for (String pool : POOLS) {
             for (int i = 0; i < ATTRIBUTES.length; i++) {
                 final String attribute = ATTRIBUTES[i];

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ClassLoadingGaugeSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ClassLoadingGaugeSet.java
@@ -2,6 +2,7 @@ package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricSet;
 
 import java.lang.management.ClassLoadingMXBean;
@@ -25,10 +26,10 @@ public class ClassLoadingGaugeSet implements MetricSet {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        final Map<String, Metric> gauges = new HashMap<>();
-        gauges.put("loaded", (Gauge<Long>) mxBean::getTotalLoadedClassCount);
-        gauges.put("unloaded", (Gauge<Long>) mxBean::getUnloadedClassCount);
+    public Map<MetricName, Metric> getMetrics() {
+        final Map<MetricName, Metric> gauges = new HashMap<>();
+        gauges.put(MetricName.build("loaded"), (Gauge<Long>) mxBean::getTotalLoadedClassCount);
+        gauges.put(MetricName.build("unloaded"), (Gauge<Long>) mxBean::getUnloadedClassCount);
 
         return gauges;
     }

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/GarbageCollectorMetricSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/GarbageCollectorMetricSet.java
@@ -2,6 +2,7 @@ package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricSet;
 
 import java.lang.management.GarbageCollectorMXBean;
@@ -41,8 +42,8 @@ public class GarbageCollectorMetricSet implements MetricSet {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        final Map<String, Metric> gauges = new HashMap<>();
+    public Map<MetricName, Metric> getMetrics() {
+        final Map<MetricName, Metric> gauges = new HashMap<>();
         for (final GarbageCollectorMXBean gc : garbageCollectors) {
             final String name = WHITESPACE.matcher(gc.getName()).replaceAll("-");
             gauges.put(name(name, "count"), (Gauge<Long>) gc::getCollectionCount);

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/JvmAttributeGaugeSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/JvmAttributeGaugeSet.java
@@ -2,6 +2,7 @@ package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricSet;
 
 import java.lang.management.ManagementFactory;
@@ -34,17 +35,17 @@ public class JvmAttributeGaugeSet implements MetricSet {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        final Map<String, Metric> gauges = new HashMap<>();
+    public Map<MetricName, Metric> getMetrics() {
+        final Map<MetricName, Metric> gauges = new HashMap<>();
 
-        gauges.put("name", (Gauge<String>) runtime::getName);
-        gauges.put("vendor", (Gauge<String>) () -> String.format(Locale.US,
+        gauges.put(MetricName.build("name"), (Gauge<String>) runtime::getName);
+        gauges.put(MetricName.build("vendor"), (Gauge<String>) () -> String.format(Locale.US,
                 "%s %s %s (%s)",
                 runtime.getVmVendor(),
                 runtime.getVmName(),
                 runtime.getVmVersion(),
                 runtime.getSpecVersion()));
-        gauges.put("uptime", (Gauge<Long>) runtime::getUptime);
+        gauges.put(MetricName.build("uptime"), (Gauge<Long>) runtime::getUptime);
 
         return Collections.unmodifiableMap(gauges);
     }

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/MemoryUsageGaugeSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/MemoryUsageGaugeSet.java
@@ -2,6 +2,7 @@ package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricSet;
 import com.codahale.metrics.RatioGauge;
 
@@ -40,23 +41,23 @@ public class MemoryUsageGaugeSet implements MetricSet {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        final Map<String, Metric> gauges = new HashMap<>();
+    public Map<MetricName, Metric> getMetrics() {
+        final Map<MetricName, Metric> gauges = new HashMap<>();
 
-        gauges.put("total.init", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getInit() +
+        gauges.put(MetricName.build("total.init"), (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getInit() +
                 mxBean.getNonHeapMemoryUsage().getInit());
-        gauges.put("total.used", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getUsed() +
+        gauges.put(MetricName.build("total.used"), (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getUsed() +
                 mxBean.getNonHeapMemoryUsage().getUsed());
-        gauges.put("total.max", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getMax() +
+        gauges.put(MetricName.build("total.max"), (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getMax() +
                 mxBean.getNonHeapMemoryUsage().getMax());
-        gauges.put("total.committed", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getCommitted() +
+        gauges.put(MetricName.build("total.committed"), (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getCommitted() +
                 mxBean.getNonHeapMemoryUsage().getCommitted());
 
-        gauges.put("heap.init", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getInit());
-        gauges.put("heap.used", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getUsed());
-        gauges.put("heap.max", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getMax());
-        gauges.put("heap.committed", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getCommitted());
-        gauges.put("heap.usage", new RatioGauge() {
+        gauges.put(MetricName.build("heap.init"), (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getInit());
+        gauges.put(MetricName.build("heap.used"), (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getUsed());
+        gauges.put(MetricName.build("heap.max"), (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getMax());
+        gauges.put(MetricName.build("heap.committed"), (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getCommitted());
+        gauges.put(MetricName.build("heap.usage"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 final MemoryUsage usage = mxBean.getHeapMemoryUsage();
@@ -64,11 +65,11 @@ public class MemoryUsageGaugeSet implements MetricSet {
             }
         });
 
-        gauges.put("non-heap.init", (Gauge<Long>) () -> mxBean.getNonHeapMemoryUsage().getInit());
-        gauges.put("non-heap.used", (Gauge<Long>) () -> mxBean.getNonHeapMemoryUsage().getUsed());
-        gauges.put("non-heap.max", (Gauge<Long>) () -> mxBean.getNonHeapMemoryUsage().getMax());
-        gauges.put("non-heap.committed", (Gauge<Long>) () -> mxBean.getNonHeapMemoryUsage().getCommitted());
-        gauges.put("non-heap.usage", new RatioGauge() {
+        gauges.put(MetricName.build("non-heap.init"), (Gauge<Long>) () -> mxBean.getNonHeapMemoryUsage().getInit());
+        gauges.put(MetricName.build("non-heap.used"), (Gauge<Long>) () -> mxBean.getNonHeapMemoryUsage().getUsed());
+        gauges.put(MetricName.build("non-heap.max"), (Gauge<Long>) () -> mxBean.getNonHeapMemoryUsage().getMax());
+        gauges.put(MetricName.build("non-heap.committed"), (Gauge<Long>) () -> mxBean.getNonHeapMemoryUsage().getCommitted());
+        gauges.put(MetricName.build("non-heap.usage"), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 final MemoryUsage usage = mxBean.getNonHeapMemoryUsage();
@@ -77,7 +78,7 @@ public class MemoryUsageGaugeSet implements MetricSet {
         });
 
         for (final MemoryPoolMXBean pool : memoryPools) {
-            final String poolName = name("pools", WHITESPACE.matcher(pool.getName()).replaceAll("-"));
+            final String poolName = "pools." + WHITESPACE.matcher(pool.getName()).replaceAll("-");
 
             gauges.put(name(poolName, "usage"), new RatioGauge() {
                 @Override

--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ThreadStatesGaugeSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ThreadStatesGaugeSet.java
@@ -2,6 +2,7 @@ package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricName;
 import com.codahale.metrics.MetricSet;
 
 import java.lang.management.ManagementFactory;
@@ -45,18 +46,18 @@ public class ThreadStatesGaugeSet implements MetricSet {
     }
 
     @Override
-    public Map<String, Metric> getMetrics() {
-        final Map<String, Metric> gauges = new HashMap<>();
+    public Map<MetricName, Metric> getMetrics() {
+        final Map<MetricName, Metric> gauges = new HashMap<>();
 
         for (final Thread.State state : Thread.State.values()) {
             gauges.put(name(state.toString().toLowerCase(), "count"),
                     (Gauge<Object>) () -> getThreadCount(state));
         }
 
-        gauges.put("count", (Gauge<Integer>) threads::getThreadCount);
-        gauges.put("daemon.count", (Gauge<Integer>) threads::getDaemonThreadCount);
-        gauges.put("deadlock.count", (Gauge<Integer>) () -> deadlockDetector.getDeadlockedThreads().size());
-        gauges.put("deadlocks", (Gauge<Set<String>>) deadlockDetector::getDeadlockedThreads);
+        gauges.put(MetricName.build("count"), (Gauge<Integer>) threads::getThreadCount);
+        gauges.put(MetricName.build("daemon.count"), (Gauge<Integer>) threads::getDaemonThreadCount);
+        gauges.put(MetricName.build("deadlock.count"), (Gauge<Integer>) () -> deadlockDetector.getDeadlockedThreads().size());
+        gauges.put(MetricName.build("deadlocks"), (Gauge<Set<String>>) deadlockDetector::getDeadlockedThreads);
 
         return Collections.unmodifiableMap(gauges);
     }

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/BufferPoolMetricSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/BufferPoolMetricSetTest.java
@@ -1,6 +1,8 @@
 package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricName;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -14,6 +16,16 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("rawtypes")
 public class BufferPoolMetricSetTest {
+
+    private static final MetricName DIRECT = MetricName.build("direct");
+    private static final MetricName MAPPED = MetricName.build("mapped");
+    private static final MetricName DIRECT_COUNT = DIRECT.resolve("count");
+    private static final MetricName DIRECT_CAPACITY = DIRECT.resolve("capacity");
+    private static final MetricName DIRECT_USED = DIRECT.resolve("used");
+    private static final MetricName MAPPED_COUNT = MAPPED.resolve("count");
+    private static final MetricName MAPPED_CAPACITY = MAPPED.resolve("capacity");
+    private static final MetricName MAPPED_USED = MAPPED.resolve("used");
+
     private final MBeanServer mBeanServer = mock(MBeanServer.class);
     private final BufferPoolMetricSet buffers = new BufferPoolMetricSet(mBeanServer);
 
@@ -30,12 +42,12 @@ public class BufferPoolMetricSetTest {
     @Test
     public void includesGaugesForDirectAndMappedPools() {
         assertThat(buffers.getMetrics().keySet())
-                .containsOnly("direct.count",
-                        "mapped.used",
-                        "mapped.capacity",
-                        "direct.capacity",
-                        "mapped.count",
-                        "direct.used");
+                .containsOnly(DIRECT_COUNT,
+                        DIRECT_USED,
+                        DIRECT_CAPACITY,
+                        MAPPED_COUNT,
+                        MAPPED_USED,
+                        MAPPED_CAPACITY);
     }
 
     @Test
@@ -43,14 +55,14 @@ public class BufferPoolMetricSetTest {
         when(mBeanServer.getMBeanInfo(mapped)).thenThrow(new InstanceNotFoundException());
 
         assertThat(buffers.getMetrics().keySet())
-                .containsOnly("direct.count",
-                        "direct.capacity",
-                        "direct.used");
+                .containsOnly(DIRECT_COUNT,
+                        DIRECT_USED,
+                        DIRECT_CAPACITY);
     }
 
     @Test
     public void includesAGaugeForDirectCount() throws Exception {
-        final Gauge gauge = (Gauge) buffers.getMetrics().get("direct.count");
+        final Gauge gauge = (Gauge) buffers.getMetrics().get(DIRECT_COUNT);
 
         when(mBeanServer.getAttribute(direct, "Count")).thenReturn(100);
 
@@ -60,7 +72,7 @@ public class BufferPoolMetricSetTest {
 
     @Test
     public void includesAGaugeForDirectMemoryUsed() throws Exception {
-        final Gauge gauge = (Gauge) buffers.getMetrics().get("direct.used");
+        final Gauge gauge = (Gauge) buffers.getMetrics().get(DIRECT_USED);
 
         when(mBeanServer.getAttribute(direct, "MemoryUsed")).thenReturn(100);
 
@@ -70,7 +82,7 @@ public class BufferPoolMetricSetTest {
 
     @Test
     public void includesAGaugeForDirectCapacity() throws Exception {
-        final Gauge gauge = (Gauge) buffers.getMetrics().get("direct.capacity");
+        final Gauge gauge = (Gauge) buffers.getMetrics().get(DIRECT_CAPACITY);
 
         when(mBeanServer.getAttribute(direct, "TotalCapacity")).thenReturn(100);
 
@@ -80,7 +92,7 @@ public class BufferPoolMetricSetTest {
 
     @Test
     public void includesAGaugeForMappedCount() throws Exception {
-        final Gauge gauge = (Gauge) buffers.getMetrics().get("mapped.count");
+        final Gauge gauge = (Gauge) buffers.getMetrics().get(MAPPED_COUNT);
 
         when(mBeanServer.getAttribute(mapped, "Count")).thenReturn(100);
 
@@ -90,7 +102,7 @@ public class BufferPoolMetricSetTest {
 
     @Test
     public void includesAGaugeForMappedMemoryUsed() throws Exception {
-        final Gauge gauge = (Gauge) buffers.getMetrics().get("mapped.used");
+        final Gauge gauge = (Gauge) buffers.getMetrics().get(MAPPED_USED);
 
         when(mBeanServer.getAttribute(mapped, "MemoryUsed")).thenReturn(100);
 
@@ -100,7 +112,7 @@ public class BufferPoolMetricSetTest {
 
     @Test
     public void includesAGaugeForMappedCapacity() throws Exception {
-        final Gauge gauge = (Gauge) buffers.getMetrics().get("mapped.capacity");
+        final Gauge gauge = (Gauge) buffers.getMetrics().get(MAPPED_CAPACITY);
 
         when(mBeanServer.getAttribute(mapped, "TotalCapacity")).thenReturn(100);
 

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ClassLoadingGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ClassLoadingGaugeSetTest.java
@@ -1,6 +1,8 @@
 package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricName;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -24,13 +26,13 @@ public class ClassLoadingGaugeSetTest {
 
     @Test
     public void loadedGauge() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("loaded");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(MetricName.build("loaded"));
         assertThat(gauge.getValue()).isEqualTo(2L);
     }
 
     @Test
     public void unLoadedGauge() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("unloaded");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(MetricName.build("unloaded"));
         assertThat(gauge.getValue()).isEqualTo(1L);
     }
 

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/GarbageCollectorMetricSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/GarbageCollectorMetricSetTest.java
@@ -1,6 +1,8 @@
 package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricName;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -16,6 +18,9 @@ public class GarbageCollectorMetricSetTest {
     private final GarbageCollectorMXBean gc = mock(GarbageCollectorMXBean.class);
     private final GarbageCollectorMetricSet metrics = new GarbageCollectorMetricSet(Collections.singletonList(gc));
 
+    private static final MetricName PS_OLDGEN_TIME = MetricName.build("PS-OldGen.time");
+    private static final MetricName PS_OLDGEN_COUNT = MetricName.build("PS-OldGen.count");
+
     @Before
     public void setUp() {
         when(gc.getName()).thenReturn("PS OldGen");
@@ -26,19 +31,19 @@ public class GarbageCollectorMetricSetTest {
     @Test
     public void hasGaugesForGcCountsAndElapsedTimes() {
         assertThat(metrics.getMetrics().keySet())
-                .containsOnly("PS-OldGen.time", "PS-OldGen.count");
+                .containsOnly(PS_OLDGEN_TIME, PS_OLDGEN_COUNT);
     }
 
     @Test
     public void hasAGaugeForGcCounts() {
-        final Gauge<Long> gauge = (Gauge<Long>) metrics.getMetrics().get("PS-OldGen.count");
+        final Gauge<Long> gauge = (Gauge<Long>) metrics.getMetrics().get(PS_OLDGEN_COUNT);
         assertThat(gauge.getValue())
                 .isEqualTo(1L);
     }
 
     @Test
     public void hasAGaugeForGcTimes() {
-        final Gauge<Long> gauge = (Gauge<Long>) metrics.getMetrics().get("PS-OldGen.time");
+        final Gauge<Long> gauge = (Gauge<Long>) metrics.getMetrics().get(PS_OLDGEN_TIME);
         assertThat(gauge.getValue())
                 .isEqualTo(2L);
     }

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/JvmAttributeGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/JvmAttributeGaugeSetTest.java
@@ -1,6 +1,7 @@
 package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricName;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,12 +30,14 @@ public class JvmAttributeGaugeSetTest {
     @Test
     public void hasASetOfGauges() {
         assertThat(gauges.getMetrics().keySet())
-                .containsOnly("vendor", "name", "uptime");
+                .containsOnly(MetricName.build("vendor"),
+                        MetricName.build("name"),
+                        MetricName.build("uptime"));
     }
 
     @Test
     public void hasAGaugeForTheJVMName() {
-        final Gauge<String> gauge = (Gauge<String>) gauges.getMetrics().get("name");
+        final Gauge<String> gauge = (Gauge<String>) gauges.getMetrics().get(MetricName.build("name"));
 
         assertThat(gauge.getValue())
                 .isEqualTo("9928@example.com");
@@ -42,7 +45,7 @@ public class JvmAttributeGaugeSetTest {
 
     @Test
     public void hasAGaugeForTheJVMVendor() {
-        final Gauge<String> gauge = (Gauge<String>) gauges.getMetrics().get("vendor");
+        final Gauge<String> gauge = (Gauge<String>) gauges.getMetrics().get(MetricName.build("vendor"));
 
         assertThat(gauge.getValue())
                 .isEqualTo("Oracle Corporation Java HotSpot(TM) 64-Bit Server VM 23.7-b01 (1.7)");
@@ -50,7 +53,7 @@ public class JvmAttributeGaugeSetTest {
 
     @Test
     public void hasAGaugeForTheJVMUptime() {
-        final Gauge<Long> gauge = (Gauge<Long>) gauges.getMetrics().get("uptime");
+        final Gauge<Long> gauge = (Gauge<Long>) gauges.getMetrics().get(MetricName.build("uptime"));
 
         assertThat(gauge.getValue())
                 .isEqualTo(100L);
@@ -58,7 +61,7 @@ public class JvmAttributeGaugeSetTest {
 
     @Test
     public void autoDiscoversTheRuntimeBean() {
-        final Gauge<Long> gauge = (Gauge<Long>) new JvmAttributeGaugeSet().getMetrics().get("uptime");
+        final Gauge<Long> gauge = (Gauge<Long>) new JvmAttributeGaugeSet().getMetrics().get(MetricName.build("uptime"));
 
         assertThat(gauge.getValue()).isPositive();
     }

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/MemoryUsageGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/MemoryUsageGaugeSetTest.java
@@ -1,6 +1,8 @@
 package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricName;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,6 +29,37 @@ public class MemoryUsageGaugeSetTest {
     private final MemoryUsageGaugeSet gauges = new MemoryUsageGaugeSet(mxBean,
             Arrays.asList(memoryPool,
                     weirdMemoryPool));
+
+    private static final MetricName TOTAL = MetricName.build("total");
+    private static final MetricName HEAP = MetricName.build("heap");
+    private static final MetricName NON_HEAP = MetricName.build("non-heap");
+    private static final MetricName POOLS = MetricName.build("pools");
+
+    private static final MetricName TOTAL_MAX = TOTAL.resolve("max");
+    private static final MetricName TOTAL_INIT = TOTAL.resolve("init");
+    private static final MetricName TOTAL_USED = TOTAL.resolve("used");
+    private static final MetricName TOTAL_COMMITTED = TOTAL.resolve("committed");
+    private static final MetricName POOLS_BIG_POOL_USAGE = POOLS.resolve("Big-Pool.usage");
+    private static final MetricName POOLS_BIG_POOL_USED = POOLS.resolve("Big-Pool.used");
+    private static final MetricName POOLS_BIG_POOL_INIT = POOLS.resolve("Big-Pool.init");
+    private static final MetricName POOLS_BIG_POOL_COMMITED = POOLS.resolve("Big-Pool.committed");
+    private static final MetricName POOLS_BIG_POOL_MAX = POOLS.resolve("Big-Pool.max");
+    private static final MetricName POOLS_WEIRD_POOL_USAGE = POOLS.resolve("Weird-Pool.usage");
+    private static final MetricName POOLS_WEIRD_POOL_INIT = POOLS.resolve("Weird-Pool.init");
+    private static final MetricName POOLS_WEIRD_POOL_MAX = POOLS.resolve("Weird-Pool.max");
+    private static final MetricName POOLS_WEIRD_POOL_USED = POOLS.resolve("Weird-Pool.used");
+    private static final MetricName POOLS_WEIRD_POOL_USED_AFTER_GC = POOLS.resolve("Weird-Pool.used-after-gc");
+    private static final MetricName POOLS_WEIRD_POOL_COMMITTED = POOLS.resolve("Weird-Pool.committed");
+    private static final MetricName HEAP_INIT = HEAP.resolve("init");
+    private static final MetricName HEAP_COMMITTED = HEAP.resolve("committed");
+    private static final MetricName HEAP_USAGE = HEAP.resolve("usage");
+    private static final MetricName HEAP_USED = HEAP.resolve("used");
+    private static final MetricName HEAP_MAX = HEAP.resolve("max");
+    private static final MetricName NON_HEAP_USAGE = NON_HEAP.resolve("usage");
+    private static final MetricName NON_HEAP_MAX = NON_HEAP.resolve("max");
+    private static final MetricName NON_HEAP_USED = NON_HEAP.resolve("used");
+    private static final MetricName NON_HEAP_INIT = NON_HEAP.resolve("init");
+    private static final MetricName NON_HEAP_COMMITTED = NON_HEAP.resolve("committed");
 
     @Before
     public void setUp() {
@@ -70,37 +103,37 @@ public class MemoryUsageGaugeSetTest {
     public void hasASetOfGauges() {
         assertThat(gauges.getMetrics().keySet())
                 .containsOnly(
-                        "heap.init",
-                        "heap.committed",
-                        "heap.used",
-                        "heap.usage",
-                        "heap.max",
-                        "non-heap.init",
-                        "non-heap.committed",
-                        "non-heap.used",
-                        "non-heap.usage",
-                        "non-heap.max",
-                        "total.init",
-                        "total.committed",
-                        "total.used",
-                        "total.max",
-                        "pools.Big-Pool.init",
-                        "pools.Big-Pool.committed",
-                        "pools.Big-Pool.used",
-                        "pools.Big-Pool.usage",
-                        "pools.Big-Pool.max",
+                        TOTAL_MAX,
+                        TOTAL_INIT,
+                        TOTAL_USED,
+                        TOTAL_COMMITTED,
+                        HEAP_INIT,
+                        HEAP_COMMITTED,
+                        HEAP_USAGE,
+                        HEAP_USED,
+                        HEAP_MAX,
+                        NON_HEAP_USAGE,
+                        NON_HEAP_MAX,
+                        NON_HEAP_USED,
+                        NON_HEAP_INIT,
+                        NON_HEAP_COMMITTED,
+                        POOLS_BIG_POOL_INIT,
+                        POOLS_BIG_POOL_COMMITED,
+                        POOLS_BIG_POOL_USED,
+                        POOLS_BIG_POOL_USAGE,
+                        POOLS_BIG_POOL_MAX,
                         // skip in non-collected pools - "pools.Big-Pool.used-after-gc",
-                        "pools.Weird-Pool.init",
-                        "pools.Weird-Pool.committed",
-                        "pools.Weird-Pool.used",
-                        "pools.Weird-Pool.used-after-gc",
-                        "pools.Weird-Pool.usage",
-                        "pools.Weird-Pool.max");
+                        POOLS_WEIRD_POOL_USAGE,
+                        POOLS_WEIRD_POOL_USED,
+                        POOLS_WEIRD_POOL_INIT,
+                        POOLS_WEIRD_POOL_MAX,
+                        POOLS_WEIRD_POOL_COMMITTED,
+                        POOLS_WEIRD_POOL_USED_AFTER_GC);
     }
 
     @Test
     public void hasAGaugeForTotalCommitted() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("total.committed");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(TOTAL_COMMITTED);
 
         assertThat(gauge.getValue())
                 .isEqualTo(11L);
@@ -108,7 +141,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForTotalInit() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("total.init");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(TOTAL_INIT);
 
         assertThat(gauge.getValue())
                 .isEqualTo(22L);
@@ -116,7 +149,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForTotalUsed() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("total.used");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(TOTAL_USED);
 
         assertThat(gauge.getValue())
                 .isEqualTo(33L);
@@ -124,7 +157,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForTotalMax() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("total.max");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(TOTAL_MAX);
 
         assertThat(gauge.getValue())
                 .isEqualTo(44L);
@@ -132,7 +165,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForHeapCommitted() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.committed");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(HEAP_COMMITTED);
 
         assertThat(gauge.getValue())
                 .isEqualTo(10L);
@@ -140,7 +173,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForHeapInit() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.init");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(HEAP_INIT);
 
         assertThat(gauge.getValue())
                 .isEqualTo(20L);
@@ -148,7 +181,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForHeapUsed() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.used");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(HEAP_USED);
 
         assertThat(gauge.getValue())
                 .isEqualTo(30L);
@@ -156,7 +189,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForHeapMax() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.max");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(HEAP_MAX);
 
         assertThat(gauge.getValue())
                 .isEqualTo(40L);
@@ -164,7 +197,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForHeapUsage() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.usage");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(HEAP_USAGE);
 
         assertThat(gauge.getValue())
                 .isEqualTo(0.75);
@@ -172,7 +205,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForNonHeapCommitted() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.committed");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(NON_HEAP_COMMITTED);
 
         assertThat(gauge.getValue())
                 .isEqualTo(1L);
@@ -180,7 +213,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForNonHeapInit() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.init");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(NON_HEAP_INIT);
 
         assertThat(gauge.getValue())
                 .isEqualTo(2L);
@@ -188,7 +221,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForNonHeapUsed() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.used");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(NON_HEAP_USED);
 
         assertThat(gauge.getValue())
                 .isEqualTo(3L);
@@ -196,7 +229,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForNonHeapMax() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.max");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(NON_HEAP_MAX);
 
         assertThat(gauge.getValue())
                 .isEqualTo(4L);
@@ -204,7 +237,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForNonHeapUsage() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.usage");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(NON_HEAP_USAGE);
 
         assertThat(gauge.getValue())
                 .isEqualTo(0.75);
@@ -212,7 +245,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForMemoryPoolUsage() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Big-Pool.usage");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(POOLS_BIG_POOL_USAGE);
 
         assertThat(gauge.getValue())
                 .isEqualTo(0.75);
@@ -220,7 +253,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForWeirdMemoryPoolInit() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Weird-Pool.init");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(POOLS_WEIRD_POOL_INIT);
 
         assertThat(gauge.getValue())
                 .isEqualTo(200L);
@@ -228,7 +261,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForWeirdMemoryPoolCommitted() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Weird-Pool.committed");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(POOLS_WEIRD_POOL_COMMITTED);
 
         assertThat(gauge.getValue())
                 .isEqualTo(100L);
@@ -236,7 +269,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForWeirdMemoryPoolUsed() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Weird-Pool.used");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(POOLS_WEIRD_POOL_USED);
 
         assertThat(gauge.getValue())
                 .isEqualTo(300L);
@@ -244,7 +277,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForWeirdMemoryPoolUsage() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Weird-Pool.usage");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(POOLS_WEIRD_POOL_USAGE);
 
         assertThat(gauge.getValue())
                 .isEqualTo(3.0);
@@ -252,7 +285,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForWeirdMemoryPoolMax() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Weird-Pool.max");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(POOLS_WEIRD_POOL_MAX);
 
         assertThat(gauge.getValue())
                 .isEqualTo(-1L);
@@ -260,7 +293,7 @@ public class MemoryUsageGaugeSetTest {
 
     @Test
     public void hasAGaugeForWeirdCollectionPoolUsed() {
-        final Gauge gauge = (Gauge) gauges.getMetrics().get("pools.Weird-Pool.used-after-gc");
+        final Gauge gauge = (Gauge) gauges.getMetrics().get(POOLS_WEIRD_POOL_USED_AFTER_GC);
 
         assertThat(gauge.getValue())
                 .isEqualTo(290L);

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadStatesGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/ThreadStatesGaugeSetTest.java
@@ -1,6 +1,7 @@
 package com.codahale.metrics.jvm;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricName;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -28,6 +29,17 @@ public class ThreadStatesGaugeSetTest {
 
     private final Set<String> deadlocks = new HashSet<>();
 
+    private static final MetricName TERMINATED_COUNT = MetricName.build("terminated.count");
+    private static final MetricName NEW_COUNT = MetricName.build("new.count");
+    private static final MetricName COUNT = MetricName.build("count");
+    private static final MetricName TIMED_WAITING_COUNT = MetricName.build("timed_waiting.count");
+    private static final MetricName DEADLOCKS = MetricName.build("deadlocks");
+    private static final MetricName BLOCKED_COUNT = MetricName.build("blocked.count");
+    private static final MetricName WAITING_COUNT = MetricName.build("waiting.count");
+    private static final MetricName DAEMON_COUNT = MetricName.build("daemon.count");
+    private static final MetricName RUNNABLE_COUNT = MetricName.build("runnable.count");
+    private static final MetricName DEADLOCK_COUNT = MetricName.build("deadlock.count");
+
     @Before
     public void setUp() {
         deadlocks.add("yay");
@@ -54,69 +66,69 @@ public class ThreadStatesGaugeSetTest {
     @Test
     public void hasASetOfGauges() {
         assertThat(gauges.getMetrics().keySet())
-            .containsOnly("terminated.count",
-                "new.count",
-                "count",
-                "timed_waiting.count",
-                "deadlocks",
-                "blocked.count",
-                "waiting.count",
-                "daemon.count",
-                "runnable.count",
-                "deadlock.count");
+                .containsOnly(TERMINATED_COUNT,
+                        NEW_COUNT,
+                        COUNT,
+                        TIMED_WAITING_COUNT,
+                        DEADLOCKS,
+                        BLOCKED_COUNT,
+                        WAITING_COUNT,
+                        DAEMON_COUNT,
+                        RUNNABLE_COUNT,
+                        DEADLOCK_COUNT);
     }
 
     @Test
     public void hasAGaugeForEachThreadState() {
-        assertThat(((Gauge<?>) gauges.getMetrics().get("new.count")).getValue())
+        assertThat(((Gauge<?>) gauges.getMetrics().get(NEW_COUNT)).getValue())
             .isEqualTo(1);
 
-        assertThat(((Gauge<?>) gauges.getMetrics().get("runnable.count")).getValue())
+        assertThat(((Gauge<?>) gauges.getMetrics().get(RUNNABLE_COUNT)).getValue())
             .isEqualTo(1);
 
-        assertThat(((Gauge<?>) gauges.getMetrics().get("blocked.count")).getValue())
+        assertThat(((Gauge<?>) gauges.getMetrics().get(BLOCKED_COUNT)).getValue())
             .isEqualTo(1);
 
-        assertThat(((Gauge<?>) gauges.getMetrics().get("waiting.count")).getValue())
+        assertThat(((Gauge<?>) gauges.getMetrics().get(WAITING_COUNT)).getValue())
             .isEqualTo(1);
 
-        assertThat(((Gauge<?>) gauges.getMetrics().get("timed_waiting.count")).getValue())
+        assertThat(((Gauge<?>) gauges.getMetrics().get(TIMED_WAITING_COUNT)).getValue())
             .isEqualTo(1);
 
-        assertThat(((Gauge<?>) gauges.getMetrics().get("terminated.count")).getValue())
+        assertThat(((Gauge<?>) gauges.getMetrics().get(TERMINATED_COUNT)).getValue())
             .isEqualTo(1);
     }
 
     @Test
     public void hasAGaugeForTheNumberOfThreads() {
-        assertThat(((Gauge<?>) gauges.getMetrics().get("count")).getValue())
+        assertThat(((Gauge<?>) gauges.getMetrics().get(COUNT)).getValue())
             .isEqualTo(12);
     }
 
     @Test
     public void hasAGaugeForTheNumberOfDaemonThreads() {
-        assertThat(((Gauge<?>) gauges.getMetrics().get("daemon.count")).getValue())
+        assertThat(((Gauge<?>) gauges.getMetrics().get(DAEMON_COUNT)).getValue())
             .isEqualTo(13);
     }
 
     @Test
     public void hasAGaugeForAnyDeadlocks() {
-        assertThat(((Gauge<?>) gauges.getMetrics().get("deadlocks")).getValue())
+        assertThat(((Gauge<?>) gauges.getMetrics().get(DEADLOCKS)).getValue())
             .isEqualTo(deadlocks);
     }
 
     @Test
     public void hasAGaugeForAnyDeadlockCount() {
-        assertThat(((Gauge<?>) gauges.getMetrics().get("deadlock.count")).getValue())
+        assertThat(((Gauge<?>) gauges.getMetrics().get(DEADLOCK_COUNT)).getValue())
             .isEqualTo(1);
     }
 
     @Test
     public void autoDiscoversTheMXBeans() {
         final ThreadStatesGaugeSet set = new ThreadStatesGaugeSet();
-        assertThat(((Gauge<?>) set.getMetrics().get("count")).getValue())
+        assertThat(((Gauge<?>) set.getMetrics().get(COUNT)).getValue())
             .isNotNull();
-        assertThat(((Gauge<?>) set.getMetrics().get("deadlocks")).getValue())
+        assertThat(((Gauge<?>) set.getMetrics().get(DEADLOCKS)).getValue())
             .isNotNull();
     }
 }

--- a/metrics-log4j2/src/main/java/com/codahale/metrics/log4j2/InstrumentedAppender.java
+++ b/metrics-log4j2/src/main/java/com/codahale/metrics/log4j2/InstrumentedAppender.java
@@ -75,7 +75,7 @@ public class InstrumentedAppender extends AbstractAppender {
      *                         logged and then passed to the application.
      */
     public InstrumentedAppender(MetricRegistry registry, Filter filter, Layout<? extends Serializable> layout, boolean ignoreExceptions) {
-        super(name(Appender.class), filter, layout, ignoreExceptions);
+        super(name(Appender.class).getKey(), filter, layout, ignoreExceptions);
         this.registry = registry;
     }
 


### PR DESCRIPTION
Original contribution is in #561 by @udoprog.

> This is a large refactoring meant to change the way metric names are represented to better suit a wide variety of backends.
> 
> Quite a few metric backend systems are starting to use a general concept of 'tags' which is a step back from having too encode information in the (string) names of the metrics:
> 
> * KairosDB (http://code.google.com/p/kairosdb/),
> * OpenTSDB (http://opentsdb.net/overview.html)
> 
> Tags are meant to allow for natural grouping of similar timeseries allowing for the ability to easily correlate freely between the timeseries that incorporate them.
> 
> For example, take the following two timeseries.
> 
> * example.com.interface.traffic.eth0.in
> * example.com.interface.traffic.eth0.out
> 
> Using tags, these would be represented as;
> 
> * interface.traffic {host=example.com, interface=eth0, direction=in}
> * interface.traffic {host=example.com, interface=eth0, direction=out}
  