### PR TITLE
InfluxDB reporter for metrics 5.0

### DIFF
--- a/metrics-influxdb/pom.xml
+++ b/metrics-influxdb/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.dropwizard.metrics5</groupId>
+        <artifactId>metrics-parent</artifactId>
+        <version>5.0.0-rc1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>metrics-influxdb</artifactId>
+    <name>InfluxDB integration for Metrics</name>
+    <packaging>bundle</packaging>
+    <description>
+        A reporter for Metrics which announces measurements to an InfluxDB server.
+    </description>
+
+    <properties>
+        <javaModuleName>com.codahale.metrics.influxdb</javaModuleName>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dropwizard.metrics5</groupId>
+                <artifactId>metrics-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard.metrics5</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/GarbageFreeScheduledReporter.java
+++ b/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/GarbageFreeScheduledReporter.java
@@ -1,0 +1,199 @@
+package io.dropwizard.metrics5.influxdb;
+
+import io.dropwizard.metrics5.Counter;
+import io.dropwizard.metrics5.Gauge;
+import io.dropwizard.metrics5.Histogram;
+import io.dropwizard.metrics5.Meter;
+import io.dropwizard.metrics5.MetricAttribute;
+import io.dropwizard.metrics5.MetricFilter;
+import io.dropwizard.metrics5.MetricName;
+import io.dropwizard.metrics5.MetricRegistry;
+import io.dropwizard.metrics5.MetricRegistryListener;
+import io.dropwizard.metrics5.ScheduledReporter;
+import io.dropwizard.metrics5.Timer;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public abstract class GarbageFreeScheduledReporter extends ScheduledReporter {
+
+    private MetricRegistry registry;
+    private RegistryMirror mirror;
+    
+    protected GarbageFreeScheduledReporter(MetricRegistry registry, 
+            String name, 
+            MetricFilter filter, 
+            TimeUnit rateUnit, 
+            TimeUnit durationUnit) {
+        super(registry, name, filter, rateUnit, durationUnit);
+        init(registry, filter);
+    }
+
+    protected GarbageFreeScheduledReporter(MetricRegistry registry, 
+            String name, 
+            MetricFilter filter, 
+            TimeUnit rateUnit, 
+            TimeUnit durationUnit, 
+            ScheduledExecutorService executor) {
+        super(registry, name, filter, rateUnit, durationUnit, executor);
+        init(registry, filter);
+    }
+
+    protected GarbageFreeScheduledReporter(MetricRegistry registry, 
+            String name, 
+            MetricFilter filter, 
+            TimeUnit rateUnit, 
+            TimeUnit durationUnit, 
+            ScheduledExecutorService executor, 
+            boolean shutdownExecutorOnStop) {
+        super(registry, name, filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop);
+        init(registry, filter);
+    }
+
+    protected GarbageFreeScheduledReporter(MetricRegistry registry, 
+            String name,
+            MetricFilter filter, 
+            TimeUnit rateUnit, 
+            TimeUnit durationUnit, 
+            ScheduledExecutorService executor, 
+            boolean shutdownExecutorOnStop, 
+            Set<MetricAttribute> disabledMetricAttributes) {
+        super(registry, name, filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop, disabledMetricAttributes);
+        init(registry, filter);
+    }
+    
+    private void init(MetricRegistry registry, MetricFilter filter) {
+        this.registry = registry;
+        this.mirror = new RegistryMirror(filter);
+        mirror.register(registry);
+    }
+
+    @Override
+    public void stop() {
+        try {
+            super.stop();
+        } finally {
+            mirror.unregister(registry);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public void report() {
+        synchronized (this) {
+            report(mirror.gauges(), 
+                    mirror.counters(), 
+                    mirror.histograms(), 
+                    mirror.meters(), 
+                    mirror.timers());
+        }
+    }
+    
+    private static class RegistryMirror implements MetricRegistryListener {
+
+        private final MetricFilter filter;
+        @SuppressWarnings("rawtypes") // because of signature in ScheduledReporter#report(..)
+        private final ConcurrentSkipListMap<MetricName, Gauge> gauges = new ConcurrentSkipListMap<>();
+        private final ConcurrentSkipListMap<MetricName, Counter> counters = new ConcurrentSkipListMap<>();
+        private final ConcurrentSkipListMap<MetricName, Histogram> histograms = new ConcurrentSkipListMap<>();
+        private final ConcurrentSkipListMap<MetricName, Meter> meters = new ConcurrentSkipListMap<>();
+        private final ConcurrentSkipListMap<MetricName, Timer> timers = new ConcurrentSkipListMap<>();
+
+        public RegistryMirror(MetricFilter filter) {
+            this.filter = filter;
+        }
+        
+        public void register(MetricRegistry registry) {
+            registry.addListener(this);
+        }
+        public void unregister(MetricRegistry registry) {
+            registry.removeListener(this);
+        }
+
+        @SuppressWarnings("rawtypes") // because of signature in ScheduledReporter#report(..)
+        SortedMap<MetricName, Gauge> gauges() {
+            return gauges;
+        }
+
+        SortedMap<MetricName, Counter> counters() {
+            return counters;
+        }
+
+        SortedMap<MetricName, Histogram> histograms() {
+            return histograms;
+        }
+
+        SortedMap<MetricName, Meter> meters() {
+            return meters;
+        }
+
+        SortedMap<MetricName, Timer> timers() {
+            return timers;
+        }
+        
+        
+        @Override
+        public void onGaugeAdded(MetricName name, Gauge<?> gauge) {
+            if (filter.matches(name, gauge)) {
+                gauges.put(name, gauge);
+            }
+        }
+
+        @Override
+        public void onGaugeRemoved(MetricName name) {
+            gauges.remove(name);
+        }
+
+        @Override
+        public void onCounterAdded(MetricName name, Counter counter) {
+            if (filter.matches(name, counter)) {
+                counters.put(name, counter);
+            }
+        }
+
+        @Override
+        public void onCounterRemoved(MetricName name) {
+            counters.remove(name);
+        }
+
+        @Override
+        public void onHistogramAdded(MetricName name, Histogram histogram) {
+            if (filter.matches(name, histogram)) {
+                histograms.put(name, histogram);
+            }
+        }
+
+        @Override
+        public void onHistogramRemoved(MetricName name) {
+            histograms.remove(name);
+        }
+
+        @Override
+        public void onMeterAdded(MetricName name, Meter meter) {
+            if (filter.matches(name, meter)) {
+                meters.put(name, meter);
+            }
+        }
+
+        @Override
+        public void onMeterRemoved(MetricName name) {
+            meters.remove(name);
+        }
+
+        @Override
+        public void onTimerAdded(MetricName name, Timer timer) {
+            if (filter.matches(name, timer)) {
+                timers.put(name, timer);
+            }
+        }
+
+        @Override
+        public void onTimerRemoved(MetricName name) {
+            timers.remove(name);
+        }
+        
+    }
+    
+}

--- a/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbLineBuilder.java
+++ b/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbLineBuilder.java
@@ -1,0 +1,166 @@
+package io.dropwizard.metrics5.influxdb;
+
+import io.dropwizard.metrics5.MetricAttribute;
+import io.dropwizard.metrics5.MetricName;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+/**
+ * A builder to create a "measurement line" according to the Influx DB line protocol.
+ * 
+ * Intended usage:
+ * <pre>
+ * // first:
+ * builder.writeMeasurement(name);
+ * 
+ * // then write one or more fields:
+ * builder.writeFieldIfEnabled(key, value);
+ * // ... or ...
+ * builder.writeField(key).writeFieldValue(value);
+ * 
+ * // finally:
+ * builder.writeTimestampMillis(time);
+ * if (builder.hasValues()) {
+ *     StringBuilder sb = builder.get(); // the result is here
+ * }
+ * <pre>
+ */
+class InfluxDbLineBuilder {
+
+    private final StringBuilder str = new StringBuilder();
+    private boolean firstField;
+
+    private final Set<MetricAttribute> disabledMetricAttributes;
+    private final MetricName prefix;
+    private final Map<MetricName, String> encodedNameCache = new WeakHashMap<>();
+
+    InfluxDbLineBuilder(Set<MetricAttribute> disabledMetricAttributes, MetricName prefix) {
+        this.disabledMetricAttributes = disabledMetricAttributes;
+        this.prefix = prefix != null ? prefix : MetricName.build();
+    }
+
+    InfluxDbLineBuilder writeMeasurement(MetricName name) {
+        str.setLength(0);
+        str.append(encodedNameCache.computeIfAbsent(name, this::writeMeasurementNoCache));
+        str.append(' ');
+        firstField = true;
+        return this;
+    }
+
+    private String writeMeasurementNoCache(MetricName name) {
+        StringBuilder sb = new StringBuilder();
+
+        MetricName prefixedName = MetricName.join(prefix, name);
+        appendName(prefixedName.getKey(), sb);
+        // InfluxDB Performance and Setup Tips:
+        // Sort tags by key before sending them to the database. 
+        // The sort should match the results from the Go bytes.Compare function.
+        prefixedName.getTags()
+                .entrySet()
+                .stream()
+                .sorted(Comparator.comparing(Map.Entry::getKey))
+                .forEach(tag -> {
+            sb.append(',');
+            appendName(tag.getKey(), sb);
+            sb.append('=');
+            appendName(tag.getValue(), sb);
+        });
+        return sb.toString();
+    }
+
+    InfluxDbLineBuilder writeField(MetricAttribute key) {
+        if (!firstField) {
+            str.append(',');
+        }
+        str.append(key.getCode()).append('=');
+        firstField = false;
+        return this;
+    }
+
+    InfluxDbLineBuilder writeField(String key) {
+        if (!firstField) {
+            str.append(',');
+        }
+        appendName(key, str);
+        str.append('=');
+        firstField = false;
+        return this;
+    }
+
+    InfluxDbLineBuilder writeFieldValue(double value) {
+        str.append(value);
+        return this;
+    }
+
+    InfluxDbLineBuilder writeFieldValue(long value) {
+        str.append(value).append('i');
+        return this;
+    }
+
+    InfluxDbLineBuilder writeFieldValue(String value) {
+        str.append('"');
+        appendString(value, str);
+        str.append('"');
+        return this;
+    }
+
+    InfluxDbLineBuilder writeFieldValue(boolean value) {
+        str.append(value ? 't' : 'f');
+        return this;
+    }
+
+    InfluxDbLineBuilder writeTimestampMillis(long utcMillis) {
+        str.append(' ').append(utcMillis).append("000000\n");
+        return this;
+    }
+
+    InfluxDbLineBuilder writeFieldIfEnabled(MetricAttribute key, double value) {
+        if (!disabledMetricAttributes.contains(key)) {
+            writeField(key);
+            writeFieldValue(value);
+        }
+        return this;
+    }
+
+    InfluxDbLineBuilder writeFieldIfEnabled(MetricAttribute key, long value) {
+        if (!disabledMetricAttributes.contains(key)) {
+            writeField(key);
+            writeFieldValue(value);
+        }
+        return this;
+    }
+
+    boolean hasValues() {
+        return !firstField;
+    }
+    
+    StringBuilder get() {
+        return str;
+    }    
+    
+    private static void appendName(CharSequence field, StringBuilder dst) {
+        int len = field.length();
+        for (int i=0; i<len; i++) {
+            char ch = field.charAt(i);
+            if (ch == ',' || ch == '=' || ch == ' ') {
+                // escape
+                dst.append('\\');
+            }
+            dst.append(ch);
+        }
+    }
+    private static void appendString(CharSequence field, StringBuilder dst) {
+        int len = field.length();
+        for (int i=0; i<len; i++) {
+            char ch = field.charAt(i);
+            if (ch == '"') {
+                // escape
+                dst.append('\\');
+            }
+            dst.append(ch);
+        }
+    }
+    
+}

--- a/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbReporter.java
+++ b/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbReporter.java
@@ -1,0 +1,518 @@
+package io.dropwizard.metrics5.influxdb;
+
+import io.dropwizard.metrics5.Clock;
+import io.dropwizard.metrics5.Counter;
+import io.dropwizard.metrics5.Gauge;
+import io.dropwizard.metrics5.Histogram;
+import io.dropwizard.metrics5.Meter;
+import io.dropwizard.metrics5.Metered;
+import io.dropwizard.metrics5.MetricAttribute;
+import io.dropwizard.metrics5.MetricName;
+import java.util.Map;
+
+import static io.dropwizard.metrics5.MetricAttribute.*;
+import io.dropwizard.metrics5.MetricFilter;
+import io.dropwizard.metrics5.MetricRegistry;
+import io.dropwizard.metrics5.ScheduledReporter;
+import io.dropwizard.metrics5.Snapshot;
+import io.dropwizard.metrics5.Timer;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.WeakHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A reporter which publishes metric values to InfluxDB.
+ * 
+ * <p>
+ * Metrics are reported according to the 
+ * <a href="https://docs.influxdata.com/influxdb/v1.4/write_protocols/line_protocol_reference/">InfluxDB Line Protocol</a>.
+ * Brief line protocol syntax as follows:
+ * <pre>
+ * measurement(,tag_key=tag_val)* field_key=field_val(,field_key_n=field_value_n)* (nanoseconds-timestamp)?
+ * </pre>
+ * 
+ * <p>
+ * This InfluxDB reporter is "garbage free" in steady state.
+ * This means objects and buffers are reused and no temporary objects are allocated as much as possible.
+ */
+public class InfluxDbReporter extends ScheduledReporter {
+
+    /**
+     * Returns a new Builder for {@link InfluxDbReporter}.
+     *
+     * @param registry the registry to report
+     * @return a Builder instance for a {@link InfluxDbReporter}
+     */
+    public static Builder forRegistry(MetricRegistry registry) {
+        return new Builder(registry);
+    }
+
+    /**
+     * A builder for {@link GraphiteReporter} instances. Defaults to not using a prefix, using the
+     * default clock, converting rates to events/second, converting durations to milliseconds, and
+     * not filtering metrics.
+     */
+    public static class Builder {
+        private final MetricRegistry registry;
+        private Clock clock;
+        private MetricName prefix;
+        private TimeUnit rateUnit;
+        private TimeUnit durationUnit;
+        private MetricFilter filter;
+        private ScheduledExecutorService executor;
+        private boolean shutdownExecutorOnStop;
+        private Set<MetricAttribute> disabledMetricAttributes;
+
+        private Builder(MetricRegistry registry) {
+            this.registry = registry;
+            this.clock = Clock.defaultClock();
+            this.prefix = null;
+            this.rateUnit = TimeUnit.SECONDS;
+            this.durationUnit = TimeUnit.MILLISECONDS;
+            this.filter = MetricFilter.ALL;
+            this.executor = null;
+            this.shutdownExecutorOnStop = true;
+            this.disabledMetricAttributes = Collections.emptySet();
+        }
+
+        /**
+         * Specifies whether or not, the executor (used for reporting) will be stopped with same time with reporter.
+         * Default value is true.
+         * Setting this parameter to false, has the sense in combining with providing external managed executor via 
+         * {@link #scheduleOn(ScheduledExecutorService)}.
+         *
+         * @param shutdownExecutorOnStop if true, then executor will be stopped in same time with this reporter
+         * @return {@code this}
+         */
+        public Builder shutdownExecutorOnStop(boolean shutdownExecutorOnStop) {
+            this.shutdownExecutorOnStop = shutdownExecutorOnStop;
+            return this;
+        }
+
+        /**
+         * Specifies the executor to use while scheduling reporting of metrics.
+         * Default value is null.
+         * Null value leads to executor will be auto created on start.
+         *
+         * @param executor the executor to use while scheduling reporting of metrics.
+         * @return {@code this}
+         */
+        public Builder scheduleOn(ScheduledExecutorService executor) {
+            this.executor = executor;
+            return this;
+        }
+
+        /**
+         * Use the given {@link Clock} instance for the time.
+         *
+         * @param clock a {@link Clock} instance
+         * @return {@code this}
+         */
+        public Builder withClock(Clock clock) {
+            this.clock = clock;
+            return this;
+        }
+
+        /**
+         * Prefix all metric names with the given name.
+         *
+         * @param prefix the prefix for all metric names
+         * @return {@code this}
+         */
+        public Builder prefixedWith(MetricName prefix) {
+            this.prefix = prefix;
+            return this;
+        }
+
+        /**
+         * Convert rates to the given time unit.
+         *
+         * @param rateUnit a unit of time
+         * @return {@code this}
+         */
+        public Builder convertRatesTo(TimeUnit rateUnit) {
+            this.rateUnit = rateUnit;
+            return this;
+        }
+
+        /**
+         * Convert durations to the given time unit.
+         *
+         * @param durationUnit a unit of time
+         * @return {@code this}
+         */
+        public Builder convertDurationsTo(TimeUnit durationUnit) {
+            this.durationUnit = durationUnit;
+            return this;
+        }
+
+        /**
+         * Only report metrics which match the given filter.
+         *
+         * @param filter a {@link MetricFilter}
+         * @return {@code this}
+         */
+        public Builder filter(MetricFilter filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        /**
+         * Don't report the passed metric attributes for all metrics (e.g. "p999", "stddev" or "m15").
+         *
+         * @param disabledMetricAttributes the disabled metric attributes
+         * @return {@code this}
+         */
+        public Builder disabledMetricAttributes(Set<MetricAttribute> disabledMetricAttributes) {
+            this.disabledMetricAttributes = disabledMetricAttributes;
+            return this;
+        }
+
+        /**
+         * Builds a GraphiteReporter with the given properties, sending metrics using the
+         * given InfluxDbSender.
+         *
+         * @param sender the GraphiteSender
+         * @return the GraphiteReporter
+         */
+        public InfluxDbReporter build(InfluxDbSender sender) {
+            return new InfluxDbReporter(registry,
+                    sender,
+                    clock,
+                    prefix,
+                    rateUnit,
+                    durationUnit,
+                    filter,
+                    executor,
+                    shutdownExecutorOnStop,
+                    disabledMetricAttributes);
+        }
+    }
+    
+    private static final Logger LOGGER = LoggerFactory.getLogger(InfluxDbReporter.class);
+    private static final String VALUE = "value";
+    
+    private final Clock clock;
+    private final MetricName prefix;
+    private final InfluxDbSender sender;
+
+    private final WeakHashMap<MetricName, char[]> encodedNameCache = new WeakHashMap<>();
+    private final StringBuilder str = new StringBuilder();
+    private boolean firstField;
+    
+    /**
+     * Creates a new InfluxDbReporter instance.
+     *
+     * @param registry               the MetricRegistry containing the metrics this reporter will report
+     * @param sender                 the InfluxDbSender which is responsible for sending metrics to a influxdb
+     *                               server via a transport protocol
+     * @param clock                  the instance of the time. Use {@link Clock#defaultClock()} for the default
+     * @param prefix                 the prefix of all metric names (may be null)
+     * @param rateUnit               the time unit of in which rates will be converted
+     * @param durationUnit           the time unit of in which durations will be converted
+     * @param filter                 the filter for which metrics to report
+     * @param executor               the executor to use while scheduling reporting of metrics (may be null).
+     * @param shutdownExecutorOnStop if true, then executor will be stopped in same time with this reporter
+     * @param disabledMetricAttributes the disable metric attributes
+     */
+    protected InfluxDbReporter(MetricRegistry registry,
+                               InfluxDbSender sender,
+                               Clock clock,
+                               MetricName prefix,
+                               TimeUnit rateUnit,
+                               TimeUnit durationUnit,
+                               MetricFilter filter,
+                               ScheduledExecutorService executor,
+                               boolean shutdownExecutorOnStop,
+                               Set<MetricAttribute> disabledMetricAttributes) {
+        super(registry, "influxdb-reporter", filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop,
+                disabledMetricAttributes);
+        this.sender = sender;
+        this.clock = clock;
+        this.prefix = prefix != null ? prefix : MetricName.build();
+    }    
+    
+    @Override
+    @SuppressWarnings("rawtypes")
+    public void report(SortedMap<MetricName, Gauge> gauges, 
+            SortedMap<MetricName, Counter> counters, 
+            SortedMap<MetricName, Histogram> histograms, 
+            SortedMap<MetricName, Meter> meters, 
+            SortedMap<MetricName, Timer> timers) {
+
+        final long timestamp = clock.getTime();
+
+        try {
+            sender.connect();
+
+            for (Map.Entry<MetricName, Gauge> entry : gauges.entrySet()) {
+                reportGauge(entry.getKey(), entry.getValue(), timestamp);
+            }
+
+            for (Map.Entry<MetricName, Counter> entry : counters.entrySet()) {
+                reportCounter(entry.getKey(), entry.getValue(), timestamp);
+            }
+
+            for (Map.Entry<MetricName, Histogram> entry : histograms.entrySet()) {
+                reportHistogram(entry.getKey(), entry.getValue(), timestamp);
+            }
+
+            for (Map.Entry<MetricName, Meter> entry : meters.entrySet()) {
+                reportMetered(entry.getKey(), entry.getValue(), timestamp);
+            }
+
+            for (Map.Entry<MetricName, Timer> entry : timers.entrySet()) {
+                reportTimer(entry.getKey(), entry.getValue(), timestamp);
+            }
+            sender.flush();
+        } catch (IOException e) {
+            LOGGER.warn("Unable to report to InfluxDb", sender, e);
+        } finally {
+            try {
+                sender.disconnect();
+            } catch (IOException e) {
+                LOGGER.warn("Error disconnecting InfluxDb", sender, e);
+            }
+        }
+    }
+    
+    @Override
+    public void stop() {
+        try {
+            super.stop();
+        } finally {
+            try {
+                sender.close();
+            } catch (IOException e) {
+                LOGGER.debug("Error disconnecting from InfluxDb", e);
+            }
+        }
+    }
+    
+    private void reportTimer(MetricName name, Timer timer, long timestamp) throws IOException {
+        final Snapshot snapshot = timer.getSnapshot();
+        writeMeasurement(name);
+        writeFieldIfEnabled(MAX,    convertDuration(snapshot.getMax()));
+        writeFieldIfEnabled(MEAN,   convertDuration(snapshot.getMean()));
+        writeFieldIfEnabled(MIN,    convertDuration(snapshot.getMin()));
+        writeFieldIfEnabled(STDDEV, convertDuration(snapshot.getStdDev()));
+        writeFieldIfEnabled(P50,    convertDuration(snapshot.getMedian()));
+        writeFieldIfEnabled(P75,    convertDuration(snapshot.get75thPercentile()));
+        writeFieldIfEnabled(P95,    convertDuration(snapshot.get95thPercentile()));
+        writeFieldIfEnabled(P98,    convertDuration(snapshot.get98thPercentile()));
+        writeFieldIfEnabled(P99,    convertDuration(snapshot.get99thPercentile()));
+        writeFieldIfEnabled(P999,   convertDuration(snapshot.get999thPercentile()));
+        writeMeteredFieldsIfEnabled(timer);
+        if (hasValues()) {
+            writeTimestampMillis(timestamp);
+            reportLine();
+        }
+    }
+
+
+    private void reportHistogram(MetricName name, Histogram histogram, long timestamp) throws IOException {
+        writeMeasurement(name);
+        final Snapshot snapshot = histogram.getSnapshot();
+        writeFieldIfEnabled(COUNT, histogram.getCount());
+        writeFieldIfEnabled(SUM, histogram.getSum());
+        writeFieldIfEnabled(MAX,    snapshot.getMax());
+        writeFieldIfEnabled(MEAN,   snapshot.getMean());
+        writeFieldIfEnabled(MIN,    snapshot.getMin());
+        writeFieldIfEnabled(STDDEV, snapshot.getStdDev());
+        writeFieldIfEnabled(P50,    snapshot.getMedian());
+        writeFieldIfEnabled(P75,    snapshot.get75thPercentile());
+        writeFieldIfEnabled(P95,    snapshot.get95thPercentile());
+        writeFieldIfEnabled(P98,    snapshot.get98thPercentile());
+        writeFieldIfEnabled(P99,    snapshot.get99thPercentile());
+        writeFieldIfEnabled(P999,   snapshot.get999thPercentile());
+        if (hasValues()) {
+            writeTimestampMillis(timestamp);
+            reportLine();
+        }
+    }
+    
+    
+    private void reportMetered(MetricName name, Metered meter, long timestamp) throws IOException {
+        writeMeasurement(name);
+        writeMeteredFieldsIfEnabled(meter);
+        if (hasValues()) {
+            writeTimestampMillis(timestamp);
+            reportLine();
+        }
+    }
+
+    private void writeMeteredFieldsIfEnabled(Metered meter) {
+        writeFieldIfEnabled(COUNT,     meter.getCount());
+        writeFieldIfEnabled(SUM,       meter.getSum());
+        writeFieldIfEnabled(M1_RATE,   convertRate(meter.getOneMinuteRate()));
+        writeFieldIfEnabled(M5_RATE,   convertRate(meter.getFiveMinuteRate()));
+        writeFieldIfEnabled(M15_RATE,  convertRate(meter.getFifteenMinuteRate()));
+        writeFieldIfEnabled(MEAN_RATE, convertRate(meter.getMeanRate()));
+    }
+    
+    private void reportCounter(MetricName name, Counter counter, long timestamp) throws IOException {
+        writeMeasurement(name);
+        writeFieldIfEnabled(COUNT, counter.getCount());
+        if (hasValues()) {
+            writeTimestampMillis(timestamp);
+            reportLine();
+        }
+    }
+
+    private void reportGauge(MetricName name, Gauge<?> gauge, long timestamp) throws IOException {
+        writeMeasurement(name);
+        Object value = gauge.getValue();
+        if (value != null) {
+            writeField(VALUE);
+            if (value instanceof Number) {
+                Number number = (Number) value;
+                if (number instanceof Long || 
+                        number instanceof Integer || 
+                        number instanceof Short || 
+                        number instanceof Byte) {
+                    writeFieldValue(number.longValue());
+                } else {
+                    writeFieldValue(number.doubleValue());
+                }
+            } else if (value instanceof Boolean) {
+                writeFieldValue(((Boolean)value));
+            } else {
+                writeFieldValue(value.toString());
+            }
+        }
+        writeTimestampMillis(timestamp);
+        reportLine();
+    }    
+    
+    private void reset() {
+        str.delete(0, str.length());
+    }
+    
+    private void writeMeasurement(MetricName name) {
+        reset();
+        char[] nameChars = encodedNameCache.get(name);
+        if (nameChars != null) {
+            str.append(nameChars);
+        } else {
+            writeMeasurementNoCache(name);
+            nameChars = new char[str.length()];
+            str.getChars(0, str.length(), nameChars, 0);
+            encodedNameCache.put(name, nameChars);
+        }
+        
+        str.append(' ');
+        firstField = true;
+    }
+    
+    private void writeMeasurementNoCache(MetricName name) {
+        MetricName prefixedName = MetricName.join(prefix, name);
+        
+        appendName(prefixedName.getKey(), str);
+        Map<String, String> tags = prefixedName.getTags();
+        if (!tags.isEmpty()) {
+            // InfluxDB Performance and Setup Tips:
+            // Sort tags by key before sending them to the database. 
+            // The sort should match the results from the Go bytes.Compare function.
+            TreeMap<String, String> sortedTags = new TreeMap<>(tags);
+            for (Map.Entry<String, String> tag : sortedTags.entrySet()) {
+                str.append(',');
+                appendName(tag.getKey(), str);
+                str.append('=');
+                appendName(tag.getValue(), str);
+            }
+        }
+    }
+    
+    private void writeTimestampMillis(long utcMillis) {
+        str.append(' ').append(utcMillis).append("000000\n");
+    }
+    
+    private boolean hasValues() {
+        return !firstField;
+    }
+    
+    private void reportLine() throws IOException {
+        sender.send(str);
+    }
+
+    private void writeFieldIfEnabled(MetricAttribute key, double value) {
+        if (!getDisabledMetricAttributes().contains(key)) {
+            writeField(key);
+            writeFieldValue(value);
+        }
+    }
+    
+    private void writeFieldIfEnabled(MetricAttribute key, long value) {
+        if (!getDisabledMetricAttributes().contains(key)) {
+            writeField(key);
+            writeFieldValue(value);
+        }
+    }
+    
+    private void writeField(MetricAttribute key) {
+        if (!firstField) {
+            str.append(',');
+        }
+        str.append(key.getCode()) // no need to escape, only safe chars
+           .append('=');
+        firstField = false;
+    }
+    
+    private void writeField(String key) {
+        if (!firstField) {
+            str.append(',');
+        }
+        appendName(key, str);
+        str.append('=');
+        firstField = false;
+    }
+    
+    private void writeFieldValue(double value) {
+        str.append(value);
+    }
+    
+    private void writeFieldValue(long value) {
+        str.append(value).append('i');
+    }
+    
+    private void writeFieldValue(String value) {
+        str.append('"');
+        appendString(value, str);
+        str.append('"');
+    }
+    
+    private void writeFieldValue(boolean value) {
+        str.append(value ? 't' : 'f');
+    }
+    
+    private static void appendName(CharSequence field, StringBuilder dst) {
+        int len = field.length();
+        for (int i=0; i<len; i++) {
+            char ch = field.charAt(i);
+            if (ch == ',' || ch == '=' || ch == ' ') {
+                // escape
+                dst.append('\\');
+            }
+            dst.append(ch);
+        }
+    }
+    private static void appendString(CharSequence field, StringBuilder dst) {
+        int len = field.length();
+        for (int i=0; i<len; i++) {
+            char ch = field.charAt(i);
+            if (ch == '"') {
+                // escape
+                dst.append('\\');
+            }
+            dst.append(ch);
+        }
+    }
+    
+}

--- a/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbReporter.java
+++ b/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbReporter.java
@@ -175,11 +175,11 @@ public class InfluxDbReporter extends GarbageFreeScheduledReporter {
         }
 
         /**
-         * Builds a GraphiteReporter with the given properties, sending metrics using the
+         * Builds a InfluxDbReporter with the given properties, sending metrics using the
          * given InfluxDbSender.
          *
-         * @param sender the GraphiteSender
-         * @return the GraphiteReporter
+         * @param sender the InfluxDbSender
+         * @return the InfluxDbReporter
          */
         public InfluxDbReporter build(InfluxDbSender sender) {
             return new InfluxDbReporter(registry,

--- a/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbReporter.java
+++ b/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbReporter.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import static io.dropwizard.metrics5.MetricAttribute.*;
 import io.dropwizard.metrics5.MetricFilter;
 import io.dropwizard.metrics5.MetricRegistry;
-import io.dropwizard.metrics5.ScheduledReporter;
 import io.dropwizard.metrics5.Snapshot;
 import io.dropwizard.metrics5.Timer;
 import java.io.IOException;
@@ -42,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * This InfluxDB reporter is "garbage free" in steady state.
  * This means objects and buffers are reused and no temporary objects are allocated as much as possible.
  */
-public class InfluxDbReporter extends ScheduledReporter {
+public class InfluxDbReporter extends GarbageFreeScheduledReporter {
 
     /**
      * Returns a new Builder for {@link InfluxDbReporter}.

--- a/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbReporter.java
+++ b/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbReporter.java
@@ -55,7 +55,7 @@ public class InfluxDbReporter extends ScheduledReporter {
     }
 
     /**
-     * A builder for {@link GraphiteReporter} instances. Defaults to not using a prefix, using the
+     * A builder for {@link InfluxDbReporter} instances. Defaults to not using a prefix, using the
      * default clock, converting rates to events/second, converting durations to milliseconds, and
      * not filtering metrics.
      */

--- a/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbSender.java
+++ b/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbSender.java
@@ -1,0 +1,47 @@
+package io.dropwizard.metrics5.influxdb;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+public interface InfluxDbSender extends Closeable {
+    /**
+     * Connects to the server.
+     *
+     * @throws IllegalStateException if the client is already connected
+     * @throws IOException           if there is an error connecting
+     */
+    void connect() throws IllegalStateException, IOException;
+
+    /**
+     * Sends the given measurement to the server.
+     * 
+     * <p>
+     * <b>NOTE:</b> The caller may modify the <code>measurement</code> buffer after this call.
+     * The implementation of this method MUST NOT keep any reference to the buffer after this call.
+     * </p>
+     *
+     * @param measurement a single measurement line, 
+     * according to the InfluxDb line protocol including a trailing newline.
+     * @throws IOException if there was an error sending the metric
+     */
+    void send(StringBuilder measurement) throws IOException;
+
+    /**
+     * Flushes buffer, if applicable
+     *
+     * @throws IOException if there was an error during flushing metrics to the server
+     */
+    void flush() throws IOException;
+    
+    /**
+     * Disconnects from the server.
+     * 
+     * @throws IOException           if there is an error disconnecting
+     */
+    void disconnect() throws IOException;
+    
+    /**
+     * Returns true if ready to send data
+     */
+    boolean isConnected();
+}

--- a/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbUdpSender.java
+++ b/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbUdpSender.java
@@ -1,7 +1,6 @@
 package io.dropwizard.metrics5.influxdb;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;

--- a/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbUdpSender.java
+++ b/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbUdpSender.java
@@ -1,0 +1,148 @@
+package io.dropwizard.metrics5.influxdb;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.channels.DatagramChannel;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetEncoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
+import java.util.Objects;
+
+public class InfluxDbUdpSender implements InfluxDbSender {
+
+    private final InetSocketAddress address;
+    private int mtu = 1500;
+
+    private DatagramChannel datagramChannel = null;
+
+    private ByteBuffer byteBuf;
+    private CharBuffer charBuf;
+    private final CharsetEncoder encoder = Charset.forName("UTF-8")
+            .newEncoder()
+            .onMalformedInput(CodingErrorAction.REPLACE)
+            .onUnmappableCharacter(CodingErrorAction.REPLACE);
+
+    /**
+     * Creates a new client which sends data to given address using UDP
+     *
+     * @param hostname The hostname of the InfluxDb server
+     * @param port     The port of the InfluxDb server
+     */
+    public InfluxDbUdpSender(String hostname, int port) {
+        this(new InetSocketAddress(hostname, port));
+    }
+
+    /**
+     * Creates a new client which sends data to given address using UDP
+     *
+     * @param address the address of the InfluxDb server
+     */
+    public InfluxDbUdpSender(InetSocketAddress address) {
+        this.address = Objects.requireNonNull(address);
+        charBuf = CharBuffer.allocate(mtu*2);
+        byteBuf = ByteBuffer.allocate(mtu*2);
+    }
+
+    // for testing
+    void setMTU(int mtu) {
+        this.mtu = mtu;
+    }
+
+    // for testing
+    void setDatagramChannel(DatagramChannel datagramChannel) {
+        this.datagramChannel = datagramChannel;
+    }
+    
+    @Override
+    public void connect() throws IllegalStateException, IOException {
+        if (datagramChannel == null) {
+            datagramChannel = DatagramChannel.open();
+        }
+        byteBuf.clear();
+    }
+
+    @Override
+    public boolean isConnected() {
+        return datagramChannel != null;
+    }
+    
+    @Override
+    public void disconnect() throws IOException {
+        // ignore, keep the datagram channel open
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            datagramChannel.close();
+        } finally {
+            datagramChannel = null;
+        }
+    }
+
+    @Override
+    public void send(StringBuilder str) throws IOException {
+        int len = byteBuf.position();
+        encode(str);
+        int len2 = byteBuf.position();
+        if (len2 >= mtu) {
+            if (len == 0) {
+                // send current buffer (one single measurement exceeds the MTU)
+                sendBuffer();
+                byteBuf.clear();
+            } else {
+                // send previous buffer
+                byteBuf.position(len);
+                sendBuffer();
+                byteBuf.limit(len2);
+                byteBuf.compact();
+            }
+        }
+    }
+    
+    @Override
+    public void flush() throws IOException {
+        if (byteBuf.position() > 0) {
+            sendBuffer();
+            byteBuf.clear();
+        }
+    }
+    
+    private void sendBuffer() throws IOException {
+        byteBuf.flip();
+        datagramChannel.send(byteBuf, address);
+    }
+        
+    private void encode(StringBuilder str) {
+        // copy chars
+        if (charBuf.capacity() < str.length()) {
+            charBuf = CharBuffer.allocate(str.length());
+        } else {
+            charBuf.clear();
+        }
+        str.getChars(0, str.length(), charBuf.array(), charBuf.arrayOffset());
+        charBuf.limit(str.length());
+        
+        // encode chars
+        encoder.reset();
+        
+        for(;;) {
+            CoderResult result = encoder.encode(charBuf, byteBuf, true);
+            if (result.isOverflow()) {
+                // grow the buffer
+                ByteBuffer byteBuf2 = ByteBuffer.allocate(byteBuf.capacity()*2);
+                byteBuf.flip();
+                byteBuf2.put(byteBuf);
+                byteBuf = byteBuf2;
+            } else { // underflow, i.e. done
+                break;
+            }
+        }
+    }
+
+    
+}

--- a/metrics-influxdb/src/test/java/io/dropwizard/metrics5/influxdb/InfluxDbLineBuilderAssumptionsTest.java
+++ b/metrics-influxdb/src/test/java/io/dropwizard/metrics5/influxdb/InfluxDbLineBuilderAssumptionsTest.java
@@ -5,7 +5,7 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class InfluxDbReporterAssumptionsTest {
+public class InfluxDbLineBuilderAssumptionsTest {
 
     @Test
     public void ensureMetricAttributeCodesAreSafeFieldKeys() {

--- a/metrics-influxdb/src/test/java/io/dropwizard/metrics5/influxdb/InfluxDbReporterAssumptionsTest.java
+++ b/metrics-influxdb/src/test/java/io/dropwizard/metrics5/influxdb/InfluxDbReporterAssumptionsTest.java
@@ -1,0 +1,17 @@
+package io.dropwizard.metrics5.influxdb;
+
+import io.dropwizard.metrics5.MetricAttribute;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InfluxDbReporterAssumptionsTest {
+
+    @Test
+    public void ensureMetricAttributeCodesAreSafeFieldKeys() {
+        for (MetricAttribute ma : MetricAttribute.values()) {
+            String code = ma.getCode();
+            assertThat(code).doesNotContainPattern("[,= ]");
+        }
+    }
+}

--- a/metrics-influxdb/src/test/java/io/dropwizard/metrics5/influxdb/InfluxDbReporterTest.java
+++ b/metrics-influxdb/src/test/java/io/dropwizard/metrics5/influxdb/InfluxDbReporterTest.java
@@ -1,0 +1,469 @@
+package io.dropwizard.metrics5.influxdb;
+
+import io.dropwizard.metrics5.Clock;
+import io.dropwizard.metrics5.Counter;
+import io.dropwizard.metrics5.Gauge;
+import io.dropwizard.metrics5.Histogram;
+import io.dropwizard.metrics5.Meter;
+import io.dropwizard.metrics5.MetricAttribute;
+import io.dropwizard.metrics5.MetricFilter;
+import io.dropwizard.metrics5.MetricName;
+import io.dropwizard.metrics5.MetricRegistry;
+import io.dropwizard.metrics5.Snapshot;
+import io.dropwizard.metrics5.Timer;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.times;
+
+public class InfluxDbReporterTest {
+    private static final MetricName GAUGE = MetricName.build("gauge");
+    private static final MetricName METER = MetricName.build("meter");
+    private static final MetricName COUNTER = MetricName.build("counter");
+
+    private final long timestamp = 1000198;
+    private final Clock clock = mock(Clock.class);
+    private final InfluxDbSender sender = mock(InfluxDbSender.class);
+    private final List<String> send = new ArrayList<>();
+    private final MetricRegistry registry = mock(MetricRegistry.class);
+    private final InfluxDbReporter reporter = InfluxDbReporter.forRegistry(registry)
+        .withClock(clock)
+        .prefixedWith(new MetricName("prefix", map("foo", "bar")))
+        .convertRatesTo(TimeUnit.SECONDS)
+        .convertDurationsTo(TimeUnit.MILLISECONDS)
+        .filter(MetricFilter.ALL)
+        .disabledMetricAttributes(Collections.emptySet())
+        .build(sender);
+
+    private final InfluxDbReporter minuteRateReporter = InfluxDbReporter
+        .forRegistry(registry)
+        .withClock(clock)
+        .prefixedWith(new MetricName("prefix", map("foo", "bar")))
+        .convertRatesTo(TimeUnit.MINUTES)
+        .convertDurationsTo(TimeUnit.MILLISECONDS)
+        .filter(MetricFilter.ALL)
+        .disabledMetricAttributes(Collections.emptySet())
+        .build(sender);
+
+    @Before
+    public void setUp() throws IOException {
+        when(clock.getTime()).thenReturn(timestamp * 1000);
+        send.clear();
+        doAnswer(invocation -> send.add(invocation.getArgument(0).toString()))
+                .when(sender).send(any(StringBuilder.class));
+    }
+
+    @Test
+    public void reportsStringGaugeValues() throws Exception {
+        reporter.report(map(GAUGE, gauge("value")),
+            map(),
+            map(),
+            map(),
+            map());
+
+        final InOrder inOrder = inOrder(sender);
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender).send(anySb());
+        inOrder.verify(sender).flush();
+        inOrder.verify(sender).disconnect();
+
+        verifyNoMoreInteractions(sender);
+        assertThat(send).first().isEqualTo("prefix.gauge,foo=bar value=\"value\" 1000198000000000\n");
+    }
+
+    @Test
+    public void reportsByteGaugeValues() throws Exception {
+        reporter.report(map(GAUGE, gauge((byte) 1)),
+            map(),
+            map(),
+            map(),
+            map());
+
+        final InOrder inOrder = inOrder(sender);
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender).send(anySb());
+        inOrder.verify(sender).flush();
+        inOrder.verify(sender).disconnect();
+
+        verifyNoMoreInteractions(sender);
+        assertThat(send).first().isEqualTo("prefix.gauge,foo=bar value=1i 1000198000000000\n");
+    }
+
+    @Test
+    public void reportsShortGaugeValues() throws Exception {
+        reporter.report(map(GAUGE, gauge((short) 1)),
+            map(),
+            map(),
+            map(),
+            map());
+
+        final InOrder inOrder = inOrder(sender);
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender).send(anySb());
+        inOrder.verify(sender).flush();
+        inOrder.verify(sender).disconnect();
+
+        verifyNoMoreInteractions(sender);
+        assertThat(send).first().isEqualTo("prefix.gauge,foo=bar value=1i 1000198000000000\n");
+    }
+
+    @Test
+    public void reportsIntegerGaugeValues() throws Exception {
+        reporter.report(map(GAUGE, gauge(1)),
+            map(),
+            map(),
+            map(),
+            map());
+
+        final InOrder inOrder = inOrder(sender);
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender).send(anySb());
+        inOrder.verify(sender).flush();
+        inOrder.verify(sender).disconnect();
+
+        verifyNoMoreInteractions(sender);
+        assertThat(send).first().isEqualTo("prefix.gauge,foo=bar value=1i 1000198000000000\n");
+    }
+
+    @Test
+    public void reportsLongGaugeValues() throws Exception {
+        reporter.report(map(GAUGE, gauge(1L)),
+            map(),
+            map(),
+            map(),
+            map());
+
+        final InOrder inOrder = inOrder(sender);
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender).send(anySb());
+        inOrder.verify(sender).flush();
+        inOrder.verify(sender).disconnect();
+
+        verifyNoMoreInteractions(sender);
+        assertThat(send).first().isEqualTo("prefix.gauge,foo=bar value=1i 1000198000000000\n");
+    }
+
+    @Test
+    public void reportsFloatGaugeValues() throws Exception {
+        reporter.report(map(GAUGE, gauge(1.5f)),
+            map(),
+            map(),
+            map(),
+            map());
+
+        final InOrder inOrder = inOrder(sender);
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender).send(anySb());
+        inOrder.verify(sender).flush();
+        inOrder.verify(sender).disconnect();
+
+        verifyNoMoreInteractions(sender);
+        assertThat(send).first().isEqualTo("prefix.gauge,foo=bar value=1.5 1000198000000000\n");
+    }
+
+    @Test
+    public void reportsDoubleGaugeValues() throws Exception {
+        reporter.report(map(GAUGE, gauge(1.1)),
+            map(),
+            map(),
+            map(),
+            map());
+
+        final InOrder inOrder = inOrder(sender);
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender).send(anySb());
+        inOrder.verify(sender).flush();
+        inOrder.verify(sender).disconnect();
+
+        verifyNoMoreInteractions(sender);
+        assertThat(send).first().isEqualTo("prefix.gauge,foo=bar value=1.1 1000198000000000\n");
+    }
+
+    @Test
+    public void reportsBooleanGaugeValues() throws Exception {
+        reporter.report(map(GAUGE, gauge(true)),
+            map(),
+            map(),
+            map(),
+            map());
+
+        reporter.report(map(GAUGE, gauge(false)),
+            map(),
+            map(),
+            map(),
+            map());
+        final InOrder inOrder = inOrder(sender);
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender).send(anySb());
+        inOrder.verify(sender).flush();
+        inOrder.verify(sender).disconnect();
+        
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender).send(anySb());
+        inOrder.verify(sender).flush();
+        inOrder.verify(sender).disconnect();
+
+        verifyNoMoreInteractions(sender);
+        
+        assertThat(send).element(0).isEqualTo("prefix.gauge,foo=bar value=t 1000198000000000\n");
+        assertThat(send).element(1).isEqualTo("prefix.gauge,foo=bar value=f 1000198000000000\n");
+    }
+
+    @Test
+    public void reportsCounters() throws Exception {
+        final Counter counter = mock(Counter.class);
+        when(counter.getCount()).thenReturn(100L);
+
+        reporter.report(map(),
+            map(COUNTER, counter),
+            map(),
+            map(),
+            map());
+
+        final InOrder inOrder = inOrder(sender);
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender).send(anySb());
+        inOrder.verify(sender).flush();
+        inOrder.verify(sender).disconnect();
+
+        verifyNoMoreInteractions(sender);
+        assertThat(send).first().isEqualTo("prefix.counter,foo=bar count=100i 1000198000000000\n");
+    }
+
+    @Test
+    public void reportsHistograms() throws Exception {
+        final Histogram histogram = mock(Histogram.class);
+        when(histogram.getCount()).thenReturn(1L);
+        when(histogram.getSum()).thenReturn(12L);
+
+        final Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.getMax()).thenReturn(2L);
+        when(snapshot.getMean()).thenReturn(3.0);
+        when(snapshot.getMin()).thenReturn(4L);
+        when(snapshot.getStdDev()).thenReturn(5.0);
+        when(snapshot.getMedian()).thenReturn(6.0);
+        when(snapshot.get75thPercentile()).thenReturn(7.0);
+        when(snapshot.get95thPercentile()).thenReturn(8.0);
+        when(snapshot.get98thPercentile()).thenReturn(9.0);
+        when(snapshot.get99thPercentile()).thenReturn(10.0);
+        when(snapshot.get999thPercentile()).thenReturn(11.0);
+
+        when(histogram.getSnapshot()).thenReturn(snapshot);
+
+        reporter.report(map(),
+            map(),
+            map(MetricName.build("histogram"), histogram),
+            map(),
+            map());
+
+        final InOrder inOrder = inOrder(sender);
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender).send(anySb());
+        inOrder.verify(sender).flush();
+        inOrder.verify(sender).disconnect();
+
+        verifyNoMoreInteractions(sender);
+        assertThat(send).first().isEqualTo("prefix.histogram,foo=bar count=1i,sum=12i,max=2i,mean=3.0,min=4i,stddev=5.0,p50=6.0,p75=7.0,p95=8.0,p98=9.0,p99=10.0,p999=11.0 1000198000000000\n");
+
+    }
+
+    @Test
+    public void reportsMeters() throws Exception {
+        final Meter meter = mock(Meter.class);
+        when(meter.getCount()).thenReturn(1L);
+        when(meter.getSum()).thenReturn(6L);
+        when(meter.getOneMinuteRate()).thenReturn(2.0);
+        when(meter.getFiveMinuteRate()).thenReturn(3.0);
+        when(meter.getFifteenMinuteRate()).thenReturn(4.0);
+        when(meter.getMeanRate()).thenReturn(5.0);
+
+        reporter.report(map(),
+            map(),
+            map(),
+            map(METER, meter),
+            map());
+
+        final InOrder inOrder = inOrder(sender);
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender).send(anySb());
+        inOrder.verify(sender).flush();
+        inOrder.verify(sender).disconnect();
+
+        verifyNoMoreInteractions(sender);
+        assertThat(send).first().isEqualTo("prefix.meter,foo=bar count=1i,sum=6i,m1_rate=2.0,m5_rate=3.0,m15_rate=4.0,mean_rate=5.0 1000198000000000\n");
+    }
+
+    @Test
+    public void reportsMetersInMinutes() throws Exception {
+        final Meter meter = mock(Meter.class);
+        when(meter.getCount()).thenReturn(1L);
+        when(meter.getSum()).thenReturn(6L);
+        when(meter.getOneMinuteRate()).thenReturn(2.0);
+        when(meter.getFiveMinuteRate()).thenReturn(3.0);
+        when(meter.getFifteenMinuteRate()).thenReturn(4.0);
+        when(meter.getMeanRate()).thenReturn(5.0);
+
+        minuteRateReporter.report(this.map(),
+            this.map(),
+            this.map(),
+            this.map(METER, meter),
+            this.map());
+
+        final InOrder inOrder = inOrder(sender);
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender).send(anySb());
+        inOrder.verify(sender).flush();
+        inOrder.verify(sender).disconnect();
+
+        verifyNoMoreInteractions(sender);
+        assertThat(send).first().isEqualTo("prefix.meter,foo=bar count=1i,sum=6i,m1_rate=120.0,m5_rate=180.0,m15_rate=240.0,mean_rate=300.0 1000198000000000\n");
+    }
+
+    @Test
+    public void reportsTimers() throws Exception {
+        final Timer timer = mock(Timer.class);
+        when(timer.getCount()).thenReturn(1L);
+        when(timer.getSum()).thenReturn(6L);
+        when(timer.getMeanRate()).thenReturn(2.0);
+        when(timer.getOneMinuteRate()).thenReturn(3.0);
+        when(timer.getFiveMinuteRate()).thenReturn(4.0);
+        when(timer.getFifteenMinuteRate()).thenReturn(5.0);
+
+        final Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.getMax()).thenReturn(TimeUnit.MILLISECONDS.toNanos(100));
+        when(snapshot.getMean()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(200));
+        when(snapshot.getMin()).thenReturn(TimeUnit.MILLISECONDS.toNanos(300));
+        when(snapshot.getStdDev()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(400));
+        when(snapshot.getMedian()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(500));
+        when(snapshot.get75thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(600));
+        when(snapshot.get95thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(700));
+        when(snapshot.get98thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(800));
+        when(snapshot.get99thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(900));
+        when(snapshot.get999thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS
+            .toNanos(1000));
+
+        when(timer.getSnapshot()).thenReturn(snapshot);
+
+        reporter.report(map(),
+            map(),
+            map(),
+            map(),
+            map(MetricName.build("timer"), timer));
+
+        final InOrder inOrder = inOrder(sender);
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender).send(anySb());
+        inOrder.verify(sender).flush();
+        inOrder.verify(sender).disconnect();
+
+        verifyNoMoreInteractions(sender);
+        assertThat(send).first().isEqualTo("prefix.timer,foo=bar max=100.0,mean=200.0,min=300.0,stddev=400.0,p50=500.0,p75=600.0,p95=700.0,p98=800.0,p99=900.0,p999=1000.0,count=1i,sum=6i,m1_rate=3.0,m5_rate=4.0,m15_rate=5.0,mean_rate=2.0 1000198000000000\n");
+
+        reporter.close();
+    }
+
+    @Test
+    public void disconnectsIfSenderIsUnavailable() throws Exception {
+        doThrow(new UnknownHostException("UNKNOWN-HOST")).when(sender).connect();
+        reporter.report(map(GAUGE, gauge(1)),
+            map(),
+            map(),
+            map(),
+            map());
+
+        final InOrder inOrder = inOrder(sender);
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender).disconnect();
+
+
+        verifyNoMoreInteractions(sender);
+    }
+
+    @Test
+    public void closesConnectionOnReporterStop() throws Exception {
+        reporter.stop();
+
+        verify(sender).close();
+
+        verifyNoMoreInteractions(sender);
+    }
+
+    @Test
+    public void disabledMetricsAttribute() throws Exception {
+        final Meter meter = mock(Meter.class);
+        when(meter.getCount()).thenReturn(1L);
+        when(meter.getSum()).thenReturn(6L);
+        when(meter.getOneMinuteRate()).thenReturn(2.0);
+        when(meter.getFiveMinuteRate()).thenReturn(3.0);
+        when(meter.getFifteenMinuteRate()).thenReturn(4.0);
+        when(meter.getMeanRate()).thenReturn(5.0);
+
+        final Counter counter = mock(Counter.class);
+        when(counter.getCount()).thenReturn(11L);
+
+        Set<MetricAttribute> disabledMetricAttributes = EnumSet.of(MetricAttribute.M15_RATE, MetricAttribute.M5_RATE);
+        InfluxDbReporter reporterWithdisabledMetricAttributes = InfluxDbReporter.forRegistry(registry)
+            .withClock(clock)
+            .prefixedWith(MetricName.build("prefix"))
+            .convertRatesTo(TimeUnit.SECONDS)
+            .convertDurationsTo(TimeUnit.MILLISECONDS)
+            .filter(MetricFilter.ALL)
+            .disabledMetricAttributes(disabledMetricAttributes)
+            .build(sender);
+        reporterWithdisabledMetricAttributes.report(map(),
+            map(COUNTER, counter),
+            map(),
+            map(METER, meter),
+            map());
+
+        final InOrder inOrder = inOrder(sender);
+        inOrder.verify(sender).connect();
+        inOrder.verify(sender, times(2)).send(anySb());
+        inOrder.verify(sender).flush();
+        inOrder.verify(sender).disconnect();
+
+        verifyNoMoreInteractions(sender);
+        
+        assertThat(send).element(0).isEqualTo("prefix.counter count=11i 1000198000000000\n");
+        assertThat(send).element(1).isEqualTo("prefix.meter count=1i,sum=6i,m1_rate=2.0,mean_rate=5.0 1000198000000000\n");
+    }
+
+    private <T> SortedMap<MetricName, T> map() {
+        return new TreeMap<>();
+    }
+
+    private <K,V> SortedMap<K, V> map(K key, V value) {
+        final TreeMap<K, V> map = new TreeMap<>();
+        map.put(key, value);
+        return map;
+    }
+
+    private <T> Gauge<T> gauge(T value) {
+        return () -> value;
+    }
+    
+    private StringBuilder anySb() {
+        return any(StringBuilder.class);
+    }
+}

--- a/metrics-influxdb/src/test/java/io/dropwizard/metrics5/influxdb/InfluxDbUdpTest.java
+++ b/metrics-influxdb/src/test/java/io/dropwizard/metrics5/influxdb/InfluxDbUdpTest.java
@@ -1,0 +1,79 @@
+package io.dropwizard.metrics5.influxdb;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.channels.DatagramChannel;
+import java.util.ArrayList;
+import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Before;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+
+public class InfluxDbUdpTest {
+
+    private final String host = "example.com";
+    private final int port = 1234;
+
+    private InfluxDbUdpSender influxdbUdp;
+    private final DatagramChannel datagramChannel = Mockito.mock(DatagramChannel.class);
+    private final List<byte[]> sent = new ArrayList<>();
+    
+    @Before
+    public void setUp() throws IOException {
+        sent.clear();
+        doAnswer(invocation -> {
+            sent.add(toBytes(invocation.getArgument(0))); 
+            return 0;
+        }).when(datagramChannel).send(any(ByteBuffer.class), any(SocketAddress.class));
+        influxdbUdp = new InfluxDbUdpSender(host, port);
+        influxdbUdp.setDatagramChannel(datagramChannel);
+    }
+
+    @Test
+    public void writesValue() throws Exception {
+        influxdbUdp.send(new StringBuilder("räksmörgås value=123 456000000000\n"));
+        influxdbUdp.flush();
+        
+        verify(datagramChannel).send(any(), any());
+        
+        assertThat(sent).first().isEqualTo("räksmörgås value=123 456000000000\n".getBytes("UTF-8"));
+    }
+
+    @Test
+    public void batchesValues() throws Exception {
+        influxdbUdp.send(new StringBuilder("name1 value=111 456000000000\n"));
+        influxdbUdp.send(new StringBuilder("name2 value=222 456000000000\n"));
+        influxdbUdp.flush();
+
+        verify(datagramChannel).send(any(), any());
+        
+        assertThat(sent).first().isEqualTo(
+                "name1 value=111 456000000000\nname2 value=222 456000000000\n".getBytes("UTF-8"));
+    }
+    
+    @Test
+    public void respectsMTU() throws Exception {
+        influxdbUdp.setMTU(40);
+        influxdbUdp.send(new StringBuilder("name1 value=111 456000000000\n"));
+        influxdbUdp.send(new StringBuilder("name2 value=222 456000000000\n"));
+        influxdbUdp.flush();
+
+        verify(datagramChannel, times(2)).send(any(), any());
+        
+        assertThat(sent).element(0).isEqualTo("name1 value=111 456000000000\n".getBytes("UTF-8"));
+        assertThat(sent).element(1).isEqualTo("name2 value=222 456000000000\n".getBytes("UTF-8"));
+    }
+
+    private byte[] toBytes(ByteBuffer buf) {
+        byte[] bytes = new byte[buf.remaining()];
+        buf.get(bytes);
+        return bytes;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <module>metrics-healthchecks</module>
         <module>metrics-ehcache</module>
         <module>metrics-graphite</module>
+        <module>metrics-influxdb</module>
         <module>metrics-httpclient</module>
         <module>metrics-httpasyncclient</module>
         <module>metrics-jcache</module>


### PR DESCRIPTION
Metric reporter for influxDB over UDP.

- Native **support for tags** in MetricName.
- **Low pressure on the GC** in the reporter, i.e. avoid creating garbage.

With the addition of tag support in MetricName 5.0.0 I think it is reasonable to add a reporter that is capable of using those tags natively. While there are a few 3rd party metrics-influxdb implementations out there, many of these fail to keep up to date with the latest metrics version. 