### PR TITLE
Include timestamp in serialized JSON output for HealthCheck.Result (#1365)

### DIFF
--- a/metrics-json/src/main/java/com/codahale/metrics/json/HealthCheckModule.java
+++ b/metrics-json/src/main/java/com/codahale/metrics/json/HealthCheckModule.java
@@ -43,6 +43,7 @@ public class HealthCheckModule extends Module {
                 }
             }
 
+            json.writeStringField("timestamp", result.getTimestamp());
             json.writeEndObject();
         }
 

--- a/metrics-json/src/test/java/com/codahale/metrics/json/HealthCheckModuleTest.java
+++ b/metrics-json/src/test/java/com/codahale/metrics/json/HealthCheckModuleTest.java
@@ -18,26 +18,33 @@ public class HealthCheckModuleTest {
 
     @Test
     public void serializesAHealthyResult() throws Exception {
-        assertThat(mapper.writeValueAsString(HealthCheck.Result.healthy()))
-            .isEqualTo("{\"healthy\":true,\"duration\":0}");
+        HealthCheck.Result result = HealthCheck.Result.healthy();
+        assertThat(mapper.writeValueAsString(result))
+            .isEqualTo("{\"healthy\":true,\"duration\":0,\"timestamp\":\"" + result.getTimestamp() + "\"}");
     }
 
     @Test
     public void serializesAHealthyResultWithAMessage() throws Exception {
-        assertThat(mapper.writeValueAsString(HealthCheck.Result.healthy("yay for %s", "me")))
+        HealthCheck.Result result = HealthCheck.Result.healthy("yay for %s", "me");
+        assertThat(mapper.writeValueAsString(result))
             .isEqualTo("{" +
                 "\"healthy\":true," +
                 "\"message\":\"yay for me\"," +
-                "\"duration\":0}");
+                "\"duration\":0," +
+                "\"timestamp\":\"" + result.getTimestamp() + "\"" +
+                "}");
     }
 
     @Test
     public void serializesAnUnhealthyResult() throws Exception {
-        assertThat(mapper.writeValueAsString(HealthCheck.Result.unhealthy("boo")))
+        HealthCheck.Result result = HealthCheck.Result.unhealthy("boo");
+        assertThat(mapper.writeValueAsString(result))
             .isEqualTo("{" +
                 "\"healthy\":false," +
                 "\"message\":\"boo\"," +
-                "\"duration\":0}");
+                "\"duration\":0," +
+                "\"timestamp\":\"" + result.getTimestamp() + "\"" +
+                "}");
     }
 
     @Test
@@ -48,7 +55,8 @@ public class HealthCheckModuleTest {
             new StackTraceElement("Blah", "bloo", "Blah.java", 100)
         });
 
-        assertThat(mapper.writeValueAsString(HealthCheck.Result.unhealthy(e)))
+        HealthCheck.Result result = HealthCheck.Result.unhealthy(e);
+        assertThat(mapper.writeValueAsString(result))
             .isEqualTo("{" +
                 "\"healthy\":false," +
                 "\"message\":\"oh no\"," +
@@ -56,7 +64,8 @@ public class HealthCheckModuleTest {
                 "\"message\":\"oh no\"," +
                 "\"stack\":[\"Blah.bloo(Blah.java:100)\"]" +
                 "}," +
-                "\"duration\":0" +
+                "\"duration\":0," +
+                "\"timestamp\":\"" + result.getTimestamp() + "\"" +
                 "}");
     }
 
@@ -75,7 +84,8 @@ public class HealthCheckModuleTest {
         });
         when(b.getCause()).thenReturn(a);
 
-        assertThat(mapper.writeValueAsString(HealthCheck.Result.unhealthy(b)))
+        HealthCheck.Result result = HealthCheck.Result.unhealthy(b);
+        assertThat(mapper.writeValueAsString(result))
             .isEqualTo("{" +
                 "\"healthy\":false," +
                 "\"message\":\"oh well\"," +
@@ -87,7 +97,8 @@ public class HealthCheckModuleTest {
                 "\"stack\":[\"Blah.bloo(Blah.java:100)\"]" +
                 "}" +
                 "}," +
-                "\"duration\":0" +
+                "\"duration\":0," +
+                "\"timestamp\":\"" + result.getTimestamp() + "\"" +
                 "}");
     }
 
@@ -123,7 +134,8 @@ public class HealthCheckModuleTest {
                 "\"String\":\"string\"," +
                 "\"complex\":{" +
                 "\"field\":\"value\"" +
-                "}" +
+                "}," +
+                "\"timestamp\":\"" + result.getTimestamp() + "\"" +
                 "}");
     }
 }

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
@@ -90,7 +90,8 @@ public class HealthCheckServletTest extends AbstractServletTest {
         assertThat(response.getStatus())
                 .isEqualTo(200);
         assertThat(response.getContent())
-                .contains("{\"fun\":{\"healthy\":true,\"message\":\"whee\",\"duration\":0}}");
+                .startsWith("{\"fun\":{\"healthy\":true,\"message\":\"whee\",\"duration\":0,\"timestamp\":\"")
+                .endsWith("\"}}");
         assertThat(response.get(HttpHeader.CONTENT_TYPE))
                 .isEqualTo("application/json");
     }
@@ -126,7 +127,8 @@ public class HealthCheckServletTest extends AbstractServletTest {
         assertThat(response.getStatus())
                 .isEqualTo(200);
         assertThat(response.getContent())
-                .contains("{\"fun\":{\"healthy\":true,\"message\":\"whee\",\"duration\":0}}");
+                .startsWith("{\"fun\":{\"healthy\":true,\"message\":\"whee\",\"duration\":0,\"timestamp\":\"")
+                .endsWith("\"}}");
         assertThat(response.get(HttpHeader.CONTENT_TYPE))
                 .isEqualTo("application/json");
     }
@@ -162,7 +164,10 @@ public class HealthCheckServletTest extends AbstractServletTest {
         assertThat(response.getStatus())
                 .isEqualTo(500);
         assertThat(response.getContent())
-                .contains("{\"fun\":{\"healthy\":true,\"message\":\"whee\",\"duration\":", "},\"notFun\":{\"healthy\":false,\"message\":\"whee\",\"duration\":0}}"); 
+                .contains(
+                        "{\"fun\":{\"healthy\":true,\"message\":\"whee\",\"duration\":0,\"timestamp\":\"",
+                        "\"},\"notFun\":{\"healthy\":false,\"message\":\"whee\",\"duration\":0,\"timestamp\":\"")
+                .endsWith("\"}}");
         assertThat(response.get(HttpHeader.CONTENT_TYPE))
                 .isEqualTo("application/json");
     }
@@ -187,13 +192,13 @@ public class HealthCheckServletTest extends AbstractServletTest {
         assertThat(response.getStatus())
                 .isEqualTo(200);
         assertThat(response.getContent())
-                .isEqualTo(String.format("{%n" +
+                .startsWith(String.format("{%n" +
                         "  \"fun\" : {%n" +
                         "    \"healthy\" : true,%n" +
                         "    \"message\" : \"whee\",%n" +
-                        "    \"duration\" : 0%n" +
-                        "  }%n" +
-                        "}"));
+                        "    \"duration\" : 0,%n" +
+                        "    \"timestamp\" : \""))
+                .endsWith(String.format("\"%n  }%n}"));
         assertThat(response.get(HttpHeader.CONTENT_TYPE))
                 .isEqualTo("application/json");
     }


### PR DESCRIPTION
- Include timestamp in JSON output from HealthCheckModule
- Update HealthCheckModuleTest
- Update HealthCheckServletTest (since actual timestamp is from a
  ZonedDateTime.now() call in HealthCheck.Result's private constructor,
  the test cannot easily match the exact timestamp. More refactoring
  would need to be done to permit using a mock Clock in order to
  do that. As a result the tests now verify the presence of the
  timestamp but not the actual value)

Closes #1365 