### PR TITLE
Add remove function for metric set,fix #1007

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -304,12 +304,12 @@ public class MetricRegistry implements MetricSet {
      * Object will be instance of Boolean in case single metric,
      * if metric set it will be returned as instance of Hashmap with status as Boolean for each metric in the set
      */
-    public Map<String,Object> removeAll(MetricSet metrics) {
+    public Map<String, Object> removeAll(MetricSet metrics) {
         return removeAll(null, metrics);
     }
 
-    public Map<String,Object> removeAll(String prefix, MetricSet metrics) {
-        HashMap removedMetricsStatus=new HashMap();
+    public Map<String, Object> removeAll(String prefix, MetricSet metrics) {
+        HashMap removedMetricsStatus = new HashMap();
         for (Map.Entry<String, Metric> entry : metrics.getMetrics().entrySet()) {
             if (entry.getValue() instanceof MetricSet) {
                 removedMetricsStatus.put(entry.getKey(), removeAll(name(prefix, entry.getKey()), (MetricSet) entry.getValue()));

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -309,7 +309,7 @@ public class MetricRegistry implements MetricSet {
     }
 
     public Map<String, Object> removeAll(String prefix, MetricSet metrics) {
-        HashMap removedMetricsStatus = new HashMap();
+        HashMap<String, Object> removedMetricsStatus = new HashMap<String, Object>();
         for (Map.Entry<String, Metric> entry : metrics.getMetrics().entrySet()) {
             if (entry.getValue() instanceof MetricSet) {
                 removedMetricsStatus.put(entry.getKey(), removeAll(name(prefix, entry.getKey()), (MetricSet) entry.getValue()));

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -1,6 +1,7 @@
 package com.codahale.metrics;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -294,6 +295,31 @@ public class MetricRegistry implements MetricSet {
         }
     }
 
+    
+    /**
+     * Given a metric set, removes them.
+     *
+     * @param metrics a set of metrics
+     * @return Hashmap with the removed status for each metric or metric sub set,
+     * Object will be instance of Boolean in case single metric,
+     * if metric set it will be returned as instance of Hashmap with status as Boolean for each metric in the set
+     */
+    public Map<String,Object> removeAll(MetricSet metrics) {
+        return removeAll(null, metrics);
+    }
+
+    public Map<String,Object> removeAll(String prefix, MetricSet metrics) {
+        HashMap removedMetricsStatus=new HashMap();
+        for (Map.Entry<String, Metric> entry : metrics.getMetrics().entrySet()) {
+            if (entry.getValue() instanceof MetricSet) {
+                removedMetricsStatus.put(entry.getKey(), removeAll(name(prefix, entry.getKey()), (MetricSet) entry.getValue()));
+            } else {
+                removedMetricsStatus.put(entry.getKey(), remove(name(prefix, entry.getKey())));
+            }
+        }
+        return removedMetricsStatus;
+    }
+    
     /**
      * Adds a {@link MetricRegistryListener} to a collection of listeners that will be notified on
      * metric creation.  Listeners will be notified in the order in which they are added.

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
@@ -449,11 +449,11 @@ public class MetricRegistryTest {
         assertThat(registry.getNames())
                 .containsOnly("gauge", "counter", "metricsSubset.meter");
 
-        Map<String,Object> removedMetricsStatus=registry.removeAll(metrics);
-        HashMap<String,Object> removedSubSetMetricsStatus=new HashMap<String,Object>();
+        Map<String, Object> removedMetricsStatus = registry.removeAll(metrics);
+        HashMap<String, Object> removedSubSetMetricsStatus = new HashMap<String, Object>();
         removedSubSetMetricsStatus.put("meter", true);
         assertThat(removedMetricsStatus).isNotEmpty().hasSize(3);
-        assertThat(removedMetricsStatus).contains(entry("gauge", true), entry("counter", true), entry("metricsSubset",removedSubSetMetricsStatus));
+        assertThat(removedMetricsStatus).contains(entry("gauge", true), entry("counter", true), entry("metricsSubset", removedSubSetMetricsStatus));
         assertThat(registry.getNames()).doesNotContain("gauge", "counter", "metricsSubset.meter");
 
         verify(listener).onCounterRemoved("counter");


### PR DESCRIPTION
Adding a new function removeAll inverse to registerAll to remove all the metrics in the metrics set.