### PR TITLE
Provide a type-safe way to create a custom counter

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics5/MetricRegistry.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics5/MetricRegistry.java
@@ -144,10 +144,10 @@ public class MetricRegistry implements MetricSet {
      * @param supplier a MetricSupplier that can be used to manufacture a counter.
      * @return a new or pre-existing {@link Counter}
      */
-    public Counter counter(MetricName name, final MetricSupplier<Counter> supplier) {
-        return getOrAdd(name, new MetricBuilder<Counter>() {
+    public <T extends Counter> T counter(MetricName name, final MetricSupplier<T> supplier) {
+        return getOrAdd(name, new MetricBuilder<T>() {
             @Override
-            public Counter newMetric() {
+            public T newMetric() {
                 return supplier.newMetric();
             }
 

--- a/metrics-core/src/test/java/io/dropwizard/metrics5/MetricRegistryTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics5/MetricRegistryTest.java
@@ -14,6 +14,18 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 public class MetricRegistryTest {
+
+    private static class CustomCounter extends Counter {
+
+        CustomCounter() {
+            super();
+        }
+
+        public void incTheAnswer() {
+            inc(42);
+        }
+    }
+
     private static final MetricName TIMER2 = MetricName.build("timer");
     private static final MetricName METER2 = MetricName.build("meter");
     private static final MetricName HISTOGRAM2 = MetricName.build("histogram");
@@ -29,7 +41,6 @@ public class MetricRegistryTest {
     private final Histogram histogram = mock(Histogram.class);
     private final Meter meter = mock(Meter.class);
     private final Timer timer = mock(Timer.class);
-
     @Before
     public void setUp() {
         registry.addListener(listener);
@@ -84,6 +95,14 @@ public class MetricRegistryTest {
         verify(listener).onCounterAdded(THING, counter1);
     }
 
+    @Test
+    public void createsTypesafeCustomCounter() {
+        MetricName name = MetricName.build("custom-counter");
+        final CustomCounter customCounter = registry.counter(name, CustomCounter::new);
+        customCounter.incTheAnswer();
+
+        assertThat(registry.counter(name).getCount()).isEqualTo(42);
+    }
 
     @Test
     public void removingACounterTriggersANotification() {


### PR DESCRIPTION
Practically, the only way to customize a counter is too extend it. That means users who provide a new supplier will probably use a new class that extends `Counter`. It would be nice if the `counter(MetricName name, MetricSupplier<Counter> supplier)` method returned a counter with the same type as specified in the `MetricSupplier` implementation. This will save a redundant type cast for the user and avoid a potential compilation warning. Since it's a breaking change, it can be done only in the 5.0 version.

Fixes #1261.