### PR TITLE
Add Metrics 3/4 legacy adapter

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics5/ScheduledReporter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics5/ScheduledReporter.java
@@ -258,27 +258,27 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
                                 SortedMap<MetricName, Meter> meters,
                                 SortedMap<MetricName, Timer> timers);
 
-    protected String getRateUnit() {
+    public String getRateUnit() {
         return rateUnit;
     }
 
-    protected String getDurationUnit() {
+    public String getDurationUnit() {
         return durationUnit;
     }
 
-    protected double convertDuration(double duration) {
+    public double convertDuration(double duration) {
         return duration / durationFactor;
     }
 
-    protected double convertRate(double rate) {
+    public double convertRate(double rate) {
         return rate * rateFactor;
     }
 
-    protected boolean isShutdownExecutorOnStop() {
+    public boolean isShutdownExecutorOnStop() {
         return shutdownExecutorOnStop;
     }
 
-    protected Set<MetricAttribute> getDisabledMetricAttributes() {
+    public Set<MetricAttribute> getDisabledMetricAttributes() {
         return disabledMetricAttributes;
     }
 

--- a/metrics-core/src/main/java/io/dropwizard/metrics5/Slf4jReporter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics5/Slf4jReporter.java
@@ -311,7 +311,7 @@ public class Slf4jReporter extends ScheduledReporter {
     }
 
     @Override
-    protected String getRateUnit() {
+    public String getRateUnit() {
         return "events/" + super.getRateUnit();
     }
 

--- a/metrics-legacy-adapter-healthchecks/pom.xml
+++ b/metrics-legacy-adapter-healthchecks/pom.xml
@@ -1,0 +1,19 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.dropwizard.metrics5</groupId>
+        <artifactId>metrics-parent</artifactId>
+        <version>5.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>metrics-legacy-adapter-healthchecks</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard.metrics5</groupId>
+            <artifactId>metrics-healthchecks</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/metrics-legacy-adapter-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
+++ b/metrics-legacy-adapter-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
@@ -1,0 +1,168 @@
+package com.codahale.metrics.health;
+
+import java.util.Map;
+import java.util.Objects;
+
+@Deprecated
+public abstract class HealthCheck {
+
+    public static class Result {
+
+        public static HealthCheck.Result healthy() {
+            return new Result(io.dropwizard.metrics5.health.HealthCheck.Result.healthy());
+        }
+
+        public static HealthCheck.Result healthy(String message) {
+            return new Result(io.dropwizard.metrics5.health.HealthCheck.Result.healthy(message));
+        }
+
+        public static HealthCheck.Result healthy(String message, Object... args) {
+            return new Result(io.dropwizard.metrics5.health.HealthCheck.Result.healthy(message, args));
+        }
+
+        public static HealthCheck.Result unhealthy(String message) {
+            return new Result(io.dropwizard.metrics5.health.HealthCheck.Result.unhealthy(message));
+        }
+
+        public static HealthCheck.Result unhealthy(String message, Object... args) {
+            return new Result(io.dropwizard.metrics5.health.HealthCheck.Result.unhealthy(message, args));
+        }
+
+        public static HealthCheck.Result unhealthy(Throwable error) {
+            return new Result(io.dropwizard.metrics5.health.HealthCheck.Result.unhealthy(error));
+        }
+
+        public static HealthCheck.Result of(io.dropwizard.metrics5.health.HealthCheck.Result delegate) {
+            return new Result(delegate);
+        }
+
+        public static HealthCheck.ResultBuilder builder() {
+            return new HealthCheck.ResultBuilder();
+        }
+
+        private final io.dropwizard.metrics5.health.HealthCheck.Result delegate;
+
+        private Result(io.dropwizard.metrics5.health.HealthCheck.Result delegate) {
+            this.delegate = delegate;
+        }
+
+        private Result(io.dropwizard.metrics5.health.HealthCheck.ResultBuilder builder) {
+            this.delegate = builder.build();
+        }
+
+        public boolean isHealthy() {
+            return delegate.isHealthy();
+        }
+
+        public String getMessage() {
+            return delegate.getMessage();
+        }
+
+        public Throwable getError() {
+            return delegate.getError();
+        }
+
+        public String getTimestamp() {
+            return delegate.getTimestamp();
+        }
+
+        public Map<String, Object> getDetails() {
+            return delegate.getDetails();
+        }
+
+        public io.dropwizard.metrics5.health.HealthCheck.Result getDelegate() {
+            return delegate;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o instanceof Result) {
+                final Result that = (Result) o;
+                return Objects.equals(delegate, that.delegate);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(delegate);
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+    }
+
+    public static class ResultBuilder {
+
+        private io.dropwizard.metrics5.health.HealthCheck.ResultBuilder delegate;
+
+        protected ResultBuilder() {
+            delegate = io.dropwizard.metrics5.health.HealthCheck.Result.builder();
+        }
+
+        public HealthCheck.ResultBuilder healthy() {
+            delegate.healthy();
+            return this;
+        }
+
+        public HealthCheck.ResultBuilder unhealthy() {
+            delegate.unhealthy();
+            return this;
+        }
+
+        public HealthCheck.ResultBuilder unhealthy(Throwable error) {
+            delegate.unhealthy(error);
+            return this;
+        }
+
+        public HealthCheck.ResultBuilder withMessage(String message) {
+            delegate.withMessage(message);
+            return this;
+        }
+
+        public HealthCheck.ResultBuilder withMessage(String message, Object... args) {
+            delegate.withMessage(message, args);
+            return this;
+        }
+
+        public HealthCheck.ResultBuilder withDetail(String key, Object data) {
+            delegate.withDetail(key, data);
+            return this;
+        }
+
+        public HealthCheck.Result build() {
+            return new HealthCheck.Result(delegate);
+        }
+    }
+
+    protected abstract HealthCheck.Result check() throws Exception;
+
+    public HealthCheck.Result execute() {
+        try {
+            return check();
+        } catch (Exception e) {
+            return HealthCheck.Result.unhealthy(e);
+        }
+    }
+
+    public io.dropwizard.metrics5.health.HealthCheck transform() {
+        final HealthCheck original = this;
+        return new io.dropwizard.metrics5.health.HealthCheck() {
+            @Override
+            protected Result check() throws Exception {
+                return original.check().delegate;
+            }
+        };
+    }
+
+    public static HealthCheck of(io.dropwizard.metrics5.health.HealthCheck delegate) {
+        return new HealthCheck() {
+            @Override
+            protected Result check() throws Exception {
+                return new Result(delegate.execute());
+            }
+        };
+    }
+}

--- a/metrics-legacy-adapter-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckFilter.java
+++ b/metrics-legacy-adapter-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckFilter.java
@@ -1,0 +1,14 @@
+package com.codahale.metrics.health;
+
+@Deprecated
+public interface HealthCheckFilter {
+
+    HealthCheckFilter ALL = (name, healthCheck) -> true;
+
+    boolean matches(String name, HealthCheck healthCheck);
+
+    default io.dropwizard.metrics5.health.HealthCheckFilter transform() {
+        final HealthCheckFilter origin = this;
+        return (name, healthCheck) -> origin.matches(name, HealthCheck.of(healthCheck));
+    }
+}

--- a/metrics-legacy-adapter-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistry.java
+++ b/metrics-legacy-adapter-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistry.java
@@ -1,0 +1,89 @@
+package com.codahale.metrics.health;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+@Deprecated
+public class HealthCheckRegistry {
+
+    private final io.dropwizard.metrics5.health.HealthCheckRegistry delegate;
+
+    public HealthCheckRegistry() {
+        this(new io.dropwizard.metrics5.health.HealthCheckRegistry());
+    }
+
+    public HealthCheckRegistry(int asyncExecutorPoolSize) {
+        this(new io.dropwizard.metrics5.health.HealthCheckRegistry(asyncExecutorPoolSize));
+    }
+
+    public HealthCheckRegistry(ScheduledExecutorService asyncExecutorService) {
+        this(new io.dropwizard.metrics5.health.HealthCheckRegistry(asyncExecutorService));
+    }
+
+    private HealthCheckRegistry(io.dropwizard.metrics5.health.HealthCheckRegistry delegate) {
+        this.delegate = delegate;
+    }
+
+    public static HealthCheckRegistry of(io.dropwizard.metrics5.health.HealthCheckRegistry reg) {
+        return new HealthCheckRegistry(reg);
+    }
+
+    public void addListener(HealthCheckRegistryListener listener) {
+        delegate.addListener(listener.transform());
+    }
+
+    public void removeListener(HealthCheckRegistryListener listener) {
+        delegate.removeListener(listener.transform());
+    }
+
+    public void register(String name, HealthCheck healthCheck) {
+        delegate.register(name, healthCheck.transform());
+    }
+
+    public void unregister(String name) {
+        delegate.unregister(name);
+    }
+
+    public SortedSet<String> getNames() {
+        return delegate.getNames();
+    }
+
+    public HealthCheck.Result runHealthCheck(String name) throws NoSuchElementException {
+        return HealthCheck.Result.of(delegate.runHealthCheck(name));
+    }
+
+    public SortedMap<String, HealthCheck.Result> runHealthChecks() {
+        return convertHealthChecks(delegate.runHealthChecks());
+    }
+
+    public SortedMap<String, HealthCheck.Result> runHealthChecks(HealthCheckFilter filter) {
+        return convertHealthChecks(delegate.runHealthChecks(filter.transform()));
+    }
+
+    public SortedMap<String, HealthCheck.Result> runHealthChecks(ExecutorService executor) {
+        return convertHealthChecks(delegate.runHealthChecks(executor));
+    }
+
+    public SortedMap<String, HealthCheck.Result> runHealthChecks(ExecutorService executor,
+                                                                 HealthCheckFilter filter) {
+        return convertHealthChecks(delegate.runHealthChecks(executor, filter.transform()));
+    }
+
+    private SortedMap<String, HealthCheck.Result> convertHealthChecks(
+            SortedMap<String, io.dropwizard.metrics5.health.HealthCheck.Result> originResults) {
+        final SortedMap<String, HealthCheck.Result> results = new TreeMap<>();
+        for (Map.Entry<String, io.dropwizard.metrics5.health.HealthCheck.Result> entry : originResults.entrySet()) {
+            results.put(entry.getKey(), HealthCheck.Result.of(entry.getValue()));
+        }
+        return results;
+    }
+
+    public void shutdown() {
+        delegate.shutdown();
+    }
+}

--- a/metrics-legacy-adapter-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistryListener.java
+++ b/metrics-legacy-adapter-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheckRegistryListener.java
@@ -1,0 +1,49 @@
+package com.codahale.metrics.health;
+
+import java.util.EventListener;
+import java.util.Objects;
+
+@Deprecated
+public interface HealthCheckRegistryListener extends EventListener {
+
+    void onHealthCheckAdded(String name, HealthCheck healthCheck);
+
+    void onHealthCheckRemoved(String name, HealthCheck healthCheck);
+
+    default io.dropwizard.metrics5.health.HealthCheckRegistryListener transform() {
+        return new Adapter(this);
+    }
+
+    class Adapter implements io.dropwizard.metrics5.health.HealthCheckRegistryListener {
+
+        private final HealthCheckRegistryListener delegate;
+
+        public Adapter(HealthCheckRegistryListener delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void onHealthCheckAdded(String name, io.dropwizard.metrics5.health.HealthCheck healthCheck) {
+            delegate.onHealthCheckAdded(name, HealthCheck.of(healthCheck));
+        }
+
+        @Override
+        public void onHealthCheckRemoved(String name, io.dropwizard.metrics5.health.HealthCheck healthCheck) {
+            delegate.onHealthCheckRemoved(name, HealthCheck.of(healthCheck));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o instanceof Adapter) {
+                final Adapter that = (Adapter) o;
+                return Objects.equals(delegate, that.delegate);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(delegate);
+        }
+    }
+}

--- a/metrics-legacy-adapter-healthchecks/src/main/test/java/com/codahale/metrics/health/HealthCheckRegistryTest.java
+++ b/metrics-legacy-adapter-healthchecks/src/main/test/java/com/codahale/metrics/health/HealthCheckRegistryTest.java
@@ -1,0 +1,193 @@
+package com.codahale.metrics.health;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.SortedMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class HealthCheckRegistryTest {
+
+    public static class DbCheck extends HealthCheck {
+        @Override
+        protected Result check() throws Exception {
+            return Result.unhealthy("DB is down");
+        }
+    }
+
+    public static class DummyHealthCheck extends HealthCheck {
+        @Override
+        protected Result check() throws Exception {
+            return Result.healthy();
+        }
+    }
+
+    public static class ProviderApiCheck extends HealthCheck {
+        @Override
+        protected Result check() throws Exception {
+            return Result.healthy("Provider API is up");
+        }
+    }
+
+    private HealthCheckRegistry registry = new HealthCheckRegistry();
+
+    @After
+    public void tearDown() throws Exception {
+        registry.shutdown();
+    }
+
+    @Test
+    public void testCreate() {
+        registry.register("test-hc", new DummyHealthCheck());
+        assertThat(registry.getNames()).containsExactly("test-hc");
+    }
+
+    @Test
+    public void testCreateWithCustomPool() {
+        registry = new HealthCheckRegistry(4);
+        registry.register("test-hc", new DummyHealthCheck());
+        assertThat(registry.getNames()).containsExactly("test-hc");
+    }
+
+    @Test
+    public void testCreateWithCustomExecutor() {
+        registry = new HealthCheckRegistry(Executors.newSingleThreadScheduledExecutor());
+        registry.register("test-hc", new DummyHealthCheck());
+        assertThat(registry.getNames()).containsExactly("test-hc");
+    }
+
+    @Test
+    public void testUnregisterHealthCheck() {
+        registry.register("test-hc", new DummyHealthCheck());
+        registry.register("provider-api-hc", new ProviderApiCheck());
+
+        registry.unregister("test-hc");
+        assertThat(registry.getNames()).containsExactly("provider-api-hc");
+    }
+
+    @Test
+    public void testRunHealthChecks() {
+        registry.register("test-hc", new DummyHealthCheck());
+        registry.register("db-hc", new DbCheck());
+
+        SortedMap<String, HealthCheck.Result> healthChecks = registry.runHealthChecks();
+        assertThat(healthChecks).containsOnlyKeys("test-hc", "db-hc");
+        assertThat(healthChecks.get("test-hc").isHealthy()).isTrue();
+        assertThat(healthChecks.get("db-hc").isHealthy()).isFalse();
+        assertThat(healthChecks.get("db-hc").getMessage()).isEqualTo("DB is down");
+    }
+
+    @Test
+    public void testRunSpecificHealthCheck() {
+        registry.register("test-hc", new DummyHealthCheck());
+        registry.register("db-hc", new DbCheck());
+
+        HealthCheck.Result healthCheck = registry.runHealthCheck("db-hc");
+        assertThat(healthCheck.isHealthy()).isFalse();
+        assertThat(healthCheck.getMessage()).isEqualTo("DB is down");
+    }
+
+    @Test
+    public void testRunHealthCheckWithFilter() {
+        registry.register("test-hc", new DummyHealthCheck());
+        registry.register("db-hc", new DbCheck());
+        registry.register("provider-api-hc", new ProviderApiCheck());
+
+        SortedMap<String, HealthCheck.Result> healthChecks = registry.runHealthChecks(
+                (name, healthCheck) -> !name.equals("test-hc"));
+        assertThat(healthChecks).containsOnlyKeys("provider-api-hc", "db-hc");
+        assertThat(healthChecks.get("provider-api-hc").isHealthy()).isTrue();
+        assertThat(healthChecks.get("provider-api-hc").getMessage()).isEqualTo("Provider API is up");
+        assertThat(healthChecks.get("db-hc").isHealthy()).isFalse();
+        assertThat(healthChecks.get("db-hc").getMessage()).isEqualTo("DB is down");
+    }
+
+    @Test
+    public void testRunHealthCheckWithoutFiltering() {
+        registry.register("test-hc", new DummyHealthCheck());
+        registry.register("db-hc", new DbCheck());
+        registry.register("provider-api-hc", new ProviderApiCheck());
+
+        assertThat(registry.runHealthChecks(HealthCheckFilter.ALL))
+                .containsOnlyKeys("test-hc", "provider-api-hc", "db-hc");
+    }
+
+    @Test
+    public void testAddListener() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        registry.addListener(new HealthCheckRegistryListener() {
+            @Override
+            public void onHealthCheckAdded(String name, HealthCheck healthCheck) {
+                assertThat(name).isEqualTo("test-hc");
+                latch.countDown();
+            }
+
+            @Override
+            public void onHealthCheckRemoved(String name, HealthCheck healthCheck) {
+
+            }
+        });
+
+        registry.register("test-hc", new DummyHealthCheck());
+
+        latch.await(5, TimeUnit.SECONDS);
+        assertThat(latch.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testAddListenerRemoveCallback() throws Exception {
+        registry.register("test-hc", new DummyHealthCheck());
+
+        CountDownLatch latch = new CountDownLatch(1);
+        registry.addListener(new HealthCheckRegistryListener() {
+            @Override
+            public void onHealthCheckAdded(String name, HealthCheck healthCheck) {
+            }
+
+            @Override
+            public void onHealthCheckRemoved(String name, HealthCheck healthCheck) {
+                assertThat(name).isEqualTo("test-hc");
+                latch.countDown();
+            }
+        });
+
+        registry.unregister("test-hc");
+
+        latch.await(5, TimeUnit.SECONDS);
+        assertThat(latch.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testRemoveListener() throws Exception {
+        CountDownLatch addLatch = new CountDownLatch(1);
+        CountDownLatch removeLatch = new CountDownLatch(1);
+        HealthCheckRegistryListener listener = new HealthCheckRegistryListener() {
+            @Override
+            public void onHealthCheckAdded(String name, HealthCheck healthCheck) {
+                assertThat(name).isEqualTo("test-hc");
+                addLatch.countDown();
+            }
+
+            @Override
+            public void onHealthCheckRemoved(String name, HealthCheck healthCheck) {
+                assertThat(name).isEqualTo("test-hc");
+                removeLatch.countDown();
+            }
+        };
+        registry.addListener(listener);
+        registry.register("test-hc", new DummyHealthCheck());
+        addLatch.await(5, TimeUnit.SECONDS);
+        assertThat(addLatch.getCount()).isEqualTo(0);
+
+        registry.removeListener(listener);
+
+        registry.unregister("test-hc");
+        removeLatch.await(100, TimeUnit.MILLISECONDS);
+        assertThat(removeLatch.getCount()).isEqualTo(1);
+    }
+}

--- a/metrics-legacy-adapter-healthchecks/src/main/test/java/com/codahale/metrics/health/HealthCheckTest.java
+++ b/metrics-legacy-adapter-healthchecks/src/main/test/java/com/codahale/metrics/health/HealthCheckTest.java
@@ -1,0 +1,126 @@
+package com.codahale.metrics.health;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+@SuppressWarnings("deprecation")
+public class HealthCheckTest {
+
+    @Test
+    public void testCreateHealthyCheck() {
+        HealthCheck healthCheck = new HealthCheck() {
+            @Override
+            protected Result check() throws Exception {
+                return Result.healthy();
+            }
+        };
+        assertThat(healthCheck.execute().isHealthy()).isTrue();
+    }
+
+    @Test
+    public void testCreateHealthyCheckWithMessage() {
+        HealthCheck healthCheck = new HealthCheck() {
+            @Override
+            protected Result check() throws Exception {
+                return Result.healthy("DB is up");
+            }
+        };
+        HealthCheck.Result result = healthCheck.execute();
+        assertThat(result.isHealthy()).isTrue();
+        assertThat(result.getMessage()).isEqualTo("DB is up");
+    }
+
+    @Test
+    public void testCreateHealthyCheckWithDynamicMessage() {
+        HealthCheck healthCheck = new HealthCheck() {
+            @Override
+            protected Result check() throws Exception {
+                return Result.healthy("DB %s is up", "se-us-1");
+            }
+        };
+        HealthCheck.Result result = healthCheck.execute();
+        assertThat(result.isHealthy()).isTrue();
+        assertThat(result.getMessage()).isEqualTo("DB se-us-1 is up");
+    }
+
+    @Test
+    public void testCreateUnhealthyCheck() {
+        HealthCheck healthCheck = new HealthCheck() {
+            @Override
+            protected Result check() throws Exception {
+                return Result.unhealthy("DB is down");
+            }
+        };
+        HealthCheck.Result result = healthCheck.execute();
+        assertThat(result.isHealthy()).isFalse();
+        assertThat(result.getMessage()).isEqualTo("DB is down");
+    }
+
+    @Test
+    public void testCreateUnhealthyCheckWithDynamicMessage() {
+        HealthCheck healthCheck = new HealthCheck() {
+            @Override
+            protected Result check() throws Exception {
+                return Result.unhealthy("DB %s is down", "se-us-1");
+            }
+        };
+        HealthCheck.Result result = healthCheck.execute();
+        assertThat(result.isHealthy()).isFalse();
+        assertThat(result.getMessage()).isEqualTo("DB se-us-1 is down");
+    }
+
+    @Test
+    public void testThrowExceptionInHealthCheck() {
+        HealthCheck healthCheck = new HealthCheck() {
+            @Override
+            protected Result check() throws Exception {
+                throw new IllegalStateException("DB is down");
+            }
+        };
+        HealthCheck.Result result = healthCheck.execute();
+        assertThat(result.isHealthy()).isFalse();
+        assertThat(result.getMessage()).isEqualTo("DB is down");
+        assertThat(result.getError()).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void testBuildCustomResult() {
+        HealthCheck healthCheck = new HealthCheck() {
+            @Override
+            protected Result check() throws Exception {
+                return Result.builder()
+                        .healthy()
+                        .withMessage("DB is up")
+                        .withDetail("responseTime", 5)
+                        .build();
+            }
+        };
+
+        HealthCheck.Result result = healthCheck.execute();
+        assertThat(result.isHealthy()).isTrue();
+        assertThat(result.getMessage()).isEqualTo("DB is up");
+        assertThat(result.getDetails()).containsExactly(entry("responseTime", 5));
+    }
+
+
+    @Test
+    public void testBuildCustomUnhealthyResult() {
+        HealthCheck healthCheck = new HealthCheck() {
+            @Override
+            protected Result check() throws Exception {
+                return Result.builder()
+                        .unhealthy()
+                        .withMessage("DB %s is down", "se-us-1")
+                        .withDetail("retries", 3)
+                        .build();
+            }
+        };
+
+        HealthCheck.Result result = healthCheck.execute();
+        assertThat(result.isHealthy()).isFalse();
+        assertThat(result.getMessage()).isEqualTo("DB se-us-1 is down");
+        assertThat(result.getDetails()).containsExactly(entry("retries", 3));
+    }
+}

--- a/metrics-legacy-adapter/pom.xml
+++ b/metrics-legacy-adapter/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>io.dropwizard.metrics5</groupId>
+		<artifactId>metrics-parent</artifactId>
+		<version>5.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>metrics-legacy-adapter</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.dropwizard.metrics5</groupId>
+			<artifactId>metrics-core</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/CachedGauge.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/CachedGauge.java
@@ -1,0 +1,42 @@
+package com.codahale.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public abstract class CachedGauge<T> implements Gauge<T> {
+
+    private final io.dropwizard.metrics5.CachedGauge<T> gauge;
+
+    public CachedGauge(io.dropwizard.metrics5.CachedGauge<T> gauge) {
+        this.gauge = requireNonNull(gauge);
+    }
+
+    protected CachedGauge(long timeout, TimeUnit timeoutUnit) {
+        final CachedGauge<T> original = this;
+        gauge = new io.dropwizard.metrics5.CachedGauge<T>(timeout, timeoutUnit) {
+            @Override
+            protected T loadValue() {
+                return original.loadValue();
+            }
+        };
+    }
+
+    protected CachedGauge(Clock clock, long timeout, TimeUnit timeoutUnit) {
+        final CachedGauge<T> original = this;
+        gauge = new io.dropwizard.metrics5.CachedGauge<T>(clock.getDelegate(), timeout, timeoutUnit) {
+            @Override
+            protected T loadValue() {
+                return original.loadValue();
+            }
+        };
+    }
+
+    protected abstract T loadValue();
+
+    public T getValue() {
+        return gauge.getValue();
+    }
+
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Clock.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Clock.java
@@ -1,0 +1,66 @@
+package com.codahale.metrics;
+
+@Deprecated
+public abstract class Clock {
+
+    public abstract long getTick();
+
+    public long getTime() {
+        return System.currentTimeMillis();
+    }
+
+    public io.dropwizard.metrics5.Clock getDelegate() {
+        if (this instanceof DelegateClock) {
+            return ((DelegateClock) this).delegate;
+        }
+        final Clock original = this;
+        return new io.dropwizard.metrics5.Clock() {
+            @Override
+            public long getTick() {
+                return original.getTick();
+            }
+
+            @Override
+            public long getTime() {
+                return original.getTime();
+            }
+        };
+    }
+
+    public static Clock of(io.dropwizard.metrics5.Clock delegate) {
+        return new DelegateClock(delegate);
+    }
+
+    public static Clock defaultClock() {
+        return of(io.dropwizard.metrics5.Clock.defaultClock());
+    }
+
+    public static class UserTimeClock extends Clock {
+
+        private final io.dropwizard.metrics5.Clock delegate = new io.dropwizard.metrics5.Clock.UserTimeClock();
+
+        @Override
+        public long getTick() {
+            return delegate.getTick();
+        }
+
+        @Override
+        public long getTime() {
+            return delegate.getTime();
+        }
+    }
+
+    private static class DelegateClock extends Clock {
+
+        private final io.dropwizard.metrics5.Clock delegate;
+
+        private DelegateClock(io.dropwizard.metrics5.Clock delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public long getTick() {
+            return delegate.getTick();
+        }
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/ConsoleReporter.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/ConsoleReporter.java
@@ -1,0 +1,92 @@
+package com.codahale.metrics;
+
+import java.io.PrintStream;
+import java.util.Locale;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TimeZone;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Deprecated
+public class ConsoleReporter extends ScheduledReporter {
+
+    public static Builder forRegistry(MetricRegistry registry) {
+        return new Builder(registry);
+    }
+
+    public static class Builder {
+
+        private io.dropwizard.metrics5.ConsoleReporter.Builder delegate;
+
+        private Builder(MetricRegistry metricRegistry) {
+            delegate = io.dropwizard.metrics5.ConsoleReporter.forRegistry(metricRegistry.getDelegate());
+        }
+
+        public Builder shutdownExecutorOnStop(boolean shutdownExecutorOnStop) {
+            delegate.shutdownExecutorOnStop(shutdownExecutorOnStop);
+            return this;
+        }
+
+        public Builder scheduleOn(ScheduledExecutorService executor) {
+            delegate.scheduleOn(executor);
+            return this;
+        }
+
+        public Builder outputTo(PrintStream output) {
+            delegate.outputTo(output);
+            return this;
+        }
+
+        public Builder formattedFor(Locale locale) {
+            delegate.formattedFor(locale);
+            return this;
+        }
+
+        public Builder withClock(Clock clock) {
+            delegate.withClock(clock.getDelegate());
+            return this;
+        }
+
+        public Builder formattedFor(TimeZone timeZone) {
+            delegate.formattedFor(timeZone);
+            return this;
+        }
+
+        public Builder convertRatesTo(TimeUnit rateUnit) {
+            delegate.convertRatesTo(rateUnit);
+            return this;
+        }
+
+        public Builder convertDurationsTo(TimeUnit durationUnit) {
+            delegate.convertDurationsTo(durationUnit);
+            return this;
+        }
+
+        public Builder filter(MetricFilter filter) {
+            delegate.filter(filter.transform());
+            return this;
+        }
+
+        public Builder disabledMetricAttributes(Set<MetricAttribute> disabledMetricAttributes) {
+            delegate.disabledMetricAttributes(MetricAttribute.transform(disabledMetricAttributes));
+            return this;
+        }
+
+        public ConsoleReporter build() {
+            return new ConsoleReporter(delegate.build());
+        }
+    }
+
+    private ConsoleReporter(io.dropwizard.metrics5.ScheduledReporter delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters,
+                       SortedMap<String, Histogram> histograms, SortedMap<String, Meter> meters,
+                       SortedMap<String, Timer> timers) {
+        getDelegate().report(transform(gauges), transform(counters), transform(histograms), transform(meters),
+                transform(timers));
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Counter.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Counter.java
@@ -1,0 +1,44 @@
+package com.codahale.metrics;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public class Counter implements Metric, Counting {
+
+    private final io.dropwizard.metrics5.Counter counter;
+
+    public Counter() {
+        this(new io.dropwizard.metrics5.Counter());
+    }
+
+    public Counter(io.dropwizard.metrics5.Counter counter) {
+        this.counter = requireNonNull(counter);
+    }
+
+    public void inc() {
+        counter.inc();
+    }
+
+    public void inc(long n) {
+        counter.inc(n);
+    }
+
+    public void dec() {
+        counter.dec();
+    }
+
+    public void dec(long n) {
+        counter.dec(n);
+    }
+
+    @Override
+    public long getCount() {
+        return counter.getCount();
+    }
+
+    @Override
+    public io.dropwizard.metrics5.Counter getDelegate() {
+        return counter;
+    }
+
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Counting.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Counting.java
@@ -1,0 +1,7 @@
+package com.codahale.metrics;
+
+@Deprecated
+public interface Counting {
+
+    long getCount();
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/CsvFileProvider.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/CsvFileProvider.java
@@ -1,0 +1,9 @@
+package com.codahale.metrics;
+
+import java.io.File;
+
+@Deprecated
+public interface CsvFileProvider {
+
+    File getFile(File directory, String metricName);
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/CsvReporter.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/CsvReporter.java
@@ -1,0 +1,87 @@
+package com.codahale.metrics;
+
+import java.io.File;
+import java.util.Locale;
+import java.util.SortedMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Deprecated
+public class CsvReporter extends ScheduledReporter {
+
+    public static Builder forRegistry(MetricRegistry registry) {
+        return new Builder(registry);
+    }
+
+    public static class Builder {
+
+        private io.dropwizard.metrics5.CsvReporter.Builder delegate;
+
+        private Builder(MetricRegistry metricRegistry) {
+            delegate = io.dropwizard.metrics5.CsvReporter.forRegistry(metricRegistry.getDelegate());
+        }
+
+        public CsvReporter.Builder shutdownExecutorOnStop(boolean shutdownExecutorOnStop) {
+            delegate.shutdownExecutorOnStop(shutdownExecutorOnStop);
+            return this;
+        }
+
+
+        public CsvReporter.Builder scheduleOn(ScheduledExecutorService executor) {
+            delegate.scheduleOn(executor);
+            return this;
+        }
+
+        public CsvReporter.Builder formatFor(Locale locale) {
+            delegate.formatFor(locale);
+            return this;
+        }
+
+
+        public CsvReporter.Builder convertRatesTo(TimeUnit rateUnit) {
+            delegate.convertRatesTo(rateUnit);
+            return this;
+        }
+
+        public CsvReporter.Builder convertDurationsTo(TimeUnit durationUnit) {
+            delegate.convertDurationsTo(durationUnit);
+            return this;
+        }
+
+        public CsvReporter.Builder withSeparator(String separator) {
+            delegate.withSeparator(separator);
+            return this;
+        }
+
+        public CsvReporter.Builder withClock(Clock clock) {
+            delegate.withClock(clock.getDelegate());
+            return this;
+        }
+
+        public CsvReporter.Builder filter(MetricFilter filter) {
+            delegate.filter(filter.transform());
+            return this;
+        }
+
+        public Builder withCsvFileProvider(CsvFileProvider csvFileProvider) {
+            delegate.withCsvFileProvider(csvFileProvider::getFile);
+            return this;
+        }
+
+        public CsvReporter build(File directory) {
+            return new CsvReporter(delegate.build(directory));
+        }
+    }
+    
+    public CsvReporter(io.dropwizard.metrics5.CsvReporter delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters,
+                       SortedMap<String, Histogram> histograms, SortedMap<String, Meter> meters,
+                       SortedMap<String, Timer> timers) {
+        getDelegate().report(transform(gauges), transform(counters), transform(histograms), transform(meters),
+                transform(timers));
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/DerivativeGauge.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/DerivativeGauge.java
@@ -1,0 +1,24 @@
+package com.codahale.metrics;
+
+@Deprecated
+public abstract class DerivativeGauge<F, T> implements Gauge<T> {
+
+    private final io.dropwizard.metrics5.DerivativeGauge<F, T> delegate;
+
+    protected DerivativeGauge(Gauge<F> base) {
+        DerivativeGauge<F, T> original = this;
+        delegate = new io.dropwizard.metrics5.DerivativeGauge<F, T>(base.getDelegate()) {
+            @Override
+            protected T transform(F value) {
+                return original.transform(base.getValue());
+            }
+        };
+    }
+
+    protected abstract T transform(F value);
+
+    @Override
+    public T getValue() {
+        return delegate.getValue();
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
@@ -1,0 +1,45 @@
+package com.codahale.metrics;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public class ExponentiallyDecayingReservoir implements Reservoir {
+
+    private final io.dropwizard.metrics5.ExponentiallyDecayingReservoir delegate;
+
+    public ExponentiallyDecayingReservoir() {
+        this(new io.dropwizard.metrics5.ExponentiallyDecayingReservoir());
+    }
+
+    public ExponentiallyDecayingReservoir(int size, double alpha) {
+        this(new io.dropwizard.metrics5.ExponentiallyDecayingReservoir(size, alpha));
+    }
+
+    public ExponentiallyDecayingReservoir(int size, double alpha, Clock clock) {
+        this(new io.dropwizard.metrics5.ExponentiallyDecayingReservoir(size, alpha, clock.getDelegate()));
+    }
+
+    public ExponentiallyDecayingReservoir(io.dropwizard.metrics5.ExponentiallyDecayingReservoir delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    @Override
+    public io.dropwizard.metrics5.Reservoir getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public void update(long value) {
+        delegate.update(value);
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        return Snapshot.of(delegate.getSnapshot());
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/FixedNameCsvFileProvider.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/FixedNameCsvFileProvider.java
@@ -1,0 +1,15 @@
+package com.codahale.metrics;
+
+import java.io.File;
+
+@Deprecated
+public class FixedNameCsvFileProvider implements CsvFileProvider {
+
+    private final io.dropwizard.metrics5.FixedNameCsvFileProvider delegate =
+            new io.dropwizard.metrics5.FixedNameCsvFileProvider();
+
+    @Override
+    public File getFile(File directory, String metricName) {
+        return delegate.getFile(directory, metricName);
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Gauge.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Gauge.java
@@ -1,0 +1,38 @@
+package com.codahale.metrics;
+
+@Deprecated
+public interface Gauge<T> extends Metric {
+
+    T getValue();
+
+    @Override
+    default io.dropwizard.metrics5.Gauge<T> getDelegate() {
+        return new GaugeAdapter<>(this);
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> Gauge<T> of(io.dropwizard.metrics5.Gauge<T> gauge) {
+        if (gauge instanceof GaugeAdapter) {
+            return ((GaugeAdapter) gauge).delegate;
+        }
+        return gauge::getValue;
+    }
+
+    class GaugeAdapter<T> implements io.dropwizard.metrics5.Gauge<T> {
+
+        private final Gauge<T> delegate;
+
+        GaugeAdapter(Gauge<T> gauge) {
+            this.delegate = gauge;
+        }
+
+        Gauge<T> getGauge() {
+            return delegate;
+        }
+
+        @Override
+        public T getValue() {
+            return delegate.getValue();
+        }
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Histogram.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Histogram.java
@@ -1,0 +1,40 @@
+package com.codahale.metrics;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public class Histogram implements Metric, Sampling, Counting {
+
+    private final io.dropwizard.metrics5.Histogram delegate;
+
+    public Histogram(io.dropwizard.metrics5.Histogram delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    public Histogram(Reservoir reservoir) {
+        this.delegate = new io.dropwizard.metrics5.Histogram(reservoir.getDelegate());
+    }
+
+    public void update(int value) {
+        delegate.update(value);
+    }
+
+    public void update(long value) {
+        delegate.update(value);
+    }
+
+    @Override
+    public long getCount() {
+        return delegate.getCount();
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        return Snapshot.of(delegate.getSnapshot());
+    }
+
+    @Override
+    public io.dropwizard.metrics5.Histogram getDelegate() {
+        return delegate;
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/InstrumentedExecutorService.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/InstrumentedExecutorService.java
@@ -1,0 +1,95 @@
+package com.codahale.metrics;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public class InstrumentedExecutorService implements ExecutorService {
+
+    private final io.dropwizard.metrics5.InstrumentedExecutorService delegate;
+
+    public InstrumentedExecutorService(io.dropwizard.metrics5.InstrumentedExecutorService delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    public InstrumentedExecutorService(ExecutorService delegate, MetricRegistry registry) {
+        this(new io.dropwizard.metrics5.InstrumentedExecutorService(delegate, registry.getDelegate()));
+    }
+
+    public InstrumentedExecutorService(ExecutorService delegate, MetricRegistry registry, String name) {
+        this(new io.dropwizard.metrics5.InstrumentedExecutorService(delegate, registry.getDelegate(), name));
+    }
+
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return delegate.submit(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return delegate.submit(task, result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return delegate.submit(task);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return delegate.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return delegate.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return delegate.invokeAny(tasks, timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        delegate.execute(command);
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/InstrumentedScheduledExecutorService.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/InstrumentedScheduledExecutorService.java
@@ -1,0 +1,116 @@
+package com.codahale.metrics;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public class InstrumentedScheduledExecutorService implements ScheduledExecutorService {
+
+    private final io.dropwizard.metrics5.InstrumentedScheduledExecutorService delegate;
+
+    public InstrumentedScheduledExecutorService(io.dropwizard.metrics5.InstrumentedScheduledExecutorService delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    public InstrumentedScheduledExecutorService(ScheduledExecutorService delegate, MetricRegistry registry) {
+        this(new io.dropwizard.metrics5.InstrumentedScheduledExecutorService(delegate, registry.getDelegate()));
+    }
+
+    public InstrumentedScheduledExecutorService(ScheduledExecutorService delegate, MetricRegistry registry, String name) {
+        this(new io.dropwizard.metrics5.InstrumentedScheduledExecutorService(delegate, registry.getDelegate(), name));
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return delegate.schedule(command, delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return delegate.schedule(callable, delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return delegate.scheduleAtFixedRate(command, initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return delegate.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+    }
+
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return delegate.submit(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return delegate.submit(task, result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return delegate.submit(task);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return delegate.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return delegate.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return delegate.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return delegate.invokeAny(tasks, timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        delegate.execute(command);
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/InstrumentedThreadFactory.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/InstrumentedThreadFactory.java
@@ -1,0 +1,28 @@
+package com.codahale.metrics;
+
+import java.util.concurrent.ThreadFactory;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public class InstrumentedThreadFactory implements ThreadFactory {
+
+    private final io.dropwizard.metrics5.InstrumentedThreadFactory delegate;
+
+    public InstrumentedThreadFactory(io.dropwizard.metrics5.InstrumentedThreadFactory delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    public InstrumentedThreadFactory(ThreadFactory delegate, MetricRegistry registry) {
+        this(new io.dropwizard.metrics5.InstrumentedThreadFactory(delegate, registry.getDelegate()));
+    }
+
+    public InstrumentedThreadFactory(ThreadFactory delegate, MetricRegistry registry, String name) {
+        this(new io.dropwizard.metrics5.InstrumentedThreadFactory(delegate, registry.getDelegate(), name));
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        return delegate.newThread(r);
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Meter.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Meter.java
@@ -1,0 +1,59 @@
+package com.codahale.metrics;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public class Meter implements Metered {
+
+    private final io.dropwizard.metrics5.Meter delegate;
+
+    public Meter() {
+        this(new io.dropwizard.metrics5.Meter());
+    }
+
+    public Meter(Clock clock) {
+        this(new io.dropwizard.metrics5.Meter(clock.getDelegate()));
+    }
+
+    public Meter(io.dropwizard.metrics5.Meter delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    public void mark() {
+        delegate.mark();
+    }
+
+    public void mark(long n) {
+        delegate.mark(n);
+    }
+
+    @Override
+    public long getCount() {
+        return delegate.getCount();
+    }
+
+    @Override
+    public double getFifteenMinuteRate() {
+        return delegate.getFifteenMinuteRate();
+    }
+
+    @Override
+    public double getFiveMinuteRate() {
+        return delegate.getFiveMinuteRate();
+    }
+
+    @Override
+    public double getMeanRate() {
+        return delegate.getMeanRate();
+    }
+
+    @Override
+    public double getOneMinuteRate() {
+        return delegate.getOneMinuteRate();
+    }
+
+    @Override
+    public io.dropwizard.metrics5.Meter getDelegate() {
+        return delegate;
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Metered.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Metered.java
@@ -1,0 +1,16 @@
+package com.codahale.metrics;
+
+@Deprecated
+public interface Metered extends Metric, Counting {
+
+    @Override
+    long getCount();
+
+    double getFifteenMinuteRate();
+
+    double getFiveMinuteRate();
+
+    double getMeanRate();
+
+    double getOneMinuteRate();
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Metric.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Metric.java
@@ -1,0 +1,26 @@
+package com.codahale.metrics;
+
+@Deprecated
+public interface Metric {
+
+    io.dropwizard.metrics5.Metric getDelegate();
+
+    @SuppressWarnings("unchecked")
+    static Metric of(io.dropwizard.metrics5.Metric metric) {
+        if (metric instanceof io.dropwizard.metrics5.Counter) {
+            return new Counter((io.dropwizard.metrics5.Counter) metric);
+        } else if (metric instanceof io.dropwizard.metrics5.Histogram) {
+            return new Histogram((io.dropwizard.metrics5.Histogram) metric);
+        } else if (metric instanceof io.dropwizard.metrics5.Meter) {
+            return new Meter((io.dropwizard.metrics5.Meter) metric);
+        } else if (metric instanceof io.dropwizard.metrics5.Timer) {
+            return new Timer((io.dropwizard.metrics5.Timer) metric);
+        } else if (metric instanceof io.dropwizard.metrics5.Gauge) {
+            return Gauge.of((io.dropwizard.metrics5.Gauge) metric);
+        } else if (metric instanceof io.dropwizard.metrics5.MetricSet) {
+            return MetricSet.of((io.dropwizard.metrics5.MetricSet) metric);
+        } else {
+            throw new IllegalArgumentException("Can't find adaptor class for metric of type: " + metric.getClass().getName());
+        }
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricAttribute.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricAttribute.java
@@ -1,0 +1,44 @@
+package com.codahale.metrics;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+@Deprecated
+public enum MetricAttribute {
+
+    MAX("max"),
+    MEAN("mean"),
+    MIN("min"),
+    STDDEV("stddev"),
+    P50("p50"),
+    P75("p75"),
+    P95("p95"),
+    P98("p98"),
+    P99("p99"),
+    P999("p999"),
+    COUNT("count"),
+    SUM("sum"),
+    M1_RATE("m1_rate"),
+    M5_RATE("m5_rate"),
+    M15_RATE("m15_rate"),
+    MEAN_RATE("mean_rate");
+
+    private final String code;
+
+    MetricAttribute(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public static Set<io.dropwizard.metrics5.MetricAttribute> transform(Set<MetricAttribute> metricAttributes) {
+        EnumSet<io.dropwizard.metrics5.MetricAttribute> newAttributes = EnumSet.noneOf(
+                io.dropwizard.metrics5.MetricAttribute.class);
+        for (MetricAttribute ma : metricAttributes) {
+            newAttributes.add(io.dropwizard.metrics5.MetricAttribute.valueOf(ma.name()));
+        }
+        return newAttributes;
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricFilter.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricFilter.java
@@ -1,0 +1,26 @@
+package com.codahale.metrics;
+
+@Deprecated
+public interface MetricFilter {
+
+    MetricFilter ALL = (name, metric) -> true;
+
+    static MetricFilter startsWith(String prefix) {
+        return (name, metric) -> name.startsWith(prefix);
+    }
+
+    static MetricFilter endsWith(String suffix) {
+        return (name, metric) -> name.endsWith(suffix);
+    }
+
+    static MetricFilter contains(String substring) {
+        return (name, metric) -> name.contains(substring);
+    }
+
+    boolean matches(String name, Metric metric);
+
+    default io.dropwizard.metrics5.MetricFilter transform() {
+        final MetricFilter origin = this;
+        return (name, metric) -> origin.matches(name.getKey(), Metric.of(metric));
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -1,0 +1,179 @@
+package com.codahale.metrics;
+
+import io.dropwizard.metrics5.MetricName;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.SortedMap;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.unmodifiableSortedSet;
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public class MetricRegistry implements MetricSet {
+
+    private final io.dropwizard.metrics5.MetricRegistry delegate;
+
+    public static String name(Class<?> klass, String... names) {
+        return io.dropwizard.metrics5.MetricRegistry.name(klass, names).getKey();
+    }
+
+    public static String name(String name, String... names) {
+        return io.dropwizard.metrics5.MetricRegistry.name(name, names).getKey();
+    }
+
+    public MetricRegistry() {
+        this(new io.dropwizard.metrics5.MetricRegistry());
+    }
+
+    public MetricRegistry(io.dropwizard.metrics5.MetricRegistry delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    public <T extends Metric> T register(String name, T metric) throws IllegalArgumentException {
+        delegate.register(MetricName.build(name), metric.getDelegate());
+        return metric;
+    }
+
+    public void registerAll(MetricSet metrics) throws IllegalArgumentException {
+        delegate.registerAll(metrics.getDelegate());
+    }
+
+    @SuppressWarnings("unchecked")
+    public Gauge gauge(String name, MetricSupplier<Gauge> supplier) {
+        return Gauge.of(delegate.gauge(MetricName.build(name), supplier.transform()));
+    }
+
+    public Counter counter(String name) {
+        return new Counter(delegate.counter(name));
+    }
+
+    public Counter counter(String name, MetricSupplier<Counter> supplier) {
+        return new Counter(delegate.counter(MetricName.build(name), supplier.transform()));
+    }
+
+    public Histogram histogram(String name) {
+        return new Histogram(delegate.histogram(MetricName.build(name)));
+    }
+
+    public Histogram histogram(String name, MetricSupplier<Histogram> supplier) {
+        return new Histogram(delegate.histogram(MetricName.build(name), supplier.transform()));
+    }
+
+    public Meter meter(String name) {
+        return new Meter(delegate.meter(MetricName.build(name)));
+    }
+
+    public Meter meter(String name, MetricSupplier<Meter> supplier) {
+        return new Meter(delegate.meter(MetricName.build(name), supplier.transform()));
+    }
+
+    public Timer timer(String name) {
+        return new Timer(delegate.timer(MetricName.build(name)));
+    }
+
+    public Timer timer(String name, MetricSupplier<Timer> supplier) {
+        return new Timer(delegate.timer(MetricName.build(name), supplier.transform()));
+    }
+
+    public boolean remove(String name) {
+        return delegate.remove(MetricName.build(name));
+    }
+
+    public void removeMatching(MetricFilter filter) {
+        delegate.removeMatching(filter.transform());
+    }
+
+    public void addListener(MetricRegistryListener listener) {
+        delegate.addListener(new MetricRegistryListener.Adapter(listener));
+    }
+
+    public void removeListener(MetricRegistryListener listener) {
+        delegate.removeListener(new MetricRegistryListener.Adapter(listener));
+    }
+
+    public SortedSet<String> getNames() {
+        return unmodifiableSortedSet(delegate.getNames()
+                .stream()
+                .map(MetricName::getKey)
+                .collect(Collectors.toCollection(TreeSet::new)));
+    }
+
+    public SortedMap<String, Gauge> getGauges() {
+        return adaptMetrics(delegate.getGauges());
+    }
+
+    public SortedMap<String, Gauge> getGauges(MetricFilter filter) {
+        return adaptMetrics(delegate.getGauges(filter.transform()));
+    }
+
+    public SortedMap<String, Counter> getCounters() {
+        return adaptMetrics(delegate.getCounters());
+    }
+
+    public SortedMap<String, Counter> getCounters(MetricFilter filter) {
+        return adaptMetrics(delegate.getCounters(filter.transform()));
+    }
+
+    public SortedMap<String, Histogram> getHistograms() {
+        return adaptMetrics(delegate.getHistograms());
+    }
+
+    public SortedMap<String, Histogram> getHistograms(MetricFilter filter) {
+        return adaptMetrics(delegate.getHistograms(filter.transform()));
+    }
+
+    public SortedMap<String, Meter> getMeters() {
+        return adaptMetrics(delegate.getMeters());
+    }
+
+    public SortedMap<String, Meter> getMeters(MetricFilter filter) {
+        return adaptMetrics(delegate.getMeters(filter.transform()));
+    }
+
+    public SortedMap<String, Timer> getTimers() {
+        return adaptMetrics(delegate.getTimers());
+    }
+
+    public SortedMap<String, Timer> getTimers(MetricFilter filter) {
+        return adaptMetrics(delegate.getTimers(filter.transform()));
+    }
+
+    @Override
+    public Map<String, Metric> getMetrics() {
+        return adaptMetrics(delegate.getMetrics());
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T extends Metric> SortedMap<String, T> adaptMetrics(
+            Map<MetricName, ? extends io.dropwizard.metrics5.Metric> metrics) {
+        final SortedMap<String, T> items = new TreeMap<>();
+        for (Map.Entry<MetricName, ? extends io.dropwizard.metrics5.Metric> entry : metrics.entrySet()) {
+            items.put(entry.getKey().getKey(), (T) Metric.of(entry.getValue()));
+        }
+        return Collections.unmodifiableSortedMap(items);
+    }
+
+    @Override
+    public io.dropwizard.metrics5.MetricRegistry getDelegate() {
+        return delegate;
+    }
+
+    @FunctionalInterface
+    public interface MetricSupplier<T extends Metric> {
+
+        T newMetric();
+
+        @SuppressWarnings("unchecked")
+        default <M extends io.dropwizard.metrics5.Metric>
+        io.dropwizard.metrics5.MetricRegistry.MetricSupplier<M> transform() {
+            MetricSupplier<T> original = this;
+            return () -> (M) original.newMetric().getDelegate();
+        }
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricRegistryListener.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricRegistryListener.java
@@ -1,0 +1,144 @@
+package com.codahale.metrics;
+
+import io.dropwizard.metrics5.MetricName;
+
+import java.util.EventListener;
+
+@Deprecated
+public interface MetricRegistryListener extends EventListener {
+
+    abstract class Base implements MetricRegistryListener {
+        @Override
+        public void onGaugeAdded(String name, Gauge<?> gauge) {
+        }
+
+        @Override
+        public void onGaugeRemoved(String name) {
+        }
+
+        @Override
+        public void onCounterAdded(String name, Counter counter) {
+        }
+
+        @Override
+        public void onCounterRemoved(String name) {
+        }
+
+        @Override
+        public void onHistogramAdded(String name, Histogram histogram) {
+        }
+
+        @Override
+        public void onHistogramRemoved(String name) {
+        }
+
+        @Override
+        public void onMeterAdded(String name, Meter meter) {
+        }
+
+        @Override
+        public void onMeterRemoved(String name) {
+        }
+
+        @Override
+        public void onTimerAdded(String name, Timer timer) {
+        }
+
+        @Override
+        public void onTimerRemoved(String name) {
+        }
+    }
+
+    void onGaugeAdded(String name, Gauge<?> gauge);
+
+    void onGaugeRemoved(String name);
+
+    void onCounterAdded(String name, Counter counter);
+
+    void onCounterRemoved(String name);
+
+    void onHistogramAdded(String name, Histogram histogram);
+
+    void onHistogramRemoved(String name);
+
+    void onMeterAdded(String name, Meter meter);
+
+    void onMeterRemoved(String name);
+
+    void onTimerAdded(String name, Timer timer);
+
+    void onTimerRemoved(String name);
+
+    class Adapter implements io.dropwizard.metrics5.MetricRegistryListener {
+
+        private MetricRegistryListener delegate;
+
+        public Adapter(MetricRegistryListener delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void onGaugeAdded(MetricName name, io.dropwizard.metrics5.Gauge<?> gauge) {
+            delegate.onGaugeAdded(name.getKey(), Gauge.of(gauge));
+        }
+
+        @Override
+        public void onGaugeRemoved(MetricName name) {
+            delegate.onGaugeRemoved(name.getKey());
+        }
+
+        @Override
+        public void onCounterAdded(MetricName name, io.dropwizard.metrics5.Counter counter) {
+            delegate.onCounterAdded(name.getKey(), new Counter(counter));
+        }
+
+        @Override
+        public void onCounterRemoved(MetricName name) {
+            delegate.onCounterRemoved(name.getKey());
+        }
+
+        @Override
+        public void onHistogramAdded(MetricName name, io.dropwizard.metrics5.Histogram histogram) {
+            delegate.onHistogramAdded(name.getKey(), new Histogram(histogram));
+        }
+
+        @Override
+        public void onHistogramRemoved(MetricName name) {
+            delegate.onHistogramRemoved(name.getKey());
+        }
+
+        @Override
+        public void onMeterAdded(MetricName name, io.dropwizard.metrics5.Meter meter) {
+            delegate.onMeterAdded(name.getKey(), new Meter(meter));
+        }
+
+        @Override
+        public void onMeterRemoved(MetricName name) {
+            delegate.onMeterRemoved(name.getKey());
+        }
+
+        @Override
+        public void onTimerAdded(MetricName name, io.dropwizard.metrics5.Timer timer) {
+            delegate.onTimerAdded(name.getKey(), new Timer(timer));
+        }
+
+        @Override
+        public void onTimerRemoved(MetricName name) {
+            delegate.onTimerRemoved(name.getKey());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o instanceof Adapter) {
+                Adapter adapter = (Adapter) o;
+                return delegate.equals(adapter.delegate);
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return delegate.hashCode();
+        }
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricSet.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricSet.java
@@ -1,0 +1,55 @@
+package com.codahale.metrics;
+
+import io.dropwizard.metrics5.MetricName;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Deprecated
+public interface MetricSet extends Metric {
+
+    Map<String, Metric> getMetrics();
+
+    @Override
+    default io.dropwizard.metrics5.MetricSet getDelegate() {
+        return new Adapter(this);
+    }
+
+    static MetricSet of(io.dropwizard.metrics5.MetricSet original) {
+        return new MetricSet() {
+            @Override
+            public Map<String, Metric> getMetrics() {
+                final Map<String, Metric> items = new HashMap<>();
+                for (Map.Entry<MetricName, io.dropwizard.metrics5.Metric> entry : original.getMetrics().entrySet()) {
+                    items.put(entry.getKey().getKey(), Metric.of(entry.getValue()));
+                }
+                return Collections.unmodifiableMap(items);
+            }
+
+            @Override
+            public io.dropwizard.metrics5.MetricSet getDelegate() {
+                return original;
+            }
+        };
+    }
+
+    class Adapter implements io.dropwizard.metrics5.MetricSet {
+
+        private final MetricSet delegate;
+
+        Adapter(MetricSet delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Map<MetricName, io.dropwizard.metrics5.Metric> getMetrics() {
+            final Map<MetricName, io.dropwizard.metrics5.Metric> items = new HashMap<>();
+            for (Map.Entry<String, Metric> entry : delegate.getMetrics().entrySet()) {
+                items.put(MetricName.build(entry.getKey()), entry.getValue().getDelegate());
+            }
+            return Collections.unmodifiableMap(items);
+        }
+    }
+
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/RatioGauge.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/RatioGauge.java
@@ -1,0 +1,36 @@
+package com.codahale.metrics;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public abstract class RatioGauge implements Gauge<Double> {
+
+    public static class Ratio {
+
+        private io.dropwizard.metrics5.RatioGauge.Ratio delegate;
+
+        public static Ratio of(double numerator, double denominator) {
+            return new Ratio(io.dropwizard.metrics5.RatioGauge.Ratio.of(numerator, denominator));
+        }
+
+        public Ratio(io.dropwizard.metrics5.RatioGauge.Ratio delegate) {
+            this.delegate = requireNonNull(delegate);
+        }
+
+        public double getValue() {
+            return delegate.getValue();
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+    }
+
+    protected abstract Ratio getRatio();
+
+    @Override
+    public Double getValue() {
+        return getRatio().getValue();
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Reporter.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Reporter.java
@@ -1,0 +1,6 @@
+package com.codahale.metrics;
+
+@Deprecated
+public interface Reporter {
+
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Reservoir.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Reservoir.java
@@ -1,0 +1,13 @@
+package com.codahale.metrics;
+
+@Deprecated
+public interface Reservoir {
+
+    int size();
+
+    void update(long value);
+
+    Snapshot getSnapshot();
+
+    io.dropwizard.metrics5.Reservoir getDelegate();
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Sampling.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Sampling.java
@@ -1,0 +1,7 @@
+package com.codahale.metrics;
+
+@Deprecated
+public interface Sampling {
+
+    Snapshot getSnapshot();
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -1,0 +1,152 @@
+package com.codahale.metrics;
+
+import io.dropwizard.metrics5.MetricName;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public abstract class ScheduledReporter implements Closeable, Reporter {
+
+    private io.dropwizard.metrics5.ScheduledReporter delegate;
+
+    protected ScheduledReporter(io.dropwizard.metrics5.ScheduledReporter delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    protected ScheduledReporter(MetricRegistry registry, String name, MetricFilter filter, TimeUnit rateUnit,
+                                TimeUnit durationUnit) {
+        delegate = new Adapter(registry, name, filter, rateUnit, durationUnit, this);
+    }
+
+    protected ScheduledReporter(MetricRegistry registry, String name, MetricFilter filter, TimeUnit rateUnit,
+                                TimeUnit durationUnit, ScheduledExecutorService executor) {
+        delegate = new Adapter(registry, name, filter, rateUnit, durationUnit, executor, this);
+    }
+
+    protected ScheduledReporter(MetricRegistry registry, String name, MetricFilter filter, TimeUnit rateUnit,
+                                TimeUnit durationUnit, ScheduledExecutorService executor, boolean shutdownExecutorOnStop) {
+        delegate = new Adapter(registry, name, filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop, this);
+    }
+
+    protected ScheduledReporter(MetricRegistry registry, String name, MetricFilter filter, TimeUnit rateUnit,
+                                TimeUnit durationUnit, ScheduledExecutorService executor, boolean shutdownExecutorOnStop,
+                                Set<MetricAttribute> disabledMetricAttributes) {
+        delegate = new Adapter(registry, name, filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop,
+                disabledMetricAttributes, this);
+    }
+
+    public void start(long period, TimeUnit unit) {
+        delegate.start(period, unit);
+    }
+
+    synchronized public void start(long initialDelay, long period, TimeUnit unit) {
+        delegate.start(initialDelay, period, unit);
+    }
+
+    public void stop() {
+        delegate.stop();
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+    public void report() {
+        delegate.report();
+    }
+
+    public io.dropwizard.metrics5.ScheduledReporter getDelegate() {
+        return delegate;
+    }
+
+    @SuppressWarnings("rawtypes")
+    public abstract void report(SortedMap<String, Gauge> gauges,
+                                SortedMap<String, Counter> counters,
+                                SortedMap<String, Histogram> histograms,
+                                SortedMap<String, Meter> meters,
+                                SortedMap<String, Timer> timers);
+
+    @SuppressWarnings("unchecked")
+    protected <T extends io.dropwizard.metrics5.Metric> SortedMap<MetricName, T> transform(
+            SortedMap<String, ? extends Metric> metrics) {
+        final SortedMap<MetricName, T> items = new TreeMap<>();
+        for (Map.Entry<String, ? extends Metric> entry : metrics.entrySet()) {
+            items.put(MetricName.build(entry.getKey()), (T) entry.getValue().getDelegate());
+        }
+        return Collections.unmodifiableSortedMap(items);
+    }
+
+    protected String getRateUnit() {
+        return delegate.getRateUnit();
+    }
+
+    protected String getDurationUnit() {
+        return delegate.getDurationUnit();
+    }
+
+    protected double convertDuration(double duration) {
+        return delegate.convertDuration(duration);
+    }
+
+    protected double convertRate(double rate) {
+        return delegate.convertRate(rate);
+    }
+
+    protected boolean isShutdownExecutorOnStop() {
+        return delegate.isShutdownExecutorOnStop();
+    }
+
+    protected Set<io.dropwizard.metrics5.MetricAttribute> getDisabledMetricAttributes() {
+        return delegate.getDisabledMetricAttributes();
+    }
+
+    public static class Adapter extends io.dropwizard.metrics5.ScheduledReporter {
+
+        private final ScheduledReporter delegate;
+
+        public Adapter(MetricRegistry registry, String name, MetricFilter filter, TimeUnit rateUnit, TimeUnit durationUnit,
+                       ScheduledReporter delegate) {
+            super(registry.getDelegate(), name, filter.transform(), rateUnit, durationUnit);
+            this.delegate = delegate;
+        }
+
+        public Adapter(MetricRegistry registry, String name, MetricFilter filter, TimeUnit rateUnit, TimeUnit durationUnit,
+                       ScheduledExecutorService executor, ScheduledReporter delegate) {
+            super(registry.getDelegate(), name, filter.transform(), rateUnit, durationUnit, executor);
+            this.delegate = delegate;
+        }
+
+        public Adapter(MetricRegistry registry, String name, MetricFilter filter, TimeUnit rateUnit, TimeUnit durationUnit,
+                       ScheduledExecutorService executor, boolean shutdownExecutorOnStop, ScheduledReporter delegate) {
+            super(registry.getDelegate(), name, filter.transform(), rateUnit, durationUnit, executor, shutdownExecutorOnStop);
+            this.delegate = delegate;
+        }
+
+        public Adapter(MetricRegistry registry, String name, MetricFilter filter, TimeUnit rateUnit, TimeUnit durationUnit,
+                       ScheduledExecutorService executor, boolean shutdownExecutorOnStop, Set<MetricAttribute> disabledMetricAttributes,
+                       ScheduledReporter delegate) {
+            super(registry.getDelegate(), name, filter.transform(), rateUnit, durationUnit, executor, shutdownExecutorOnStop,
+                    MetricAttribute.transform(disabledMetricAttributes));
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void report(SortedMap<MetricName, io.dropwizard.metrics5.Gauge> gauges, SortedMap<MetricName, io.dropwizard.metrics5.Counter> counters,
+                           SortedMap<MetricName, io.dropwizard.metrics5.Histogram> histograms, SortedMap<MetricName, io.dropwizard.metrics5.Meter> meters,
+                           SortedMap<MetricName, io.dropwizard.metrics5.Timer> timers) {
+            delegate.report(MetricRegistry.adaptMetrics(gauges), MetricRegistry.adaptMetrics(counters),
+                    MetricRegistry.adaptMetrics(histograms), MetricRegistry.adaptMetrics(meters),
+                    MetricRegistry.adaptMetrics(timers));
+        }
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/SharedMetricRegistries.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/SharedMetricRegistries.java
@@ -1,0 +1,49 @@
+package com.codahale.metrics;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+@Deprecated
+public class SharedMetricRegistries {
+
+    public static void clear() {
+        io.dropwizard.metrics5.SharedMetricRegistries.clear();
+    }
+
+    public static Set<String> names() {
+        return io.dropwizard.metrics5.SharedMetricRegistries.names();
+    }
+
+    public static void remove(String key) {
+        io.dropwizard.metrics5.SharedMetricRegistries.remove(key);
+    }
+
+    public static MetricRegistry add(String name, MetricRegistry registry) {
+        io.dropwizard.metrics5.SharedMetricRegistries.add(name, registry.getDelegate());
+        return registry;
+    }
+
+    public static MetricRegistry getOrCreate(String name) {
+        return new MetricRegistry(io.dropwizard.metrics5.SharedMetricRegistries.getOrCreate(name));
+    }
+
+    public synchronized static MetricRegistry setDefault(String name) {
+        return new MetricRegistry(io.dropwizard.metrics5.SharedMetricRegistries.setDefault(name));
+    }
+
+    public static MetricRegistry setDefault(String name, MetricRegistry metricRegistry) {
+        io.dropwizard.metrics5.SharedMetricRegistries.setDefault(name, metricRegistry.getDelegate());
+        return metricRegistry;
+    }
+
+    public static MetricRegistry getDefault() {
+        return new MetricRegistry(io.dropwizard.metrics5.SharedMetricRegistries.getDefault());
+    }
+
+    public static MetricRegistry tryGetDefault() {
+        return Optional.ofNullable(io.dropwizard.metrics5.SharedMetricRegistries.tryGetDefault())
+                .map(MetricRegistry::new)
+                .orElse(null);
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Slf4jReporter.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Slf4jReporter.java
@@ -1,0 +1,90 @@
+package com.codahale.metrics;
+
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+
+import java.util.SortedMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public class Slf4jReporter extends ScheduledReporter {
+
+    public static Slf4jReporter.Builder forRegistry(MetricRegistry registry) {
+        return new Slf4jReporter.Builder(io.dropwizard.metrics5.Slf4jReporter.forRegistry(registry.getDelegate()));
+    }
+
+    public enum LoggingLevel {TRACE, DEBUG, INFO, WARN, ERROR}
+
+    public static class Builder {
+
+        private io.dropwizard.metrics5.Slf4jReporter.Builder delegate;
+
+        private Builder(io.dropwizard.metrics5.Slf4jReporter.Builder delegate) {
+            this.delegate = requireNonNull(delegate);
+        }
+
+        public Slf4jReporter.Builder shutdownExecutorOnStop(boolean shutdownExecutorOnStop) {
+            delegate.shutdownExecutorOnStop(shutdownExecutorOnStop);
+            return this;
+        }
+
+        public Slf4jReporter.Builder scheduleOn(ScheduledExecutorService executor) {
+            delegate.scheduleOn(executor);
+            return this;
+        }
+
+        public Slf4jReporter.Builder outputTo(Logger logger) {
+            delegate.outputTo(logger);
+            return this;
+        }
+
+        public Slf4jReporter.Builder markWith(Marker marker) {
+            delegate.markWith(marker);
+            return this;
+        }
+
+        public Slf4jReporter.Builder prefixedWith(String prefix) {
+            delegate.prefixedWith(prefix);
+            return this;
+        }
+
+        public Slf4jReporter.Builder convertRatesTo(TimeUnit rateUnit) {
+            delegate.convertRatesTo(rateUnit);
+            return this;
+        }
+
+        public Slf4jReporter.Builder convertDurationsTo(TimeUnit durationUnit) {
+            delegate.convertDurationsTo(durationUnit);
+            return this;
+        }
+
+        public Slf4jReporter.Builder filter(MetricFilter filter) {
+            delegate.filter(filter.transform());
+            return this;
+        }
+
+        public Slf4jReporter.Builder withLoggingLevel(LoggingLevel loggingLevel) {
+            delegate.withLoggingLevel(io.dropwizard.metrics5.Slf4jReporter.LoggingLevel.valueOf(loggingLevel.name()));
+            return this;
+        }
+
+        public Slf4jReporter build() {
+            return new Slf4jReporter(delegate.build());
+        }
+    }
+
+    private Slf4jReporter(io.dropwizard.metrics5.ScheduledReporter delegate) {
+        super(delegate);
+    }
+
+    @Override
+    public void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters,
+                       SortedMap<String, Histogram> histograms, SortedMap<String, Meter> meters,
+                       SortedMap<String, Timer> timers) {
+        getDelegate().report(transform(gauges), transform(counters), transform(histograms), transform(meters),
+                transform(timers));
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/SlidingTimeWindowArrayReservoir.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/SlidingTimeWindowArrayReservoir.java
@@ -1,0 +1,43 @@
+package com.codahale.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public class SlidingTimeWindowArrayReservoir implements Reservoir {
+
+    private io.dropwizard.metrics5.SlidingTimeWindowArrayReservoir delegate;
+
+    public SlidingTimeWindowArrayReservoir(long window, TimeUnit windowUnit) {
+        this(new io.dropwizard.metrics5.SlidingTimeWindowArrayReservoir(window, windowUnit));
+    }
+
+    public SlidingTimeWindowArrayReservoir(long window, TimeUnit windowUnit, Clock clock) {
+        this(new io.dropwizard.metrics5.SlidingTimeWindowArrayReservoir(window, windowUnit, clock.getDelegate()));
+    }
+
+    public SlidingTimeWindowArrayReservoir(io.dropwizard.metrics5.SlidingTimeWindowArrayReservoir delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    @Override
+    public io.dropwizard.metrics5.Reservoir getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public void update(long value) {
+        delegate.update(value);
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        return Snapshot.of(delegate.getSnapshot());
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/SlidingTimeWindowReservoir.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/SlidingTimeWindowReservoir.java
@@ -1,0 +1,43 @@
+package com.codahale.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public class SlidingTimeWindowReservoir implements Reservoir {
+
+    private io.dropwizard.metrics5.SlidingTimeWindowReservoir delegate;
+
+    public SlidingTimeWindowReservoir(long window, TimeUnit windowUnit) {
+        this(new io.dropwizard.metrics5.SlidingTimeWindowReservoir(window, windowUnit));
+    }
+
+    public SlidingTimeWindowReservoir(long window, TimeUnit windowUnit, Clock clock) {
+        this(new io.dropwizard.metrics5.SlidingTimeWindowReservoir(window, windowUnit, clock.getDelegate()));
+    }
+
+    public SlidingTimeWindowReservoir(io.dropwizard.metrics5.SlidingTimeWindowReservoir delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    @Override
+    public io.dropwizard.metrics5.Reservoir getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public void update(long value) {
+        delegate.update(value);
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        return Snapshot.of(delegate.getSnapshot());
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/SlidingWindowReservoir.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/SlidingWindowReservoir.java
@@ -1,0 +1,37 @@
+package com.codahale.metrics;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public class SlidingWindowReservoir implements Reservoir {
+
+    private io.dropwizard.metrics5.SlidingWindowReservoir delegate;
+
+    public SlidingWindowReservoir(int size) {
+        this(new io.dropwizard.metrics5.SlidingWindowReservoir(size));
+    }
+
+    public SlidingWindowReservoir(io.dropwizard.metrics5.SlidingWindowReservoir delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    @Override
+    public io.dropwizard.metrics5.Reservoir getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public void update(long value) {
+        delegate.update(value);
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        return Snapshot.of(delegate.getSnapshot());
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Snapshot.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Snapshot.java
@@ -1,0 +1,92 @@
+package com.codahale.metrics;
+
+import java.io.OutputStream;
+
+@Deprecated
+public abstract class Snapshot {
+
+    public abstract double getValue(double quantile);
+
+    public abstract long[] getValues();
+
+    public abstract int size();
+
+    public double getMedian() {
+        return getValue(0.5);
+    }
+
+    public double get75thPercentile() {
+        return getValue(0.75);
+    }
+
+    public double get95thPercentile() {
+        return getValue(0.95);
+    }
+
+    public double get98thPercentile() {
+        return getValue(0.98);
+    }
+
+    public double get99thPercentile() {
+        return getValue(0.99);
+    }
+
+    public double get999thPercentile() {
+        return getValue(0.999);
+    }
+
+    public abstract long getMax();
+
+    public abstract double getMean();
+
+    public abstract long getMin();
+
+    public abstract double getStdDev();
+
+    public abstract void dump(OutputStream output);
+
+    public static Snapshot of(io.dropwizard.metrics5.Snapshot delegate) {
+        return new Snapshot() {
+
+            @Override
+            public double getValue(double quantile) {
+                return delegate.getValue(quantile);
+            }
+
+            @Override
+            public long[] getValues() {
+                return delegate.getValues();
+            }
+
+            @Override
+            public int size() {
+                return delegate.size();
+            }
+
+            @Override
+            public long getMax() {
+                return delegate.getMax();
+            }
+
+            @Override
+            public double getMean() {
+                return delegate.getMean();
+            }
+
+            @Override
+            public long getMin() {
+                return delegate.getMin();
+            }
+
+            @Override
+            public double getStdDev() {
+                return delegate.getStdDev();
+            }
+
+            @Override
+            public void dump(OutputStream output) {
+                delegate.dump(output);
+            }
+        };
+    }
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Timer.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/Timer.java
@@ -1,0 +1,104 @@
+package com.codahale.metrics;
+
+import java.io.Closeable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public class Timer implements Metered, Sampling {
+
+    private final io.dropwizard.metrics5.Timer delegate;
+
+    public static class Context implements Closeable {
+
+        private final io.dropwizard.metrics5.Timer.Context context;
+
+        private Context(io.dropwizard.metrics5.Timer.Context context) {
+            this.context = context;
+        }
+
+        public long stop() {
+            return context.stop();
+        }
+
+        @Override
+        public void close() {
+            context.close();
+        }
+    }
+
+    public Timer() {
+        this(new io.dropwizard.metrics5.Timer());
+    }
+
+    public Timer(Reservoir reservoir) {
+        this(reservoir, Clock.defaultClock());
+    }
+
+    public Timer(Reservoir reservoir, Clock clock) {
+        this(new io.dropwizard.metrics5.Timer(reservoir.getDelegate(), clock.getDelegate()));
+    }
+
+    public Timer(io.dropwizard.metrics5.Timer delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        return Snapshot.of(delegate.getSnapshot());
+    }
+
+    @Override
+    public long getCount() {
+        return delegate.getCount();
+    }
+
+    @Override
+    public double getFifteenMinuteRate() {
+        return delegate.getFifteenMinuteRate();
+    }
+
+    @Override
+    public double getFiveMinuteRate() {
+        return delegate.getFiveMinuteRate();
+    }
+
+    @Override
+    public double getMeanRate() {
+        return delegate.getMeanRate();
+    }
+
+    @Override
+    public double getOneMinuteRate() {
+        return delegate.getOneMinuteRate();
+    }
+
+    public void update(long duration, TimeUnit unit) {
+        delegate.update(duration, unit);
+    }
+
+    public <T> T time(Callable<T> event) throws Exception {
+        return delegate.time(event);
+    }
+
+    public void time(Runnable event) {
+        delegate.time(event);
+    }
+
+    public <T> T timeSupplier(Supplier<T> event) {
+        return delegate.timeSupplier(event);
+    }
+
+    public Context time() {
+        return new Context(delegate.time());
+    }
+
+    public io.dropwizard.metrics5.Timer getDelegate() {
+        return delegate;
+    }
+
+
+}

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/UniformReservoir.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/UniformReservoir.java
@@ -1,0 +1,41 @@
+package com.codahale.metrics;
+
+import static java.util.Objects.requireNonNull;
+
+@Deprecated
+public class UniformReservoir implements Reservoir {
+
+    private io.dropwizard.metrics5.UniformReservoir delegate;
+
+    public UniformReservoir() {
+        this(new io.dropwizard.metrics5.UniformReservoir());
+    }
+
+    public UniformReservoir(int size) {
+        this(new io.dropwizard.metrics5.UniformReservoir(size));
+    }
+
+    public UniformReservoir(io.dropwizard.metrics5.UniformReservoir delegate) {
+        this.delegate = requireNonNull(delegate);
+    }
+
+    @Override
+    public io.dropwizard.metrics5.Reservoir getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    @Override
+    public void update(long value) {
+        delegate.update(value);
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        return Snapshot.of(delegate.getSnapshot());
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/CachedGaugeTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/CachedGaugeTest.java
@@ -1,0 +1,34 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class CachedGaugeTest {
+
+    @Test
+    public void testCreate() {
+        CachedGauge<String> cachedGauge = new CachedGauge<String>(100, TimeUnit.MILLISECONDS) {
+            @Override
+            protected String loadValue() {
+                return "heavyValue";
+            }
+        };
+        assertThat(cachedGauge.getValue()).isEqualTo("heavyValue");
+    }
+
+    @Test
+    public void testCreateWothClock() {
+        CachedGauge<String> cachedGauge = new CachedGauge<String>(new Clock.UserTimeClock(), 100,
+                TimeUnit.MILLISECONDS) {
+            @Override
+            protected String loadValue() {
+                return "heavyValue";
+            }
+        };
+        assertThat(cachedGauge.getValue()).isEqualTo("heavyValue");
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/ClockTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/ClockTest.java
@@ -1,0 +1,32 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class ClockTest {
+
+    @Test
+    public void testDefaultClockCanBeUsed() {
+        Clock clock = Clock.defaultClock();
+        assertThat(clock.getTick()).isGreaterThan(0);
+    }
+
+    @Test
+    public void testUserTimeClockCanBeUsed() {
+        Clock clock = new Clock.UserTimeClock();
+        assertThat(clock.getTick()).isGreaterThan(0);
+    }
+
+    @Test
+    public void testCustomTimeClockCanBeUsed() {
+        Clock clock = new Clock() {
+            @Override
+            public long getTick() {
+                return 24;
+            }
+        };
+        assertThat(clock.getTick()).isEqualTo(24);
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
@@ -1,0 +1,119 @@
+package com.codahale.metrics;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.EnumSet;
+import java.util.Locale;
+import java.util.TimeZone;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class ConsoleReporterTest {
+
+    private ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private String dateHeader = System.getProperty("java.version").startsWith("1.8") ?
+            "3/18/13 1:04:36 AM =============================================================" :
+            "3/18/13, 1:04:36 AM ============================================================";
+
+    @After
+    public void tearDown() throws Exception {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testCreateConsoleReporter() throws Exception {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+        MetricRegistry metricRegistry = new MetricRegistry();
+        metricRegistry.timer("test-timer");
+        metricRegistry.meter("test-meter");
+        metricRegistry.histogram("test-histogram");
+        metricRegistry.counter("test-counter");
+        metricRegistry.register("test-gauge", (Gauge<Integer>) () -> 20);
+
+        ConsoleReporter consoleReporter = ConsoleReporter.forRegistry(metricRegistry)
+                .shutdownExecutorOnStop(false)
+                .scheduleOn(executor)
+                .outputTo(new PrintStream(byteArrayOutputStream))
+                .formattedFor(Locale.ENGLISH)
+                .withClock(new Clock() {
+
+                    @Override
+                    public long getTime() {
+                        return 1363568676000L;
+                    }
+
+                    @Override
+                    public long getTick() {
+                        return 0;
+                    }
+                }).formattedFor(TimeZone.getTimeZone("UTC"))
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .filter(MetricFilter.ALL)
+                .disabledMetricAttributes(EnumSet.of(MetricAttribute.P98, MetricAttribute.P99))
+                .build();
+        consoleReporter.report();
+
+        assertThat(new String(byteArrayOutputStream.toByteArray(), StandardCharsets.UTF_8))
+                .isEqualToNormalizingNewlines(dateHeader + "\n" +
+                        "\n" +
+                        "-- Gauges ----------------------------------------------------------------------\n" +
+                        "test-gauge\n" +
+                        "             value = 20\n" +
+                        "\n" +
+                        "-- Counters --------------------------------------------------------------------\n" +
+                        "test-counter\n" +
+                        "             count = 0\n" +
+                        "\n" +
+                        "-- Histograms ------------------------------------------------------------------\n" +
+                        "test-histogram\n" +
+                        "             count = 0\n" +
+                        "               sum = 0\n" +
+                        "               min = 0\n" +
+                        "               max = 0\n" +
+                        "              mean = 0.00\n" +
+                        "            stddev = 0.00\n" +
+                        "            median = 0.00\n" +
+                        "              75% <= 0.00\n" +
+                        "              95% <= 0.00\n" +
+                        "            99.9% <= 0.00\n" +
+                        "\n" +
+                        "-- Meters ----------------------------------------------------------------------\n" +
+                        "test-meter\n" +
+                        "             count = 0\n" +
+                        "               sum = 0\n" +
+                        "         mean rate = 0.00 events/second\n" +
+                        "     1-minute rate = 0.00 events/second\n" +
+                        "     5-minute rate = 0.00 events/second\n" +
+                        "    15-minute rate = 0.00 events/second\n" +
+                        "\n" +
+                        "-- Timers ----------------------------------------------------------------------\n" +
+                        "test-timer\n" +
+                        "             count = 0\n" +
+                        "               sum = 0\n" +
+                        "         mean rate = 0.00 calls/second\n" +
+                        "     1-minute rate = 0.00 calls/second\n" +
+                        "     5-minute rate = 0.00 calls/second\n" +
+                        "    15-minute rate = 0.00 calls/second\n" +
+                        "               min = 0.00 milliseconds\n" +
+                        "               max = 0.00 milliseconds\n" +
+                        "              mean = 0.00 milliseconds\n" +
+                        "            stddev = 0.00 milliseconds\n" +
+                        "            median = 0.00 milliseconds\n" +
+                        "              75% <= 0.00 milliseconds\n" +
+                        "              95% <= 0.00 milliseconds\n" +
+                        "            99.9% <= 0.00 milliseconds\n" +
+                        "\n" +
+                        "\n"
+                );
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/CounterTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/CounterTest.java
@@ -1,0 +1,40 @@
+package com.codahale.metrics;
+
+import io.dropwizard.metrics5.Counter;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class CounterTest {
+
+    private Counter counter = new Counter();
+
+    @Test
+    public void testIncrementCounter() {
+        counter.inc();
+
+        assertThat(counter.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testIncrementCounterOnManyPoints() {
+        counter.inc(5);
+
+        assertThat(counter.getCount()).isEqualTo(5);
+    }
+
+    @Test
+    public void testDecrementCounter() {
+        counter.dec();
+
+        assertThat(counter.getCount()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testDecrementCounterOnManyPoints() {
+        counter.dec(5);
+
+        assertThat(counter.getCount()).isEqualTo(-5);
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/DerivativeGaugeTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/DerivativeGaugeTest.java
@@ -1,0 +1,20 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class DerivativeGaugeTest {
+
+    @Test
+    public void testCalculate() {
+        DerivativeGauge<String, Integer> derivativeGauge = new DerivativeGauge<String, Integer>(() -> "23") {
+            @Override
+            protected Integer transform(String value) {
+                return Integer.parseInt(value);
+            }
+        };
+        assertThat(derivativeGauge.getValue()).isEqualTo(23);
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/ExponentiallyDecayingReservoirTest.java
@@ -1,0 +1,53 @@
+package com.codahale.metrics;
+
+import org.assertj.core.data.Offset;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class ExponentiallyDecayingReservoirTest {
+
+    @Test
+    public void testCreateReservoir() {
+        ExponentiallyDecayingReservoir reservoir = new ExponentiallyDecayingReservoir();
+        reservoir.update(120);
+        reservoir.update(190);
+        reservoir.update(200);
+        reservoir.update(130);
+        reservoir.update(140);
+
+        Snapshot snapshot = reservoir.getSnapshot();
+        assertThat(snapshot.size()).isEqualTo(5);
+        assertThat(snapshot.getValues()).contains(120, 130, 140, 190, 200);
+        assertThat(snapshot.getMin()).isEqualTo(120);
+        assertThat(snapshot.getMax()).isEqualTo(200);
+        assertThat(snapshot.getStdDev()).isEqualTo(32.62, Offset.offset(0.1));
+        assertThat(snapshot.get75thPercentile()).isEqualTo(190);
+        assertThat(snapshot.get95thPercentile()).isEqualTo(200);
+        assertThat(snapshot.get98thPercentile()).isEqualTo(200);
+        assertThat(snapshot.get99thPercentile()).isEqualTo(200);
+        assertThat(snapshot.get999thPercentile()).isEqualTo(200);
+    }
+
+    @Test
+    public void testCreateReservoirWithCustomSizeAndAlpha() {
+        ExponentiallyDecayingReservoir reservoir = new ExponentiallyDecayingReservoir(512, 0.01);
+        reservoir.update(100);
+        assertThat(reservoir.size()).isEqualTo(1);
+    }
+
+
+    @Test
+    public void testCreateReservoirWithCustomSizeAlphaAndClock() {
+        ExponentiallyDecayingReservoir reservoir = new ExponentiallyDecayingReservoir(512, 0.01,
+                new Clock() {
+                    @Override
+                    public long getTick() {
+                        return 24;
+                    }
+                });
+        reservoir.update(100);
+        assertThat(reservoir.size()).isEqualTo(1);
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/FixedNameCsvFileProviderTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/FixedNameCsvFileProviderTest.java
@@ -1,0 +1,35 @@
+package com.codahale.metrics;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class FixedNameCsvFileProviderTest {
+
+    private Path tempDirectory;
+    private FixedNameCsvFileProvider fixedNameCsvFileProvider = new FixedNameCsvFileProvider();
+
+    @Before
+    public void setUp() throws Exception {
+        tempDirectory = Files.createTempDirectory("csv-test");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        Files.delete(tempDirectory);
+    }
+
+    @Test
+    public void getFile() throws Exception {
+        File file = fixedNameCsvFileProvider.getFile(tempDirectory.toFile(), "timer-test");
+        assertThat(file.toString()).startsWith(tempDirectory.toString());
+        assertThat(file.toString()).endsWith("timer-test.csv");
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/GaugeTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/GaugeTest.java
@@ -1,0 +1,16 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class GaugeTest {
+
+    private Gauge<Integer> gauge = () -> 83;
+
+    @Test
+    public void testGetValue() {
+        assertThat(gauge.getValue()).isEqualTo(83);
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/HistogramTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/HistogramTest.java
@@ -1,0 +1,33 @@
+package com.codahale.metrics;
+
+import org.assertj.core.data.Offset;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class HistogramTest {
+
+    @Test
+    public void testCreate() {
+        Histogram histogram = new Histogram(new ExponentiallyDecayingReservoir());
+        histogram.update(120);
+        histogram.update(190);
+        histogram.update(200L);
+        histogram.update(130);
+        histogram.update(140);
+
+        assertThat(histogram.getCount()).isEqualTo(5);
+        Snapshot snapshot = histogram.getSnapshot();
+        assertThat(snapshot.size()).isEqualTo(5);
+        assertThat(snapshot.getValues()).contains(120, 130, 140, 190, 200);
+        assertThat(snapshot.getMin()).isEqualTo(120);
+        assertThat(snapshot.getMax()).isEqualTo(200);
+        assertThat(snapshot.getStdDev()).isEqualTo(32.62, Offset.offset(0.1));
+        assertThat(snapshot.get75thPercentile()).isEqualTo(190);
+        assertThat(snapshot.get95thPercentile()).isEqualTo(200);
+        assertThat(snapshot.get98thPercentile()).isEqualTo(200);
+        assertThat(snapshot.get99thPercentile()).isEqualTo(200);
+        assertThat(snapshot.get999thPercentile()).isEqualTo(200);
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/InstrumentedExecutorServiceTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/InstrumentedExecutorServiceTest.java
@@ -1,0 +1,35 @@
+package com.codahale.metrics;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class InstrumentedExecutorServiceTest {
+
+
+    @Test
+    public void testCreate() throws Exception {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        MetricRegistry registry = new MetricRegistry();
+        InstrumentedExecutorService instrumentedExecutorService = new InstrumentedExecutorService(executorService,
+                registry, "test-instrumented");
+        CountDownLatch countDownLatch = new CountDownLatch(10);
+        for (int i = 0; i < 10; i++) {
+            instrumentedExecutorService.submit(countDownLatch::countDown);
+        }
+        countDownLatch.await(5, TimeUnit.SECONDS);
+        executorService.shutdown();
+        executorService.awaitTermination(5, TimeUnit.SECONDS);
+
+        assertThat(registry.getMetrics()).containsOnlyKeys("test-instrumented.completed",
+                "test-instrumented.submitted", "test-instrumented.duration", "test-instrumented.idle",
+                "test-instrumented.running");
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/InstrumentedScheduledExecutorServiceTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/InstrumentedScheduledExecutorServiceTest.java
@@ -1,0 +1,37 @@
+package com.codahale.metrics;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class InstrumentedScheduledExecutorServiceTest {
+    private ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+
+    @After
+    public void tearDown() {
+        executorService.shutdown();
+    }
+
+    @Test
+    public void testCreate() throws Exception {
+        MetricRegistry registry = new MetricRegistry();
+        InstrumentedScheduledExecutorService instrumentedExecutorService = new InstrumentedScheduledExecutorService(
+                executorService, registry, "test-scheduled-instrumented");
+        CountDownLatch countDownLatch = new CountDownLatch(10);
+        instrumentedExecutorService.scheduleAtFixedRate(countDownLatch::countDown, 0, 10, TimeUnit.MILLISECONDS);
+        countDownLatch.await(5, TimeUnit.SECONDS);
+        instrumentedExecutorService.shutdown();
+
+        assertThat(registry.getMetrics()).containsOnlyKeys("test-scheduled-instrumented.completed",
+                "test-scheduled-instrumented.submitted", "test-scheduled-instrumented.duration", "test-scheduled-instrumented.running",
+                "test-scheduled-instrumented.scheduled.once", "test-scheduled-instrumented.scheduled.overrun",
+                "test-scheduled-instrumented.scheduled.percent-of-period", "test-scheduled-instrumented.scheduled.repetitively");
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/InstrumentedThreadFactoryTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/InstrumentedThreadFactoryTest.java
@@ -1,0 +1,27 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class InstrumentedThreadFactoryTest {
+
+    @Test
+    public void testFactory() throws Exception {
+        MetricRegistry registry = new MetricRegistry();
+        InstrumentedThreadFactory threadFactory = new InstrumentedThreadFactory(Thread::new, registry,
+                "test-instrumented-thread-factory");
+        CountDownLatch latch = new CountDownLatch(4);
+        for (int i = 0; i < 4; i++) {
+            threadFactory.newThread(latch::countDown).run();
+        }
+        latch.await(5, TimeUnit.SECONDS);
+        assertThat(registry.meter("test-instrumented-thread-factory.created").getCount()).isEqualTo(4);
+        assertThat(registry.counter("test-instrumented-thread-factory.running").getCount()).isEqualTo(0);
+        assertThat(registry.meter("test-instrumented-thread-factory.terminated").getCount()).isEqualTo(4);
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/MeterTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/MeterTest.java
@@ -1,0 +1,53 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class MeterTest {
+
+    @Test
+    public void testCreateMeteer() {
+        Meter meter = new Meter();
+        assertThat(meter.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testCreateMeterWithCustomClock() {
+        Meter meter = new Meter(new Clock() {
+            @Override
+            public long getTick() {
+                return 0;
+            }
+        });
+        assertThat(meter.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testMark() {
+        Meter meter = new Meter(new Clock() {
+
+            private long start = System.nanoTime();
+
+            @Override
+            public long getTick() {
+                return start += TimeUnit.SECONDS.toNanos(1);
+            }
+        });
+        for (int i = 0; i < 60; i++) {
+            meter.mark();
+        }
+        for (int i = 0; i < 60; i++) {
+            meter.mark(2);
+        }
+
+        assertThat(meter.getCount()).isEqualTo(180);
+        assertThat(meter.getFifteenMinuteRate()).isBetween(1.0, 2.0);
+        assertThat(meter.getFiveMinuteRate()).isBetween(1.0, 2.0);
+        assertThat(meter.getOneMinuteRate()).isBetween(1.0, 2.0);
+        assertThat(meter.getMeanRate()).isBetween(1.0, 2.0);
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/MetricRegistryTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/MetricRegistryTest.java
@@ -1,0 +1,503 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
+
+@SuppressWarnings("deprecation")
+public class MetricRegistryTest {
+
+    private MetricRegistry metricRegistry = new MetricRegistry();
+
+    @Test
+    public void testRegisterMetric() {
+        Counter counter = metricRegistry.register("test-counter", new Counter());
+        counter.inc(42);
+        assertThat(metricRegistry.counter("test-counter").getCount()).isEqualTo(42);
+    }
+
+    @Test
+    public void testRegisterAll() {
+        metricRegistry.registerAll(() -> {
+            Map<String, Metric> map = new HashMap<>();
+            map.put("test-counter", new Counter());
+            map.put("test-gauge", (Gauge<Integer>) () -> 28);
+            map.put("test-histogram", new Histogram(new ExponentiallyDecayingReservoir()));
+            return map;
+        });
+        Map<String, Metric> metrics = metricRegistry.getMetrics();
+        assertThat(metrics).containsOnlyKeys("test-counter", "test-histogram", "test-gauge");
+        assertThat(metrics.get("test-counter")).isInstanceOf(Counter.class);
+        assertThat(metrics.get("test-histogram")).isInstanceOf(Histogram.class);
+        assertThat(metrics.get("test-gauge")).isInstanceOf(Gauge.class);
+    }
+
+    @Test
+    public void testCreateCustomGauge() {
+        Gauge gauge = metricRegistry.gauge("test-gauge-supplier", () -> () -> 42);
+        assertThat(gauge.getValue()).isEqualTo(42);
+    }
+
+    @Test
+    public void testCreateCounter() {
+        Counter counter = metricRegistry.counter("test-counter");
+        counter.inc(42);
+        assertThat(metricRegistry.counter("test-counter").getCount()).isEqualTo(42);
+    }
+
+    @Test
+    public void testCreateCustomCounter() {
+        Counter counter = metricRegistry.counter("test-custom-counter", () -> {
+            Counter c = new Counter();
+            c.inc(8);
+            return c;
+        });
+        counter.inc(16);
+        assertThat(metricRegistry.counter("test-custom-counter").getCount()).isEqualTo(24);
+    }
+
+    @Test
+    public void testCreateHistogram() {
+        Histogram histogram = metricRegistry.histogram("test-histogram");
+        histogram.update(100);
+        histogram.update(200);
+        histogram.update(180);
+        assertThat(metricRegistry.histogram("test-histogram").getSnapshot().getMean())
+                .isCloseTo(160.0, offset(0.1));
+    }
+
+    @Test
+    public void testCreateCustomHistogram() {
+        Histogram histogram = metricRegistry.histogram("test-custom-histogram",
+                () -> new Histogram(new SlidingWindowReservoir(2)));
+        histogram.update(100);
+        histogram.update(200);
+        histogram.update(180);
+        assertThat(metricRegistry.histogram("test-custom-histogram").getSnapshot().getMean())
+                .isCloseTo(190.0, offset(0.1));
+    }
+
+    @Test
+    public void testCreateMeter() {
+        Meter meter = metricRegistry.meter("test-meter");
+        meter.mark();
+        meter.mark(2);
+
+        assertThat(metricRegistry.meter("test-meter").getCount()).isEqualTo(3);
+    }
+
+    @Test
+    public void testCreateCustomMeter() {
+        Meter meter = metricRegistry.meter("test-custom-meter", () -> {
+            Meter m = new Meter();
+            m.mark(16);
+            return m;
+        });
+        meter.mark();
+
+        assertThat(metricRegistry.meter("test-custom-meter").getCount()).isEqualTo(17);
+    }
+
+    @Test
+    public void testCreateTimer() {
+        Timer timer = metricRegistry.timer("test-timer");
+        timer.update(100, TimeUnit.MILLISECONDS);
+        timer.update(200, TimeUnit.MILLISECONDS);
+        timer.update(180, TimeUnit.MILLISECONDS);
+
+        assertThat(metricRegistry.timer("test-timer").getCount()).isEqualTo(3);
+    }
+
+    @Test
+    public void testCreateCustomTimer() {
+        Timer timer = metricRegistry.timer("custom-test-timer", () -> {
+            Timer t = new Timer(new UniformReservoir());
+            t.update(300, TimeUnit.MILLISECONDS);
+            t.update(200, TimeUnit.MILLISECONDS);
+            return t;
+        });
+        timer.update(180, TimeUnit.MILLISECONDS);
+
+        assertThat(metricRegistry.timer("custom-test-timer").getCount()).isEqualTo(3);
+    }
+
+    @Test
+    public void testRemoveMetric() {
+        metricRegistry.timer("test-timer");
+        metricRegistry.counter("test-counter");
+        metricRegistry.meter("test-meter");
+
+        assertThat(metricRegistry.remove("test-counter")).isTrue();
+
+        assertThat(metricRegistry.getMetrics()).containsOnlyKeys("test-timer", "test-meter");
+    }
+
+    @Test
+    public void testRemoveMatching() {
+        metricRegistry.counter("test-counter");
+        metricRegistry.timer("test-timer");
+        metricRegistry.timer("test-custom-timer");
+        metricRegistry.meter("test-meter");
+
+        metricRegistry.removeMatching((name, metric) -> metric instanceof Timer && name.startsWith("test"));
+        assertThat(metricRegistry.getMetrics()).containsOnlyKeys("test-counter", "test-meter");
+    }
+
+    @Test
+    public void testAddListenerForGauge() throws Exception {
+        CountDownLatch gaugeAddedLatch = new CountDownLatch(1);
+        CountDownLatch gaugeRemovedLatch = new CountDownLatch(1);
+        metricRegistry.addListener(new MetricRegistryListener.Base() {
+            @Override
+            public void onGaugeAdded(String name, Gauge<?> gauge) {
+                assertThat(name).isEqualTo("test-gauge");
+                assertThat(gauge.getValue()).isEqualTo(42);
+                gaugeAddedLatch.countDown();
+            }
+
+            @Override
+            public void onGaugeRemoved(String name) {
+                assertThat(name).isEqualTo("test-gauge");
+                gaugeRemovedLatch.countDown();
+            }
+        });
+
+        metricRegistry.register("test-gauge", (Gauge<Integer>) () -> 42);
+        gaugeAddedLatch.await(5, TimeUnit.SECONDS);
+        assertThat(gaugeAddedLatch.getCount()).isEqualTo(0);
+
+        metricRegistry.remove("test-gauge");
+        gaugeRemovedLatch.await(5, TimeUnit.SECONDS);
+        assertThat(gaugeRemovedLatch.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testAddListenerForCounter() throws Exception {
+        CountDownLatch counterAddedLatch = new CountDownLatch(1);
+        CountDownLatch counterRemovedLatch = new CountDownLatch(1);
+        metricRegistry.addListener(new MetricRegistryListener.Base() {
+            @Override
+            public void onCounterAdded(String name, Counter counter) {
+                assertThat(name).isEqualTo("test-counter");
+                counterAddedLatch.countDown();
+            }
+
+            @Override
+            public void onCounterRemoved(String name) {
+                assertThat(name).isEqualTo("test-counter");
+                counterRemovedLatch.countDown();
+            }
+        });
+
+        metricRegistry.counter("test-counter");
+        counterAddedLatch.await(5, TimeUnit.SECONDS);
+        assertThat(counterAddedLatch.getCount()).isEqualTo(0);
+
+        metricRegistry.remove("test-counter");
+        counterRemovedLatch.await(5, TimeUnit.SECONDS);
+        assertThat(counterRemovedLatch.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testAddListenerForHistogram() throws Exception {
+        CountDownLatch histogramAddedLatch = new CountDownLatch(1);
+        CountDownLatch histogramRemovedLatch = new CountDownLatch(1);
+        metricRegistry.addListener(new MetricRegistryListener.Base() {
+
+
+            @Override
+            public void onHistogramAdded(String name, Histogram histogram) {
+                assertThat(name).isEqualTo("test-histogram");
+                histogramAddedLatch.countDown();
+            }
+
+            @Override
+            public void onHistogramRemoved(String name) {
+                assertThat(name).isEqualTo("test-histogram");
+                histogramRemovedLatch.countDown();
+            }
+        });
+
+        metricRegistry.histogram("test-histogram");
+        histogramAddedLatch.await(5, TimeUnit.SECONDS);
+        assertThat(histogramAddedLatch.getCount()).isEqualTo(0);
+
+        metricRegistry.remove("test-histogram");
+        histogramRemovedLatch.await(5, TimeUnit.SECONDS);
+        assertThat(histogramRemovedLatch.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testAddListenerForMeter() throws Exception {
+        CountDownLatch meterAddedLatch = new CountDownLatch(1);
+        CountDownLatch meterRemovedLatch = new CountDownLatch(1);
+        metricRegistry.addListener(new MetricRegistryListener.Base() {
+
+            @Override
+            public void onMeterAdded(String name, Meter meter) {
+                assertThat(name).isEqualTo("test-meter");
+                meterAddedLatch.countDown();
+            }
+
+            @Override
+            public void onMeterRemoved(String name) {
+                assertThat(name).isEqualTo("test-meter");
+                meterRemovedLatch.countDown();
+            }
+        });
+
+        metricRegistry.meter("test-meter");
+        meterAddedLatch.await(5, TimeUnit.SECONDS);
+        assertThat(meterAddedLatch.getCount()).isEqualTo(0);
+
+        metricRegistry.remove("test-meter");
+        meterRemovedLatch.await(5, TimeUnit.SECONDS);
+        assertThat(meterRemovedLatch.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testAddListenerForTimer() throws Exception {
+        CountDownLatch timerAddedLatch = new CountDownLatch(1);
+        CountDownLatch timerRemovedLatch = new CountDownLatch(1);
+        metricRegistry.addListener(new MetricRegistryListener.Base() {
+
+            @Override
+            public void onTimerAdded(String name, Timer timer) {
+                assertThat(name).isEqualTo("test-timer");
+                timerAddedLatch.countDown();
+            }
+
+            @Override
+            public void onTimerRemoved(String name) {
+                assertThat(name).isEqualTo("test-timer");
+                timerRemovedLatch.countDown();
+            }
+        });
+
+        metricRegistry.timer("test-timer");
+        timerAddedLatch.await(5, TimeUnit.SECONDS);
+        assertThat(timerAddedLatch.getCount()).isEqualTo(0);
+
+        metricRegistry.remove("test-timer");
+        timerRemovedLatch.await(5, TimeUnit.SECONDS);
+        assertThat(timerRemovedLatch.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testRemoveListener() throws Exception {
+        CountDownLatch gaugeAddedLatch = new CountDownLatch(1);
+        MetricRegistryListener listener = new MetricRegistryListener.Base() {
+            @Override
+            public void onGaugeAdded(String name, Gauge<?> gauge) {
+                gaugeAddedLatch.countDown();
+            }
+        };
+        metricRegistry.addListener(listener);
+        metricRegistry.removeListener(listener);
+
+        metricRegistry.register("test-gauge", (Gauge<Integer>) () -> 39);
+
+        gaugeAddedLatch.await(100, TimeUnit.MILLISECONDS);
+        assertThat(gaugeAddedLatch.getCount()).isEqualTo(1);
+    }
+
+    @Test
+    public void testGetNames() {
+        metricRegistry.counter("test-counter");
+        metricRegistry.timer("test-timer");
+        metricRegistry.timer("test-custom-timer");
+        metricRegistry.meter("test-meter");
+
+        assertThat(metricRegistry.getNames()).containsExactly("test-counter", "test-custom-timer",
+                "test-meter", "test-timer");
+    }
+
+    @Test
+    public void testGetGauges() {
+        metricRegistry.counter("test-counter");
+        metricRegistry.timer("test-timer");
+        metricRegistry.meter("test-meter");
+        metricRegistry.register("test-text-gauge-2", new CachedGauge<String>(1, TimeUnit.MINUTES) {
+            @Override
+            protected String loadValue() {
+                return "eu2";
+            }
+        });
+        metricRegistry.register("test-gauge", (Gauge<Integer>) () -> 42);
+        metricRegistry.register("test-text-gauge-1", new DerivativeGauge<Integer, String>(() -> 1) {
+            @Override
+            protected String transform(Integer value) {
+                return "eu" + value;
+            }
+        });
+
+        SortedMap<String, Gauge> gauges = metricRegistry.getGauges();
+        assertThat(gauges).containsOnlyKeys("test-gauge", "test-text-gauge-1", "test-text-gauge-2");
+    }
+
+    @Test
+    public void testGetGaugesWithFilter() {
+        metricRegistry.counter("test-counter");
+        metricRegistry.timer("test-timer");
+        metricRegistry.meter("test-meter");
+        metricRegistry.register("test-text-gauge-2", new CachedGauge<String>(1, TimeUnit.MINUTES) {
+            @Override
+            protected String loadValue() {
+                return "eu2";
+            }
+        });
+        metricRegistry.register("test-gauge", (Gauge<Integer>) () -> 42);
+        metricRegistry.register("test-text-gauge-1", new DerivativeGauge<Integer, String>(() -> 1) {
+            @Override
+            protected String transform(Integer value) {
+                return "eu" + value;
+            }
+        });
+
+        assertThat(metricRegistry.getGauges((name, metric) -> name.contains("gauge") && metric instanceof CachedGauge))
+                .containsOnlyKeys("test-text-gauge-2");
+    }
+
+    @Test
+    public void testGetHistograms() {
+        metricRegistry.counter("test-counter");
+        metricRegistry.timer("test-timer");
+        metricRegistry.meter("test-meter");
+        metricRegistry.histogram("test-histogram-1");
+        metricRegistry.histogram("test-histogram-3");
+        metricRegistry.histogram("test-histogram-2");
+
+        assertThat(metricRegistry.getHistograms())
+                .containsOnlyKeys("test-histogram-1", "test-histogram-2", "test-histogram-3");
+    }
+
+    @Test
+    public void testGetHistogramsWithFilter() {
+        metricRegistry.counter("sw-counter");
+        metricRegistry.timer("sw-timer");
+        metricRegistry.meter("sw-meter");
+        metricRegistry.histogram("sw-histogram-1");
+        metricRegistry.histogram("se-histogram-3");
+        metricRegistry.histogram("sw-histogram-2");
+
+        assertThat(metricRegistry.getHistograms(MetricFilter.startsWith("sw")))
+                .containsOnlyKeys("sw-histogram-1", "sw-histogram-2");
+    }
+
+    @Test
+    public void testGetCounters() {
+        metricRegistry.histogram("test-histogram");
+        metricRegistry.timer("test-timer");
+        metricRegistry.meter("test-meter");
+        metricRegistry.counter("test-counter-1");
+        metricRegistry.counter("test-counter-3");
+        metricRegistry.counter("test-counter-2");
+
+        assertThat(metricRegistry.getCounters())
+                .containsOnlyKeys("test-counter-1", "test-counter-2", "test-counter-3");
+    }
+
+    @Test
+    public void testGetCountersWithFilter() {
+        metricRegistry.histogram("test-histogram");
+        metricRegistry.timer("test-timer");
+        metricRegistry.meter("test-meter");
+        metricRegistry.counter("test-counter-1");
+        metricRegistry.counter("test-counter-3");
+        metricRegistry.counter("test-cnt-2");
+
+        assertThat(metricRegistry.getCounters(MetricFilter.contains("counter")))
+                .containsOnlyKeys("test-counter-1", "test-counter-3");
+    }
+
+    @Test
+    public void testGetMeters() {
+        metricRegistry.register("test-gauge", (Gauge<Integer>) () -> 42);
+        metricRegistry.histogram("test-histogram");
+        metricRegistry.timer("test-timer");
+        metricRegistry.counter("test-counter");
+        metricRegistry.meter("test-meter-1");
+        metricRegistry.meter("test-meter-3");
+        metricRegistry.meter("test-meter-2");
+
+        assertThat(metricRegistry.getMeters()).containsOnlyKeys("test-meter-1", "test-meter-2", "test-meter-3");
+    }
+
+    @Test
+    public void testGetMetersWithFilter() {
+        metricRegistry.register("sw-gauge", (Gauge<Integer>) () -> 42);
+        metricRegistry.histogram("sw-histogram");
+        metricRegistry.timer("sw-timer");
+        metricRegistry.counter("sw-counter");
+        metricRegistry.meter("nw-meter-1");
+        metricRegistry.meter("sw-meter-3");
+        metricRegistry.meter("nw-meter-2");
+
+        assertThat(metricRegistry.getMeters(MetricFilter.startsWith("sw"))).containsOnlyKeys("sw-meter-3");
+    }
+
+    @Test
+    public void testGetTimers() {
+        metricRegistry.histogram("test-histogram");
+        metricRegistry.meter("test-meter");
+        metricRegistry.counter("test-counter");
+        metricRegistry.timer("test-timer-1");
+        metricRegistry.timer("test-timer-3");
+        metricRegistry.timer("test-timer-2");
+
+        assertThat(metricRegistry.getTimers()).containsOnlyKeys("test-timer-1", "test-timer-2", "test-timer-3");
+    }
+
+    @Test
+    public void testGetTimersWithFilter() {
+        metricRegistry.histogram("test-histogram-2");
+        metricRegistry.meter("test-meter-2");
+        metricRegistry.counter("test-counter-2");
+        metricRegistry.timer("test-timer-1");
+        metricRegistry.timer("test-timer-3");
+        metricRegistry.timer("test-timer-2");
+
+        assertThat(metricRegistry.getTimers(MetricFilter.endsWith("2"))).containsOnlyKeys("test-timer-2");
+    }
+
+    @Test
+    public void testGetMetrics() {
+        metricRegistry.register("test-text-gauge-2", new CachedGauge<String>(1, TimeUnit.MINUTES) {
+            @Override
+            protected String loadValue() {
+                return "eu2";
+            }
+        });
+        metricRegistry.register("test-gauge", (Gauge<Integer>) () -> 42);
+        metricRegistry.register("test-text-gauge-1", new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(1, 2);
+            }
+        });
+        metricRegistry.histogram("test-histogram-1");
+        metricRegistry.histogram("test-histogram-2");
+        metricRegistry.meter("test-meter-1");
+        metricRegistry.meter("test-meter-2");
+        metricRegistry.counter("test-counter");
+        metricRegistry.timer("test-timer-1");
+        metricRegistry.timer("test-timer-2");
+        MetricRegistry subMetrics = new MetricRegistry();
+        subMetrics.counter("sb-counter-1");
+        subMetrics.counter("sb-counter-2");
+        subMetrics.histogram("sb-histogram-1");
+        metricRegistry.register("test-ms", subMetrics);
+
+        assertThat(metricRegistry.getMetrics()).containsOnlyKeys("test-text-gauge-2", "test-gauge", "test-text-gauge-1",
+                "test-histogram-1", "test-histogram-2", "test-meter-1", "test-meter-2", "test-counter",
+                "test-timer-1", "test-timer-2",
+                "test-ms.sb-counter-1", "test-ms.sb-counter-2", "test-ms.sb-histogram-1");
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/RatioGaugeTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/RatioGaugeTest.java
@@ -1,0 +1,28 @@
+package com.codahale.metrics;
+
+import org.assertj.core.data.Offset;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class RatioGaugeTest {
+
+    private RatioGauge ratioGauge = new RatioGauge() {
+        @Override
+        protected Ratio getRatio() {
+            return Ratio.of(1, 3);
+        }
+    };
+
+    @Test
+    public void testViewRatin() {
+        assertThat(ratioGauge.getRatio().toString()).isEqualTo("1.0:3.0");
+    }
+
+
+    @Test
+    public void testCalculateRatio() {
+        assertThat(ratioGauge.getValue()).isCloseTo(0.33, Offset.offset(0.01));
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
@@ -1,0 +1,79 @@
+package com.codahale.metrics;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.SortedMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class ScheduledReporterTest {
+
+    private MetricRegistry metricRegistry = new MetricRegistry();
+    private ScheduledReporter scheduledReporter;
+
+    @Before
+    public void setUp() throws Exception {
+        metricRegistry.register("sw-gauge", (Gauge<Integer>) () -> 28);
+        metricRegistry.counter("sw-counter");
+        metricRegistry.timer("sw-timer");
+        metricRegistry.meter("sw-meter");
+        metricRegistry.histogram("sw-histogram");
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        scheduledReporter.stop();
+    }
+
+    private ScheduledReporter createScheduledReporter(CountDownLatch latch) {
+        return new ScheduledReporter(metricRegistry, "test", MetricFilter.ALL, TimeUnit.MILLISECONDS,
+                TimeUnit.MINUTES) {
+            @Override
+            public void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters,
+                               SortedMap<String, Histogram> histograms, SortedMap<String, Meter> meters,
+                               SortedMap<String, Timer> timers) {
+                assertThat(gauges).containsOnlyKeys("sw-gauge");
+                assertThat(counters).containsOnlyKeys("sw-counter");
+                assertThat(histograms).containsOnlyKeys("sw-histogram");
+                assertThat(meters).containsOnlyKeys("sw-meter");
+                assertThat(timers).containsOnlyKeys("sw-timer");
+                latch.countDown();
+            }
+        };
+    }
+
+    @Test
+    public void testReport() throws Exception {
+        CountDownLatch latch = new CountDownLatch(1);
+        scheduledReporter = createScheduledReporter(latch);
+        scheduledReporter.report();
+
+        latch.await(5, TimeUnit.SECONDS);
+        assertThat(latch.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testStart() throws Exception {
+        CountDownLatch latch = new CountDownLatch(2);
+        scheduledReporter = createScheduledReporter(latch);
+        scheduledReporter.start(10, TimeUnit.MILLISECONDS);
+
+        latch.await(5, TimeUnit.SECONDS);
+        assertThat(latch.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    public void testStartWithoutDelay() throws Exception {
+        CountDownLatch latch = new CountDownLatch(2);
+        scheduledReporter = createScheduledReporter(latch);
+        scheduledReporter.start(0, 10, TimeUnit.MILLISECONDS);
+
+        latch.await(5, TimeUnit.SECONDS);
+        assertThat(latch.getCount()).isEqualTo(0);
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/SharedMetricRegistriesTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/SharedMetricRegistriesTest.java
@@ -1,0 +1,53 @@
+package com.codahale.metrics;
+
+import org.junit.After;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+@SuppressWarnings("deprecation")
+public class SharedMetricRegistriesTest {
+
+    @After
+    public void tearDown() throws Exception {
+        SharedMetricRegistries.clear();
+    }
+
+    @Test
+    public void testGetOrCreateMetricRegistry() {
+        SharedMetricRegistries.getOrCreate("get-or-create").counter("test-counter");
+
+        assertThat(SharedMetricRegistries.getOrCreate("get-or-create").getCounters())
+                .containsOnlyKeys("test-counter");
+    }
+
+    @Test
+    public void testAddMetricRegistry() {
+        MetricRegistry metricRegistry = new MetricRegistry();
+        metricRegistry.histogram("test-histogram");
+        SharedMetricRegistries.add("add", metricRegistry);
+
+        assertThat(SharedMetricRegistries.getOrCreate("add").getHistograms())
+                .containsOnlyKeys("test-histogram");
+    }
+
+    @Test
+    public void testNames() {
+        SharedMetricRegistries.add("registry-1", new MetricRegistry());
+        SharedMetricRegistries.add("registry-2", new MetricRegistry());
+        SharedMetricRegistries.add("registry-3", new MetricRegistry());
+
+        assertThat(SharedMetricRegistries.names()).containsOnly("registry-1", "registry-2", "registry-3");
+    }
+
+    @Test
+    public void testTryGetDefaultRegistry() {
+        assertThat(SharedMetricRegistries.tryGetDefault()).isNull();
+    }
+
+    @Test
+    public void testGetDefaultRegistry() {
+        assertThatIllegalStateException().isThrownBy(SharedMetricRegistries::getDefault);
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/Slf4jReporterTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/Slf4jReporterTest.java
@@ -1,0 +1,55 @@
+package com.codahale.metrics;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("deprecation")
+public class Slf4jReporterTest {
+
+    private ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private Logger logger = mock(Logger.class);
+    private Marker marker = mock(Marker.class);
+
+    @Before
+    public void setUp() throws Exception {
+        when(logger.isInfoEnabled(marker)).thenReturn(true);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        executor.shutdownNow();
+    }
+
+    @Test
+    public void testReport() throws Exception {
+        MetricRegistry metricRegistry = new MetricRegistry();
+        metricRegistry.counter("test-counter").inc(100);
+
+        Slf4jReporter slf4jReporter = Slf4jReporter.forRegistry(metricRegistry)
+                .shutdownExecutorOnStop(false)
+                .scheduleOn(executor)
+                .outputTo(logger)
+                .markWith(marker)
+                .prefixedWith("us-nw")
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .filter(MetricFilter.ALL)
+                .withLoggingLevel(Slf4jReporter.LoggingLevel.INFO)
+                .build();
+
+        slf4jReporter.report();
+
+        verify(logger).info(marker, "type={}, name={}, count={}", "COUNTER", "us-nw.test-counter", 100L);
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/SlidingTimeWindowArrayReservoirTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/SlidingTimeWindowArrayReservoirTest.java
@@ -1,0 +1,34 @@
+package com.codahale.metrics;
+
+import org.assertj.core.data.Offset;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class SlidingTimeWindowArrayReservoirTest {
+
+    @Test
+    public void testCreateWithWindow() {
+        SlidingTimeWindowArrayReservoir reservoir = new SlidingTimeWindowArrayReservoir(1, TimeUnit.HOURS);
+        reservoir.update(100);
+        reservoir.update(200);
+        reservoir.update(30);
+
+        assertThat(reservoir.size()).isEqualTo(3);
+        assertThat(reservoir.getSnapshot().getMean()).isCloseTo(110, Offset.offset(0.1));
+    }
+
+    @Test
+    public void testCreateWithWindowAndClock() {
+        SlidingTimeWindowArrayReservoir reservoir = new SlidingTimeWindowArrayReservoir(1, TimeUnit.HOURS,
+                new Clock.UserTimeClock());
+        reservoir.update(400);
+        reservoir.update(300);
+
+        assertThat(reservoir.size()).isEqualTo(2);
+        assertThat(reservoir.getSnapshot().getMean()).isCloseTo(350, Offset.offset(0.1));
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/SlidingTimeWindowReservoirTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/SlidingTimeWindowReservoirTest.java
@@ -1,0 +1,34 @@
+package com.codahale.metrics;
+
+import org.assertj.core.data.Offset;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class SlidingTimeWindowReservoirTest {
+
+    @Test
+    public void testCreateWithWindow() {
+        SlidingTimeWindowReservoir reservoir = new SlidingTimeWindowReservoir(1, TimeUnit.HOURS);
+        reservoir.update(100);
+        reservoir.update(200);
+        reservoir.update(30);
+
+        assertThat(reservoir.size()).isEqualTo(3);
+        assertThat(reservoir.getSnapshot().getMean()).isCloseTo(110, Offset.offset(0.1));
+    }
+
+    @Test
+    public void testCreateWithWindowAndClock() {
+        SlidingTimeWindowReservoir reservoir = new SlidingTimeWindowReservoir(1, TimeUnit.HOURS,
+                new Clock.UserTimeClock());
+        reservoir.update(400);
+        reservoir.update(300);
+
+        assertThat(reservoir.size()).isEqualTo(2);
+        assertThat(reservoir.getSnapshot().getMean()).isCloseTo(350, Offset.offset(0.1));
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/SlidingWindowReservoirTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/SlidingWindowReservoirTest.java
@@ -1,0 +1,33 @@
+package com.codahale.metrics;
+
+import org.assertj.core.data.Offset;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class SlidingWindowReservoirTest {
+
+    @Test
+    public void testCreateWithBigWindow() {
+        SlidingWindowReservoir reservoir = new SlidingWindowReservoir(100);
+        reservoir.update(100);
+        reservoir.update(220);
+        reservoir.update(130);
+
+        assertThat(reservoir.size()).isEqualTo(3);
+        assertThat(reservoir.getSnapshot().getMean()).isCloseTo(150, Offset.offset(0.1));
+    }
+
+    @Test
+    public void testCreateWithLowWindow() {
+        SlidingWindowReservoir reservoir = new SlidingWindowReservoir(3);
+        reservoir.update(500);
+        reservoir.update(220);
+        reservoir.update(100);
+        reservoir.update(40);
+
+        assertThat(reservoir.size()).isEqualTo(3);
+        assertThat(reservoir.getSnapshot().getMean()).isCloseTo(120, Offset.offset(0.1));
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/SnapshotTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/SnapshotTest.java
@@ -1,0 +1,38 @@
+package com.codahale.metrics;
+
+import io.dropwizard.metrics5.UniformSnapshot;
+import org.assertj.core.data.Offset;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class SnapshotTest {
+
+    @Test
+    public void testCreateSnapshot() throws Exception {
+        Snapshot snapshot = Snapshot.of(new UniformSnapshot(new long[]{5, 1, 2, 3, 4}));
+
+        assertThat(snapshot.getValues()).isEqualTo(new long[]{1, 2, 3, 4, 5});
+        assertThat(snapshot.size()).isEqualTo(5);
+        assertThat(snapshot.getMin()).isEqualTo(1);
+        assertThat(snapshot.getMax()).isEqualTo(5);
+        assertThat(snapshot.getStdDev()).isEqualTo(1.58, Offset.offset(0.01));
+        assertThat(snapshot.getMedian()).isEqualTo(3, Offset.offset(0.01));
+        assertThat(snapshot.get75thPercentile()).isEqualTo(4.5, Offset.offset(0.01));
+        assertThat(snapshot.get95thPercentile()).isEqualTo(5, Offset.offset(0.01));
+        assertThat(snapshot.get98thPercentile()).isEqualTo(5, Offset.offset(0.01));
+        assertThat(snapshot.get99thPercentile()).isEqualTo(5, Offset.offset(0.01));
+        assertThat(snapshot.get999thPercentile()).isEqualTo(5, Offset.offset(0.01));
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        snapshot.dump(baos);
+        assertThat(baos.toString("UTF-8")).isEqualToNormalizingNewlines("1\n" +
+                "2\n" +
+                "3\n" +
+                "4\n" +
+                "5\n");
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/TimerTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/TimerTest.java
@@ -1,0 +1,93 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class TimerTest {
+
+    private static class ManualClock extends Clock {
+
+        long startTime = System.nanoTime();
+
+        @Override
+        public long getTick() {
+            return startTime += 100_000_000;
+        }
+    }
+
+    private static void verifyOneEvent(Timer timer) {
+        assertThat(timer.getCount()).isEqualTo(1);
+        assertThat(timer.getSnapshot().getValues()).containsExactly(100_000_000L);
+    }
+
+    @Test
+    public void testCreate() {
+        Timer timer = new Timer();
+        timer.update(100, TimeUnit.MILLISECONDS);
+        timer.update(200, TimeUnit.MILLISECONDS);
+
+        assertThat(timer.getCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void testCreateWithCustomReservoir() {
+        Timer timer = new Timer(new SlidingWindowReservoir(100));
+        timer.update(100, TimeUnit.MILLISECONDS);
+        timer.update(200, TimeUnit.MILLISECONDS);
+
+        assertThat(timer.getCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void testCreateWithCustomReservoirAndClock() {
+        Timer timer = new Timer(new SlidingWindowReservoir(100), new Clock.UserTimeClock());
+        timer.update(100, TimeUnit.MILLISECONDS);
+        timer.update(200, TimeUnit.MILLISECONDS);
+
+        assertThat(timer.getCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void testTimerContext() {
+        Timer timer = new Timer(new SlidingWindowReservoir(100), new ManualClock());
+        timer.time().stop();
+
+        verifyOneEvent(timer);
+    }
+
+    @Test
+    public void testTimerRunnable() {
+        Timer timer = new Timer(new SlidingWindowReservoir(100), new ManualClock());
+
+        AtomicInteger counter = new AtomicInteger();
+        timer.time((Runnable) counter::incrementAndGet);
+
+        assertThat(counter.get()).isEqualTo(1);
+        verifyOneEvent(timer);
+    }
+
+    @Test
+    public void testTimerCallable() throws Exception {
+        Timer timer = new Timer(new SlidingWindowReservoir(100), new ManualClock());
+
+        String message = timer.time(() -> "SUCCESS");
+
+        assertThat(message).isEqualTo("SUCCESS");
+        verifyOneEvent(timer);
+    }
+
+    @Test
+    public void testTimerSupplier() throws Exception {
+        Timer timer = new Timer(new SlidingWindowReservoir(100), new ManualClock());
+
+        Integer result = timer.timeSupplier(() -> 42);
+
+        assertThat(result).isEqualTo(42);
+        verifyOneEvent(timer);
+    }
+}

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/UniformReservoirTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/UniformReservoirTest.java
@@ -1,0 +1,42 @@
+package com.codahale.metrics;
+
+import org.assertj.core.data.Offset;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+public class UniformReservoirTest {
+
+    @Test
+    public void testCreateReservoir() {
+        UniformReservoir reservoir = new UniformReservoir();
+        reservoir.update(120);
+        reservoir.update(190);
+        reservoir.update(200);
+        reservoir.update(130);
+        reservoir.update(140);
+
+        Snapshot snapshot = reservoir.getSnapshot();
+        assertThat(snapshot.size()).isEqualTo(5);
+        assertThat(snapshot.getValues()).contains(120, 130, 140, 190, 200);
+        assertThat(snapshot.getMin()).isEqualTo(120);
+        assertThat(snapshot.getMax()).isEqualTo(200);
+        assertThat(snapshot.getStdDev()).isEqualTo(36.47, Offset.offset(0.1));
+        assertThat(snapshot.get75thPercentile()).isEqualTo(195);
+        assertThat(snapshot.get95thPercentile()).isEqualTo(200);
+        assertThat(snapshot.get98thPercentile()).isEqualTo(200);
+        assertThat(snapshot.get99thPercentile()).isEqualTo(200);
+        assertThat(snapshot.get999thPercentile()).isEqualTo(200);
+    }
+
+    @Test
+    public void testCreateReservoirWithCustomSize() {
+        UniformReservoir reservoir = new UniformReservoir(128);
+        reservoir.update(440);
+        reservoir.update(250);
+        reservoir.update(380);
+
+        assertThat(reservoir.size()).isEqualTo(3);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,8 @@
         <module>metrics-servlets</module>
         <module>metrics-jcstress</module>
         <module>metrics-jmx</module>
+        <module>metrics-legacy-adapter</module>
+        <module>metrics-legacy-adapter-healthchecks</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This adds an adapter modules for core and health check abstractions which should allow software which is depended Metrics 3/4 to coexist together with Metrics 5.0.
    
The idea to allow users to run their Dropwizard/Spring Boot apps with Metrics 5.0. The adapter will provide an API compatible with the old Metrics API whiich will delegate requests to the new module.
    
Old integrations and reporters will work, and at the same time it should possible to implement new reporters to take advantages of tags for metric names and the sum of measurements for Timers.