### PR TITLE
JMXReporter: report meter/timer sums as doubles

### DIFF
--- a/metrics-jmx/src/main/java/io/dropwizard/metrics5/jmx/JmxReporter.java
+++ b/metrics-jmx/src/main/java/io/dropwizard/metrics5/jmx/JmxReporter.java
@@ -340,7 +340,7 @@ public class JmxReporter implements Reporter, Closeable {
     public interface JmxMeterMBean extends MetricMBean {
         long getCount();
 
-        long getSum();
+        double getSum();
 
         double getMeanRate();
 
@@ -371,7 +371,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public long getSum() {
+        public double getSum() {
             return metric.getSum();
         }
 
@@ -499,8 +499,8 @@ public class JmxReporter implements Reporter, Closeable {
         }
         
         @Override
-        public long getSum() {
-        	return (long)(super.getSum() * durationFactor);
+        public double getSum() {
+        	return super.getSum() * durationFactor;
         }
 
         @Override

--- a/metrics-jmx/src/test/java/io/dropwizard/metrics5/jmx/JmxReporterTest.java
+++ b/metrics-jmx/src/test/java/io/dropwizard/metrics5/jmx/JmxReporterTest.java
@@ -214,7 +214,7 @@ public class JmxReporterTest {
 
         assertThat(values(attributes))
                 .contains(entry("Count", 1L))
-                .contains(entry("Sum", 6L))
+                .contains(entry("Sum", 6.0))
                 .contains(entry("MeanRate", 2.0))
                 .contains(entry("OneMinuteRate", 3.0))
                 .contains(entry("FiveMinuteRate", 4.0))
@@ -246,7 +246,7 @@ public class JmxReporterTest {
 
         assertThat(values(attributes))
                 .contains(entry("Count", 1L))
-                .contains(entry("Sum", 6L))
+                .contains(entry("Sum", 6.0))
                 .contains(entry("MeanRate", 2.0))
                 .contains(entry("OneMinuteRate", 3.0))
                 .contains(entry("FiveMinuteRate", 4.0))


### PR DESCRIPTION
As discussed in #1309. `double` is slightly less sensical for `Meter` sums, but it allows better precision for `Timer`s.