### PR TITLE
Expose numeric values (JmxGaugeMBean)

### DIFF
--- a/metrics-jmx/src/main/java/com/codahale/metrics/jmx/JmxReporter.java
+++ b/metrics-jmx/src/main/java/com/codahale/metrics/jmx/JmxReporter.java
@@ -184,6 +184,7 @@ public class JmxReporter implements Reporter, Closeable {
     @SuppressWarnings("UnusedDeclaration")
     public interface JmxGaugeMBean extends MetricMBean {
         Object getValue();
+        Number getNumber();
     }
 
     private static class JmxGauge extends AbstractBean implements JmxGaugeMBean {
@@ -197,6 +198,12 @@ public class JmxReporter implements Reporter, Closeable {
         @Override
         public Object getValue() {
             return metric.getValue();
+        }
+
+        @Override
+        public Number getNumber() {
+            Object value = metric.getValue();
+            return value instanceof Number ? (Number) value : 0;
         }
     }
 

--- a/metrics-jmx/src/test/java/com/codahale/metrics/jmx/JmxReporterTest.java
+++ b/metrics-jmx/src/test/java/com/codahale/metrics/jmx/JmxReporterTest.java
@@ -148,10 +148,10 @@ public class JmxReporterTest {
 
     @Test
     public void registersMBeansForGauges() throws Exception {
-        final AttributeList attributes = getAttributes("gauges", "gauge", "Value");
+        final AttributeList attributes = getAttributes("gauges", "gauge", "Value", "Number");
 
         assertThat(values(attributes))
-                .contains(entry("Value", 1));
+                .contains(entry("Value", 1), entry("Number", 1));
     }
 
     @Test
@@ -258,7 +258,7 @@ public class JmxReporterTest {
         reporter.stop();
 
         try {
-            getAttributes("gauges", "gauge", "Value");
+            getAttributes("gauges", "gauge", "Value", "Number");
             failBecauseExceptionWasNotThrown(InstanceNotFoundException.class);
         } catch (InstanceNotFoundException e) {
 


### PR DESCRIPTION
The purpose of this PR is to allow for easy visualization of gauges in Java Mission Control.

Class `JmxGaugeMBean` was updated so that it will now expose numeric values as `Number`. If the gauge does not represent a number, then the exposed value will be `0`. The actual value can be accessed through `Value` in any case.

- Fixes #1408 
