### PR TITLE
[jvm] Params to include sync info in thread dump.

### DIFF
--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ThreadDump.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/ThreadDump.java
@@ -23,12 +23,29 @@ public class ThreadDump {
     }
 
     /**
-     * Dumps all of the threads' current information to an output stream.
+     * Dumps all of the threads' current information, including synchronization, to an output stream.
      *
      * @param out an output stream
      */
     public void dump(OutputStream out) {
-        final ThreadInfo[] threads = this.threadMXBean.dumpAllThreads(true, true);
+        dump(true, true, out);
+    }
+
+    /**
+     * Dumps all of the threads' current information, optionally including synchronization, to an output stream.
+     *
+     * Having control over including synchronization info allows using this method (and its wrappers, i.e.
+     * ThreadDumpServlet) in environments where getting object monitor and/or ownable synchronizer usage is not
+     * supported. It can also speed things up.
+     *
+     * See {@link ThreadMXBean#dumpAllThreads(boolean, boolean)}
+     *
+     * @param lockedMonitors dump all locked monitors if true
+     * @param lockedSynchronizers dump all locked ownable synchronizers if true
+     * @param out an output stream
+     */
+    public void dump(boolean lockedMonitors, boolean lockedSynchronizers, OutputStream out) {
+        final ThreadInfo[] threads = this.threadMXBean.dumpAllThreads(lockedMonitors, lockedSynchronizers);
         final PrintWriter writer = new PrintWriter(new OutputStreamWriter(out, UTF_8));
 
         for (int ti = threads.length - 1; ti >= 0; ti--) {

--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/ThreadDumpServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/ThreadDumpServlet.java
@@ -34,6 +34,9 @@ public class ThreadDumpServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req,
                          HttpServletResponse resp) throws ServletException, IOException {
+        final boolean includeMonitors = getParam(req.getParameter("monitors"), true);
+        final boolean includeSynchronizers = getParam(req.getParameter("synchronizers"), true);
+
         resp.setStatus(HttpServletResponse.SC_OK);
         resp.setContentType(CONTENT_TYPE);
         resp.setHeader("Cache-Control", "must-revalidate,no-cache,no-store");
@@ -42,7 +45,11 @@ public class ThreadDumpServlet extends HttpServlet {
             return;
         }
         try (OutputStream output = resp.getOutputStream()) {
-            threadDump.dump(output);
+            threadDump.dump(includeMonitors, includeSynchronizers, output);
         }
+    }
+
+    private static Boolean getParam(String initParam, boolean defaultValue) {
+        return initParam == null ? defaultValue : Boolean.parseBoolean(initParam);
     }
 }


### PR DESCRIPTION
Having control over including synchronization info allows using this method (and its wrappers, i.e. ThreadDumpServlet) in environments where getting object monitor and/or ownable synchronizer usage is not supported. 

Also, in a few experiments, it can also speed things up, especially for large heaps.