### PR TITLE
Switch from Oracle JDK 9 to OpenJDK 10 for testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: java
 dist: trusty
+
+before_install:
+  - 'wget https://raw.githubusercontent.com/sormuras/bach/master/install-jdk.sh'
+
 install: echo "I trust Maven."
 
 # don't just run the tests, also run error-prone
@@ -14,11 +18,8 @@ matrix:
           packages:
             - oracle-java8-installer
     - os: linux
-      jdk: oraclejdk9
-      addons:
-        apt:
-          packages:
-            - oracle-java9-installer
+      env: JDK='OpenJDK 10'
+      install: . ./install-jdk.sh -F 10
 
 notifications:
   email:

--- a/metrics-jcache/pom.xml
+++ b/metrics-jcache/pom.xml
@@ -22,9 +22,9 @@
 
     <profiles>
         <profile>
-            <id>jdk9</id>
+            <id>jdk10</id>
             <activation>
-                <jdk>9</jdk>
+                <jdk>10</jdk>
             </activation>
             <build>
                 <plugins>
@@ -33,8 +33,8 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>3.7.0</version>
                         <configuration>
-                            <source>9</source>
-                            <target>9</target>
+                            <source>1.8</source>
+                            <target>1.8</target>
                             <forceJavacCompilerUse>true</forceJavacCompilerUse>
                             <showWarnings>true</showWarnings>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -142,9 +142,9 @@
 
     <profiles>
         <profile>
-            <id>jdk9</id>
+            <id>jdk10</id>
             <activation>
-                <jdk>9</jdk>
+                <jdk>10</jdk>
             </activation>
             <build>
                 <plugins>
@@ -153,8 +153,8 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>3.7.0</version>
                         <configuration>
-                            <source>9</source>
-                            <target>9</target>
+                            <source>1.8</source>
+                            <target>1.8</target>
                             <forceJavacCompilerUse>true</forceJavacCompilerUse>
                             <showWarnings>true</showWarnings>
                         </configuration>


### PR DESCRIPTION
JDK9 is EOL. Use OpenJDK, because Travis doesn't support yet Oracle JDK 10.