### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,6 @@ Source code for 5.x.x is resided in the [5.0-development branch](https://github.
 License
 -------
 
-Copyright (c) 2010-2013 Coda Hale, Yammer.com, 2014-2017 Dropwizard Team
+Copyright (c) 2010-2013 Coda Hale, Yammer.com, 2014-2018 Dropwizard Team
 
 Published under Apache Software License 2.0, see LICENSE

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ For more information, please see [the documentation](http://dropwizard.github.io
 
 ### Versions
 
-#### Version 4.x.x ([Javadoc](https://www.javadoc.io/doc/io.dropwizard.metrics/metrics-core/4.0.1))
+#### Version 4.x.x ([Javadoc](https://www.javadoc.io/doc/io.dropwizard.metrics/metrics-core/4.0.3))
 
-Version 4.x.x (the last release is 4.0.2) is a Java 8/9 compatible and the most fresh release of Metrics. The version targets Java 8 and removes a lot of internal cruft from 3.2.x (for instance, there's no dependency on the Unsafe API and custom `LongAdder` and `ThreadLocalRandom` implementations). It's mostly compatible with the 3.2 API and the update should be painless in Java 8 environments. If you have a 3rd party application which is dependent on an old version of Metrics, you can force a new version by adding `metrics-bom` to your Maven configuration. Check out the [release notes](https://github.com/dropwizard/metrics/releases/tag/v4.0.0) for 4.0.0.
+Version 4.x.x (the last release is 4.0.3) is a Java 8/9 compatible and the most fresh release of Metrics. The version targets Java 8 and removes a lot of internal cruft from 3.2.x (for instance, there's no dependency on the Unsafe API and custom `LongAdder` and `ThreadLocalRandom` implementations). It's mostly compatible with the 3.2 API and the update should be painless in Java 8 environments. If you have a 3rd party application which is dependent on an old version of Metrics, you can force a new version by adding `metrics-bom` to your Maven configuration. Check out the [release notes](https://github.com/dropwizard/metrics/releases/tag/v4.0.0) for 4.0.0.
 
 Source code for 4.1.x is resided in the [4.1-development branch](https://github.com/dropwizard/metrics/tree/4.1-development).
 


### PR DESCRIPTION
Update to latest release 4.0.3 and extend copyright to 2018. The redirect on https://metrics.dropwizard.io is currently https://metrics.dropwizard.io/4.0.0/ and should be also point to https://metrics.dropwizard.io/4.0.3 (which is not yet available)