### PR TITLE
Add clock to result builder

### DIFF
--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
@@ -1,14 +1,22 @@
 package com.codahale.metrics.health;
 
+import com.codahale.metrics.Clock;
+import org.junit.Test;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
-
 public class HealthCheckTest {
+
+    private static final DateTimeFormatter DATE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+
     private static class ExampleHealthCheck extends HealthCheck {
         private final HealthCheck underlying;
 
@@ -113,6 +121,20 @@ public class HealthCheckTest {
     }
 
     @Test
+    public void canHaveHealthyBuilderWithFormattedMessage() {
+        final HealthCheck.Result result = HealthCheck.Result.builder()
+                .healthy()
+                .withMessage("There are %d %s in the %s", 42, "foos", "bar")
+                .build();
+
+        assertThat(result.isHealthy())
+                .isTrue();
+
+        assertThat(result.getMessage())
+                .isEqualTo("There are 42 foos in the bar");
+    }
+
+    @Test
     public void canHaveHealthyBuilderWithDetail() {
         final HealthCheck.Result result = HealthCheck.Result.builder()
                 .healthy()
@@ -208,14 +230,48 @@ public class HealthCheckTest {
     }
 
     @Test
+    public void canHaveUserSuppliedClockForTimestamp() {
+        ZonedDateTime dateTime = ZonedDateTime.now().minusMinutes(10);
+        Clock clock = clockWithFixedTime(dateTime);
+
+        HealthCheck.Result result = HealthCheck.Result.builder()
+                .healthy()
+                .usingClock(clock)
+                .build();
+
+        assertThat(result.isHealthy()).isTrue();
+
+        assertThat(result.getTimestamp())
+                .isEqualTo(DATE_TIME_FORMATTER.format(dateTime));
+    }
+
+    @Test
     public void toStringWorksEvenForNullAttributes() {
+        ZonedDateTime dateTime = ZonedDateTime.now().minusMinutes(25);
+        Clock clock = clockWithFixedTime(dateTime);
+
         final HealthCheck.Result resultWithNullDetailValue = HealthCheck.Result.builder()
                 .unhealthy()
                 .withDetail("aNullDetail", null)
+                .usingClock(clock)
                 .build();
         assertThat(resultWithNullDetailValue.toString())
                 .contains(
-                        "Result{isHealthy=false, duration=0, timestamp=", // Skip the timestamp part of the String.
+                        "Result{isHealthy=false, duration=0, timestamp=" + DATE_TIME_FORMATTER.format(dateTime),
                         ", aNullDetail=null}");
+    }
+
+    private static Clock clockWithFixedTime(ZonedDateTime dateTime) {
+        return new Clock() {
+            @Override
+            public long getTick() {
+                return 0;
+            }
+
+            @Override
+            public long getTime() {
+                return dateTime.toInstant().toEpochMilli();
+            }
+        };
     }
 }

--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -16,6 +16,7 @@
     </description>
 
     <properties>
+        <javaModuleName>com.codahale.metrics.logback</javaModuleName>
         <logback.version>1.2.3</logback.version>
     </properties>
 


### PR DESCRIPTION
Add ability to provide a custom Clock to health check ResultBuilder

- Add Clock argument to private HealthCheck.Result constructors
- Use Clock.defaultClock() as the default clock in HealthCheck.Result
- Use the Clock instance to obtain the current time for the timestamp
  in HealthCheck.Result private constructor
- Add a Clock to HealthCheck.ResultBuilder with Clock.defaultClock() as
  the default value
- Add usingClock(Clock) to HealthCheck.ResultBuilder to allow customizing
  the Clock when using the builder to create health check Results
- Add test of ResultBuilder#usingClock in HealthCheckTest
- Update toString test in HealthCheckTest making use of
  ResultBuilder#usingClock so that the timestamp can be included in the
  equality check
- Add a new test of the ResultBuilder#withMessage(String, Object...) method
  in HealthCheckTest (because IntelliJ flagged it as not used)
- Update HealthCheckServletTest to use ResultBuilder#usingClock so that
  the assertions can include the timestamp and check the entire response
  content of the health check

In both HealthCheckTest and HealthCheckServletTest I duplicated the
date/time pattern from HealthCheck.Result, which is not ideal, but is
better than exposing the Result's private Pattern. Unless the pattern
is also made configurable, this seemed like a decent trade-off.

Closes #1371