### PR TITLE
Make amqp-client optional

### DIFF
--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -51,6 +51,7 @@
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
+            <scope>optional</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
It's not a mandatory dependency for metrics-graphite.