### PR TITLE
Refactoring of MetricName for Metrics 5.0

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics5/MetricName.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics5/MetricName.java
@@ -14,7 +14,7 @@ import java.util.TreeSet;
 public class MetricName implements Comparable<MetricName> {
 
     private static final String SEPARATOR = ".";
-    private static final Map<String, String> EMPTY_TAGS = Collections.unmodifiableMap(new HashMap<String, String>());
+    private static final Map<String, String> EMPTY_TAGS = Collections.emptyMap();
     static final MetricName EMPTY = new MetricName("");
 
     private final String key;

--- a/metrics-core/src/main/java/io/dropwizard/metrics5/MetricName.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics5/MetricName.java
@@ -153,11 +153,7 @@ public class MetricName implements Comparable<MetricName> {
 
     @Override
     public int compareTo(MetricName o) {
-        if (o == null) {
-            return -1;
-        }
-
-        int c = compareName(key, o.getKey());
+        int c = key.compareTo(o.getKey());
         if (c != 0) {
             return c;
         }
@@ -165,30 +161,18 @@ public class MetricName implements Comparable<MetricName> {
         return compareTags(tags, o.getTags());
     }
 
-    private int compareName(String left, String right) {
-        if (left.isEmpty() && right.isEmpty()) {
-            return 0;
-        } else if (left.isEmpty()) {
-            return 1;
-        } else if (right.isEmpty()) {
-            return -1;
-        }
-
-        return left.compareTo(right);
-    }
-
     private int compareTags(Map<String, String> left, Map<String, String> right) {
         if (left.isEmpty() && right.isEmpty()) {
             return 0;
         } else if (left.isEmpty()) {
-            return 1;
-        } else if (right.isEmpty()) {
             return -1;
+        } else if (right.isEmpty()) {
+            return 1;
         }
         final Iterable<String> keys = uniqueSortedKeys(left, right);
-        for (final String key : keys) {
-            final String a = left.get(key);
-            final String b = right.get(key);
+        for (final String k : keys) {
+            final String a = left.get(k);
+            final String b = right.get(k);
             if (a == null && b == null) {
                 continue;
             } else if (a == null) {

--- a/metrics-core/src/main/java/io/dropwizard/metrics5/MetricName.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics5/MetricName.java
@@ -18,7 +18,7 @@ public class MetricName implements Comparable<MetricName> {
 
     private static final String SEPARATOR = ".";
     private static final Map<String, String> EMPTY_TAGS = Collections.emptyMap();
-    static final MetricName EMPTY = new MetricName("");
+    static final MetricName EMPTY = new MetricName("", EMPTY_TAGS);
 
     /**
      * Returns an empty metric name.
@@ -31,10 +31,6 @@ public class MetricName implements Comparable<MetricName> {
     private final String key;
     private final Map<String, String> tags;
     
-    private MetricName(String key) {
-        this(key, EMPTY_TAGS);
-    }
-
     public MetricName(String key, Map<String, String> tags) {
         this.key = Objects.requireNonNull(key);
         this.tags = tags.isEmpty() ? EMPTY_TAGS : unmodifiableSortedCopy(tags);

--- a/metrics-core/src/main/java/io/dropwizard/metrics5/MetricName.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics5/MetricName.java
@@ -26,7 +26,7 @@ public class MetricName implements Comparable<MetricName> {
 
     public MetricName(String key, Map<String, String> tags) {
         this.key = Objects.requireNonNull(key);
-        this.tags = tags.isEmpty() ? EMPTY_TAGS : Collections.unmodifiableMap(tags);
+        this.tags = tags.isEmpty() ? EMPTY_TAGS : Collections.unmodifiableMap(new HashMap<>(tags));
     }
 
     public String getKey() {

--- a/metrics-core/src/main/java/io/dropwizard/metrics5/MetricName.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics5/MetricName.java
@@ -44,6 +44,10 @@ public class MetricName implements Comparable<MetricName> {
         return key;
     }
 
+    /**
+     * Returns the tags, sorted by key.
+     * @return the tags (immutable), sorted by key.
+     */
     public Map<String, String> getTags() {
         return tags;
     }

--- a/metrics-core/src/main/java/io/dropwizard/metrics5/MetricName.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics5/MetricName.java
@@ -67,8 +67,9 @@ public class MetricName implements Comparable<MetricName> {
      * @return A newly created metric name with the specified tags associated with it.
      */
     public MetricName tagged(Map<String, String> add) {
-        final Map<String, String> newTags = new HashMap<>(add);
+        final Map<String, String> newTags = new HashMap<>();
         newTags.putAll(tags);
+        newTags.putAll(add);
         return new MetricName(key, newTags);
     }
 

--- a/metrics-core/src/main/java/io/dropwizard/metrics5/MetricRegistry.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics5/MetricRegistry.java
@@ -537,9 +537,9 @@ public class MetricRegistry implements MetricSet {
 
         for (Map.Entry<MetricName, Metric> entry : metrics.getMetrics().entrySet()) {
             if (entry.getValue() instanceof MetricSet) {
-                registerAll(MetricName.join(prefix, entry.getKey()), (MetricSet) entry.getValue());
+                registerAll(prefix.append(entry.getKey()), (MetricSet) entry.getValue());
             } else {
-                register(MetricName.join(prefix, entry.getKey()), entry.getValue());
+                register(prefix.append(entry.getKey()), entry.getValue());
             }
         }
     }

--- a/metrics-core/src/main/java/io/dropwizard/metrics5/Slf4jReporter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics5/Slf4jReporter.java
@@ -316,7 +316,7 @@ public class Slf4jReporter extends ScheduledReporter {
     }
 
     private String prefix(MetricName metricName) {
-        return MetricName.join(prefix, metricName).toString();
+        return prefix.append(metricName).toString();
     }
 
     /* private class to allow logger configuration */

--- a/metrics-core/src/test/java/io/dropwizard/metrics5/MetricNameTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics5/MetricNameTest.java
@@ -14,7 +14,7 @@ public class MetricNameTest {
         assertThat(MetricName.EMPTY.getKey()).isEqualTo("");
 
         assertThat(MetricName.build()).isEqualTo(MetricName.EMPTY);
-        assertThat(MetricName.EMPTY.resolve(null)).isEqualTo(MetricName.EMPTY);
+        assertThat(MetricName.EMPTY.resolve((String)null)).isEqualTo(MetricName.EMPTY);
     }
 
     @Test
@@ -26,7 +26,7 @@ public class MetricNameTest {
     @Test
     public void testResolveToEmpty() {
         final MetricName name = MetricName.build("foo");
-        assertThat(name.resolve(null)).isEqualTo(MetricName.build("foo"));
+        assertThat(name.resolve((String)null)).isEqualTo(MetricName.build("foo"));
     }
 
     @Test
@@ -38,7 +38,7 @@ public class MetricNameTest {
     @Test
     public void testResolveBothEmpty() {
         final MetricName name = MetricName.build();
-        assertThat(name.resolve(null)).isEqualTo(MetricName.EMPTY);
+        assertThat(name.resolve((String)null)).isEqualTo(MetricName.EMPTY);
     }
 
     @Test

--- a/metrics-core/src/test/java/io/dropwizard/metrics5/MetricNameTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics5/MetricNameTest.java
@@ -83,4 +83,15 @@ public class MetricNameTest {
         assertThat(b.resolve("key").compareTo(b)).isGreaterThan(0);
         assertThat(b.compareTo(b.resolve("key"))).isLessThan(0);
     }
+
+    @Test
+    public void testCompareTo2() {
+        final MetricName a = MetricName.EMPTY.tagged("a", "x");
+        final MetricName b = MetricName.EMPTY.tagged("b", "x");
+
+        assertThat(MetricName.EMPTY.compareTo(a)).isLessThan(0);
+        assertThat(MetricName.EMPTY.compareTo(b)).isLessThan(0);
+        assertThat(a.compareTo(b)).isLessThan(0);
+        assertThat(b.compareTo(a)).isGreaterThan(0);
+    }
 }

--- a/metrics-core/src/test/java/io/dropwizard/metrics5/MetricNameTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics5/MetricNameTest.java
@@ -80,7 +80,7 @@ public class MetricNameTest {
 
         assertThat(a.compareTo(b)).isLessThan(0);
         assertThat(b.compareTo(a)).isGreaterThan(0);
-        assertThat(b.resolve("key").compareTo(b)).isLessThan(0);
-        assertThat(b.compareTo(b.resolve("key"))).isGreaterThan(0);
+        assertThat(b.resolve("key").compareTo(b)).isGreaterThan(0);
+        assertThat(b.compareTo(b.resolve("key"))).isLessThan(0);
     }
 }

--- a/metrics-graphite/src/main/java/io/dropwizard/metrics5/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics5/graphite/GraphiteReporter.java
@@ -384,7 +384,7 @@ public class GraphiteReporter extends ScheduledReporter {
     }
 
     private String prefix(MetricName name, String... components) {
-        return MetricName.join(MetricName.join(prefix, name), MetricName.build(components)).getKey();
+        return prefix.append(name).resolve(components).getKey();
     }
 
     private String format(long n) {

--- a/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbLineBuilder.java
+++ b/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbLineBuilder.java
@@ -39,7 +39,7 @@ class InfluxDbLineBuilder {
 
     InfluxDbLineBuilder(Set<MetricAttribute> disabledMetricAttributes, MetricName prefix) {
         this.disabledMetricAttributes = disabledMetricAttributes;
-        this.prefix = prefix != null ? prefix : MetricName.build();
+        this.prefix = prefix != null ? prefix : MetricName.empty();
     }
 
     InfluxDbLineBuilder writeMeasurement(MetricName name) {
@@ -53,7 +53,7 @@ class InfluxDbLineBuilder {
     private String writeMeasurementNoCache(MetricName name) {
         StringBuilder sb = new StringBuilder();
 
-        MetricName prefixedName = MetricName.join(prefix, name);
+        MetricName prefixedName = prefix.append(name);
         appendName(prefixedName.getKey(), sb);
         // InfluxDB Performance and Setup Tips:
         // Sort tags by key before sending them to the database. 

--- a/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbLineBuilder.java
+++ b/metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbLineBuilder.java
@@ -3,7 +3,6 @@ package io.dropwizard.metrics5.influxdb;
 import io.dropwizard.metrics5.MetricAttribute;
 import io.dropwizard.metrics5.MetricName;
 
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -58,16 +57,13 @@ class InfluxDbLineBuilder {
         // InfluxDB Performance and Setup Tips:
         // Sort tags by key before sending them to the database. 
         // The sort should match the results from the Go bytes.Compare function.
-        prefixedName.getTags()
-                .entrySet()
-                .stream()
-                .sorted(Comparator.comparing(Map.Entry::getKey))
-                .forEach(tag -> {
-                    sb.append(',');
-                    appendName(tag.getKey(), sb);
-                    sb.append('=');
-                    appendName(tag.getValue(), sb);
-                });
+        // ... tags are already sorted in MetricName
+        for (Map.Entry<String, String> tag : prefixedName.getTags().entrySet()) {
+            sb.append(',');
+            appendName(tag.getKey(), sb);
+            sb.append('=');
+            appendName(tag.getValue(), sb);
+        }
         return sb.toString();
     }
 


### PR DESCRIPTION
This pull request is a collection of various bug-fixes and improvements to MetricName. Either accept as is, or use it as a basis for discussion.

NOTE: non-backwards compatible changes, but since MetricName has not yet been released this is not an issue (if this pull request is accepted before the release of 5.0.0).

**Major changes** (each in separate commits):

- Bug-fix: Defensive copy of tags in constructor.
- Bug-fix: `tagged` should replace any previous tags (compare with implementation of join).
- Harmonization of `resolve`, `tagged`, `join` and `build`. 
  - `resolve` changed to vararg, to also replace `build(String...)`
  - `static join` (vararg) changed to `append(MetricName)`. All usages of `join` (vararg) were 2 args, and were replaced with e.g. `prefix.append(name)`.
  - `static empty()` is now exposed.
- Changed comparator to follow conventions, i.e. shorter string/sequence is smaller than longer string/sequence.
- Keep tags sorted internally, and optionally expose that in the API as well.