### PR TITLE
Edit DefaultObjectNameFactory to support tagged metrics as default

### DIFF
--- a/metrics-jmx/src/main/java/io/dropwizard/metrics5/jmx/DefaultObjectNameFactory.java
+++ b/metrics-jmx/src/main/java/io/dropwizard/metrics5/jmx/DefaultObjectNameFactory.java
@@ -21,6 +21,7 @@ public class DefaultObjectNameFactory implements ObjectNameFactory {
 
             properties.put("name", name.getKey());
             properties.put("type", type);
+            properties.putAll(name.getTags());
             objectName = new ObjectName(domain, properties);
 
             /*

--- a/metrics-jmx/src/test/java/io/dropwizard/metrics5/jmx/DefaultObjectNameFactoryTest.java
+++ b/metrics-jmx/src/test/java/io/dropwizard/metrics5/jmx/DefaultObjectNameFactoryTest.java
@@ -12,14 +12,19 @@ public class DefaultObjectNameFactoryTest {
     @Test
     public void createsObjectNameWithDomainInInput() {
         DefaultObjectNameFactory f = new DefaultObjectNameFactory();
-        ObjectName on = f.createName("type", "com.domain", MetricName.build("something.with.dots"));
+        ObjectName on = f.createName("type", "com.domain", MetricName.build("something.with.dots").tagged("foo", "bar", "baz", "biz"));
         assertThat(on.getDomain()).isEqualTo("com.domain");
+        assertThat(on.getKeyProperty("foo")).isEqualTo("bar");
+        assertThat(on.getKeyProperty("baz")).isEqualTo("biz");
     }
 
     @Test
     public void createsObjectNameWithNameAsKeyPropertyName() {
         DefaultObjectNameFactory f = new DefaultObjectNameFactory();
-        ObjectName on = f.createName("type", "com.domain", MetricName.build("something.with.dots"));
+        ObjectName on = f.createName("type", "com.domain", MetricName.build("something.with.dots").tagged("foo", "bar", "baz", "biz"));
         assertThat(on.getKeyProperty("name")).isEqualTo("something.with.dots");
+        assertThat(on.getKeyProperty("foo")).isEqualTo("bar");
+        assertThat(on.getKeyProperty("baz")).isEqualTo("biz");
+
     }
 }


### PR DESCRIPTION
As #1347 I opened, metrics-jmx's DefaulfObjectNameFactory doesn't support tagged metrics.

This fix make jmxReporter can report tagged metrics