### PR TITLE
Bump amqp-client version to 4.9.1

### DIFF
--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <javaModuleName>com.codahale.metrics.graphite</javaModuleName>
-        <rabbitmq.version>4.4.1</rabbitmq.version>
+        <rabbitmq.version>4.9.1</rabbitmq.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Fix a security alert about using an outdated dependency.