### PR TITLE
Adding in a duration field to the healthcheck result

### DIFF
--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
@@ -101,7 +101,7 @@ public abstract class HealthCheck {
         private final Throwable error;
         private final Map<String, Object> details;
         private final String timestamp;
-        private Long duration;
+        private long duration;
 
         private Result(boolean isHealthy, String message, Throwable error) {
             this(isHealthy, message, error, null);
@@ -162,7 +162,7 @@ public abstract class HealthCheck {
          *
          * @return the duration
          */
-        public Long getDuration() {
+        public long getDuration() {
             return duration;
         }
 
@@ -171,7 +171,7 @@ public abstract class HealthCheck {
          *
          * @param duration The duration in milliseconds
          */
-        public void setDuration(Long duration) {
+        public void setDuration(long duration) {
             this.duration = duration;
         }
 
@@ -192,7 +192,7 @@ public abstract class HealthCheck {
                     !(error != null ? !error.equals(result.error) : result.error != null) &&
                     !(message != null ? !message.equals(result.message) : result.message != null) &&
                     !(timestamp != null ? !timestamp.equals(result.timestamp) : result.timestamp != null) &&
-                    !(duration != null ? !duration.equals(result.duration) : result.duration != null);
+                    duration == result.duration;
         }
 
         @Override
@@ -201,7 +201,7 @@ public abstract class HealthCheck {
             result = PRIME * result + (message != null ? message.hashCode() : 0);
             result = PRIME * result + (error != null ? error.hashCode() : 0);
             result = PRIME * result + (timestamp != null ? timestamp.hashCode() : 0);
-            result = PRIME * result + (duration != null ? duration.hashCode() : 0);
+            result = PRIME * result + Long.hashCode(duration);
             return result;
         }
 
@@ -215,9 +215,7 @@ public abstract class HealthCheck {
             if (error != null) {
                 builder.append(", error=").append(error);
             }
-            if (duration != null) {
-                builder.append(", duration=").append(duration);
-            }
+            builder.append(", duration=").append(duration);
             builder.append(", timestamp=").append(timestamp);
             if (details != null) {
                 for (Map.Entry<String, Object> e : details.entrySet()) {

--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/HealthCheck.java
@@ -25,7 +25,7 @@ public abstract class HealthCheck {
          * @return a healthy {@link Result} with no additional message
          */
         public static Result healthy() {
-            return new Result(true, null, null, null);
+            return new Result(true, null, null);
         }
 
         /**
@@ -35,7 +35,7 @@ public abstract class HealthCheck {
          * @return a healthy {@link Result} with an additional message
          */
         public static Result healthy(String message) {
-            return new Result(true, message, null, null);
+            return new Result(true, message, null);
         }
 
         /**
@@ -59,7 +59,7 @@ public abstract class HealthCheck {
          * @return an unhealthy {@link Result} with the given message
          */
         public static Result unhealthy(String message) {
-            return new Result(false, message, null, null);
+            return new Result(false, message, null);
         }
 
         /**
@@ -83,7 +83,7 @@ public abstract class HealthCheck {
          * @return an unhealthy {@link Result} with the given {@code error}
          */
         public static Result unhealthy(Throwable error) {
-            return new Result(false, error.getMessage(), error, null);
+            return new Result(false, error.getMessage(), error);
         }
 
 

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
@@ -1,7 +1,9 @@
 package com.codahale.metrics.health;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
@@ -181,6 +183,8 @@ public class HealthCheckTest {
 
         assertThat(healthCheck.execute())
                 .isEqualTo(result);
+
+        verify(result).setDuration(isA(Long.class));
     }
 
     @Test
@@ -199,6 +203,8 @@ public class HealthCheckTest {
                 .isEqualTo(e);
         assertThat(actual.getDetails())
                 .isNull();
+        assertThat(actual.getDuration())
+                .isNotNull();
     }
 
     @Test

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
@@ -215,7 +215,7 @@ public class HealthCheckTest {
                 .build();
         assertThat(resultWithNullDetailValue.toString())
                 .contains(
-                        "Result{isHealthy=false, timestamp=", // Skip the timestamp part of the String.
+                        "Result{isHealthy=false, duration=0, timestamp=", // Skip the timestamp part of the String.
                         ", aNullDetail=null}");
     }
 }

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
@@ -2,7 +2,6 @@ package com.codahale.metrics.health;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
@@ -1,6 +1,7 @@
 package com.codahale.metrics.health;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -184,7 +185,7 @@ public class HealthCheckTest {
         assertThat(healthCheck.execute())
                 .isEqualTo(result);
 
-        verify(result).setDuration(isA(Long.class));
+        verify(result).setDuration(anyLong());
     }
 
     @Test
@@ -204,7 +205,7 @@ public class HealthCheckTest {
         assertThat(actual.getDetails())
                 .isNull();
         assertThat(actual.getDuration())
-                .isNotNull();
+                .isGreaterThanOrEqualTo(0);
     }
 
     @Test

--- a/metrics-json/src/main/java/com/codahale/metrics/json/HealthCheckModule.java
+++ b/metrics-json/src/main/java/com/codahale/metrics/json/HealthCheckModule.java
@@ -34,6 +34,7 @@ public class HealthCheckModule extends Module {
             }
 
             serializeThrowable(json, result.getError(), "error");
+            json.writeNumberField("duration", result.getDuration());
 
             Map<String, Object> details = result.getDetails();
             if (details != null && !details.isEmpty()) {

--- a/metrics-json/src/test/java/com/codahale/metrics/json/HealthCheckModuleTest.java
+++ b/metrics-json/src/test/java/com/codahale/metrics/json/HealthCheckModuleTest.java
@@ -19,7 +19,7 @@ public class HealthCheckModuleTest {
     @Test
     public void serializesAHealthyResult() throws Exception {
         assertThat(mapper.writeValueAsString(HealthCheck.Result.healthy()))
-            .isEqualTo("{\"healthy\":true}");
+            .isEqualTo("{\"healthy\":true,\"duration\":0}");
     }
 
     @Test
@@ -27,7 +27,8 @@ public class HealthCheckModuleTest {
         assertThat(mapper.writeValueAsString(HealthCheck.Result.healthy("yay for %s", "me")))
             .isEqualTo("{" +
                 "\"healthy\":true," +
-                "\"message\":\"yay for me\"}");
+                "\"message\":\"yay for me\"," +
+                "\"duration\":0}");
     }
 
     @Test
@@ -35,7 +36,8 @@ public class HealthCheckModuleTest {
         assertThat(mapper.writeValueAsString(HealthCheck.Result.unhealthy("boo")))
             .isEqualTo("{" +
                 "\"healthy\":false," +
-                "\"message\":\"boo\"}");
+                "\"message\":\"boo\"," +
+                "\"duration\":0}");
     }
 
     @Test
@@ -53,7 +55,8 @@ public class HealthCheckModuleTest {
                 "\"error\":{" +
                 "\"message\":\"oh no\"," +
                 "\"stack\":[\"Blah.bloo(Blah.java:100)\"]" +
-                "}" +
+                "}," +
+                "\"duration\":0" +
                 "}");
     }
 
@@ -83,7 +86,8 @@ public class HealthCheckModuleTest {
                 "\"message\":\"oh no\"," +
                 "\"stack\":[\"Blah.bloo(Blah.java:100)\"]" +
                 "}" +
-                "}" +
+                "}," +
+                "\"duration\":0" +
                 "}");
     }
 
@@ -108,6 +112,7 @@ public class HealthCheckModuleTest {
         assertThat(mapper.writeValueAsString(result))
             .isEqualTo("{" +
                 "\"healthy\":true," +
+                "\"duration\":0," +
                 "\"boolean\":true," +
                 "\"integer\":1," +
                 "\"long\":2," +

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
@@ -76,7 +76,7 @@ public class HealthCheckServletTest extends AbstractServletTest {
         assertThat(response.getStatus())
                 .isEqualTo(200);
         assertThat(response.getContent())
-                .isEqualTo("{\"fun\":{\"healthy\":true,\"message\":\"whee\"}}");
+                .contains("{\"fun\":{\"healthy\":true,\"message\":\"whee\",\"duration\":", "}}"); // Ignore variable duration time
         assertThat(response.get(HttpHeader.CONTENT_TYPE))
                 .isEqualTo("application/json");
     }
@@ -102,7 +102,7 @@ public class HealthCheckServletTest extends AbstractServletTest {
         assertThat(response.getStatus())
                 .isEqualTo(200);
         assertThat(response.getContent())
-                .isEqualTo("{\"fun\":{\"healthy\":true,\"message\":\"whee\"}}");
+                .contains("{\"fun\":{\"healthy\":true,\"message\":\"whee\",\"duration\":", "}}"); // Ignore variable duration time
         assertThat(response.get(HttpHeader.CONTENT_TYPE))
                 .isEqualTo("application/json");
     }
@@ -128,7 +128,7 @@ public class HealthCheckServletTest extends AbstractServletTest {
         assertThat(response.getStatus())
                 .isEqualTo(500);
         assertThat(response.getContent())
-                .isEqualTo("{\"fun\":{\"healthy\":true,\"message\":\"whee\"},\"notFun\":{\"healthy\":false,\"message\":\"whee\"}}");
+                .contains("{\"fun\":{\"healthy\":true,\"message\":\"whee\",\"duration\":", "},\"notFun\":{\"healthy\":false,\"message\":\"whee\",\"duration\":", "}}"); // Ignore variable duration time
         assertThat(response.get(HttpHeader.CONTENT_TYPE))
                 .isEqualTo("application/json");
     }
@@ -152,7 +152,8 @@ public class HealthCheckServletTest extends AbstractServletTest {
                 .isEqualTo(String.format("{%n" +
                         "  \"fun\" : {%n" +
                         "    \"healthy\" : true,%n" +
-                        "    \"message\" : \"whee\"%n" +
+                        "    \"message\" : \"whee\",%n" +
+                        "    \"duration\" : 0%n" +
                         "  }%n" +
                         "}"));
         assertThat(response.get(HttpHeader.CONTENT_TYPE))


### PR DESCRIPTION
Adding in a duration field to the healthcheck result that is populated with the time it took to execute the given healthcheck.

This will aide in troubleshooting slow healthchecks.

Fixes #1359