### PR TITLE
Healthceck as an interface 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For more information, please see [the documentation](http://dropwizard.github.io
 
 #### Version 4.x.x ([Javadoc](https://www.javadoc.io/doc/io.dropwizard.metrics/metrics-core/4.0.1))
 
-Version 4.x.x (the last release is 4.0.1) is a Java 8/9 compatible and the most fresh release of Metrics. The version targets Java 8 and removes a lot of internal cruft from 3.2.x (for instance, there's no dependency on the Unsafe API and custom `LongAdder` and `ThreadLocalRandom` implementations). It's mostly compatible with the 3.2 API and the update should be painless in Java 8 environments. If you have a 3rd party application which is dependent on an old version of Metrics, you can force a new version by adding `metrics-bom` to your Maven configuration. Check out the [release notes](https://github.com/dropwizard/metrics/releases/tag/v4.0.0) for 4.0.0.
+Version 4.x.x (the last release is 4.0.2) is a Java 8/9 compatible and the most fresh release of Metrics. The version targets Java 8 and removes a lot of internal cruft from 3.2.x (for instance, there's no dependency on the Unsafe API and custom `LongAdder` and `ThreadLocalRandom` implementations). It's mostly compatible with the 3.2 API and the update should be painless in Java 8 environments. If you have a 3rd party application which is dependent on an old version of Metrics, you can force a new version by adding `metrics-bom` to your Maven configuration. Check out the [release notes](https://github.com/dropwizard/metrics/releases/tag/v4.0.0) for 4.0.0.
 
 Source code for 4.1.x is resided in the [4.1-development branch](https://github.com/dropwizard/metrics/tree/4.1-development).
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Source code for 3.1.x is resided in the [3.1-maintenance branch](https://github.
 
 New not-backward compatible features (for example, support for tags) will be implemented in a 5.x.x release. The release will have new Maven coordinates, a new package name and an backwards-incompatible API. 
 
-Source code for 5.x.x is resided in the [5.0-development branch](https://github.com/dropwizard/metrics/tree5.0-development).
+Source code for 5.x.x is resided in the [5.0-development branch](https://github.com/dropwizard/metrics/tree/5.0-development).
 
 License
 -------

--- a/docs/source/manual/third-party.rst
+++ b/docs/source/manual/third-party.rst
@@ -58,6 +58,6 @@ Reporters
 * `metrics-zabbiz <https://github.com/hengyunabc/metrics-zabbix>`_ provides a reporter for `Zabbix <http://www.zabbix.com/>`_.
 * `sematext-metrics-reporter <https://github.com/sematext/sematext-metrics-reporter>`_ provides a reporter for `SPM <http://sematext.com/spm/index.html>`_.
 
-Advansed metrics implementations
+Advanced metrics implementations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * `rolling-metrics <https://github.com/vladimir-bukhtoyarov/rolling-metrics>`_ provides a collection of advanced metrics with rolling time window semantic, such as Rolling-Counter, Hit-Ratio, Top and Reservoir backed by HdrHistogram.

--- a/metrics-graphite/src/main/java/io/dropwizard/metrics5/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/io/dropwizard/metrics5/graphite/GraphiteReporter.java
@@ -158,7 +158,7 @@ public class GraphiteReporter extends ScheduledReporter {
          * Don't report the passed metric attributes for all metrics (e.g. "p999", "stddev" or "m15").
          * See {@link MetricAttribute}.
          *
-         * @param disabledMetricAttributes a {@link MetricFilter}
+         * @param disabledMetricAttributes a set of {@link MetricAttribute}
          * @return {@code this}
          */
         public Builder disabledMetricAttributes(Set<MetricAttribute> disabledMetricAttributes) {

--- a/metrics-healthchecks/src/main/java/io/dropwizard/metrics5/health/AsyncHealthCheckDecorator.java
+++ b/metrics-healthchecks/src/main/java/io/dropwizard/metrics5/health/AsyncHealthCheckDecorator.java
@@ -8,7 +8,7 @@ import java.util.concurrent.ScheduledFuture;
 /**
  * A health check decorator to manage asynchronous executions.
  */
-class AsyncHealthCheckDecorator extends HealthCheck implements Runnable {
+class AsyncHealthCheckDecorator implements HealthCheck, Runnable {
     private static final String NO_RESULT_YET_MESSAGE = "Waiting for first asynchronous check result.";
     private final HealthCheck healthCheck;
     private final ScheduledFuture<?> future;
@@ -39,7 +39,7 @@ class AsyncHealthCheckDecorator extends HealthCheck implements Runnable {
     }
 
     @Override
-    protected Result check() throws Exception {
+    public Result check() throws Exception {
         return result;
     }
 

--- a/metrics-healthchecks/src/main/java/io/dropwizard/metrics5/health/HealthCheck.java
+++ b/metrics-healthchecks/src/main/java/io/dropwizard/metrics5/health/HealthCheck.java
@@ -9,7 +9,7 @@ import java.util.Map;
 /**
  * A health check for a component of your application.
  */
-public abstract class HealthCheck {
+public interface HealthCheck {
     /**
      * The result of a {@link HealthCheck} being run. It can be healthy (with an optional message and optional details)
      * or unhealthy (with either an error message or a thrown exception and optional details).
@@ -307,7 +307,7 @@ public abstract class HealthCheck {
      * @throws Exception if there is an unhandled error during the health check; this will result in
      *                   a failed health check
      */
-    protected abstract Result check() throws Exception;
+    public Result check() throws Exception;
 
     /**
      * Executes the health check, catching and handling any exceptions raised by {@link #check()}.
@@ -315,7 +315,7 @@ public abstract class HealthCheck {
      * @return if the component is healthy, a healthy {@link Result}; otherwise, an unhealthy {@link
      * Result} with a descriptive error message or exception
      */
-    public Result execute() {
+    public default Result execute() {
         try {
             return check();
         } catch (Exception e) {

--- a/metrics-healthchecks/src/main/java/io/dropwizard/metrics5/health/HealthCheckRegistry.java
+++ b/metrics-healthchecks/src/main/java/io/dropwizard/metrics5/health/HealthCheckRegistry.java
@@ -211,7 +211,7 @@ public class HealthCheckRegistry {
             final String name = entry.getKey();
             final HealthCheck healthCheck = entry.getValue();
             if (filter.matches(name, healthCheck)) {
-                futures.put(name, executor.submit(() -> healthCheck.execute()));
+                futures.put(name, executor.submit(healthCheck::execute));
             }
         }
 

--- a/metrics-healthchecks/src/main/java/io/dropwizard/metrics5/health/jvm/ThreadDeadlockHealthCheck.java
+++ b/metrics-healthchecks/src/main/java/io/dropwizard/metrics5/health/jvm/ThreadDeadlockHealthCheck.java
@@ -8,7 +8,7 @@ import java.util.Set;
 /**
  * A health check which returns healthy if no threads are deadlocked.
  */
-public class ThreadDeadlockHealthCheck extends HealthCheck {
+public class ThreadDeadlockHealthCheck implements HealthCheck {
     private final ThreadDeadlockDetector detector;
 
     /**
@@ -28,7 +28,7 @@ public class ThreadDeadlockHealthCheck extends HealthCheck {
     }
 
     @Override
-    protected Result check() throws Exception {
+    public Result check() throws Exception {
         final Set<String> threads = detector.getDeadlockedThreads();
         if (threads.isEmpty()) {
             return Result.healthy();

--- a/metrics-healthchecks/src/test/java/io/dropwizard/metrics5/health/AsyncHealthCheckDecoratorTest.java
+++ b/metrics-healthchecks/src/test/java/io/dropwizard/metrics5/health/AsyncHealthCheckDecoratorTest.java
@@ -145,61 +145,61 @@ public class AsyncHealthCheckDecoratorTest {
     }
 
     @Async(period = -1)
-    private static class NegativePeriodAsyncHealthCheck extends HealthCheck {
+    private static class NegativePeriodAsyncHealthCheck implements HealthCheck {
 
         @Override
-        protected Result check() {
+        public Result check() {
             return null;
         }
     }
 
     @Async(period = 0)
-    private static class ZeroPeriodAsyncHealthCheck extends HealthCheck {
+    private static class ZeroPeriodAsyncHealthCheck implements HealthCheck {
 
         @Override
-        protected Result check() {
+        public Result check() {
             return null;
         }
     }
 
     @Async(period = 1, initialDelay = -1)
-    private static class NegativeInitialDelayAsyncHealthCheck extends HealthCheck {
+    private static class NegativeInitialDelayAsyncHealthCheck implements HealthCheck {
 
         @Override
-        protected Result check() {
+        public Result check() {
             return null;
         }
     }
 
     @Async(period = 1)
-    private static class DefaultAsyncHealthCheck extends HealthCheck {
+    private static class DefaultAsyncHealthCheck implements HealthCheck {
 
         @Override
-        protected Result check() {
+        public Result check() {
             return null;
         }
     }
 
     @Async(period = 1, scheduleType = Async.ScheduleType.FIXED_DELAY)
-    private static class FixedDelayAsyncHealthCheck extends HealthCheck {
+    private static class FixedDelayAsyncHealthCheck implements HealthCheck {
 
         @Override
-        protected Result check() {
+        public Result check() {
             return null;
         }
     }
 
     @Async(period = 1, initialState = Async.InitialState.UNHEALTHY)
-    private static class UnhealthyAsyncHealthCheck extends HealthCheck {
+    private static class UnhealthyAsyncHealthCheck implements HealthCheck {
 
         @Override
-        protected Result check() {
+        public Result check() {
             return null;
         }
     }
 
     @Async(period = 1, initialState = Async.InitialState.UNHEALTHY)
-    private static class ConfigurableAsyncHealthCheck extends HealthCheck {
+    private static class ConfigurableAsyncHealthCheck implements HealthCheck {
         private final Result result;
         private final Exception exception;
 
@@ -217,7 +217,7 @@ public class AsyncHealthCheckDecoratorTest {
         }
 
         @Override
-        protected Result check() throws Exception {
+        public Result check() throws Exception {
             if (exception != null) {
                 throw exception;
             }

--- a/metrics-healthchecks/src/test/java/io/dropwizard/metrics5/health/HealthCheckRegistryTest.java
+++ b/metrics-healthchecks/src/test/java/io/dropwizard/metrics5/health/HealthCheckRegistryTest.java
@@ -211,7 +211,7 @@ public class HealthCheckRegistryTest {
     }
 
     @Async(period = 10)
-    private static class TestAsyncHealthCheck extends HealthCheck {
+    private static class TestAsyncHealthCheck implements HealthCheck {
         private final Result result;
 
         TestAsyncHealthCheck(Result result) {
@@ -219,7 +219,7 @@ public class HealthCheckRegistryTest {
         }
 
         @Override
-        protected Result check() {
+        public Result check() {
             return result;
         }
     }

--- a/metrics-healthchecks/src/test/java/io/dropwizard/metrics5/health/HealthCheckTest.java
+++ b/metrics-healthchecks/src/test/java/io/dropwizard/metrics5/health/HealthCheckTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.when;
 import org.junit.Test;
 
 public class HealthCheckTest {
-    private static class ExampleHealthCheck extends HealthCheck {
+    private static class ExampleHealthCheck implements HealthCheck {
         private final HealthCheck underlying;
 
         private ExampleHealthCheck(HealthCheck underlying) {
@@ -15,7 +15,7 @@ public class HealthCheckTest {
         }
 
         @Override
-        protected Result check() {
+        public Result check() {
             return underlying.execute();
         }
     }

--- a/metrics-jvm/src/test/java/io/dropwizard/metrics5/jvm/CpuTimeClockTest.java
+++ b/metrics-jvm/src/test/java/io/dropwizard/metrics5/jvm/CpuTimeClockTest.java
@@ -13,12 +13,12 @@ public class CpuTimeClockTest {
     public void cpuTimeClock() {
         final CpuTimeClock clock = new CpuTimeClock();
 
-        assertThat((double) clock.getTime())
-                .isEqualTo(System.currentTimeMillis(),
-                        offset(200.0));
+        final long clockTime = clock.getTime();
+        final long systemTime = System.currentTimeMillis();
+        assertThat((double) clockTime).isEqualTo(systemTime, offset(200.0));
 
-        assertThat((double) clock.getTick())
-                .isEqualTo(ManagementFactory.getThreadMXBean().getCurrentThreadCpuTime(),
-                        offset(1000000.0));
+        final long clockTick = clock.getTick();
+        final long systemTick = ManagementFactory.getThreadMXBean().getCurrentThreadCpuTime();
+        assertThat((double) clockTick).isEqualTo(systemTick, offset(1000000.0));
     }
 }

--- a/metrics-legacy-adapter-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
+++ b/metrics-legacy-adapter-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
@@ -151,7 +151,7 @@ public abstract class HealthCheck {
         final HealthCheck original = this;
         return new io.dropwizard.metrics5.health.HealthCheck() {
             @Override
-            protected Result check() throws Exception {
+            public Result check() throws Exception {
                 return original.check().delegate;
             }
         };

--- a/metrics-servlets/src/test/java/io/dropwizard/metrics5/servlets/HealthCheckServletTest.java
+++ b/metrics-servlets/src/test/java/io/dropwizard/metrics5/servlets/HealthCheckServletTest.java
@@ -64,7 +64,7 @@ public class HealthCheckServletTest extends AbstractServletTest {
     public void returnsA200IfAllHealthChecksAreHealthy() throws Exception {
         registry.register("fun", new HealthCheck() {
             @Override
-            protected Result check() throws Exception {
+            public Result check() throws Exception {
                 return Result.healthy("whee");
             }
         });
@@ -83,14 +83,14 @@ public class HealthCheckServletTest extends AbstractServletTest {
     public void returnsASubsetOfHealthChecksIfFiltered() throws Exception {
         registry.register("fun", new HealthCheck() {
             @Override
-            protected Result check() throws Exception {
+            public Result check() throws Exception {
                 return Result.healthy("whee");
             }
         });
 
         registry.register("filtered", new HealthCheck() {
             @Override
-            protected Result check() throws Exception {
+            public Result check() throws Exception {
                 return Result.unhealthy("whee");
             }
         });
@@ -109,14 +109,14 @@ public class HealthCheckServletTest extends AbstractServletTest {
     public void returnsA500IfAnyHealthChecksAreUnhealthy() throws Exception {
         registry.register("fun", new HealthCheck() {
             @Override
-            protected Result check() throws Exception {
+            public Result check() throws Exception {
                 return Result.healthy("whee");
             }
         });
 
         registry.register("notFun", new HealthCheck() {
             @Override
-            protected Result check() throws Exception {
+            public Result check() throws Exception {
                 return Result.unhealthy("whee");
             }
         });
@@ -135,7 +135,7 @@ public class HealthCheckServletTest extends AbstractServletTest {
     public void optionallyPrettyPrintsTheJson() throws Exception {
         registry.register("fun", new HealthCheck() {
             @Override
-            protected Result check() throws Exception {
+            public Result check() throws Exception {
                 return Result.healthy("whee");
             }
         });

--- a/metrics-servlets/src/test/java/io/dropwizard/metrics5/servlets/HealthCheckServletTest.java
+++ b/metrics-servlets/src/test/java/io/dropwizard/metrics5/servlets/HealthCheckServletTest.java
@@ -62,12 +62,7 @@ public class HealthCheckServletTest extends AbstractServletTest {
 
     @Test
     public void returnsA200IfAllHealthChecksAreHealthy() throws Exception {
-        registry.register("fun", new HealthCheck() {
-            @Override
-            public Result check() throws Exception {
-                return Result.healthy("whee");
-            }
-        });
+        registry.register("fun", () -> HealthCheck.Result.healthy("whee"));
 
         processRequest();
 
@@ -81,19 +76,9 @@ public class HealthCheckServletTest extends AbstractServletTest {
 
     @Test
     public void returnsASubsetOfHealthChecksIfFiltered() throws Exception {
-        registry.register("fun", new HealthCheck() {
-            @Override
-            public Result check() throws Exception {
-                return Result.healthy("whee");
-            }
-        });
+        registry.register("fun", () -> HealthCheck.Result.healthy("whee"));
 
-        registry.register("filtered", new HealthCheck() {
-            @Override
-            public Result check() throws Exception {
-                return Result.unhealthy("whee");
-            }
-        });
+        registry.register("filtered", () -> HealthCheck.Result.unhealthy("whee"));
 
         processRequest();
 
@@ -107,19 +92,9 @@ public class HealthCheckServletTest extends AbstractServletTest {
 
     @Test
     public void returnsA500IfAnyHealthChecksAreUnhealthy() throws Exception {
-        registry.register("fun", new HealthCheck() {
-            @Override
-            public Result check() throws Exception {
-                return Result.healthy("whee");
-            }
-        });
+        registry.register("fun", () -> HealthCheck.Result.healthy("whee"));
 
-        registry.register("notFun", new HealthCheck() {
-            @Override
-            public Result check() throws Exception {
-                return Result.unhealthy("whee");
-            }
-        });
+        registry.register("notFun", () -> HealthCheck.Result.unhealthy("whee"));
 
         processRequest();
 
@@ -133,12 +108,7 @@ public class HealthCheckServletTest extends AbstractServletTest {
 
     @Test
     public void optionallyPrettyPrintsTheJson() throws Exception {
-        registry.register("fun", new HealthCheck() {
-            @Override
-            public Result check() throws Exception {
-                return Result.healthy("whee");
-            }
-        });
+        registry.register("fun", () -> HealthCheck.Result.healthy("whee"));
 
         request.setURI("/healthchecks?pretty=true");
 


### PR DESCRIPTION
_(#1283 repurposed for `5.0-development`)_
> 
> Been longing for `HealthCheck` to be an interface for some time and had som recent code that'd been better of if it were so decided to take a stab at it. If for nothing else to allow easier assessment of the impact of such a change.
> 
> (_wasn't able to run all tests locally due to networking weirdnesses, partly addressed in #1282, but hey it complies_ 😬)
> 
> Closes #697 
> Partly addresses #846