### PR TITLE
Reporters: report Timer sums in the Timer duration units

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics5/ConsoleReporter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics5/ConsoleReporter.java
@@ -317,7 +317,7 @@ public class ConsoleReporter extends ScheduledReporter {
     private void printTimer(Timer timer) {
         final Snapshot snapshot = timer.getSnapshot();
         printIfEnabled(MetricAttribute.COUNT, String.format(locale, "             count = %d", timer.getCount()));
-        printIfEnabled(MetricAttribute.SUM, String.format(locale, "               sum = %d", timer.getSum()));
+        printIfEnabled(MetricAttribute.SUM, String.format(locale, "               sum = %2.2f", convertDuration(timer.getSum())));
         printIfEnabled(MetricAttribute.MEAN_RATE, String.format(locale, "         mean rate = %2.2f calls/%s", convertRate(timer.getMeanRate()), getRateUnit()));
         printIfEnabled(MetricAttribute.M1_RATE, String.format(locale, "     1-minute rate = %2.2f calls/%s", convertRate(timer.getOneMinuteRate()), getRateUnit()));
         printIfEnabled(MetricAttribute.M5_RATE, String.format(locale, "     5-minute rate = %2.2f calls/%s", convertRate(timer.getFiveMinuteRate()), getRateUnit()));

--- a/metrics-core/src/main/java/io/dropwizard/metrics5/CsvReporter.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics5/CsvReporter.java
@@ -212,7 +212,7 @@ public class CsvReporter extends ScheduledReporter {
 
         this.histogramFormat = String.join(separator, "%d", "%d", "%d", "%f", "%d", "%f", "%f", "%f", "%f", "%f", "%f", "%f");
         this.meterFormat = String.join(separator, "%d", "%d", "%f", "%f", "%f", "%f", "events/%s");
-        this.timerFormat = String.join(separator, "%d", "%d", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "calls/%s", "%s");
+        this.timerFormat = String.join(separator, "%d", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "%f", "calls/%s", "%s");
     }
 
     @Override
@@ -253,7 +253,7 @@ public class CsvReporter extends ScheduledReporter {
                 "count,sum,max,mean,min,stddev,p50,p75,p95,p98,p99,p999,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit,duration_unit",
                 timerFormat,
                 timer.getCount(),
-                timer.getSum(),
+                convertDuration(timer.getSum()),
                 convertDuration(snapshot.getMax()),
                 convertDuration(snapshot.getMean()),
                 convertDuration(snapshot.getMin()),

--- a/metrics-core/src/test/java/io/dropwizard/metrics5/ConsoleReporterTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics5/ConsoleReporterTest.java
@@ -178,7 +178,7 @@ public class ConsoleReporterTest {
     public void reportsTimerValues() throws Exception {
         final Timer timer = mock(Timer.class);
         when(timer.getCount()).thenReturn(1L);
-        when(timer.getSum()).thenReturn(5L);
+        when(timer.getSum()).thenReturn(TimeUnit.MILLISECONDS.toNanos(5));
         when(timer.getMeanRate()).thenReturn(2.0);
         when(timer.getOneMinuteRate()).thenReturn(3.0);
         when(timer.getFiveMinuteRate()).thenReturn(4.0);
@@ -212,7 +212,7 @@ public class ConsoleReporterTest {
                         "-- Timers ----------------------------------------------------------------------",
                         "test.another.timer",
                         "             count = 1",
-                        "               sum = 5",
+                        "               sum = 5.00",
                         "         mean rate = 2.00 calls/second",
                         "     1-minute rate = 3.00 calls/second",
                         "     5-minute rate = 4.00 calls/second",
@@ -291,7 +291,7 @@ public class ConsoleReporterTest {
 
         final Timer timer = mock(Timer.class);
         when(timer.getCount()).thenReturn(1L);
-        when(timer.getSum()).thenReturn(6L);
+        when(timer.getSum()).thenReturn(TimeUnit.MILLISECONDS.toNanos(6));
         when(timer.getMeanRate()).thenReturn(2.0);
         when(timer.getOneMinuteRate()).thenReturn(3.0);
         when(timer.getFiveMinuteRate()).thenReturn(4.0);
@@ -325,7 +325,7 @@ public class ConsoleReporterTest {
                         "-- Timers ----------------------------------------------------------------------",
                         "test.another.timer",
                         "             count = 1",
-                        "               sum = 6",
+                        "               sum = 6.00",
                         "         mean rate = 2.00 calls/second",
                         "     1-minute rate = 3.00 calls/second",
                         "    15-minute rate = 5.00 calls/second",

--- a/metrics-core/src/test/java/io/dropwizard/metrics5/CsvReporterTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics5/CsvReporterTest.java
@@ -133,7 +133,7 @@ public class CsvReporterTest {
     public void reportsTimerValues() throws Exception {
         final Timer timer = mock(Timer.class);
         when(timer.getCount()).thenReturn(1L);
-        when(timer.getSum()).thenReturn(6L);
+        when(timer.getSum()).thenReturn(TimeUnit.MILLISECONDS.toNanos(6));
         when(timer.getMeanRate()).thenReturn(2.0);
         when(timer.getOneMinuteRate()).thenReturn(3.0);
         when(timer.getFiveMinuteRate()).thenReturn(4.0);
@@ -162,7 +162,7 @@ public class CsvReporterTest {
         assertThat(fileContents("test.another.timer.csv"))
                 .isEqualTo(csv(
                         "t,count,sum,max,mean,min,stddev,p50,p75,p95,p98,p99,p999,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit,duration_unit",
-                        "19910191,1,6,100.000000,200.000000,300.000000,400.000000,500.000000,600.000000,700.000000,800.000000,900.000000,1000.000000,2.000000,3.000000,4.000000,5.000000,calls/second,milliseconds"
+                        "19910191,1,6.000000,100.000000,200.000000,300.000000,400.000000,500.000000,600.000000,700.000000,800.000000,900.000000,1000.000000,2.000000,3.000000,4.000000,5.000000,calls/second,milliseconds"
                 ));
     }
 

--- a/metrics-jmx/src/main/java/io/dropwizard/metrics5/jmx/JmxReporter.java
+++ b/metrics-jmx/src/main/java/io/dropwizard/metrics5/jmx/JmxReporter.java
@@ -497,6 +497,11 @@ public class JmxReporter implements Reporter, Closeable {
         public double get999thPercentile() {
             return metric.getSnapshot().get999thPercentile() * durationFactor;
         }
+        
+        @Override
+        public long getSum() {
+        	return (long)(super.getSum() * durationFactor);
+        }
 
         @Override
         public long[] values() {

--- a/metrics-jmx/src/test/java/io/dropwizard/metrics5/jmx/JmxReporterTest.java
+++ b/metrics-jmx/src/test/java/io/dropwizard/metrics5/jmx/JmxReporterTest.java
@@ -1,5 +1,32 @@
 package io.dropwizard.metrics5.jmx;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.management.ManagementFactory;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.InstanceNotFoundException;
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import io.dropwizard.metrics5.Counter;
 import io.dropwizard.metrics5.Gauge;
 import io.dropwizard.metrics5.Histogram;
@@ -9,31 +36,6 @@ import io.dropwizard.metrics5.MetricName;
 import io.dropwizard.metrics5.MetricRegistry;
 import io.dropwizard.metrics5.Snapshot;
 import io.dropwizard.metrics5.Timer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import javax.management.Attribute;
-import javax.management.AttributeList;
-import javax.management.InstanceNotFoundException;
-import javax.management.JMException;
-import javax.management.MBeanServer;
-import javax.management.ObjectInstance;
-import javax.management.ObjectName;
-import java.lang.management.ManagementFactory;
-import java.util.SortedMap;
-import java.util.TreeMap;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
-import static org.assertj.core.api.Assertions.failBecauseExceptionWasNotThrown;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @SuppressWarnings("rawtypes")
 public class JmxReporterTest {
@@ -89,7 +91,7 @@ public class JmxReporterTest {
         when(meter.getFifteenMinuteRate()).thenReturn(5.0);
 
         when(timer.getCount()).thenReturn(1L);
-        when(timer.getSum()).thenReturn(6L);
+        when(timer.getSum()).thenReturn(TimeUnit.MILLISECONDS.toNanos(6));
         when(timer.getMeanRate()).thenReturn(2.0);
         when(timer.getOneMinuteRate()).thenReturn(3.0);
         when(timer.getFiveMinuteRate()).thenReturn(4.0);

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
@@ -1,7 +1,6 @@
 package com.codahale.metrics;
 
-import org.junit.After;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -13,13 +12,14 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.After;
+import org.junit.Test;
 
 @SuppressWarnings("deprecation")
 public class ConsoleReporterTest {
 
-    private ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
-    private String dateHeader = System.getProperty("java.version").startsWith("1.8") ?
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private final String dateHeader = System.getProperty("java.version").startsWith("1.8") ?
             "3/18/13 1:04:36 AM =============================================================" :
             "3/18/13, 1:04:36 AM ============================================================";
 
@@ -99,7 +99,7 @@ public class ConsoleReporterTest {
                         "-- Timers ----------------------------------------------------------------------\n" +
                         "test-timer\n" +
                         "             count = 0\n" +
-                        "               sum = 0\n" +
+                        "               sum = 0.00\n" +
                         "         mean rate = 0.00 calls/second\n" +
                         "     1-minute rate = 0.00 calls/second\n" +
                         "     5-minute rate = 0.00 calls/second\n" +


### PR DESCRIPTION
Reporting sums for `Timer`s is very useful, however they are currently always reported in nanoseconds, instead of in the `Timer`'s duration units. This is because we inherit the handling of `getSum` from `Meter`, where it has a slightly different meaning.

There are a couple of unsatisfying bits:
- `JmxTimer` loses some precision in reporting the sum, because we want to be able to report fractional values, but `JmxMeter` assumes that it can be represented as a `long`. We could probably just change `JmxMeter` to report a `double`.
- `GraphiteReporter.reportTimer` delegates to a `reportMetered`, which will do the wrong thing with the sum.