### PR TITLE
Update to Jdbi 3.3.0

### DIFF
--- a/metrics-bom/pom.xml
+++ b/metrics-bom/pom.xml
@@ -24,7 +24,7 @@
         <papertrail.profiler.version>1.0.2</papertrail.profiler.version>
         <jersey.version>2.25.1</jersey.version>
         <jdbi2.version>2.78</jdbi2.version>
-        <jdbi3.version>3.2.1</jdbi3.version>
+        <jdbi3.version>3.3.0</jdbi3.version>
         <ehcache2.version>2.10.4</ehcache2.version>
         <ehcache3.version>3.4.0</ehcache3.version>
         <cache-api.version>1.0.0</cache-api.version>

--- a/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/InstrumentedSqlLogger.java
+++ b/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/InstrumentedSqlLogger.java
@@ -1,0 +1,48 @@
+package com.codahale.metrics.jdbi3;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jdbi3.strategies.SmartNameStrategy;
+import com.codahale.metrics.jdbi3.strategies.StatementNameStrategy;
+import org.jdbi.v3.core.statement.SqlLogger;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.SQLException;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A {@link SqlLogger} implementation for JDBI which uses the SQL objects' class names and
+ * method names for millisecond-precision timers.
+ */
+public class InstrumentedSqlLogger implements SqlLogger {
+    private final MetricRegistry registry;
+    private final StatementNameStrategy statementNameStrategy;
+
+    public InstrumentedSqlLogger(MetricRegistry registry) {
+        this(registry, new SmartNameStrategy());
+    }
+
+    public InstrumentedSqlLogger(MetricRegistry registry,
+                                 StatementNameStrategy statementNameStrategy) {
+        this.registry = registry;
+        this.statementNameStrategy = statementNameStrategy;
+    }
+
+    @Override
+    public void logAfterExecution(StatementContext context) {
+        log(context);
+    }
+
+    @Override
+    public void logException(StatementContext context, SQLException ex) {
+        log(context);
+    }
+
+    private void log(StatementContext context) {
+        String statementName = statementNameStrategy.getStatementName(context);
+        if (statementName != null) {
+            final long elapsed = context.getElapsedTime(ChronoUnit.NANOS);
+            registry.timer(statementName).update(elapsed, TimeUnit.NANOSECONDS);
+        }
+    }
+}

--- a/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/InstrumentedTimingCollector.java
+++ b/metrics-jdbi3/src/main/java/com/codahale/metrics/jdbi3/InstrumentedTimingCollector.java
@@ -3,6 +3,7 @@ package com.codahale.metrics.jdbi3;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.jdbi3.strategies.SmartNameStrategy;
 import com.codahale.metrics.jdbi3.strategies.StatementNameStrategy;
+import org.jdbi.v3.core.statement.SqlLogger;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.TimingCollector;
 
@@ -11,7 +12,10 @@ import java.util.concurrent.TimeUnit;
 /**
  * A {@link TimingCollector} implementation for JDBI which uses the SQL objects' class names and
  * method names for millisecond-precision timers.
+ *
+ * @deprecated Use {@link InstrumentedSqlLogger} and {@link org.jdbi.v3.core.Jdbi#setSqlLogger(SqlLogger)} instead.
  */
+@Deprecated
 public class InstrumentedTimingCollector implements TimingCollector {
 
     private final MetricRegistry registry;

--- a/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/InstrumentedSqlLoggerTest.java
+++ b/metrics-jdbi3/src/test/java/com/codahale/metrics/jdbi3/InstrumentedSqlLoggerTest.java
@@ -1,0 +1,61 @@
+package com.codahale.metrics.jdbi3;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.codahale.metrics.jdbi3.strategies.StatementNameStrategy;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class InstrumentedSqlLoggerTest {
+    @Test
+    public void logsExecutionTime() {
+        final MetricRegistry mockRegistry = mock(MetricRegistry.class);
+        final StatementNameStrategy mockNameStrategy = mock(StatementNameStrategy.class);
+        final InstrumentedSqlLogger logger = new InstrumentedSqlLogger(mockRegistry, mockNameStrategy);
+
+        final StatementContext mockContext = mock(StatementContext.class);
+        final Timer mockTimer = mock(Timer.class);
+
+        final String statementName = "my-fake-name";
+        final long fakeElapsed = 1234L;
+
+        when(mockNameStrategy.getStatementName(mockContext)).thenReturn(statementName);
+        when(mockRegistry.timer(statementName)).thenReturn(mockTimer);
+
+        when(mockContext.getElapsedTime(ChronoUnit.NANOS)).thenReturn(fakeElapsed);
+
+        logger.logAfterExecution(mockContext);
+
+        verify(mockTimer).update(fakeElapsed, TimeUnit.NANOSECONDS);
+    }
+
+    @Test
+    public void logsExceptionTime() {
+        final MetricRegistry mockRegistry = mock(MetricRegistry.class);
+        final StatementNameStrategy mockNameStrategy = mock(StatementNameStrategy.class);
+        final InstrumentedSqlLogger logger = new InstrumentedSqlLogger(mockRegistry, mockNameStrategy);
+
+        final StatementContext mockContext = mock(StatementContext.class);
+        final Timer mockTimer = mock(Timer.class);
+
+        final String statementName = "my-fake-name";
+        final long fakeElapsed = 1234L;
+
+        when(mockNameStrategy.getStatementName(mockContext)).thenReturn(statementName);
+        when(mockRegistry.timer(statementName)).thenReturn(mockTimer);
+
+        when(mockContext.getElapsedTime(ChronoUnit.NANOS)).thenReturn(fakeElapsed);
+
+        logger.logException(mockContext, new SQLException());
+
+        verify(mockTimer).update(fakeElapsed, TimeUnit.NANOSECONDS);
+    }
+}


### PR DESCRIPTION
Jdbi's `TimingCollector` was deprecated in 3.2.

I've marked `InstrumentedTimingCollector` as deprecated as well and added a replacement `InstrumentedSqlLogger`.