### PR TITLE
Add support for signing and verifying requests to CollectD

### DIFF
--- a/metrics-collectd/src/main/java/com/codahale/metrics/collectd/CollectdReporter.java
+++ b/metrics-collectd/src/main/java/com/codahale/metrics/collectd/CollectdReporter.java
@@ -5,7 +5,6 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
-import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
@@ -38,6 +37,9 @@ public class CollectdReporter extends ScheduledReporter {
      * <li>rateUnit: TimeUnit.SECONDS</li>
      * <li>durationUnit: TimeUnit.MILLISECONDS</li>
      * <li>filter: MetricFilter.ALL</li>
+     * <li>securityLevel: NONE</li>
+     * <li>username: ""</li>
+     * <li>password: ""</li>
      * </ul>
      */
     public static Builder forRegistry(MetricRegistry registry) {
@@ -52,6 +54,9 @@ public class CollectdReporter extends ScheduledReporter {
         private TimeUnit rateUnit = TimeUnit.SECONDS;
         private TimeUnit durationUnit = TimeUnit.MILLISECONDS;
         private MetricFilter filter = MetricFilter.ALL;
+        private SecurityLevel securityLevel = SecurityLevel.NONE;
+        private String username = "";
+        private String password = "";
 
         private Builder(MetricRegistry registry) {
             this.registry = registry;
@@ -82,9 +87,32 @@ public class CollectdReporter extends ScheduledReporter {
             return this;
         }
 
+        public Builder withUsername(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder withPassword(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder withSecurityLevel(SecurityLevel securityLevel) {
+            this.securityLevel = securityLevel;
+            return this;
+        }
+
         public CollectdReporter build(Sender sender) {
-            return new CollectdReporter(
-                    registry, hostName, sender, clock, rateUnit, durationUnit, filter);
+            if (securityLevel != SecurityLevel.NONE) {
+                if (username.isEmpty()) {
+                    throw new IllegalArgumentException("username is required for securityLevel: " + securityLevel);
+                }
+                if (password.isEmpty()) {
+                    throw new IllegalArgumentException("password is required for securityLevel: " + securityLevel);
+                }
+            }
+            return new CollectdReporter(registry, hostName, sender, clock, rateUnit, durationUnit, filter,
+                    username, password, securityLevel);
         }
     }
 
@@ -99,13 +127,14 @@ public class CollectdReporter extends ScheduledReporter {
     private long period;
     private final PacketWriter writer;
 
-    private CollectdReporter(MetricRegistry registry, String hostname, Sender sender, Clock clock,
-            TimeUnit rateUnit, TimeUnit durationUnit, MetricFilter filter) {
+    private CollectdReporter(MetricRegistry registry, String hostname, Sender sender, Clock clock, TimeUnit rateUnit,
+                             TimeUnit durationUnit, MetricFilter filter, String username, String password,
+                             SecurityLevel securityLevel) {
         super(registry, REPORTER_NAME, filter, rateUnit, durationUnit);
         this.hostName = (hostname != null) ? hostname : resolveHostName();
         this.sender = sender;
         this.clock = clock;
-        writer = new PacketWriter(sender);
+        writer = new PacketWriter(sender, username, password, securityLevel);
     }
 
     private String resolveHostName() {

--- a/metrics-collectd/src/main/java/com/codahale/metrics/collectd/PacketWriter.java
+++ b/metrics-collectd/src/main/java/com/codahale/metrics/collectd/PacketWriter.java
@@ -1,10 +1,22 @@
 package com.codahale.metrics.collectd;
 
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.Mac;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.ShortBufferException;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidParameterSpecException;
 import java.util.Arrays;
 
 class PacketWriter {
@@ -17,6 +29,8 @@ class PacketWriter {
     private static final int TYPE_TYPE_INSTANCE = 5;
     private static final int TYPE_VALUES = 6;
     private static final int TYPE_INTERVAL = 7;
+    private static final int TYPE_SIGN_SHA256 = 0x0200;
+    private static final int TYPE_ENCR_AES256 = 0x0210;
 
     private static final int UINT16_LEN = 2;
     private static final int UINT32_LEN = UINT16_LEN * 2;
@@ -26,14 +40,31 @@ class PacketWriter {
 
     private static final int VALUE_COUNT_LEN = UINT16_LEN;
     private static final int NUMBER_LEN = HEADER_LEN + UINT64_LEN;
+    private static final int SIGNATURE_LEN = 36;      // 2b Type + 2b Length + 32b Hash
+    private static final int ENCRYPT_DATA_LEN = 22;   // 16b IV + 2b Type + 2b Length + 2b Username length
+    private static final int IV_LENGTH = 16;
+    private static final int SHA1_LENGTH = 20;
+
     private static final int VALUE_LEN = 9;
     private static final byte DATA_TYPE_GAUGE = (byte) 1;
     private static final byte NULL = (byte) '\0';
+    private static final String HMAC_SHA256_ALGORITHM = "HmacSHA256";
+    private static final String AES_CYPHER = "AES_256/OFB/NoPadding";
+    private static final String AES = "AES";
+    private static final String SHA_256_ALGORITHM = "SHA-256";
+    private static final String SHA_1_ALGORITHM = "SHA1";
 
     private final Sender sender;
 
-    PacketWriter(Sender sender) {
+    private final SecurityLevel securityLevel;
+    private final byte[] username;
+    private final byte[] password;
+
+    PacketWriter(Sender sender, String username, String password, SecurityLevel securityLevel) {
         this.sender = sender;
+        this.securityLevel = securityLevel;
+        this.username = username != null ? username.getBytes(StandardCharsets.UTF_8) : null;
+        this.password = password != null ? password.getBytes(StandardCharsets.UTF_8) : null;
     }
 
     void write(MetaData metaData, Number... values) throws BufferOverflowException, IOException {
@@ -41,8 +72,22 @@ class PacketWriter {
         write(packet, metaData);
         write(packet, values);
         packet.flip();
-        sender.send(packet);
+
+        switch (securityLevel) {
+            case NONE:
+                sender.send(packet);
+                break;
+            case SIGN:
+                sender.send(signPacket(packet));
+                break;
+            case ENCRYPT:
+                sender.send(encryptPacket(packet));
+                break;
+            default:
+                throw new IllegalArgumentException("Unsupported security level: " + securityLevel);
+        }
     }
+
 
     private void write(ByteBuffer buffer, MetaData metaData) {
         writeString(buffer, TYPE_HOST, metaData.getHost());
@@ -90,6 +135,141 @@ class PacketWriter {
     private void writeHeader(ByteBuffer buffer, int type, int len) {
         buffer.putShort((short) type);
         buffer.putShort((short) len);
+    }
+
+    /**
+     * Signs the provided packet, so a CollectD server can verify that its authenticity.
+     * Wire format:
+     * <pre>
+     * +-------------------------------+-------------------------------+
+     * ! Type (0x0200)                 ! Length                        !
+     * +-------------------------------+-------------------------------+
+     * ! Signature (SHA2(username + packet))                           \
+     * +-------------------------------+-------------------------------+
+     * ! Username                      ! Packet                        \
+     * +---------------------------------------------------------------+
+     * </pre>
+     *
+     * @see <a href="https://collectd.org/wiki/index.php/Binary_protocol#Signature_part">
+     * Binary protocol - CollectD | Signature part</a>
+     */
+    private ByteBuffer signPacket(ByteBuffer packet) {
+        final byte[] signature = sign(password, (ByteBuffer) ByteBuffer.allocate(packet.remaining() + username.length)
+                .put(username)
+                .put(packet)
+                .flip());
+        return (ByteBuffer) ByteBuffer.allocate(BUFFER_SIZE)
+                .putShort((short) TYPE_SIGN_SHA256)
+                .putShort((short) (username.length + SIGNATURE_LEN))
+                .put(signature)
+                .put(username)
+                .put((ByteBuffer) packet.flip())
+                .flip();
+    }
+
+    /**
+     * Encrypts the provided packet, so it's can't be eavesdropped during a transfer
+     * to a CollectD server. Wire format:
+     * <pre>
+     * +---------------------------------+-------------------------------+
+     * ! Type (0x0210)                   ! Length                        !
+     * +---------------------------------+-------------------------------+
+     * ! Username length in bytes        ! Username                      \
+     * +-----------------------------------------------------------------+
+     * ! Initialization Vector (IV)      !                               \
+     * +---------------------------------+-------------------------------+
+     * ! Encrypted bytes (AES (SHA1(packet) + packet))                   \
+     * +---------------------------------+-------------------------------+
+     * </pre>
+     *
+     * @see <a href="https://collectd.org/wiki/index.php/Binary_protocol#Encrypted_part">
+     * Binary protocol - CollectD | Encrypted part</a>
+     */
+    private ByteBuffer encryptPacket(ByteBuffer packet) {
+        final ByteBuffer payload = (ByteBuffer) ByteBuffer.allocate(SHA1_LENGTH + packet.remaining())
+                .put(sha1(packet))
+                .put((ByteBuffer) packet.flip())
+                .flip();
+        final EncryptionResult er = encrypt(password, payload);
+        return (ByteBuffer) ByteBuffer.allocate(BUFFER_SIZE)
+                .putShort((short) TYPE_ENCR_AES256)
+                .putShort((short) (ENCRYPT_DATA_LEN + username.length + er.output.remaining()))
+                .putShort((short) username.length)
+                .put(username)
+                .put(er.iv)
+                .put(er.output)
+                .flip();
+    }
+
+    private static byte[] sign(byte[] secret, ByteBuffer input) {
+        final Mac mac;
+        try {
+            mac = Mac.getInstance(HMAC_SHA256_ALGORITHM);
+            mac.init(new SecretKeySpec(secret, HMAC_SHA256_ALGORITHM));
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            throw new RuntimeException(e);
+        }
+        mac.update(input);
+        return mac.doFinal();
+    }
+
+    private static EncryptionResult encrypt(byte[] password, ByteBuffer input) {
+        final Cipher cipher;
+        try {
+            cipher = Cipher.getInstance(AES_CYPHER);
+            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(sha256(password), AES));
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidKeyException e) {
+            throw new RuntimeException(e);
+        }
+        final byte[] iv;
+        try {
+            iv = cipher.getParameters().getParameterSpec(IvParameterSpec.class).getIV();
+        } catch (InvalidParameterSpecException e) {
+            throw new RuntimeException(e);
+        }
+        if (iv.length != IV_LENGTH) {
+            throw new IllegalStateException("Bad initialization vector");
+        }
+        final ByteBuffer output = ByteBuffer.allocate(input.remaining() * 2);
+        try {
+            cipher.doFinal(input, output);
+        } catch (ShortBufferException | IllegalBlockSizeException | BadPaddingException e) {
+            throw new RuntimeException(e);
+        }
+        return new EncryptionResult(iv, (ByteBuffer) output.flip());
+    }
+
+    private static byte[] sha256(byte[] input) {
+        try {
+            return MessageDigest.getInstance(SHA_256_ALGORITHM).digest(input);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static byte[] sha1(ByteBuffer input) {
+        try {
+            final MessageDigest digest = MessageDigest.getInstance(SHA_1_ALGORITHM);
+            digest.update(input);
+            final byte[] output = digest.digest();
+            if (output.length != SHA1_LENGTH) {
+                throw new IllegalStateException("Bad SHA1 hash");
+            }
+            return output;
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class EncryptionResult {
+
+        private final byte[] iv;
+        private final ByteBuffer output;
+
+        private EncryptionResult(byte[] iv, ByteBuffer output) {
+            this.iv = iv;
+            this.output = output;
+        }
     }
 
 }

--- a/metrics-collectd/src/main/java/com/codahale/metrics/collectd/SecurityConfiguration.java
+++ b/metrics-collectd/src/main/java/com/codahale/metrics/collectd/SecurityConfiguration.java
@@ -1,0 +1,30 @@
+package com.codahale.metrics.collectd;
+
+public class SecurityConfiguration {
+
+    private final byte[] username;
+    private final byte[] password;
+    private final SecurityLevel securityLevel;
+
+    public SecurityConfiguration(byte[] username, byte[] password, SecurityLevel securityLevel) {
+        this.username = username;
+        this.password = password;
+        this.securityLevel = securityLevel;
+    }
+
+    public static SecurityConfiguration none() {
+        return new SecurityConfiguration(null, null, SecurityLevel.NONE);
+    }
+
+    public byte[] getUsername() {
+        return username;
+    }
+
+    public byte[] getPassword() {
+        return password;
+    }
+
+    public SecurityLevel getSecurityLevel() {
+        return securityLevel;
+    }
+}

--- a/metrics-collectd/src/main/java/com/codahale/metrics/collectd/SecurityLevel.java
+++ b/metrics-collectd/src/main/java/com/codahale/metrics/collectd/SecurityLevel.java
@@ -1,0 +1,8 @@
+package com.codahale.metrics.collectd;
+
+public enum SecurityLevel {
+
+    NONE,
+    SIGN,
+    ENCRYPT
+}

--- a/metrics-collectd/src/test/java/com/codahale/metrics/collectd/CollectdReporterTest.java
+++ b/metrics-collectd/src/test/java/com/codahale/metrics/collectd/CollectdReporterTest.java
@@ -1,6 +1,12 @@
 package com.codahale.metrics.collectd;
 
-import com.codahale.metrics.*;
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
 import org.collectd.api.ValueList;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -11,7 +17,9 @@ import java.util.TreeMap;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class CollectdReporterTest {
 
@@ -228,6 +236,28 @@ public class CollectdReporterTest {
 
         ValueList values = receiver.next();
         assertThat(values.getPlugin()).isEqualTo("dash_illegal.slash_illegal");
+    }
+
+    @Test
+    public void testUnableSetSecurityLevelToSignWithoutUsername() {
+        assertThatIllegalArgumentException().isThrownBy(()->
+                CollectdReporter.forRegistry(registry)
+                        .withHostName("eddie")
+                        .withSecurityLevel(SecurityLevel.SIGN)
+                        .withPassword("t1_g3r")
+                        .build(new Sender("localhost", 25826)))
+                .withMessage("username is required for securityLevel: SIGN");
+    }
+
+    @Test
+    public void testUnableSetSecurityLevelToSignWithoutPassword() {
+        assertThatIllegalArgumentException().isThrownBy(()->
+                CollectdReporter.forRegistry(registry)
+                        .withHostName("eddie")
+                        .withSecurityLevel(SecurityLevel.SIGN)
+                        .withUsername("scott")
+                        .build(new Sender("localhost", 25826)))
+                .withMessage("password is required for securityLevel: SIGN");
     }
 
     private <T> SortedMap<String, T> map() {

--- a/metrics-collectd/src/test/java/com/codahale/metrics/collectd/PacketWriterTest.java
+++ b/metrics-collectd/src/test/java/com/codahale/metrics/collectd/PacketWriterTest.java
@@ -1,0 +1,194 @@
+package com.codahale.metrics.collectd;
+
+import org.junit.Test;
+
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
+
+public class PacketWriterTest {
+
+    private MetaData metaData = new MetaData.Builder("nw-1.alpine.example.com", 1520961345L, 100)
+            .type("gauge")
+            .typeInstance("value")
+            .get();
+    private String username = "scott";
+    private String password = "t1_g$r";
+
+    @Test
+    public void testSignRequest() throws Exception {
+        AtomicBoolean packetVerified = new AtomicBoolean();
+        Sender sender = new Sender("localhost", 4009) {
+            @Override
+            public void send(ByteBuffer buffer) throws IOException {
+                short type = buffer.getShort();
+                assertThat(type).isEqualTo((short) 512);
+                short length = buffer.getShort();
+                assertThat(length).isEqualTo((short) 41);
+                byte[] packetSignature = new byte[32];
+                buffer.get(packetSignature, 0, 32);
+
+                byte[] packetUsername = new byte[length - 36];
+                buffer.get(packetUsername, 0, packetUsername.length);
+                assertThat(new String(packetUsername, UTF_8)).isEqualTo(username);
+
+                byte[] packet = new byte[buffer.remaining()];
+                buffer.get(packet);
+
+                byte[] usernameAndPacket = new byte[username.length() + packet.length];
+                System.arraycopy(packetUsername, 0, usernameAndPacket, 0, packetUsername.length);
+                System.arraycopy(packet, 0, usernameAndPacket, packetUsername.length, packet.length);
+                assertThat(sign(usernameAndPacket, password)).isEqualTo(packetSignature);
+
+                verifyPacket(packet);
+                packetVerified.set(true);
+            }
+
+            private byte[] sign(byte[] input, String password) {
+                Mac mac;
+                try {
+                    mac = Mac.getInstance("HmacSHA256");
+                    mac.init(new SecretKeySpec(password.getBytes(UTF_8), "HmacSHA256"));
+                } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+                    throw new RuntimeException(e);
+                }
+                return mac.doFinal(input);
+            }
+
+        };
+        PacketWriter packetWriter = new PacketWriter(sender, username, password, SecurityLevel.SIGN);
+        packetWriter.write(metaData, 42);
+        assertThat(packetVerified).isTrue();
+    }
+
+    @Test
+    public void testEncryptRequest() throws Exception {
+        AtomicBoolean packetVerified = new AtomicBoolean();
+        Sender sender = new Sender("localhost", 4009) {
+            @Override
+            public void send(ByteBuffer buffer) throws IOException {
+                short type = buffer.getShort();
+                assertThat(type).isEqualTo((short) 0x0210);
+                short length = buffer.getShort();
+                assertThat(length).isEqualTo((short) 134);
+                short usernameLength = buffer.getShort();
+                assertThat(usernameLength).isEqualTo((short) 5);
+                byte[] packetUsername = new byte[usernameLength];
+                buffer.get(packetUsername, 0, packetUsername.length);
+                assertThat(new String(packetUsername, UTF_8)).isEqualTo(username);
+
+                byte[] iv = new byte[16];
+                buffer.get(iv, 0, iv.length);
+                byte[] encryptedPacket = new byte[buffer.remaining()];
+                buffer.get(encryptedPacket);
+
+                byte[] decryptedPacket = decrypt(iv, encryptedPacket);
+                byte[] hash = new byte[20];
+                System.arraycopy(decryptedPacket, 0, hash, 0, 20);
+                byte[] rawData = new byte[decryptedPacket.length - 20];
+                System.arraycopy(decryptedPacket, 20, rawData, 0, decryptedPacket.length - 20);
+                assertThat(sha1(rawData)).isEqualTo(hash);
+
+                verifyPacket(rawData);
+                packetVerified.set(true);
+            }
+
+            private byte[] decrypt(byte[] iv, byte[] input) {
+                try {
+                    Cipher cipher = Cipher.getInstance("AES_256/OFB/NoPadding");
+                    cipher.init(Cipher.DECRYPT_MODE,
+                            new SecretKeySpec(sha256(password.getBytes(UTF_8)), "AES"),
+                            new IvParameterSpec(iv));
+                    return cipher.doFinal(input);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            private byte[] sha256(byte[] input) {
+                try {
+                    return MessageDigest.getInstance("SHA-256").digest(input);
+                } catch (NoSuchAlgorithmException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            private byte[] sha1(byte[] input) {
+                try {
+                    return MessageDigest.getInstance("SHA-1").digest(input);
+                } catch (NoSuchAlgorithmException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        PacketWriter packetWriter = new PacketWriter(sender, username, password, SecurityLevel.ENCRYPT);
+        packetWriter.write(metaData, 42);
+        assertThat(packetVerified).isTrue();
+    }
+
+    private void verifyPacket(byte[] packetArr) {
+        ByteBuffer packet = ByteBuffer.wrap(packetArr);
+
+        short hostType = packet.getShort();
+        assertThat(hostType).isEqualTo((short) 0);
+        short hostLength = packet.getShort();
+        assertThat(hostLength).isEqualTo((short) 28);
+        byte[] host = new byte[hostLength - 5];
+        packet.get(host, 0, host.length);
+        assertThat(new String(host)).isEqualTo("nw-1.alpine.example.com");
+        assertThat(packet.get()).isEqualTo((byte) 0);
+
+        short timestampType = packet.getShort();
+        assertThat(timestampType).isEqualTo((short) 1);
+        short timestampLength = packet.getShort();
+        assertThat(timestampLength).isEqualTo((short) 12);
+        assertThat(packet.getLong()).isEqualTo(1520961345L);
+
+        short typeType = packet.getShort();
+        assertThat(typeType).isEqualTo((short) 4);
+        short typeLength = packet.getShort();
+        assertThat(typeLength).isEqualTo((short) 10);
+        byte[] type = new byte[typeLength - 5];
+        packet.get(type, 0, type.length);
+        assertThat(new String(type)).isEqualTo("gauge");
+        assertThat(packet.get()).isEqualTo((byte) 0);
+
+        short typeInstanceType = packet.getShort();
+        assertThat(typeInstanceType).isEqualTo((short) 5);
+        short typeInstanceLength = packet.getShort();
+        assertThat(typeInstanceLength).isEqualTo((short) 10);
+        byte[] typeInstance = new byte[typeInstanceLength - 5];
+        packet.get(typeInstance, 0, typeInstance.length);
+        assertThat(new String(typeInstance)).isEqualTo("value");
+        assertThat(packet.get()).isEqualTo((byte) 0);
+
+        short periodType = packet.getShort();
+        assertThat(periodType).isEqualTo((short) 7);
+        short periodLength = packet.getShort();
+        assertThat(periodLength).isEqualTo((short) 12);
+        assertThat(packet.getLong()).isEqualTo(100);
+
+        short valuesType = packet.getShort();
+        assertThat(valuesType).isEqualTo((short) 6);
+        short valuesLength = packet.getShort();
+        assertThat(valuesLength).isEqualTo((short) 15);
+        short amountOfValues = packet.getShort();
+        assertThat(amountOfValues).isEqualTo((short) 1);
+        byte dataType = packet.get();
+        assertThat(dataType).isEqualTo((byte) 1);
+        assertThat(packet.order(ByteOrder.LITTLE_ENDIAN).getDouble()).isEqualTo(42.0, offset(0.01));
+    }
+
+}


### PR DESCRIPTION
Starting with version 4.7 the CollectD provides the possibility to cryptographically sign or encrypt the network traffic. The type of protection is configured by the securityLevel option:

* None (plain traffic)
* Sign (packets should provide a digital signature)
* Encrypt (packets should be encrypted)

This changes adds possibility to set up a username, password, and a securityLevel in the CollectD reporter, so it can send metrics data  in the format expected by the CollectD server.

Resolves #1284