### PR TITLE
Update pom.xml

### DIFF
--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <javaModuleName>com.codahale.metrics.servlets</javaModuleName>
         <jetty9.version>9.4.18.v20190429</jetty9.version>
-        <papertrail.profiler.version>1.0.2</papertrail.profiler.version>
+        <papertrail.profiler.version>1.1.1</papertrail.profiler.version>
         <servlet.version>3.1.0</servlet.version>
         <jackson.version>2.9.8</jackson.version>
     </properties>
@@ -54,7 +54,7 @@
             <artifactId>metrics-jvm</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.papertrail</groupId>
+            <groupId>com.helger</groupId>
             <artifactId>profiler</artifactId>
             <version>${papertrail.profiler.version}</version>
         </dependency>

--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/CpuProfileServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/CpuProfileServlet.java
@@ -2,6 +2,7 @@ package com.codahale.metrics.servlets;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.time.Duration;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.servlet.ServletException;
@@ -9,7 +10,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.joda.time.Duration;
 import com.papertrail.profiler.CpuProfile;
 
 /**
@@ -62,7 +62,7 @@ public class CpuProfileServlet extends HttpServlet {
     protected void doProfile(OutputStream out, int duration, int frequency, Thread.State state) throws IOException {
         if (lock.tryLock()) {
             try {
-                CpuProfile profile = CpuProfile.record(Duration.standardSeconds(duration),
+                CpuProfile profile = CpuProfile.record(Duration.ofSeconds(duration),
                         frequency, state);
                 if (profile == null) {
                     throw new RuntimeException("could not create CpuProfile");


### PR DESCRIPTION
Switched to new profiler version that has no dependency on joda-time - see https://github.com/phax/profiler and http://repo2.maven.org/maven2/com/helger/profiler/1.1.1/ for details and binaries.
Since this project already requires Java 8, getting rid of joda here makes sense to me.

The internal package names and the API are unchanged and it can be considered a drop-in replacement (except for those, who transitively expect joda-time and won't have it anymore).