### PR TITLE
Fixes issue-1455 MetricRegistryListener should be invoked before adding meter to the registry

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistryListener.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistryListener.java
@@ -3,126 +3,105 @@ package com.codahale.metrics;
 import java.util.EventListener;
 
 /**
- * Listeners for events from the registry.  Listeners must be thread-safe.
+ * Listener for events from the registry.
+ * Each on*Added method returns a meter corresponding to the one passed in, making it possible to wrap/proxy a meter
+ * before it's added to the registry. A common use case for this is interoperability with another metrics library.
+ *
+ * Listeners must be thread-safe.
  */
 public interface MetricRegistryListener extends EventListener {
     /**
-     * A no-op implementation of {@link MetricRegistryListener}.
-     */
-    abstract class Base implements MetricRegistryListener {
-        @Override
-        public void onGaugeAdded(String name, Gauge<?> gauge) {
-        }
-
-        @Override
-        public void onGaugeRemoved(String name) {
-        }
-
-        @Override
-        public void onCounterAdded(String name, Counter counter) {
-        }
-
-        @Override
-        public void onCounterRemoved(String name) {
-        }
-
-        @Override
-        public void onHistogramAdded(String name, Histogram histogram) {
-        }
-
-        @Override
-        public void onHistogramRemoved(String name) {
-        }
-
-        @Override
-        public void onMeterAdded(String name, Meter meter) {
-        }
-
-        @Override
-        public void onMeterRemoved(String name) {
-        }
-
-        @Override
-        public void onTimerAdded(String name, Timer timer) {
-        }
-
-        @Override
-        public void onTimerRemoved(String name) {
-        }
-    }
-
-    /**
      * Called when a {@link Gauge} is added to the registry.
      *
-     * @param name  the gauge's name
+     * @param name the gauge's name
      * @param gauge the gauge
+     * @return Original or another gauge
      */
-    void onGaugeAdded(String name, Gauge<?> gauge);
+    default Gauge<?> onGaugeAdded(String name, Gauge<?> gauge) {
+        return gauge;
+    }
 
     /**
      * Called when a {@link Gauge} is removed from the registry.
      *
      * @param name the gauge's name
      */
-    void onGaugeRemoved(String name);
+    default void onGaugeRemoved(String name) {
+    }
 
     /**
      * Called when a {@link Counter} is added to the registry.
      *
      * @param name    the counter's name
      * @param counter the counter
+     * @return Original or another counter
      */
-    void onCounterAdded(String name, Counter counter);
+    default Counter onCounterAdded(String name, Counter counter) {
+        return counter;
+    }
 
     /**
      * Called when a {@link Counter} is removed from the registry.
      *
      * @param name the counter's name
      */
-    void onCounterRemoved(String name);
+    default void onCounterRemoved(String name) {
+    }
 
     /**
      * Called when a {@link Histogram} is added to the registry.
      *
      * @param name      the histogram's name
      * @param histogram the histogram
+     * @return Original or another histogram
      */
-    void onHistogramAdded(String name, Histogram histogram);
+    default Histogram onHistogramAdded(String name, Histogram histogram) {
+        return histogram;
+    }
 
     /**
      * Called when a {@link Histogram} is removed from the registry.
      *
      * @param name the histogram's name
      */
-    void onHistogramRemoved(String name);
+    default void onHistogramRemoved(String name) {
+    }
 
     /**
      * Called when a {@link Meter} is added to the registry.
      *
      * @param name  the meter's name
      * @param meter the meter
+     * @return Original or another meter
      */
-    void onMeterAdded(String name, Meter meter);
+    default Meter onMeterAdded(String name, Meter meter) {
+        return meter;
+    }
 
     /**
      * Called when a {@link Meter} is removed from the registry.
      *
      * @param name the meter's name
      */
-    void onMeterRemoved(String name);
+    default void onMeterRemoved(String name) {
+    }
 
     /**
      * Called when a {@link Timer} is added to the registry.
      *
      * @param name  the timer's name
      * @param timer the timer
+     * @return Original or another timer
      */
-    void onTimerAdded(String name, Timer timer);
+    default Timer onTimerAdded(String name, Timer timer) {
+        return timer;
+    }
 
     /**
      * Called when a {@link Timer} is removed from the registry.
      *
      * @param name the timer's name
      */
-    void onTimerRemoved(String name);
+    default void onTimerRemoved(String name) {
+    }
 }

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryListenerTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryListenerTest.java
@@ -2,51 +2,46 @@ package com.codahale.metrics;
 
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
 
 public class MetricRegistryListenerTest {
-    private final Counter counter = mock(Counter.class);
-    private final Histogram histogram = mock(Histogram.class);
-    private final Meter meter = mock(Meter.class);
-    private final Timer timer = mock(Timer.class);
-    private final MetricRegistryListener listener = new MetricRegistryListener.Base() {
-
+    private final MetricRegistryListener listener = new MetricRegistryListener() {
     };
 
     @Test
-    public void noOpsOnGaugeAdded() {
-        listener.onGaugeAdded("blah", () -> {
-            throw new RuntimeException("Should not be called");
-        });
+    public void returnsSameGauge() {
+        Gauge<?> gauge = mock(Gauge.class);
+        assertThat(listener.onGaugeAdded("blah", gauge))
+                .isEqualTo(gauge);
     }
 
     @Test
-    public void noOpsOnCounterAdded() {
-        listener.onCounterAdded("blah", counter);
-
-        verifyZeroInteractions(counter);
+    public void returnsSameCounter() {
+        Counter counter = mock(Counter.class);
+        assertThat(listener.onCounterAdded("blah", counter))
+                .isEqualTo(counter);
     }
 
     @Test
-    public void noOpsOnHistogramAdded() {
-        listener.onHistogramAdded("blah", histogram);
-
-        verifyZeroInteractions(histogram);
+    public void returnsSameHistogram() {
+        Histogram histogram = mock(Histogram.class);
+        assertThat(listener.onHistogramAdded("blah", histogram))
+                .isEqualTo(histogram);
     }
 
     @Test
     public void noOpsOnMeterAdded() {
-        listener.onMeterAdded("blah", meter);
-
-        verifyZeroInteractions(meter);
+        Meter meter = mock(Meter.class);
+        assertThat(listener.onMeterAdded("blah", meter))
+                .isEqualTo(meter);
     }
 
     @Test
     public void noOpsOnTimerAdded() {
-        listener.onTimerAdded("blah", timer);
-
-        verifyZeroInteractions(timer);
+        Timer timer = mock(Timer.class);
+        assertThat(listener.onTimerAdded("blah", timer))
+                .isEqualTo(timer);
     }
 
     @Test

--- a/metrics-jmx/src/main/java/com/codahale/metrics/jmx/JmxReporter.java
+++ b/metrics-jmx/src/main/java/com/codahale/metrics/jmx/JmxReporter.java
@@ -511,7 +511,7 @@ public class JmxReporter implements Reporter, Closeable {
             this.objectNameFactory = objectNameFactory;
         }
 
-        private void registerMBean(Object mBean, ObjectName objectName) throws InstanceAlreadyExistsException, JMException {
+        private void registerMBean(Object mBean, ObjectName objectName) throws JMException {
             ObjectInstance objectInstance = mBeanServer.registerMBean(mBean, objectName);
             if (objectInstance != null) {
                 // the websphere mbeanserver rewrites the objectname to include
@@ -533,7 +533,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onGaugeAdded(String name, Gauge<?> gauge) {
+        public Gauge<?> onGaugeAdded(String name, Gauge<?> gauge) {
             try {
                 if (filter.matches(name, gauge)) {
                     final ObjectName objectName = createName("gauges", name);
@@ -544,6 +544,7 @@ public class JmxReporter implements Reporter, Closeable {
             } catch (JMException e) {
                 LOGGER.warn("Unable to register gauge", e);
             }
+            return null;
         }
 
         @Override
@@ -559,7 +560,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onCounterAdded(String name, Counter counter) {
+        public Counter onCounterAdded(String name, Counter counter) {
             try {
                 if (filter.matches(name, counter)) {
                     final ObjectName objectName = createName("counters", name);
@@ -570,6 +571,7 @@ public class JmxReporter implements Reporter, Closeable {
             } catch (JMException e) {
                 LOGGER.warn("Unable to register counter", e);
             }
+            return null;
         }
 
         @Override
@@ -585,7 +587,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onHistogramAdded(String name, Histogram histogram) {
+        public Histogram onHistogramAdded(String name, Histogram histogram) {
             try {
                 if (filter.matches(name, histogram)) {
                     final ObjectName objectName = createName("histograms", name);
@@ -596,6 +598,7 @@ public class JmxReporter implements Reporter, Closeable {
             } catch (JMException e) {
                 LOGGER.warn("Unable to register histogram", e);
             }
+            return null;
         }
 
         @Override
@@ -611,7 +614,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onMeterAdded(String name, Meter meter) {
+        public Meter onMeterAdded(String name, Meter meter) {
             try {
                 if (filter.matches(name, meter)) {
                     final ObjectName objectName = createName("meters", name);
@@ -622,6 +625,7 @@ public class JmxReporter implements Reporter, Closeable {
             } catch (JMException e) {
                 LOGGER.warn("Unable to register meter", e);
             }
+            return null;
         }
 
         @Override
@@ -637,7 +641,7 @@ public class JmxReporter implements Reporter, Closeable {
         }
 
         @Override
-        public void onTimerAdded(String name, Timer timer) {
+        public Timer onTimerAdded(String name, Timer timer) {
             try {
                 if (filter.matches(name, timer)) {
                     final ObjectName objectName = createName("timers", name);
@@ -648,6 +652,7 @@ public class JmxReporter implements Reporter, Closeable {
             } catch (JMException e) {
                 LOGGER.warn("Unable to register timer", e);
             }
+            return null;
         }
 
         @Override


### PR DESCRIPTION
Each `on*Added` method returns a meter corresponding to the one passed in, making it possible to wrap/proxy a meter before it's added to the registry. A common use case for this is interoperability with another metrics library.

Also got rid of `MetricRegistryListener.Base` since we can use `default` methods in Java 8+, and don't need an `abstract` adapter class.

Added unit tests.