### PR TITLE
Add counter for active connections

### DIFF
--- a/metrics-jetty9/src/main/java/io/dropwizard/metrics5/jetty9/InstrumentedConnectionFactory.java
+++ b/metrics-jetty9/src/main/java/io/dropwizard/metrics5/jetty9/InstrumentedConnectionFactory.java
@@ -1,15 +1,14 @@
 package io.dropwizard.metrics5.jetty9;
 
-import java.util.List;
-
+import io.dropwizard.metrics5.Counter;
+import io.dropwizard.metrics5.Timer;
 import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 
-import io.dropwizard.metrics5.Counter;
-import io.dropwizard.metrics5.Timer;
+import java.util.List;
 
 public class InstrumentedConnectionFactory extends ContainerLifeCycle implements ConnectionFactory {
     private final ConnectionFactory connectionFactory;

--- a/metrics-jetty9/src/main/java/io/dropwizard/metrics5/jetty9/InstrumentedConnectionFactory.java
+++ b/metrics-jetty9/src/main/java/io/dropwizard/metrics5/jetty9/InstrumentedConnectionFactory.java
@@ -1,7 +1,6 @@
 package io.dropwizard.metrics5.jetty9;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.EndPoint;

--- a/metrics-jetty9/src/test/java/io/dropwizard/metrics5/jetty9/InstrumentedConnectionFactoryTest.java
+++ b/metrics-jetty9/src/test/java/io/dropwizard/metrics5/jetty9/InstrumentedConnectionFactoryTest.java
@@ -1,14 +1,8 @@
 package io.dropwizard.metrics5.jetty9;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.IOException;
-import java.io.PrintWriter;
-
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import io.dropwizard.metrics5.Counter;
+import io.dropwizard.metrics5.MetricRegistry;
+import io.dropwizard.metrics5.Timer;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -20,16 +14,21 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import io.dropwizard.metrics5.Counter;
-import io.dropwizard.metrics5.MetricRegistry;
-import io.dropwizard.metrics5.Timer;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class InstrumentedConnectionFactoryTest {
     private final MetricRegistry registry = new MetricRegistry();
     private final Server server = new Server();
     private final ServerConnector connector =
             new ServerConnector(server, new InstrumentedConnectionFactory(new HttpConnectionFactory(),
-                    registry.timer("http.connections"), registry.counter("http.active-connections")));
+                    registry.timer("http.connections"),
+                    registry.counter("http.active-connections")));
     private final HttpClient client = new HttpClient();
 
     @Before


### PR DESCRIPTION
Way back in the day, the Jetty 8 instrumentation included a counter for active connections:
https://github.com/dropwizard/metrics/blob/5eb6730346cff7414229ab77a7edc074564d235c/metrics-jetty/src/main/java/com/yammer/metrics/jetty/InstrumentedSelectChannelConnector.java#L47-L49

We've had mixed results trying to add this instrumentation ourselves to Jetty 9, but I was just curious if there's a reason that it was removed? Example PR included for how it might look in `InstrumentedConnectionFactory`