### PR TITLE
Add idle time for Callable in InstrumentedExecutorService

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/InstrumentedExecutorService.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/InstrumentedExecutorService.java
@@ -176,7 +176,7 @@ public class InstrumentedExecutorService implements ExecutorService {
         public void run() {
             idleContext.stop();
             running.inc();
-            try(Timer.Context durationContext = duration.time()) {
+            try (Timer.Context durationContext = duration.time()) {
                 task.run();
             } finally {
                 running.dec();
@@ -198,7 +198,7 @@ public class InstrumentedExecutorService implements ExecutorService {
         public T call() throws Exception {
             idleContext.stop();
             running.inc();
-            try(Timer.Context context = duration.time()) {
+            try (Timer.Context context = duration.time()) {
                 return callable.call();
             } finally {
                 running.dec();

--- a/metrics-core/src/main/java/com/codahale/metrics/InstrumentedExecutorService.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/InstrumentedExecutorService.java
@@ -176,11 +176,9 @@ public class InstrumentedExecutorService implements ExecutorService {
         public void run() {
             idleContext.stop();
             running.inc();
-            final Timer.Context durationContext = duration.time();
-            try {
+            try(Timer.Context durationContext = duration.time()) {
                 task.run();
             } finally {
-                durationContext.stop();
                 running.dec();
                 completed.mark();
             }
@@ -189,19 +187,20 @@ public class InstrumentedExecutorService implements ExecutorService {
 
     private class InstrumentedCallable<T> implements Callable<T> {
         private final Callable<T> callable;
+        private final Timer.Context idleContext;
 
         InstrumentedCallable(Callable<T> callable) {
             this.callable = callable;
+            this.idleContext = idle.time();
         }
 
         @Override
         public T call() throws Exception {
+            idleContext.stop();
             running.inc();
-            final Timer.Context context = duration.time();
-            try {
+            try(Timer.Context context = duration.time()) {
                 return callable.call();
             } finally {
-                context.stop();
                 running.dec();
                 completed.mark();
             }


### PR DESCRIPTION
Noticed that we were not tracking idle time for Callables in InstrumentedExecutorService

Changes with this PR
- Track idle time for Callables
- Use try-with-resources for duration timer
- Add test to ensure that we track idle time for Callables