### PR TITLE
chore: Increase waiting timeout after cancellation in the executor tests

### DIFF
--- a/metrics-core/src/test/java/com/codahale/metrics/InstrumentedScheduledExecutorServiceTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/InstrumentedScheduledExecutorServiceTest.java
@@ -236,7 +236,7 @@ public class InstrumentedScheduledExecutorServiceTest {
         TimeUnit.MILLISECONDS.sleep(100); // Give some time for the task to be run
         countDownLatch.await(5, TimeUnit.SECONDS); // Don't cancel until it didn't complete once
         theFuture.cancel(true);
-        TimeUnit.MILLISECONDS.sleep(100);         // Wait while the task is cancelled
+        TimeUnit.MILLISECONDS.sleep(200);         // Wait while the task is cancelled
 
         assertThat(submitted.getCount()).isZero();
 
@@ -284,7 +284,7 @@ public class InstrumentedScheduledExecutorServiceTest {
         TimeUnit.MILLISECONDS.sleep(100);
         countDownLatch.await(5, TimeUnit.SECONDS);
         theFuture.cancel(true);
-        TimeUnit.MILLISECONDS.sleep(100);
+        TimeUnit.MILLISECONDS.sleep(200);
 
         assertThat(submitted.getCount()).isZero();
 


### PR DESCRIPTION
The test constantly fails on Windows, looks like it takes longer than 100ms for a thread to finish an execution and the check fails, because the code hasn't completed.