### PR TITLE
Adding ResetOnSnapshotReservoir

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ResetOnSnapshotReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ResetOnSnapshotReservoir.java
@@ -1,0 +1,33 @@
+package com.codahale.metrics;
+
+/**
+ * A Reservoir [backed by a UniformReservoir] that resets its internal state on each snapshot.
+ */
+public class ResetOnSnapshotReservoir implements Reservoir {
+    private Reservoir reservoir;
+
+    public ResetOnSnapshotReservoir() {
+        this.reservoir = getNewReservoir();
+    }
+
+    @Override
+    public void update(long value) {
+        reservoir.update(value);
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        Reservoir reservoirCopy = reservoir;
+        reservoir = getNewReservoir();
+        return reservoirCopy.getSnapshot();
+    }
+
+    @Override
+    public int size() {
+        return reservoir.size();
+    }
+
+    private Reservoir getNewReservoir() {
+        return new UniformReservoir();
+    }
+}


### PR DESCRIPTION
 The metrics library at Box has been using ExponentiallyDecayingReservoir as the default reservoir. This Reservoir uses Cormode et al's forward-decaying priority sampling method to produce a statistically representative sampling reservoir, exponentially biased towards newer entries.  The sampling aims to bias the reservoir to the past 5 minutes of measurements. Although the expected margin of error and the assumption that the data is normally distributed can cause significant inaccuracies in the percentiles.

Histograms are reported by calling the getSnapshot() method at a fixed interval of 60s and sending the percentile values to our time series database over our metrics pipeline. We use Wavefront at the backend that provides efficient visualizations on the time series data. It allows for great slicing and aggregation of the metric data for up to a minute granularity. In the scheme of reporting data every minute the Exponentially Decaying Reservoir is not optimal because it reflects the state from roughly 5 minutes in the past. With the visualizations allowing for trends over any desired duration, at the end of every minute we would like to report only information about that last minute. 

Justin Mason's Weblog [http://taint.org/2014/01/16/145944a.html] has discussed this problem in a great detail and presented a few great solutions.
However, none of those would exactly fit into our architecture for various reasons. 
One of the particularly interesting solution uses the new SlidingTimeWindowArrayReservoir, introduced in version 3.2.3 of Codahale metrics. If we used a time interval that was the same as our reporting interval of 60s, this reservoir could fix the slow decay issue of the Exponentially Decaying Reservoir.  The reason we didn't completely like this alternative is because it cuts through abstractions established in our metrics library for metrics creation versus metrics reporting. The fact that we report metrics data every 60s is purely a property of our reporters and specifying this time interval when creating the Histograms is not ideal.

To address the issue for our use case, we designed our own Reservoir called ResetOnSnapshotReservoir. This reservoir creates a new UniformReservoir every time the reporter reads a snapshot to report metrics to our time series database. For our use case, the reservoir accumulates data for 60s and when the reporter calls getSnapshot(), the existing reservoir is discarded to create a new one for the next 60s time window. We now use ResetOnSnapshotReservoir as the default reservoirs for all Histograms and Timers. 