### PR TITLE
Fix Javadoc link and update/add links to the third-party library

### DIFF
--- a/docs/source/_themes/metrics/theme.conf
+++ b/docs/source/_themes/metrics/theme.conf
@@ -14,4 +14,4 @@ landing_logo = logo.png
 landing_logo_width = 150px
 github_page = https://github.com/yay
 mailing_list = http://groups.google.com/yay
-apidocs = https://dropwizard.github.io/metrics/
+apidocs = https://www.javadoc.io/doc/io.dropwizard.metrics/metrics-core/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,7 +107,7 @@ html_theme_options = {
     'landing_logo_width': u'200px',
     'github_page': u'https://github.com/dropwizard/metrics',
     'mailing_list': u'https://groups.google.com/forum/#!forum/metrics-user',
-    'apidocs': u'https://dropwizard.github.io/metrics/' + release + '/apidocs/'
+    'apidocs': u'https://www.javadoc.io/doc/io.dropwizard.metrics/metrics-core/' + release + '/'
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/docs/source/manual/jersey.rst
+++ b/docs/source/manual/jersey.rst
@@ -11,7 +11,7 @@ which allows you to instrument methods on your `Jersey 2.x`_ resource classes:
 The ``metrics-jersey2`` module provides ``InstrumentedResourceMethodApplicationListener``, which allows
 you to instrument methods on your `Jersey 2.x`_ resource classes:
 
-.. _Jersey 2.x: https://jersey.java.net/documentation/latest/index.html
+.. _Jersey 2.x: https://eclipse-ee4j.github.io/jersey.github.io/documentation/latest/index.html
 
 An instance of ``InstrumentedResourceMethodApplicationListener`` must be registered with your Jersey
 application's ``ResourceConfig`` as a singleton provider for this to work.

--- a/docs/source/manual/log4j.rst
+++ b/docs/source/manual/log4j.rst
@@ -4,9 +4,10 @@
 Instrumenting Log4j
 ###################
 
-The ``metrics-log4j2`` module provide ``InstrumentedAppender``, a Log4j ``Appender`` implementation
+The ``metrics-log4j2`` module provide ``InstrumentedAppender``, a Log4j_ ``Appender`` implementation
 which records the rate of logged events by their logging level. You can add it to the root logger programmatically.
 
+.. _Log4j: https://logging.apache.org/log4j/
 .. code-block:: java
 
     Filter filter = null;        // That's fine if we don't use filters; https://logging.apache.org/log4j/2.x/manual/filters.html

--- a/docs/source/manual/logback.rst
+++ b/docs/source/manual/logback.rst
@@ -4,8 +4,10 @@
 Instrumenting Logback
 #####################
 
-The ``metrics-logback`` module provides ``InstrumentedAppender``, a Logback ``Appender``
+The ``metrics-logback`` module provides ``InstrumentedAppender``, a Logback_ ``Appender``
 implementation which records the rate of logged events by their logging level.
+
+.. _Logback: https://logback.qos.ch/
 
 You add it to the root logger programmatically:
 

--- a/docs/source/manual/third-party.rst
+++ b/docs/source/manual/third-party.rst
@@ -12,11 +12,11 @@ Instrumented Libraries
 
 * `camel-metrics <https://github.com/InitiumIo/camel-metrics>`_ provides component for your `Apache Camel <https://camel.apache.org/>`_ route.
 * `hdrhistogram-metrics-reservoir <https://bitbucket.org/marshallpierce/hdrhistogram-metrics-reservoir>`_ provides a Histogram reservoir backed by `HdrHistogram <http://hdrhistogram.org/>`_.
-* `jersey2-metrics <https://bitbucket.org/marshallpierce/jersey2-metrics>`_ provides integration with `Jersey 2 <https://jersey.java.net/>`_.
+* `jersey2-metrics <https://bitbucket.org/marshallpierce/jersey2-metrics>`_ provides integration with `Jersey 2 <https://eclipse-ee4j.github.io/jersey/>`_.
 * `jersey-metrics-filter <https://github.com/palominolabs/jersey-metrics-filter>`_ provides integration with Jersey 1.
 * `metrics-aspectj <https://github.com/astefanutti/metrics-aspectj>`_ provides integration with `AspectJ <http://eclipse.org/aspectj/>`_.
 * `metrics-cdi <https://github.com/astefanutti/metrics-cdi>`_ provides integration with `CDI <http://www.cdi-spec.org/>`_ environments,
-* `metrics-guice <https://github.com/palominolabs/metrics-guice>`_ provides integration with `Guice <https://code.google.com/p/google-guice/>`_.
+* `metrics-guice <https://github.com/palominolabs/metrics-guice>`_ provides integration with `Guice <https://github.com/google/guice>`_.
 * `metrics-guice-servlet <https://github.com/palominolabs/metrics-guice-servlet>`_ provides `Guice Servlet <https://github.com/google/guice/wiki/Servlets>`_ integration with AdminServlet.
 * `metrics-okhttp <https://github.com/raskasa/metrics-okhttp>`_ provides integration with `OkHttp <http://square.github.io/okhttp>`_.
 * `metrics-feign <https://github.com/mwiede/metrics-feign>`_ provides integration with `Feign <https://github.com/OpenFeign/feign>`_.
@@ -39,11 +39,11 @@ Reporters
 * `metrics-cassandra <https://github.com/brndnmtthws/metrics-cassandra>`_ provides a reporter for `Apache Cassandra <https://cassandra.apache.org/>`_.
 * `metrics-circonus <https://github.com/circonus-labs/metrics-circonus>`_ provides a registry and reporter for sending metrics (including full histograms) to `Circonus <https://www.circonus.com/>`_.
 * `metrics-datadog <https://github.com/coursera/metrics-datadog>`_ provides a reporter to send data to `Datadog <http://www.datadoghq.com/>`_.
-* `metrics-elasticsearch-reporter <https://github.com/elasticsearch/elasticsearch-metrics-reporter-java>`_ provides a reporter for `elasticsearch <http://www.elasticsearch.org/>`_
+* `metrics-elasticsearch-reporter <https://github.com/elasticsearch/elasticsearch-metrics-reporter-java>`_ provides a reporter for `elasticsearch <https://www.elastic.co/>`_
 * `metrics-hadoop-metrics2-reporter <https://github.com/joshelser/dropwizard-hadoop-metrics2>`_ provides a reporter for `Hadoop Metrics2 <https://hadoop.apache.org/docs/r2.7.2/api/org/apache/hadoop/metrics2/package-summary.html>`_.
 * `metrics-hawkular <https://github.com/hawkular/hawkular-dropwizard-reporter>`_ provides a reporter for `Hawkular Metrics <http://www.hawkular.org/>`_.
-* `metrics-influxdb <https://github.com/iZettle/dropwizard-metrics-influxdb>`_ provides a reporter for `InfluxDB <http://influxdb.org/>`_ with the Dropwizard framework integration.
-* `metrics-influxdb <https://github.com/kickstarter/dropwizard-influxdb-reporter>`_ provides a reporter for `InfluxDB <http://influxdb.org/>`_ 1.2+._
+* `metrics-influxdb <https://github.com/iZettle/dropwizard-metrics-influxdb>`_ provides a reporter for `InfluxDB <https://www.influxdata.com/>`_ with the Dropwizard framework integration.
+* `metrics-influxdb <https://github.com/kickstarter/dropwizard-influxdb-reporter>`_ provides a reporter for `InfluxDB <https://www.influxdata.com/>`_ 1.2+._
 * `metrics-instrumental <https://github.com/egineering-llc/metrics-instrumental>`_ provides a reporter to send data to `Instrumental <http://instrumentalapp.com/>`_.
 * `metrics-kafka <https://github.com/hengyunabc/metrics-kafka>`_ provides a reporter for `Kafka <http://kafka.apache.org/>`_.
 * `metrics-librato <https://github.com/librato/metrics-librato>`_ provides a reporter for `Librato Metrics <https://metrics.librato.com/>`_, a scalable metric collection, aggregation, monitoring, and alerting service.
@@ -57,7 +57,7 @@ Reporters
 * `metrics-splunk <https://github.com/zenmoto/metrics-splunk>`_ provides a reporter for `Splunk <http://www.splunk.com/>`_.
 * `metrics-statsd <https://github.com/ReadyTalk/metrics-statsd>`_ provides a Metrics 2.x and 3.x reporter for `StatsD <https://github.com/etsy/statsd/>`_
 * `metrics-zabbiz <https://github.com/hengyunabc/metrics-zabbix>`_ provides a reporter for `Zabbix <http://www.zabbix.com/>`_.
-* `sematext-metrics-reporter <https://github.com/sematext/sematext-metrics-reporter>`_ provides a reporter for `SPM <http://sematext.com/spm/index.html>`_.
+* `sematext-metrics-reporter <https://github.com/sematext/sematext-metrics-reporter>`_ provides a reporter for `SPM <https://sematext.com/spm/>`_.
 
 Advanced metrics implementations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fix Javadoc link dropwizard/metrics#1485 and update/add links to the third-party library