### PR TITLE
Add 'Automatic-Module-Name' to MANIFEST for compatibility with JDK9

### DIFF
--- a/metrics-annotation/pom.xml
+++ b/metrics-annotation/pom.xml
@@ -8,6 +8,10 @@
         <version>4.1.0-SNAPSHOT</version>
     </parent>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.annotation</javaModuleName>
+    </properties>
+
     <artifactId>metrics-annotation</artifactId>
     <name>Annotations for Metrics</name>
     <packaging>bundle</packaging>

--- a/metrics-collectd/pom.xml
+++ b/metrics-collectd/pom.xml
@@ -15,6 +15,10 @@
         A reporter for Metrics which announces measurements to Collectd.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.collectd</javaModuleName>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -16,4 +16,8 @@
         production. Metrics provides a powerful toolkit of ways to measure the behavior of critical
         components in your production environment.
     </description>
+
+    <properties>
+        <javaModuleName>com.codahale.metrics</javaModuleName>
+    </properties>
 </project>

--- a/metrics-ehcache/pom.xml
+++ b/metrics-ehcache/pom.xml
@@ -15,6 +15,10 @@
         An Ehcache wrapper providing Metrics instrumentation of caches.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.ehcache</javaModuleName>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -15,6 +15,10 @@
         A reporter for Metrics which announces measurements to a Graphite server.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.graphite</javaModuleName>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/metrics-healthchecks/pom.xml
+++ b/metrics-healthchecks/pom.xml
@@ -16,6 +16,10 @@
         allowing you to check your application's heath in production.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.health</javaModuleName>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/metrics-httpasyncclient/pom.xml
+++ b/metrics-httpasyncclient/pom.xml
@@ -16,6 +16,10 @@
         durations and rates, and other useful information.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.httpasyncclient</javaModuleName>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/metrics-httpclient/pom.xml
+++ b/metrics-httpclient/pom.xml
@@ -16,6 +16,10 @@
         durations and rates, and other useful information.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.httpclient</javaModuleName>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/metrics-jcache/pom.xml
+++ b/metrics-jcache/pom.xml
@@ -16,6 +16,10 @@
         Uses the CacheStatisticsMXBean provided statistics.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.jcache</javaModuleName>
+    </properties>
+
     <profiles>
         <profile>
             <id>jdk9</id>

--- a/metrics-jdbi/pom.xml
+++ b/metrics-jdbi/pom.xml
@@ -15,6 +15,10 @@
         A JDBI wrapper providing Metrics instrumentation of query durations and rates.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.jdbi</javaModuleName>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/metrics-jdbi3/pom.xml
+++ b/metrics-jdbi3/pom.xml
@@ -13,6 +13,10 @@
     <packaging>bundle</packaging>
     <description>Provides instrumentation of Jdbi3 data access objects</description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.jdbi3</javaModuleName>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/metrics-jersey2/pom.xml
+++ b/metrics-jersey2/pom.xml
@@ -16,6 +16,10 @@
         implementation.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.jersey2</javaModuleName>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -16,6 +16,10 @@
         metrics, and application latency and utilization.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.jetty9</javaModuleName>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/metrics-jmx/pom.xml
+++ b/metrics-jmx/pom.xml
@@ -14,6 +14,10 @@
         A set of classes which allow you to report metrics via JMX.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.jmx</javaModuleName>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -15,6 +15,10 @@
         A set of Jackson modules which provide serializers for most Metrics classes.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.json</javaModuleName>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/metrics-jvm/pom.xml
+++ b/metrics-jvm/pom.xml
@@ -16,6 +16,10 @@
         using Metrics.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.jvm</javaModuleName>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/metrics-log4j2/pom.xml
+++ b/metrics-log4j2/pom.xml
@@ -15,6 +15,10 @@
         An instrumented appender for Log4j 2.x.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.log4j2</javaModuleName>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/metrics-servlet/pom.xml
+++ b/metrics-servlet/pom.xml
@@ -15,6 +15,10 @@
         An instrumented filter for servlet environments.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.servlet</javaModuleName>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -16,6 +16,10 @@
         your production environment.
     </description>
 
+    <properties>
+        <javaModuleName>com.codahale.metrics.servlets</javaModuleName>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -327,6 +327,9 @@
                         <manifest>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>


### PR DESCRIPTION
So Metrics can be used with modular JDK9 applications. The applications can depend on the com.codahale.metrics.* namespace instead of generated file names.