### PR TITLE
Make getHealthCheck public

### DIFF
--- a/metrics-healthchecks/src/main/java/com/codahale/metrics/health/AsyncHealthCheckDecorator.java
+++ b/metrics-healthchecks/src/main/java/com/codahale/metrics/health/AsyncHealthCheckDecorator.java
@@ -8,7 +8,7 @@ import java.util.concurrent.ScheduledFuture;
 /**
  * A health check decorator to manage asynchronous executions.
  */
-class AsyncHealthCheckDecorator extends HealthCheck implements Runnable {
+public class AsyncHealthCheckDecorator extends HealthCheck implements Runnable {
     private static final String NO_RESULT_YET_MESSAGE = "Waiting for first asynchronous check result.";
     private final HealthCheck healthCheck;
     private final ScheduledFuture<?> future;
@@ -47,7 +47,7 @@ class AsyncHealthCheckDecorator extends HealthCheck implements Runnable {
         return future.cancel(true);
     }
 
-    HealthCheck getHealthCheck() {
+    public HealthCheck getHealthCheck() {
         return healthCheck;
     }
 


### PR DESCRIPTION
This is useful for anyone who might have additional annotations on their underlying healthcheck that they want to be able to combine with @Async but still test for in a `HealthCheckRegistryListener`