### PR TITLE
Enable customization of MetricsServlet.

### DIFF
--- a/metrics-json/src/main/java/com/codahale/metrics/json/MetricsModule.java
+++ b/metrics-json/src/main/java/com/codahale/metrics/json/MetricsModule.java
@@ -216,10 +216,10 @@ public class MetricsModule extends Module {
         }
     }
 
-    private final TimeUnit rateUnit;
-    private final TimeUnit durationUnit;
-    private final boolean showSamples;
-    private final MetricFilter filter;
+    protected final TimeUnit rateUnit;
+    protected final TimeUnit durationUnit;
+    protected final boolean showSamples;
+    protected final MetricFilter filter;
 
     public MetricsModule(TimeUnit rateUnit, TimeUnit durationUnit, boolean showSamples) {
         this(rateUnit, durationUnit, showSamples, MetricFilter.ALL);

--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/MetricsServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/MetricsServlet.java
@@ -114,10 +114,10 @@ public class MetricsServlet extends HttpServlet {
     private static final long serialVersionUID = 1049773947734939602L;
     private static final String CONTENT_TYPE = "application/json";
 
-    private String allowedOrigin;
-    private String jsonpParamName;
-    private transient MetricRegistry registry;
-    private transient ObjectMapper mapper;
+    protected String allowedOrigin;
+    protected String jsonpParamName;
+    protected transient MetricRegistry registry;
+    protected transient ObjectMapper mapper;
 
     public MetricsServlet() {
     }
@@ -139,7 +139,13 @@ public class MetricsServlet extends HttpServlet {
                 throw new ServletException("Couldn't find a MetricRegistry instance.");
             }
         }
+        this.allowedOrigin = context.getInitParameter(ALLOWED_ORIGIN);
+        this.jsonpParamName = context.getInitParameter(CALLBACK_PARAM);
 
+        setupMetricsModule(context);
+    }
+
+    protected void setupMetricsModule(ServletContext context) {
         final TimeUnit rateUnit = parseTimeUnit(context.getInitParameter(RATE_UNIT),
                 TimeUnit.SECONDS);
         final TimeUnit durationUnit = parseTimeUnit(context.getInitParameter(DURATION_UNIT),
@@ -149,13 +155,11 @@ public class MetricsServlet extends HttpServlet {
         if (filter == null) {
             filter = MetricFilter.ALL;
         }
+
         this.mapper = new ObjectMapper().registerModule(new MetricsModule(rateUnit,
                 durationUnit,
                 showSamples,
                 filter));
-
-        this.allowedOrigin = context.getInitParameter(ALLOWED_ORIGIN);
-        this.jsonpParamName = context.getInitParameter(CALLBACK_PARAM);
     }
 
     @Override
@@ -177,7 +181,7 @@ public class MetricsServlet extends HttpServlet {
         }
     }
 
-    private ObjectWriter getWriter(HttpServletRequest request) {
+    protected ObjectWriter getWriter(HttpServletRequest request) {
         final boolean prettyPrint = Boolean.parseBoolean(request.getParameter("pretty"));
         if (prettyPrint) {
             return mapper.writerWithDefaultPrettyPrinter();
@@ -185,7 +189,7 @@ public class MetricsServlet extends HttpServlet {
         return mapper.writer();
     }
 
-    private TimeUnit parseTimeUnit(String value, TimeUnit defaultValue) {
+    protected TimeUnit parseTimeUnit(String value, TimeUnit defaultValue) {
         try {
             return TimeUnit.valueOf(String.valueOf(value).toUpperCase(Locale.US));
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
**Summary**
`MetricsModule` should now be easier to customize with other serializers. `setupMetricsModule` can be overridden to facilitate introduction of new `MetricsModule` like objects.

**Issues**
Closes #1281 
Addresses #1281 