### PR TITLE
MetricRegistry: make registerAll with prefix public

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -501,7 +501,14 @@ public class MetricRegistry implements MetricSet {
         }
     }
 
-    private void registerAll(String prefix, MetricSet metrics) throws IllegalArgumentException {
+    /**
+     * Given a metric set, registers them with the given prefix prepended to their names.
+     *
+     * @param prefix a name prefix
+     * @param metrics a set of metrics
+     * @throws IllegalArgumentException if any of the names are already registered
+     */
+    public void registerAll(String prefix, MetricSet metrics) throws IllegalArgumentException {
         for (Map.Entry<String, Metric> entry : metrics.getMetrics().entrySet()) {
             if (entry.getValue() instanceof MetricSet) {
                 registerAll(name(prefix, entry.getKey()), (MetricSet) entry.getValue());


### PR DESCRIPTION
Fixes #1296.

This is a pretty nice QOL improvement, especially if you want to use the provided `MetricSet`s like the JVM metric sets.