### PR TITLE
Store sum of events for different metrics

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
@@ -283,6 +283,7 @@ public class ConsoleReporter extends ScheduledReporter {
 
     private void printMeter(Meter meter) {
         printIfEnabled(MetricAttribute.COUNT, String.format(locale, "             count = %d", meter.getCount()));
+        printIfEnabled(MetricAttribute.SUM, String.format(locale, "               sum = %d", meter.getSum()));
         printIfEnabled(MetricAttribute.MEAN_RATE, String.format(locale, "         mean rate = %2.2f events/%s", convertRate(meter.getMeanRate()), getRateUnit()));
         printIfEnabled(MetricAttribute.M1_RATE, String.format(locale, "     1-minute rate = %2.2f events/%s", convertRate(meter.getOneMinuteRate()), getRateUnit()));
         printIfEnabled(MetricAttribute.M5_RATE, String.format(locale, "     5-minute rate = %2.2f events/%s", convertRate(meter.getFiveMinuteRate()), getRateUnit()));
@@ -299,6 +300,7 @@ public class ConsoleReporter extends ScheduledReporter {
 
     private void printHistogram(Histogram histogram) {
         printIfEnabled(MetricAttribute.COUNT, String.format(locale, "             count = %d", histogram.getCount()));
+        printIfEnabled(MetricAttribute.SUM, String.format(locale, "               sum = %d", histogram.getSum()));
         Snapshot snapshot = histogram.getSnapshot();
         printIfEnabled(MetricAttribute.MIN, String.format(locale, "               min = %d", snapshot.getMin()));
         printIfEnabled(MetricAttribute.MAX, String.format(locale, "               max = %d", snapshot.getMax()));
@@ -315,6 +317,7 @@ public class ConsoleReporter extends ScheduledReporter {
     private void printTimer(Timer timer) {
         final Snapshot snapshot = timer.getSnapshot();
         printIfEnabled(MetricAttribute.COUNT, String.format(locale, "             count = %d", timer.getCount()));
+        printIfEnabled(MetricAttribute.SUM, String.format(locale, "               sum = %d", timer.getSum()));
         printIfEnabled(MetricAttribute.MEAN_RATE, String.format(locale, "         mean rate = %2.2f calls/%s", convertRate(timer.getMeanRate()), getRateUnit()));
         printIfEnabled(MetricAttribute.M1_RATE, String.format(locale, "     1-minute rate = %2.2f calls/%s", convertRate(timer.getOneMinuteRate()), getRateUnit()));
         printIfEnabled(MetricAttribute.M5_RATE, String.format(locale, "     5-minute rate = %2.2f calls/%s", convertRate(timer.getFiveMinuteRate()), getRateUnit()));

--- a/metrics-core/src/main/java/com/codahale/metrics/CsvReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/CsvReporter.java
@@ -210,9 +210,9 @@ public class CsvReporter extends ScheduledReporter {
         this.clock = clock;
         this.csvFileProvider = csvFileProvider;
 
-        this.histogramFormat = String.join(separator, "%d", "%d", "%f", "%d", "%f", "%f", "%f", "%f", "%f", "%f", "%f");
-        this.meterFormat = String.join(separator, "%d", "%f", "%f", "%f", "%f", "events/%s");
-        this.timerFormat = String.join(separator, "%d", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "calls/%s", "%s");
+        this.histogramFormat = String.join(separator, "%d", "%d", "%d", "%f", "%d", "%f", "%f", "%f", "%f", "%f", "%f", "%f");
+        this.meterFormat = String.join(separator, "%d", "%d", "%f", "%f", "%f", "%f", "events/%s");
+        this.timerFormat = String.join(separator, "%d", "%d", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "calls/%s", "%s");
     }
 
     @Override
@@ -250,9 +250,10 @@ public class CsvReporter extends ScheduledReporter {
 
         report(timestamp,
                 name,
-                "count,max,mean,min,stddev,p50,p75,p95,p98,p99,p999,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit,duration_unit",
+                "count,sum,max,mean,min,stddev,p50,p75,p95,p98,p99,p999,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit,duration_unit",
                 timerFormat,
                 timer.getCount(),
+                timer.getSum(),
                 convertDuration(snapshot.getMax()),
                 convertDuration(snapshot.getMean()),
                 convertDuration(snapshot.getMin()),
@@ -274,9 +275,10 @@ public class CsvReporter extends ScheduledReporter {
     private void reportMeter(long timestamp, String name, Meter meter) {
         report(timestamp,
                 name,
-                "count,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit",
+                "count,sum,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit",
                 meterFormat,
                 meter.getCount(),
+                meter.getSum(),
                 convertRate(meter.getMeanRate()),
                 convertRate(meter.getOneMinuteRate()),
                 convertRate(meter.getFiveMinuteRate()),
@@ -289,9 +291,10 @@ public class CsvReporter extends ScheduledReporter {
 
         report(timestamp,
                 name,
-                "count,max,mean,min,stddev,p50,p75,p95,p98,p99,p999",
+                "count,sum,max,mean,min,stddev,p50,p75,p95,p98,p99,p999",
                 histogramFormat,
                 histogram.getCount(),
+                histogram.getSum(),
                 snapshot.getMax(),
                 snapshot.getMean(),
                 snapshot.getMin(),

--- a/metrics-core/src/main/java/com/codahale/metrics/Histogram.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Histogram.java
@@ -8,9 +8,10 @@ import java.util.concurrent.atomic.LongAdder;
  * @see <a href="http://www.johndcook.com/standard_deviation.html">Accurately computing running
  * variance</a>
  */
-public class Histogram implements Metric, Sampling, Counting {
+public class Histogram implements Metric, Sampling, Counting, Summing {
     private final Reservoir reservoir;
     private final LongAdder count;
+    private final LongAdder sum;
 
     /**
      * Creates a new {@link Histogram} with the given reservoir.
@@ -20,6 +21,7 @@ public class Histogram implements Metric, Sampling, Counting {
     public Histogram(Reservoir reservoir) {
         this.reservoir = reservoir;
         this.count = new LongAdder();
+        this.sum = new LongAdder();
     }
 
     /**
@@ -38,6 +40,7 @@ public class Histogram implements Metric, Sampling, Counting {
      */
     public void update(long value) {
         count.increment();
+        sum.add(value);
         reservoir.update(value);
     }
 
@@ -49,6 +52,16 @@ public class Histogram implements Metric, Sampling, Counting {
     @Override
     public long getCount() {
         return count.sum();
+    }
+
+    /**
+     * Returns the sum of values recorded.
+     *
+     * @return the sum of values recorded
+     */
+    @Override
+    public long getSum() {
+        return sum.sum();
     }
 
     @Override

--- a/metrics-core/src/main/java/com/codahale/metrics/Metered.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Metered.java
@@ -3,7 +3,7 @@ package com.codahale.metrics;
 /**
  * An object which maintains mean and exponentially-weighted rate.
  */
-public interface Metered extends Metric, Counting {
+public interface Metered extends Metric, Counting, Summing {
     /**
      * Returns the number of events which have been marked.
      *
@@ -11,6 +11,14 @@ public interface Metered extends Metric, Counting {
      */
     @Override
     long getCount();
+
+    /**
+     * Returns the sum of events which have been marked.
+     *
+     * @return the sum of events which have been marked
+     */
+    @Override
+    long getSum();
 
     /**
      * Returns the fifteen-minute exponentially-weighted moving average rate at which events have

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricAttribute.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricAttribute.java
@@ -16,6 +16,7 @@ public enum MetricAttribute {
     P99("p99"),
     P999("p999"),
     COUNT("count"),
+    SUM("sum"),
     M1_RATE("m1_rate"),
     M5_RATE("m5_rate"),
     M15_RATE("m15_rate"),

--- a/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
@@ -242,12 +242,13 @@ public class Slf4jReporter extends ScheduledReporter {
     private void logTimer(String name, Timer timer) {
         final Snapshot snapshot = timer.getSnapshot();
         loggerProxy.log(marker,
-                "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, " +
+                "type={}, name={}, count={}, sum={}, min={}, max={}, mean={}, stddev={}, median={}, " +
                         "p75={}, p95={}, p98={}, p99={}, p999={}, mean_rate={}, m1={}, m5={}, " +
                         "m15={}, rate_unit={}, duration_unit={}",
                 "TIMER",
                 prefix(name),
                 timer.getCount(),
+                timer.getSum(),
                 convertDuration(snapshot.getMin()),
                 convertDuration(snapshot.getMax()),
                 convertDuration(snapshot.getMean()),
@@ -268,10 +269,11 @@ public class Slf4jReporter extends ScheduledReporter {
 
     private void logMeter(String name, Meter meter) {
         loggerProxy.log(marker,
-                "type={}, name={}, count={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}",
+                "type={}, name={}, count={}, sum={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}",
                 "METER",
                 prefix(name),
                 meter.getCount(),
+                meter.getSum(),
                 convertRate(meter.getMeanRate()),
                 convertRate(meter.getOneMinuteRate()),
                 convertRate(meter.getFiveMinuteRate()),
@@ -282,11 +284,12 @@ public class Slf4jReporter extends ScheduledReporter {
     private void logHistogram(String name, Histogram histogram) {
         final Snapshot snapshot = histogram.getSnapshot();
         loggerProxy.log(marker,
-                "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, " +
+                "type={}, name={}, count={}, sum={}, min={}, max={}, mean={}, stddev={}, " +
                         "median={}, p75={}, p95={}, p98={}, p99={}, p999={}",
                 "HISTOGRAM",
                 prefix(name),
                 histogram.getCount(),
+                histogram.getSum(),
                 snapshot.getMin(),
                 snapshot.getMax(),
                 snapshot.getMean(),

--- a/metrics-core/src/main/java/com/codahale/metrics/Summing.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Summing.java
@@ -1,0 +1,14 @@
+package com.codahale.metrics;
+
+/**
+ * An interface for metric types which aggregate a sum
+ */
+public interface Summing {
+
+    /**
+     * Return the current sum.
+     *
+     * @return the current sum
+     */
+    long getSum();
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/Timer.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Timer.java
@@ -167,6 +167,11 @@ public class Timer implements Metered, Sampling {
     }
 
     @Override
+    public long getSum() {
+        return histogram.getSum();
+    }
+
+    @Override
     public double getFifteenMinuteRate() {
         return meter.getFifteenMinuteRate();
     }

--- a/metrics-core/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
@@ -96,6 +96,7 @@ public class ConsoleReporterTest {
     public void reportsHistogramValues() throws Exception {
         final Histogram histogram = mock(Histogram.class);
         when(histogram.getCount()).thenReturn(1L);
+        when(histogram.getSum()).thenReturn(4L);
 
         final Snapshot snapshot = mock(Snapshot.class);
         when(snapshot.getMax()).thenReturn(2L);
@@ -124,6 +125,7 @@ public class ConsoleReporterTest {
                         "-- Histograms ------------------------------------------------------------------",
                         "test.histogram",
                         "             count = 1",
+                        "               sum = 4",
                         "               min = 4",
                         "               max = 2",
                         "              mean = 3.00",
@@ -143,6 +145,7 @@ public class ConsoleReporterTest {
     public void reportsMeterValues() throws Exception {
         final Meter meter = mock(Meter.class);
         when(meter.getCount()).thenReturn(1L);
+        when(meter.getSum()).thenReturn(3L);
         when(meter.getMeanRate()).thenReturn(2.0);
         when(meter.getOneMinuteRate()).thenReturn(3.0);
         when(meter.getFiveMinuteRate()).thenReturn(4.0);
@@ -161,6 +164,7 @@ public class ConsoleReporterTest {
                         "-- Meters ----------------------------------------------------------------------",
                         "test.meter",
                         "             count = 1",
+                        "               sum = 3",
                         "         mean rate = 2.00 events/second",
                         "     1-minute rate = 3.00 events/second",
                         "     5-minute rate = 4.00 events/second",
@@ -174,6 +178,7 @@ public class ConsoleReporterTest {
     public void reportsTimerValues() throws Exception {
         final Timer timer = mock(Timer.class);
         when(timer.getCount()).thenReturn(1L);
+        when(timer.getSum()).thenReturn(5L);
         when(timer.getMeanRate()).thenReturn(2.0);
         when(timer.getOneMinuteRate()).thenReturn(3.0);
         when(timer.getFiveMinuteRate()).thenReturn(4.0);
@@ -207,6 +212,7 @@ public class ConsoleReporterTest {
                         "-- Timers ----------------------------------------------------------------------",
                         "test.another.timer",
                         "             count = 1",
+                        "               sum = 5",
                         "         mean rate = 2.00 calls/second",
                         "     1-minute rate = 3.00 calls/second",
                         "     5-minute rate = 4.00 calls/second",
@@ -228,7 +234,7 @@ public class ConsoleReporterTest {
 
     @Test
     public void reportMeterWithDisabledAttributes() throws Exception {
-        Set<MetricAttribute> disabledMetricAttributes = EnumSet.of(MetricAttribute.M15_RATE, MetricAttribute.M5_RATE, MetricAttribute.COUNT);
+        Set<MetricAttribute> disabledMetricAttributes = EnumSet.of(MetricAttribute.M15_RATE, MetricAttribute.M5_RATE, MetricAttribute.COUNT, MetricAttribute.SUM);
 
         final ConsoleReporter customReporter = ConsoleReporter.forRegistry(registry)
                 .outputTo(output)
@@ -243,6 +249,7 @@ public class ConsoleReporterTest {
 
         final Meter meter = mock(Meter.class);
         when(meter.getCount()).thenReturn(1L);
+        when(meter.getSum()).thenReturn(5L);
         when(meter.getMeanRate()).thenReturn(2.0);
         when(meter.getOneMinuteRate()).thenReturn(3.0);
         when(meter.getFiveMinuteRate()).thenReturn(4.0);
@@ -284,6 +291,7 @@ public class ConsoleReporterTest {
 
         final Timer timer = mock(Timer.class);
         when(timer.getCount()).thenReturn(1L);
+        when(timer.getSum()).thenReturn(6L);
         when(timer.getMeanRate()).thenReturn(2.0);
         when(timer.getOneMinuteRate()).thenReturn(3.0);
         when(timer.getFiveMinuteRate()).thenReturn(4.0);
@@ -317,6 +325,7 @@ public class ConsoleReporterTest {
                         "-- Timers ----------------------------------------------------------------------",
                         "test.another.timer",
                         "             count = 1",
+                        "               sum = 6",
                         "         mean rate = 2.00 calls/second",
                         "     1-minute rate = 3.00 calls/second",
                         "    15-minute rate = 5.00 calls/second",
@@ -349,6 +358,7 @@ public class ConsoleReporterTest {
 
         final Histogram histogram = mock(Histogram.class);
         when(histogram.getCount()).thenReturn(1L);
+        when(histogram.getSum()).thenReturn(5L);
 
         final Snapshot snapshot = mock(Snapshot.class);
         when(snapshot.getMax()).thenReturn(2L);
@@ -377,6 +387,7 @@ public class ConsoleReporterTest {
                         "-- Histograms ------------------------------------------------------------------",
                         "test.histogram",
                         "             count = 1",
+                        "               sum = 5",
                         "              mean = 3.00",
                         "            median = 6.00",
                         "              75% <= 7.00",

--- a/metrics-core/src/test/java/com/codahale/metrics/CsvReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/CsvReporterTest.java
@@ -83,6 +83,7 @@ public class CsvReporterTest {
     public void reportsHistogramValues() throws Exception {
         final Histogram histogram = mock(Histogram.class);
         when(histogram.getCount()).thenReturn(1L);
+        when(histogram.getSum()).thenReturn(12L);
 
         final Snapshot snapshot = mock(Snapshot.class);
         when(snapshot.getMax()).thenReturn(2L);
@@ -106,8 +107,8 @@ public class CsvReporterTest {
 
         assertThat(fileContents("test.histogram.csv"))
                 .isEqualTo(csv(
-                        "t,count,max,mean,min,stddev,p50,p75,p95,p98,p99,p999",
-                        "19910191,1,2,3.000000,4,5.000000,6.000000,7.000000,8.000000,9.000000,10.000000,11.000000"
+                        "t,count,sum,max,mean,min,stddev,p50,p75,p95,p98,p99,p999",
+                        "19910191,1,12,2,3.000000,4,5.000000,6.000000,7.000000,8.000000,9.000000,10.000000,11.000000"
                 ));
     }
 
@@ -123,8 +124,8 @@ public class CsvReporterTest {
 
         assertThat(fileContents("test.meter.csv"))
                 .isEqualTo(csv(
-                        "t,count,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit",
-                        "19910191,1,2.000000,3.000000,4.000000,5.000000,events/second"
+                        "t,count,sum,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit",
+                        "19910191,1,6,2.000000,3.000000,4.000000,5.000000,events/second"
                 ));
     }
 
@@ -132,6 +133,7 @@ public class CsvReporterTest {
     public void reportsTimerValues() throws Exception {
         final Timer timer = mock(Timer.class);
         when(timer.getCount()).thenReturn(1L);
+        when(timer.getSum()).thenReturn(6L);
         when(timer.getMeanRate()).thenReturn(2.0);
         when(timer.getOneMinuteRate()).thenReturn(3.0);
         when(timer.getFiveMinuteRate()).thenReturn(4.0);
@@ -159,8 +161,8 @@ public class CsvReporterTest {
 
         assertThat(fileContents("test.another.timer.csv"))
                 .isEqualTo(csv(
-                        "t,count,max,mean,min,stddev,p50,p75,p95,p98,p99,p999,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit,duration_unit",
-                        "19910191,1,100.000000,200.000000,300.000000,400.000000,500.000000,600.000000,700.000000,800.000000,900.000000,1000.000000,2.000000,3.000000,4.000000,5.000000,calls/second,milliseconds"
+                        "t,count,sum,max,mean,min,stddev,p50,p75,p95,p98,p99,p999,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit,duration_unit",
+                        "19910191,1,6,100.000000,200.000000,300.000000,400.000000,500.000000,600.000000,700.000000,800.000000,900.000000,1000.000000,2.000000,3.000000,4.000000,5.000000,calls/second,milliseconds"
                 ));
     }
 
@@ -205,14 +207,15 @@ public class CsvReporterTest {
 
         assertThat(fileContents("test.meter.csv"))
                 .isEqualTo(csv(
-                        "t,count,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit",
-                        "19910191|1|2.000000|3.000000|4.000000|5.000000|events/second"
+                        "t,count,sum,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit",
+                        "19910191|1|6|2.000000|3.000000|4.000000|5.000000|events/second"
                 ));
     }
 
     private Meter mockMeter() {
         final Meter meter = mock(Meter.class);
         when(meter.getCount()).thenReturn(1L);
+        when(meter.getSum()).thenReturn(6L);
         when(meter.getMeanRate()).thenReturn(2.0);
         when(meter.getOneMinuteRate()).thenReturn(3.0);
         when(meter.getFiveMinuteRate()).thenReturn(4.0);

--- a/metrics-core/src/test/java/com/codahale/metrics/HistogramTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/HistogramTest.java
@@ -12,14 +12,19 @@ public class HistogramTest {
     private final Histogram histogram = new Histogram(reservoir);
 
     @Test
-    public void updatesTheCountOnUpdates() {
+    public void updatesTheCountAndSumOnUpdates() {
         assertThat(histogram.getCount())
+                .isZero();
+        assertThat(histogram.getSum())
                 .isZero();
 
         histogram.update(1);
+        histogram.update(5);
 
         assertThat(histogram.getCount())
-                .isEqualTo(1);
+                .isEqualTo(2);
+        assertThat(histogram.getSum())
+                .isEqualTo(6);
     }
 
     @Test

--- a/metrics-core/src/test/java/com/codahale/metrics/MeterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MeterTest.java
@@ -25,6 +25,9 @@ public class MeterTest {
         assertThat(meter.getCount())
                 .isZero();
 
+        assertThat(meter.getSum())
+                .isZero();
+
         assertThat(meter.getMeanRate())
                 .isEqualTo(0.0, offset(0.001));
 
@@ -42,6 +45,12 @@ public class MeterTest {
     public void marksEventsAndUpdatesRatesAndCount() {
         meter.mark();
         meter.mark(2);
+
+        assertThat(meter.getCount())
+                .isEqualTo(3);
+
+        assertThat(meter.getSum())
+                .isEqualTo(10000000000L);
 
         assertThat(meter.getMeanRate())
                 .isEqualTo(0.3, offset(0.001));

--- a/metrics-core/src/test/java/com/codahale/metrics/Slf4jReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/Slf4jReporterTest.java
@@ -66,6 +66,7 @@ public class Slf4jReporterTest {
     public void reportsHistogramValuesAtError() {
         final Histogram histogram = mock(Histogram.class);
         when(histogram.getCount()).thenReturn(1L);
+        when(histogram.getSum()).thenReturn(12L);
 
         final Snapshot snapshot = mock(Snapshot.class);
         when(snapshot.getMax()).thenReturn(2L);
@@ -89,10 +90,11 @@ public class Slf4jReporterTest {
                 map());
 
         verify(logger).error(marker,
-                "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}",
+                "type={}, name={}, count={}, sum={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}",
                 "HISTOGRAM",
                 "test.histogram",
                 1L,
+                12L,
                 4L,
                 2L,
                 3.0,
@@ -109,6 +111,7 @@ public class Slf4jReporterTest {
     public void reportsMeterValuesAtError() {
         final Meter meter = mock(Meter.class);
         when(meter.getCount()).thenReturn(1L);
+        when(meter.getSum()).thenReturn(6L);
         when(meter.getMeanRate()).thenReturn(2.0);
         when(meter.getOneMinuteRate()).thenReturn(3.0);
         when(meter.getFiveMinuteRate()).thenReturn(4.0);
@@ -122,10 +125,11 @@ public class Slf4jReporterTest {
                 map());
 
         verify(logger).error(marker,
-                "type={}, name={}, count={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}",
+                "type={}, name={}, count={}, sum={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}",
                 "METER",
                 "test.meter",
                 1L,
+                6L,
                 2.0,
                 3.0,
                 4.0,
@@ -137,6 +141,7 @@ public class Slf4jReporterTest {
     public void reportsTimerValuesAtError() {
         final Timer timer = mock(Timer.class);
         when(timer.getCount()).thenReturn(1L);
+        when(timer.getSum()).thenReturn(6L);
 
         when(timer.getMeanRate()).thenReturn(2.0);
         when(timer.getOneMinuteRate()).thenReturn(3.0);
@@ -167,10 +172,11 @@ public class Slf4jReporterTest {
                 map("test.another.timer", timer));
 
         verify(logger).error(marker,
-                "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}, duration_unit={}",
+                "type={}, name={}, count={}, sum={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}, duration_unit={}",
                 "TIMER",
                 "test.another.timer",
                 1L,
+                6L,
                 300.0,
                 100.0,
                 200.0,
@@ -220,6 +226,7 @@ public class Slf4jReporterTest {
     public void reportsHistogramValues() {
         final Histogram histogram = mock(Histogram.class);
         when(histogram.getCount()).thenReturn(1L);
+        when(histogram.getSum()).thenReturn(12L);
 
         final Snapshot snapshot = mock(Snapshot.class);
         when(snapshot.getMax()).thenReturn(2L);
@@ -243,10 +250,11 @@ public class Slf4jReporterTest {
                 map());
 
         verify(logger).info(marker,
-                "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}",
+                "type={}, name={}, count={}, sum={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}",
                 "HISTOGRAM",
                 "prefix.test.histogram",
                 1L,
+                12L,
                 4L,
                 2L,
                 3.0,
@@ -263,6 +271,7 @@ public class Slf4jReporterTest {
     public void reportsMeterValues() {
         final Meter meter = mock(Meter.class);
         when(meter.getCount()).thenReturn(1L);
+        when(meter.getSum()).thenReturn(6L);
         when(meter.getMeanRate()).thenReturn(2.0);
         when(meter.getOneMinuteRate()).thenReturn(3.0);
         when(meter.getFiveMinuteRate()).thenReturn(4.0);
@@ -276,10 +285,11 @@ public class Slf4jReporterTest {
                 map());
 
         verify(logger).info(marker,
-                "type={}, name={}, count={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}",
+                "type={}, name={}, count={}, sum={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}",
                 "METER",
                 "prefix.test.meter",
                 1L,
+                6L,
                 2.0,
                 3.0,
                 4.0,
@@ -291,6 +301,7 @@ public class Slf4jReporterTest {
     public void reportsTimerValues() {
         final Timer timer = mock(Timer.class);
         when(timer.getCount()).thenReturn(1L);
+        when(timer.getSum()).thenReturn(6L);
 
         when(timer.getMeanRate()).thenReturn(2.0);
         when(timer.getOneMinuteRate()).thenReturn(3.0);
@@ -320,10 +331,11 @@ public class Slf4jReporterTest {
                 map("test.another.timer", timer));
 
         verify(logger).info(marker,
-                "type={}, name={}, count={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}, duration_unit={}",
+                "type={}, name={}, count={}, sum={}, min={}, max={}, mean={}, stddev={}, median={}, p75={}, p95={}, p98={}, p99={}, p999={}, mean_rate={}, m1={}, m5={}, m15={}, rate_unit={}, duration_unit={}",
                 "TIMER",
                 "prefix.test.another.timer",
                 1L,
+                6L,
                 300.0,
                 100.0,
                 200.0,

--- a/metrics-core/src/test/java/com/codahale/metrics/TimerTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/TimerTest.java
@@ -30,6 +30,9 @@ public class TimerTest {
         assertThat(timer.getCount())
                 .isZero();
 
+        assertThat(timer.getSum())
+                .isZero();
+
         assertThat(timer.getMeanRate())
                 .isEqualTo(0.0, offset(0.001));
 
@@ -44,14 +47,19 @@ public class TimerTest {
     }
 
     @Test
-    public void updatesTheCountOnUpdates() {
+    public void updatesTheCountAndSumOnUpdates() {
         assertThat(timer.getCount())
+                .isZero();
+        assertThat(timer.getSum())
                 .isZero();
 
         timer.update(1, TimeUnit.SECONDS);
+        timer.update(5, TimeUnit.SECONDS);
 
         assertThat(timer.getCount())
-                .isEqualTo(1);
+                .isEqualTo(2);
+        assertThat(timer.getSum())
+                .isEqualTo(6000000000L);
     }
 
     @Test
@@ -60,6 +68,8 @@ public class TimerTest {
 
         assertThat(timer.getCount())
                 .isEqualTo(1);
+        assertThat(timer.getSum())
+                .isEqualTo(50000000);
 
         assertThat(value)
                 .isEqualTo("one");
@@ -87,6 +97,8 @@ public class TimerTest {
 
         assertThat(timer.getCount())
                 .isEqualTo(1);
+        assertThat(timer.getSum())
+                .isEqualTo(50000000);
 
         assertThat(called.get())
                 .isTrue();
@@ -100,6 +112,8 @@ public class TimerTest {
 
         assertThat(timer.getCount())
                 .isEqualTo(1);
+        assertThat(timer.getSum())
+                .isEqualTo(50000000);
 
         verify(reservoir).update(50000000);
     }
@@ -119,6 +133,8 @@ public class TimerTest {
 
         assertThat(timer.getCount())
                 .isZero();
+        assertThat(timer.getSum())
+                .isZero();
 
         verifyZeroInteractions(reservoir);
     }
@@ -126,6 +142,7 @@ public class TimerTest {
     @Test
     public void tryWithResourcesWork() {
         assertThat(timer.getCount()).isZero();
+        assertThat(timer.getSum()).isZero();
 
         int dummy = 0;
         try (Timer.Context context = timer.time()) {
@@ -135,6 +152,8 @@ public class TimerTest {
         assertThat(dummy).isEqualTo(1);
         assertThat(timer.getCount())
                 .isEqualTo(1);
+        assertThat(timer.getSum())
+                .isEqualTo(50000000);
 
         verify(reservoir).update(50000000);
     }

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -41,6 +41,7 @@ import static com.codahale.metrics.MetricAttribute.P98;
 import static com.codahale.metrics.MetricAttribute.P99;
 import static com.codahale.metrics.MetricAttribute.P999;
 import static com.codahale.metrics.MetricAttribute.STDDEV;
+import static com.codahale.metrics.MetricAttribute.SUM;
 
 /**
  * A reporter which publishes metric values to a Graphite server.
@@ -325,6 +326,7 @@ public class GraphiteReporter extends ScheduledReporter {
 
     private void reportMetered(String name, Metered meter, long timestamp) throws IOException {
         sendIfEnabled(COUNT, name, meter.getCount(), timestamp);
+        sendIfEnabled(SUM, name, meter.getSum(), timestamp);
         sendIfEnabled(M1_RATE, name, convertRate(meter.getOneMinuteRate()), timestamp);
         sendIfEnabled(M5_RATE, name, convertRate(meter.getFiveMinuteRate()), timestamp);
         sendIfEnabled(M15_RATE, name, convertRate(meter.getFifteenMinuteRate()), timestamp);
@@ -334,6 +336,7 @@ public class GraphiteReporter extends ScheduledReporter {
     private void reportHistogram(String name, Histogram histogram, long timestamp) throws IOException {
         final Snapshot snapshot = histogram.getSnapshot();
         sendIfEnabled(COUNT, name, histogram.getCount(), timestamp);
+        sendIfEnabled(SUM, name, histogram.getSum(), timestamp);
         sendIfEnabled(MAX, name, snapshot.getMax(), timestamp);
         sendIfEnabled(MEAN, name, snapshot.getMean(), timestamp);
         sendIfEnabled(MIN, name, snapshot.getMin(), timestamp);

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -248,6 +248,7 @@ public class GraphiteReporterTest {
     public void reportsHistograms() throws Exception {
         final Histogram histogram = mock(Histogram.class);
         when(histogram.getCount()).thenReturn(1L);
+        when(histogram.getSum()).thenReturn(12L);
 
         final Snapshot snapshot = mock(Snapshot.class);
         when(snapshot.getMax()).thenReturn(2L);
@@ -272,6 +273,7 @@ public class GraphiteReporterTest {
         final InOrder inOrder = inOrder(graphite);
         inOrder.verify(graphite).connect();
         inOrder.verify(graphite).send("prefix.histogram.count", "1", timestamp);
+        inOrder.verify(graphite).send("prefix.histogram.sum", "12", timestamp);
         inOrder.verify(graphite).send("prefix.histogram.max", "2", timestamp);
         inOrder.verify(graphite).send("prefix.histogram.mean", "3.00", timestamp);
         inOrder.verify(graphite).send("prefix.histogram.min", "4", timestamp);
@@ -292,6 +294,7 @@ public class GraphiteReporterTest {
     public void reportsMeters() throws Exception {
         final Meter meter = mock(Meter.class);
         when(meter.getCount()).thenReturn(1L);
+        when(meter.getSum()).thenReturn(6L);
         when(meter.getOneMinuteRate()).thenReturn(2.0);
         when(meter.getFiveMinuteRate()).thenReturn(3.0);
         when(meter.getFifteenMinuteRate()).thenReturn(4.0);
@@ -306,6 +309,7 @@ public class GraphiteReporterTest {
         final InOrder inOrder = inOrder(graphite);
         inOrder.verify(graphite).connect();
         inOrder.verify(graphite).send("prefix.meter.count", "1", timestamp);
+        inOrder.verify(graphite).send("prefix.meter.sum", "6", timestamp);
         inOrder.verify(graphite).send("prefix.meter.m1_rate", "2.00", timestamp);
         inOrder.verify(graphite).send("prefix.meter.m5_rate", "3.00", timestamp);
         inOrder.verify(graphite).send("prefix.meter.m15_rate", "4.00", timestamp);
@@ -320,6 +324,7 @@ public class GraphiteReporterTest {
     public void reportsMetersInMinutes() throws Exception {
         final Meter meter = mock(Meter.class);
         when(meter.getCount()).thenReturn(1L);
+        when(meter.getSum()).thenReturn(6L);
         when(meter.getOneMinuteRate()).thenReturn(2.0);
         when(meter.getFiveMinuteRate()).thenReturn(3.0);
         when(meter.getFifteenMinuteRate()).thenReturn(4.0);
@@ -334,6 +339,7 @@ public class GraphiteReporterTest {
         final InOrder inOrder = inOrder(graphite);
         inOrder.verify(graphite).connect();
         inOrder.verify(graphite).send("prefix.meter.count", "1", timestamp);
+        inOrder.verify(graphite).send("prefix.meter.sum", "6", timestamp);
         inOrder.verify(graphite).send("prefix.meter.m1_rate", "120.00", timestamp);
         inOrder.verify(graphite).send("prefix.meter.m5_rate", "180.00", timestamp);
         inOrder.verify(graphite).send("prefix.meter.m15_rate", "240.00", timestamp);
@@ -348,6 +354,7 @@ public class GraphiteReporterTest {
     public void reportsTimers() throws Exception {
         final Timer timer = mock(Timer.class);
         when(timer.getCount()).thenReturn(1L);
+        when(timer.getSum()).thenReturn(6L);
         when(timer.getMeanRate()).thenReturn(2.0);
         when(timer.getOneMinuteRate()).thenReturn(3.0);
         when(timer.getFiveMinuteRate()).thenReturn(4.0);
@@ -387,6 +394,7 @@ public class GraphiteReporterTest {
         inOrder.verify(graphite).send("prefix.timer.p99", "900.00", timestamp);
         inOrder.verify(graphite).send("prefix.timer.p999", "1000.00", timestamp);
         inOrder.verify(graphite).send("prefix.timer.count", "1", timestamp);
+        inOrder.verify(graphite).send("prefix.timer.sum", "6", timestamp);
         inOrder.verify(graphite).send("prefix.timer.m1_rate", "3.00", timestamp);
         inOrder.verify(graphite).send("prefix.timer.m5_rate", "4.00", timestamp);
         inOrder.verify(graphite).send("prefix.timer.m15_rate", "5.00", timestamp);
@@ -429,6 +437,7 @@ public class GraphiteReporterTest {
     public void disabledMetricsAttribute() throws Exception {
         final Meter meter = mock(Meter.class);
         when(meter.getCount()).thenReturn(1L);
+        when(meter.getSum()).thenReturn(6L);
         when(meter.getOneMinuteRate()).thenReturn(2.0);
         when(meter.getFiveMinuteRate()).thenReturn(3.0);
         when(meter.getFifteenMinuteRate()).thenReturn(4.0);
@@ -456,6 +465,7 @@ public class GraphiteReporterTest {
         inOrder.verify(graphite).connect();
         inOrder.verify(graphite).send("prefix.counter.count", "11", timestamp);
         inOrder.verify(graphite).send("prefix.meter.count", "1", timestamp);
+        inOrder.verify(graphite).send("prefix.meter.sum", "6", timestamp);
         inOrder.verify(graphite).send("prefix.meter.m1_rate", "2.00", timestamp);
         inOrder.verify(graphite).send("prefix.meter.mean_rate", "5.00", timestamp);
         inOrder.verify(graphite).flush();

--- a/metrics-jmx/src/main/java/com/codahale/metrics/jmx/JmxReporter.java
+++ b/metrics-jmx/src/main/java/com/codahale/metrics/jmx/JmxReporter.java
@@ -223,6 +223,8 @@ public class JmxReporter implements Reporter, Closeable {
     public interface JmxHistogramMBean extends MetricMBean {
         long getCount();
 
+        long getSum();
+
         long getMin();
 
         long getMax();
@@ -270,6 +272,11 @@ public class JmxReporter implements Reporter, Closeable {
         @Override
         public long getCount() {
             return metric.getCount();
+        }
+
+        @Override
+        public long getSum() {
+            return metric.getSum();
         }
 
         @Override
@@ -332,6 +339,8 @@ public class JmxReporter implements Reporter, Closeable {
     public interface JmxMeterMBean extends MetricMBean {
         long getCount();
 
+        long getSum();
+
         double getMeanRate();
 
         double getOneMinuteRate();
@@ -358,6 +367,11 @@ public class JmxReporter implements Reporter, Closeable {
         @Override
         public long getCount() {
             return metric.getCount();
+        }
+
+        @Override
+        public long getSum() {
+            return metric.getSum();
         }
 
         @Override

--- a/metrics-jmx/src/test/java/com/codahale/metrics/jmx/JmxReporterTest.java
+++ b/metrics-jmx/src/test/java/com/codahale/metrics/jmx/JmxReporterTest.java
@@ -63,6 +63,7 @@ public class JmxReporterTest {
         when(counter.getCount()).thenReturn(100L);
 
         when(histogram.getCount()).thenReturn(1L);
+        when(histogram.getSum()).thenReturn(12L);
 
         final Snapshot hSnapshot = mock(Snapshot.class);
         when(hSnapshot.getMax()).thenReturn(2L);
@@ -80,12 +81,14 @@ public class JmxReporterTest {
         when(histogram.getSnapshot()).thenReturn(hSnapshot);
 
         when(meter.getCount()).thenReturn(1L);
+        when(meter.getSum()).thenReturn(6L);
         when(meter.getMeanRate()).thenReturn(2.0);
         when(meter.getOneMinuteRate()).thenReturn(3.0);
         when(meter.getFiveMinuteRate()).thenReturn(4.0);
         when(meter.getFifteenMinuteRate()).thenReturn(5.0);
 
         when(timer.getCount()).thenReturn(1L);
+        when(timer.getSum()).thenReturn(6L);
         when(timer.getMeanRate()).thenReturn(2.0);
         when(timer.getOneMinuteRate()).thenReturn(3.0);
         when(timer.getFiveMinuteRate()).thenReturn(4.0);
@@ -166,6 +169,7 @@ public class JmxReporterTest {
     public void registersMBeansForHistograms() throws Exception {
         final AttributeList attributes = getAttributes("test.histogram",
                 "Count",
+                "Sum",
                 "Max",
                 "Mean",
                 "Min",
@@ -180,6 +184,7 @@ public class JmxReporterTest {
 
         assertThat(values(attributes))
                 .contains(entry("Count", 1L))
+                .contains(entry("Sum", 12L))
                 .contains(entry("Max", 2L))
                 .contains(entry("Mean", 3.0))
                 .contains(entry("Min", 4L))
@@ -197,6 +202,7 @@ public class JmxReporterTest {
     public void registersMBeansForMeters() throws Exception {
         final AttributeList attributes = getAttributes("test.meter",
                 "Count",
+                "Sum",
                 "MeanRate",
                 "OneMinuteRate",
                 "FiveMinuteRate",
@@ -205,6 +211,7 @@ public class JmxReporterTest {
 
         assertThat(values(attributes))
                 .contains(entry("Count", 1L))
+                .contains(entry("Sum", 6L))
                 .contains(entry("MeanRate", 2.0))
                 .contains(entry("OneMinuteRate", 3.0))
                 .contains(entry("FiveMinuteRate", 4.0))
@@ -216,6 +223,7 @@ public class JmxReporterTest {
     public void registersMBeansForTimers() throws Exception {
         final AttributeList attributes = getAttributes("test.another.timer",
                 "Count",
+                "Sum",
                 "MeanRate",
                 "OneMinuteRate",
                 "FiveMinuteRate",
@@ -235,6 +243,7 @@ public class JmxReporterTest {
 
         assertThat(values(attributes))
                 .contains(entry("Count", 1L))
+                .contains(entry("Sum", 6L))
                 .contains(entry("MeanRate", 2.0))
                 .contains(entry("OneMinuteRate", 3.0))
                 .contains(entry("FiveMinuteRate", 4.0))


### PR DESCRIPTION
Original contribution is in #1181

> This is a rework of PR #1022 by @hashbrowncipher (and fixes @slovdahl's
> issue #712). This PR is based on the 4.0-development branch, which has
> evolved further than master.
> 
> The main differences are:
> 
> * Introduction of a new Summing interface, which is implemented by
> Meter, Timer and Histogram
> * Reporting of the Summing.sum() is done as a long to avoid loss of precision on
> high values due to floating point properties
> * All reporters report the sum() property of the relevant metrics
> 
> The main purpose of storing the sum is to facilitate monitoring systems
> that use raw ascending counters (e.g. Prometheus), and time-series
> databases such as InfluxDB (see also @mevdschee comment)