### PR TITLE
feat: builder pattern for InstrumentedHttpClientConnectionManager

### DIFF
--- a/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/InstrumentedHttpClientConnectionManager.java
+++ b/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/InstrumentedHttpClientConnectionManager.java
@@ -38,16 +38,28 @@ public class InstrumentedHttpClientConnectionManager extends PoolingHttpClientCo
     private final MetricRegistry metricsRegistry;
     private final String name;
 
+    /**
+     * @deprecated Use {@link #builder(MetricRegistry)} instead.
+     */
+    @Deprecated
     public InstrumentedHttpClientConnectionManager(MetricRegistry metricRegistry) {
         this(metricRegistry, getDefaultRegistry());
     }
 
+    /**
+     * @deprecated Use {@link #builder(MetricRegistry)} instead.
+     */
+    @Deprecated
     public InstrumentedHttpClientConnectionManager(MetricRegistry metricsRegistry,
                                                    Registry<ConnectionSocketFactory> socketFactoryRegistry) {
         this(metricsRegistry, socketFactoryRegistry, -1, TimeUnit.MILLISECONDS);
     }
 
 
+    /**
+     * @deprecated Use {@link #builder(MetricRegistry)} instead.
+     */
+    @Deprecated
     public InstrumentedHttpClientConnectionManager(MetricRegistry metricsRegistry,
                                                    Registry<ConnectionSocketFactory> socketFactoryRegistry,
                                                    long connTTL,
@@ -56,6 +68,10 @@ public class InstrumentedHttpClientConnectionManager extends PoolingHttpClientCo
     }
 
 
+    /**
+     * @deprecated Use {@link #builder(MetricRegistry)} instead.
+     */
+    @Deprecated
     public InstrumentedHttpClientConnectionManager(MetricRegistry metricsRegistry,
                                                    Registry<ConnectionSocketFactory> socketFactoryRegistry,
                                                    HttpConnectionFactory<HttpRoute, ManagedHttpClientConnection>
@@ -73,6 +89,10 @@ public class InstrumentedHttpClientConnectionManager extends PoolingHttpClientCo
              name);
     }
 
+    /**
+     * @deprecated Use {@link #builder(MetricRegistry)} instead.
+     */
+    @Deprecated
     public InstrumentedHttpClientConnectionManager(MetricRegistry metricsRegistry,
                                                    HttpClientConnectionOperator httpClientConnectionOperator,
                                                    HttpConnectionFactory<HttpRoute, ManagedHttpClientConnection>
@@ -114,4 +134,76 @@ public class InstrumentedHttpClientConnectionManager extends PoolingHttpClientCo
         metricsRegistry.remove(name(HttpClientConnectionManager.class, name, "max-connections"));
         metricsRegistry.remove(name(HttpClientConnectionManager.class, name, "pending-connections"));
     }
+
+    public static Builder builder(MetricRegistry metricsRegistry) {
+        return new Builder().metricsRegistry(metricsRegistry);
+    }
+
+    public static class Builder {
+        private MetricRegistry metricsRegistry;
+        private HttpClientConnectionOperator httpClientConnectionOperator;
+        private Registry<ConnectionSocketFactory> socketFactoryRegistry = getDefaultRegistry();
+        private HttpConnectionFactory<HttpRoute, ManagedHttpClientConnection> connFactory;
+        private SchemePortResolver schemePortResolver;
+        private DnsResolver dnsResolver = SystemDefaultDnsResolver.INSTANCE;
+        private long connTTL = -1;
+        private TimeUnit connTTLTimeUnit = TimeUnit.MILLISECONDS;
+        private String name;
+
+        Builder() {
+        }
+
+        public Builder metricsRegistry(MetricRegistry metricsRegistry) {
+            this.metricsRegistry = metricsRegistry;
+            return this;
+        }
+
+        public Builder socketFactoryRegistry(Registry<ConnectionSocketFactory> socketFactoryRegistry) {
+            this.socketFactoryRegistry = socketFactoryRegistry;
+            return this;
+        }
+
+        public Builder connFactory(HttpConnectionFactory<HttpRoute, ManagedHttpClientConnection> connFactory) {
+            this.connFactory = connFactory;
+            return this;
+        }
+
+        public Builder schemePortResolver(SchemePortResolver schemePortResolver) {
+            this.schemePortResolver = schemePortResolver;
+            return this;
+        }
+
+        public Builder dnsResolver(DnsResolver dnsResolver) {
+            this.dnsResolver = dnsResolver;
+            return this;
+        }
+
+        public Builder connTTL(long connTTL) {
+            this.connTTL = connTTL;
+            return this;
+        }
+
+        public Builder connTTLTimeUnit(TimeUnit connTTLTimeUnit) {
+            this.connTTLTimeUnit = connTTLTimeUnit;
+            return this;
+        }
+
+        public Builder httpClientConnectionOperator(HttpClientConnectionOperator httpClientConnectionOperator) {
+            this.httpClientConnectionOperator = httpClientConnectionOperator;
+            return this;
+        }
+
+        public Builder name(final String name) {
+            this.name = name;
+            return this;
+        }
+
+        public InstrumentedHttpClientConnectionManager build() {
+            if (httpClientConnectionOperator == null) {
+                httpClientConnectionOperator = new DefaultHttpClientConnectionOperator(socketFactoryRegistry, schemePortResolver, dnsResolver);
+            }
+            return new InstrumentedHttpClientConnectionManager(metricsRegistry, httpClientConnectionOperator, connFactory, connTTL, connTTLTimeUnit, name);
+        }
+    }
+
 }

--- a/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/InstrumentedHttpClients.java
+++ b/metrics-httpclient/src/main/java/com/codahale/metrics/httpclient/InstrumentedHttpClients.java
@@ -28,8 +28,7 @@ public class InstrumentedHttpClients {
                                            HttpClientMetricNameStrategy metricNameStrategy) {
         return HttpClientBuilder.create()
                 .setRequestExecutor(new InstrumentedHttpRequestExecutor(metricRegistry, metricNameStrategy))
-                .setConnectionManager(new InstrumentedHttpClientConnectionManager(metricRegistry));
+                .setConnectionManager(InstrumentedHttpClientConnectionManager.builder(metricRegistry).build());
     }
-
 
 }

--- a/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/InstrumentedHttpClientConnectionManagerTest.java
+++ b/metrics-httpclient/src/test/java/com/codahale/metrics/httpclient/InstrumentedHttpClientConnectionManagerTest.java
@@ -3,6 +3,11 @@ package com.codahale.metrics.httpclient;
 import com.codahale.metrics.MetricRegistry;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 
 
 public class InstrumentedHttpClientConnectionManagerTest {
@@ -10,13 +15,28 @@ public class InstrumentedHttpClientConnectionManagerTest {
 
     @Test
     public void shouldRemoveGauges() {
-        final InstrumentedHttpClientConnectionManager instrumentedHttpClientConnectionManager = new InstrumentedHttpClientConnectionManager(metricRegistry);
+        final InstrumentedHttpClientConnectionManager instrumentedHttpClientConnectionManager = InstrumentedHttpClientConnectionManager.builder(metricRegistry).build();
         Assert.assertEquals(4, metricRegistry.getGauges().size());
 
         instrumentedHttpClientConnectionManager.close();
         Assert.assertEquals(0, metricRegistry.getGauges().size());
 
         // should be able to create another one with the same name ("")
-        new InstrumentedHttpClientConnectionManager(metricRegistry).close();
+        InstrumentedHttpClientConnectionManager.builder(metricRegistry).build().close();
+    }
+
+    @Test
+    public void configurableViaBuilder() {
+        final MetricRegistry registry = Mockito.mock(MetricRegistry.class);
+
+        InstrumentedHttpClientConnectionManager.builder(registry)
+                .name("some-name")
+                .name("some-other-name")
+                .build()
+                .close();
+
+        ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
+        Mockito.verify(registry, Mockito.atLeast(1)).register(argumentCaptor.capture(), any());
+        assertTrue(argumentCaptor.getValue().contains("some-other-name"));
     }
 }


### PR DESCRIPTION
For my project I needed to specify only the name (and metrics registry, of course) and leave all the rest  at defaults. So here is the more flexible approach.

Also, the code was auto-formatted with IntelliJ.
