### PR TITLE
chore: Use `Thread.sleep` instead of `LockSupport.park` in tests

### DIFF
--- a/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHandlerTest.java
+++ b/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHandlerTest.java
@@ -21,7 +21,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.locks.LockSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -158,7 +157,11 @@ public class InstrumentedHandlerTest {
             switch (path) {
                 case "/blocking":
                     request.setHandled(true);
-                    LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1));
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
                     httpServletResponse.setStatus(200);
                     httpServletResponse.setContentType("text/plain");
                     httpServletResponse.getWriter().write("some content from the blocking request\n");
@@ -167,7 +170,11 @@ public class InstrumentedHandlerTest {
                     request.setHandled(true);
                     final AsyncContext context = request.startAsync();
                     Thread t = new Thread(() -> {
-                        LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1));
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
                         httpServletResponse.setStatus(200);
                         httpServletResponse.setContentType("text/plain");
                         final ServletOutputStream servletOutputStream;


### PR DESCRIPTION
`LockSupport.park` can spuriously return, which makes the tests flaky.

See: https://stackoverflow.com/questions/10397881/java-locksupport-parknanos-vs-thread-sleep