### PR TITLE
Collectd tests failed with java.net.SocketException: Can't assign requested address

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,7 @@
                 <version>2.14.1</version>
                 <configuration>
                     <parallel>classes</parallel>
+                    <argLine>-Djava.net.preferIPv4Stack=true</argLine>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
When running tests locally collectd tests failed with `java.net.SocketException: Can't assign requested address`. [This StackOverflow](https://stackoverflow.com/questions/18747134/getting-cant-assign-requested-address-java-net-socketexception-using-ehcache) seemed plausble as I'm also on a Mac with wireless so I added `-Djava.net.preferIPv4Stack=true` to the Surefire configuration which fixed the problem On My Machine™ 🤷‍♂️.