### PR TITLE
Expire @Async healthchecks results after a period of time.

### DIFF
--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/AsyncHealthCheckDecorator.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/AsyncHealthCheckDecorator.java
@@ -1,5 +1,6 @@
 package com.codahale.metrics.health;
 
+import com.codahale.metrics.Clock;
 import com.codahale.metrics.health.annotation.Async;
 
 import java.util.concurrent.ScheduledExecutorService;
@@ -12,9 +13,11 @@ class AsyncHealthCheckDecorator extends HealthCheck implements Runnable {
     private static final String NO_RESULT_YET_MESSAGE = "Waiting for first asynchronous check result.";
     private final HealthCheck healthCheck;
     private final ScheduledFuture<?> future;
+    private final long healthyTtl;
+    private final Clock clock;
     private volatile Result result;
 
-    AsyncHealthCheckDecorator(HealthCheck healthCheck, ScheduledExecutorService executorService) {
+    AsyncHealthCheckDecorator(HealthCheck healthCheck, ScheduledExecutorService executorService, Clock clock) {
         check(healthCheck != null, "healthCheck cannot be null");
         check(executorService != null, "executorService cannot be null");
         Async async = healthCheck.getClass().getAnnotation(Async.class);
@@ -22,7 +25,10 @@ class AsyncHealthCheckDecorator extends HealthCheck implements Runnable {
         check(async.period() > 0, "period cannot be less than or equal to zero");
         check(async.initialDelay() >= 0, "initialDelay cannot be less than zero");
 
+
+        this.clock = clock;
         this.healthCheck = healthCheck;
+        this.healthyTtl = async.unit().toMillis(async.healthyTtl() <= 0 ? 2 * async.period() : async.healthyTtl());
         result = Async.InitialState.HEALTHY.equals(async.initialState()) ? Result.healthy(NO_RESULT_YET_MESSAGE) :
                 Result.unhealthy(NO_RESULT_YET_MESSAGE);
         if (Async.ScheduleType.FIXED_RATE.equals(async.scheduleType())) {
@@ -33,6 +39,10 @@ class AsyncHealthCheckDecorator extends HealthCheck implements Runnable {
 
     }
 
+    AsyncHealthCheckDecorator(HealthCheck healthCheck, ScheduledExecutorService executorService) {
+        this(healthCheck, executorService, Clock.defaultClock());
+    }
+
     @Override
     public void run() {
         result = healthCheck.execute();
@@ -40,6 +50,17 @@ class AsyncHealthCheckDecorator extends HealthCheck implements Runnable {
 
     @Override
     protected Result check() throws Exception {
+        long expiration = clock.getTime() - result.getTime() - healthyTtl;
+        if (expiration > 0) {
+            return Result.builder()
+                    .unhealthy()
+                    .usingClock(clock)
+                    .withMessage("Result was %s but it expired %d milliseconds ago",
+                            result.isHealthy() ? "healthy" : "unhealthy",
+                            expiration)
+                    .build();
+        }
+
         return result;
     }
 
@@ -56,5 +77,4 @@ class AsyncHealthCheckDecorator extends HealthCheck implements Runnable {
             throw new IllegalArgumentException(message);
         }
     }
-
 }

--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/annotation/Async.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/annotation/Async.java
@@ -48,7 +48,7 @@ public @interface Async {
     long initialDelay() default 0;
 
     /**
-     * Time unit of initial delay and period.
+     * Time unit of initial delay, period and healthyTtl.
      *
      * @return time unit
      */
@@ -60,5 +60,16 @@ public @interface Async {
      * @return initial health state
      */
     InitialState initialState() default InitialState.HEALTHY;
+
+    /**
+     * How long a healthy result is considered valid before being ignored.
+     *
+     * Handles cases where the asynchronous healthcheck did not run (for example thread starvation).
+     *
+     * Defaults to 2 * period
+     *
+     * @return healthy result time to live
+     */
+    long healthyTtl() default -1;
 
 }

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/AsyncHealthCheckDecoratorTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/AsyncHealthCheckDecoratorTest.java
@@ -1,5 +1,14 @@
 package com.codahale.metrics.health;
 
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.health.annotation.Async;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.any;
@@ -9,19 +18,22 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-
-import com.codahale.metrics.health.annotation.Async;
-
 /**
  * Unit tests for {@link AsyncHealthCheckDecorator}.
  */
 public class AsyncHealthCheckDecoratorTest {
+
+    private static final long CURRENT_TIME = 1551002401000L;
+    
+    private static final Clock FIXED_CLOCK = clockWithFixedTime(CURRENT_TIME);
+
+    private static final HealthCheck.Result EXPECTED_EXPIRED_RESULT = HealthCheck.Result
+            .builder()
+            .usingClock(FIXED_CLOCK)
+            .unhealthy()
+            .withMessage("Result was healthy but it expired 1 milliseconds ago")
+            .build();
+    
     private final HealthCheck mockHealthCheck = mock(HealthCheck.class);
     private final ScheduledExecutorService mockExecutorService = mock(ScheduledExecutorService.class);
 
@@ -145,6 +157,54 @@ public class AsyncHealthCheckDecoratorTest {
         assertThat(result.getError()).isEqualTo(exception);
     }
 
+    @Test
+    public void returnUnhealthyIfPreviousResultIsExpiredBasedOnTtl() throws Exception {
+        HealthCheck healthCheck = new HealthyAsyncHealthCheckWithExpiredExplicitTtlInMilliseconds();
+        AsyncHealthCheckDecorator asyncDecorator = new AsyncHealthCheckDecorator(healthCheck, mockExecutorService, FIXED_CLOCK);
+        
+        ArgumentCaptor<Runnable> runnableCaptor = forClass(Runnable.class);
+        verify(mockExecutorService, times(1)).scheduleAtFixedRate(runnableCaptor.capture(),
+                eq(0L), eq(1000L), eq(TimeUnit.MILLISECONDS));
+        Runnable capturedRunnable = runnableCaptor.getValue();
+        capturedRunnable.run();
+
+        HealthCheck.Result result = asyncDecorator.check();
+
+        assertThat(result).isEqualTo(EXPECTED_EXPIRED_RESULT);
+    }
+
+    @Test
+    public void returnUnhealthyIfPreviousResultIsExpiredBasedOnPeriod() throws Exception {
+        HealthCheck healthCheck = new HealthyAsyncHealthCheckWithExpiredTtlInMillisecondsBasedOnPeriod();
+        AsyncHealthCheckDecorator asyncDecorator = new AsyncHealthCheckDecorator(healthCheck, mockExecutorService, FIXED_CLOCK);
+
+        ArgumentCaptor<Runnable> runnableCaptor = forClass(Runnable.class);
+        verify(mockExecutorService, times(1)).scheduleAtFixedRate(runnableCaptor.capture(),
+                eq(0L), eq(1000L), eq(TimeUnit.MILLISECONDS));
+        Runnable capturedRunnable = runnableCaptor.getValue();
+        capturedRunnable.run();
+
+        HealthCheck.Result result = asyncDecorator.check();
+
+        assertThat(result).isEqualTo(EXPECTED_EXPIRED_RESULT);
+    }
+
+    @Test
+    public void convertTtlToMillisecondsWhenCheckingExpiration() throws Exception {
+        HealthCheck healthCheck = new HealthyAsyncHealthCheckWithExpiredExplicitTtlInSeconds();
+        AsyncHealthCheckDecorator asyncDecorator = new AsyncHealthCheckDecorator(healthCheck, mockExecutorService, FIXED_CLOCK);
+
+        ArgumentCaptor<Runnable> runnableCaptor = forClass(Runnable.class);
+        verify(mockExecutorService, times(1)).scheduleAtFixedRate(runnableCaptor.capture(),
+                eq(0L), eq(1L), eq(TimeUnit.SECONDS));
+        Runnable capturedRunnable = runnableCaptor.getValue();
+        capturedRunnable.run();
+
+        HealthCheck.Result result = asyncDecorator.check();
+
+        assertThat(result).isEqualTo(EXPECTED_EXPIRED_RESULT);
+    }
+
     @Async(period = -1)
     private static class NegativePeriodAsyncHealthCheck extends HealthCheck {
 
@@ -224,6 +284,47 @@ public class AsyncHealthCheckDecoratorTest {
             }
             return result;
         }
+    }
+
+    @Async(period = 1000, initialState = Async.InitialState.UNHEALTHY, healthyTtl = 3000, unit = TimeUnit.MILLISECONDS)
+    private static class HealthyAsyncHealthCheckWithExpiredExplicitTtlInMilliseconds extends HealthCheck {
+
+        @Override
+        protected Result check() {
+            return Result.builder().usingClock(clockWithFixedTime(CURRENT_TIME - 3001L)).healthy().build();
+        }
+    }
+
+    @Async(period = 1, initialState = Async.InitialState.UNHEALTHY, healthyTtl = 5, unit = TimeUnit.SECONDS)
+    private static class HealthyAsyncHealthCheckWithExpiredExplicitTtlInSeconds extends HealthCheck {
+
+        @Override
+        protected Result check() {
+            return Result.builder().usingClock(clockWithFixedTime(CURRENT_TIME - 5001L)).healthy().build();
+        }
+    }
+
+    @Async(period = 1000, initialState = Async.InitialState.UNHEALTHY, unit = TimeUnit.MILLISECONDS)
+    private static class HealthyAsyncHealthCheckWithExpiredTtlInMillisecondsBasedOnPeriod extends HealthCheck {
+
+        @Override
+        protected Result check() {
+            return Result.builder().usingClock(clockWithFixedTime(CURRENT_TIME - 2001L)).healthy().build();
+        }
+    }
+
+    private static Clock clockWithFixedTime(final long time) {
+        return new Clock() {
+            @Override
+            public long getTick() {
+                return 0;
+            }
+
+            @Override
+            public long getTime() {
+                return time;
+            }
+        };
     }
 
 }

--- a/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
+++ b/metrics-healthchecks/src/test/java/com/codahale/metrics/health/HealthCheckTest.java
@@ -241,6 +241,8 @@ public class HealthCheckTest {
 
         assertThat(result.isHealthy()).isTrue();
 
+        assertThat(result.getTime()).isEqualTo(clock.getTime());
+
         assertThat(result.getTimestamp())
                 .isEqualTo(DATE_TIME_FORMATTER.format(dateTime));
     }


### PR DESCRIPTION
Fixes #1335. Typical use case is thread starvation preventing the next async healthcheck to run.