### PR TITLE
chore: Increase a test offset for system time

### DIFF
--- a/metrics-core/src/test/java/com/codahale/metrics/ClockTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ClockTest.java
@@ -17,7 +17,7 @@ public class ClockTest {
 
         assertThat((double) clock.getTick())
                 .isEqualTo(System.nanoTime(),
-                        offset(100000.0));
+                        offset(1000000.0));
     }
 
     @Test


### PR DESCRIPTION
`System.nanoTime()` can return very different results, especially on busy CI servers. We should be more lenient during verification and increase the error window.