### PR TITLE
DefaultObjectNameFactory: use type, be a bit more conservative about quoting

### DIFF
--- a/metrics-jmx/src/main/java/com/codahale/metrics/jmx/DefaultObjectNameFactory.java
+++ b/metrics-jmx/src/main/java/com/codahale/metrics/jmx/DefaultObjectNameFactory.java
@@ -1,5 +1,7 @@
 package com.codahale.metrics.jmx;
 
+import java.util.Hashtable;
+
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
@@ -13,10 +15,28 @@ public class DefaultObjectNameFactory implements ObjectNameFactory {
     @Override
     public ObjectName createName(String type, String domain, String name) {
         try {
-            ObjectName objectName = new ObjectName(domain, "name", name);
-            if (objectName.isPattern()) {
-                objectName = new ObjectName(domain, "name", ObjectName.quote(name));
+            ObjectName objectName;
+            Hashtable<String, String> properties = new Hashtable<>();
+
+            properties.put("name", name);
+            properties.put("type", type);
+            objectName = new ObjectName(domain, properties);
+
+            /*
+             * The only way we can find out if we need to quote the properties is by
+             * checking an ObjectName that we've constructed.
+             */
+            if (objectName.isDomainPattern()) {
+                domain = ObjectName.quote(domain);
             }
+            if (objectName.isPropertyValuePattern("name")) {
+                properties.put("name", ObjectName.quote(name));
+            }
+            if (objectName.isPropertyValuePattern("type")) {
+                properties.put("type", ObjectName.quote(type));
+            }
+            objectName = new ObjectName(domain, properties);
+
             return objectName;
         } catch (MalformedObjectNameException e) {
             try {

--- a/metrics-jmx/src/test/java/com/codahale/metrics/jmx/JmxReporterTest.java
+++ b/metrics-jmx/src/test/java/com/codahale/metrics/jmx/JmxReporterTest.java
@@ -148,7 +148,7 @@ public class JmxReporterTest {
 
     @Test
     public void registersMBeansForGauges() throws Exception {
-        final AttributeList attributes = getAttributes("gauge", "Value");
+        final AttributeList attributes = getAttributes("gauges", "gauge", "Value");
 
         assertThat(values(attributes))
                 .contains(entry("Value", 1));
@@ -156,7 +156,7 @@ public class JmxReporterTest {
 
     @Test
     public void registersMBeansForCounters() throws Exception {
-        final AttributeList attributes = getAttributes("test.counter", "Count");
+        final AttributeList attributes = getAttributes("counters", "test.counter", "Count");
 
         assertThat(values(attributes))
                 .contains(entry("Count", 100L));
@@ -164,7 +164,7 @@ public class JmxReporterTest {
 
     @Test
     public void registersMBeansForHistograms() throws Exception {
-        final AttributeList attributes = getAttributes("test.histogram",
+        final AttributeList attributes = getAttributes("histograms", "test.histogram",
                 "Count",
                 "Max",
                 "Mean",
@@ -195,7 +195,7 @@ public class JmxReporterTest {
 
     @Test
     public void registersMBeansForMeters() throws Exception {
-        final AttributeList attributes = getAttributes("test.meter",
+        final AttributeList attributes = getAttributes("meters", "test.meter",
                 "Count",
                 "MeanRate",
                 "OneMinuteRate",
@@ -214,7 +214,7 @@ public class JmxReporterTest {
 
     @Test
     public void registersMBeansForTimers() throws Exception {
-        final AttributeList attributes = getAttributes("test.another.timer",
+        final AttributeList attributes = getAttributes("timers", "test.another.timer",
                 "Count",
                 "MeanRate",
                 "OneMinuteRate",
@@ -258,7 +258,7 @@ public class JmxReporterTest {
         reporter.stop();
 
         try {
-            getAttributes("gauge", "Value");
+            getAttributes("gauges", "gauge", "Value");
             failBecauseExceptionWasNotThrown(InstanceNotFoundException.class);
         } catch (InstanceNotFoundException e) {
 
@@ -297,8 +297,8 @@ public class JmxReporterTest {
         metricRegistry.counter("test*");
     }
 
-    private AttributeList getAttributes(String name, String... attributeNames) throws JMException {
-        ObjectName n = concreteObjectNameFactory.createName("only-for-logging-error", this.name, name);
+    private AttributeList getAttributes(String type, String name, String... attributeNames) throws JMException {
+        ObjectName n = concreteObjectNameFactory.createName(type, this.name, name);
         return mBeanServer.getAttributes(n, attributeNames);
     }
 


### PR DESCRIPTION
This makes `DefaultObjectNameFactory` a little cleverer. In particular, it uses the `type` argument as the `type` property of the `ObjectName`. This is used by tools like `visualvm` to give another layer of grouping, which is quite helpful.

In addition, we can be a little more conservative about which part of the name we need to quote if we need to quote something.