### PR TITLE
support for Atomic* counters in Graphite Reporter

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -16,8 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
@@ -384,10 +382,8 @@ public class GraphiteReporter extends ScheduledReporter {
             return format(((Integer) o).longValue());
         } else if (o instanceof Long) {
             return format(((Long) o).longValue());
-        } else if (o instanceof BigInteger) {
-            return format(((BigInteger) o).doubleValue());
-        } else if (o instanceof BigDecimal) {
-            return format(((BigDecimal) o).doubleValue());
+        } else if (o instanceof Number) {
+            return format(((Number) o).doubleValue());
         } else if (o instanceof Boolean) {
             return format(((Boolean) o) ? 1 : 0);
         }


### PR DESCRIPTION
support for `AtomicLong`, `AtomicInteger` and any other class that support `Number` interface