### PR TITLE
Jetty Update to 9.4.21

### DIFF
--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <javaModuleName>com.codahale.metrics.jetty9</javaModuleName>
-        <jetty9.version>9.4.20.v20190813</jetty9.version>
+        <jetty9.version>9.4.21.v20190926</jetty9.version>
     </properties>
 
     <dependencyManagement>

--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHttpChannelListener.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHttpChannelListener.java
@@ -1,5 +1,14 @@
 package com.codahale.metrics.jetty9;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.AsyncEvent;
+import javax.servlet.AsyncListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
@@ -7,75 +16,68 @@ import com.codahale.metrics.RatioGauge;
 import com.codahale.metrics.Timer;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.server.AsyncContextState;
-import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpChannel.Listener;
 import org.eclipse.jetty.server.HttpChannelState;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.handler.HandlerWrapper;
-
-import javax.servlet.AsyncEvent;
-import javax.servlet.AsyncListener;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 import static com.codahale.metrics.MetricRegistry.name;
 
 /**
- * A Jetty {@link Handler} which records various metrics about an underlying {@link Handler}
- * instance.
+ * A Jetty {@link org.eclipse.jetty.server.HttpChannel.Listener} implementation which records various metrics about
+ * underlying channel instance. Unlike {@link InstrumentedHandler} that uses internal API, this class should be
+ * future proof. To install it, just add instance of this class to {@link org.eclipse.jetty.server.Connector} as bean.
+ *
+ * @since TBD
  */
-public class InstrumentedHandler extends HandlerWrapper {
+public class InstrumentedHttpChannelListener
+    implements Listener
+{
+    private static final String START_ATTR = InstrumentedHttpChannelListener.class.getName() + ".start";
+
     private final MetricRegistry metricRegistry;
 
-    private String name;
-    private final String prefix;
-
     // the requests handled by this handler, excluding active
-    private Timer requests;
+    private final Timer requests;
 
     // the number of dispatches seen by this handler, excluding active
-    private Timer dispatches;
+    private final Timer dispatches;
 
     // the number of active requests
-    private Counter activeRequests;
+    private final Counter activeRequests;
 
     // the number of active dispatches
-    private Counter activeDispatches;
+    private final Counter activeDispatches;
 
     // the number of requests currently suspended.
-    private Counter activeSuspended;
+    private final Counter activeSuspended;
 
     // the number of requests that have been asynchronously dispatched
-    private Meter asyncDispatches;
+    private final Meter asyncDispatches;
 
     // the number of requests that expired while suspended
-    private Meter asyncTimeouts;
+    private final Meter asyncTimeouts;
 
-    private Meter[] responses;
+    private final Meter[] responses;
 
-    private Timer getRequests;
-    private Timer postRequests;
-    private Timer headRequests;
-    private Timer putRequests;
-    private Timer deleteRequests;
-    private Timer optionsRequests;
-    private Timer traceRequests;
-    private Timer connectRequests;
-    private Timer moveRequests;
-    private Timer otherRequests;
+    private final Timer getRequests;
+    private final Timer postRequests;
+    private final Timer headRequests;
+    private final Timer putRequests;
+    private final Timer deleteRequests;
+    private final Timer optionsRequests;
+    private final Timer traceRequests;
+    private final Timer connectRequests;
+    private final Timer moveRequests;
+    private final Timer otherRequests;
 
-    private AsyncListener listener;
-
-    private HttpChannelState.State DISPATCHED_HACK;
+    private final AsyncListener listener;
 
     /**
      * Create a new instrumented handler using a given metrics registry.
      *
      * @param registry the registry for the metrics
      */
-    public InstrumentedHandler(MetricRegistry registry) {
+    public InstrumentedHttpChannelListener(MetricRegistry registry) {
         this(registry, null);
     }
 
@@ -83,33 +85,12 @@ public class InstrumentedHandler extends HandlerWrapper {
      * Create a new instrumented handler using a given metrics registry.
      *
      * @param registry the registry for the metrics
-     * @param prefix   the prefix to use for the metrics names
+     * @param pref     the prefix to use for the metrics names
      */
-    public InstrumentedHandler(MetricRegistry registry, String prefix) {
+    public InstrumentedHttpChannelListener(MetricRegistry registry, String pref) {
         this.metricRegistry = registry;
-        this.prefix = prefix;
 
-        try {
-            DISPATCHED_HACK = HttpChannelState.State.valueOf("HANDLING");
-        }
-        catch (IllegalArgumentException e) {
-            DISPATCHED_HACK = HttpChannelState.State.valueOf("DISPATCHED");
-        }
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    @Override
-    protected void doStart() throws Exception {
-        super.doStart();
-
-        final String prefix = this.prefix == null ? name(getHandler().getClass(), name) : name(this.prefix, name);
+        String prefix = (pref == null) ? getClass().getName() : pref;
 
         this.requests = metricRegistry.timer(name(prefix, "requests"));
         this.dispatches = metricRegistry.timer(name(prefix, "dispatches"));
@@ -122,11 +103,11 @@ public class InstrumentedHandler extends HandlerWrapper {
         this.asyncTimeouts = metricRegistry.meter(name(prefix, "async-timeouts"));
 
         this.responses = new Meter[]{
-                metricRegistry.meter(name(prefix, "1xx-responses")), // 1xx
-                metricRegistry.meter(name(prefix, "2xx-responses")), // 2xx
-                metricRegistry.meter(name(prefix, "3xx-responses")), // 3xx
-                metricRegistry.meter(name(prefix, "4xx-responses")), // 4xx
-                metricRegistry.meter(name(prefix, "5xx-responses"))  // 5xx
+            metricRegistry.meter(name(prefix, "1xx-responses")), // 1xx
+            metricRegistry.meter(name(prefix, "2xx-responses")), // 2xx
+            metricRegistry.meter(name(prefix, "3xx-responses")), // 3xx
+            metricRegistry.meter(name(prefix, "4xx-responses")), // 4xx
+            metricRegistry.meter(name(prefix, "5xx-responses"))  // 5xx
         };
 
         this.getRequests = metricRegistry.timer(name(prefix, "get-requests"));
@@ -144,7 +125,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[3].getOneMinuteRate(),
-                        requests.getOneMinuteRate());
+                    requests.getOneMinuteRate());
             }
         });
 
@@ -152,7 +133,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[3].getFiveMinuteRate(),
-                        requests.getFiveMinuteRate());
+                    requests.getFiveMinuteRate());
             }
         });
 
@@ -160,7 +141,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[3].getFifteenMinuteRate(),
-                        requests.getFifteenMinuteRate());
+                    requests.getFifteenMinuteRate());
             }
         });
 
@@ -168,7 +149,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[4].getOneMinuteRate(),
-                        requests.getOneMinuteRate());
+                    requests.getOneMinuteRate());
             }
         });
 
@@ -176,7 +157,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             @Override
             protected Ratio getRatio() {
                 return Ratio.of(responses[4].getFiveMinuteRate(),
-                        requests.getFiveMinuteRate());
+                    requests.getFiveMinuteRate());
             }
         });
 
@@ -184,10 +165,9 @@ public class InstrumentedHandler extends HandlerWrapper {
             @Override
             public Ratio getRatio() {
                 return Ratio.of(responses[4].getFifteenMinuteRate(),
-                        requests.getFifteenMinuteRate());
+                    requests.getFifteenMinuteRate());
             }
         });
-
 
         this.listener = new AsyncListener() {
             private long startTime;
@@ -213,7 +193,7 @@ public class InstrumentedHandler extends HandlerWrapper {
                 final HttpServletRequest request = (HttpServletRequest) state.getRequest();
                 final HttpServletResponse response = (HttpServletResponse) state.getResponse();
                 updateResponses(request, response, startTime, true);
-                if (state.getHttpChannelState().getState() != DISPATCHED_HACK) {
+                if (!state.getHttpChannelState().isSuspended()) {
                     activeSuspended.dec();
                 }
             }
@@ -221,11 +201,81 @@ public class InstrumentedHandler extends HandlerWrapper {
     }
 
     @Override
-    public void handle(String path,
-                       Request request,
-                       HttpServletRequest httpRequest,
-                       HttpServletResponse httpResponse) throws IOException, ServletException {
+    public void onRequestBegin(final Request request) {
 
+    }
+
+    @Override
+    public void onBeforeDispatch(final Request request) {
+        before(request);
+    }
+
+    @Override
+    public void onDispatchFailure(final Request request, final Throwable failure) {
+
+    }
+
+    @Override
+    public void onAfterDispatch(final Request request) {
+        after(request);
+    }
+
+    @Override
+    public void onRequestContent(final Request request, final ByteBuffer content) {
+
+    }
+
+    @Override
+    public void onRequestContentEnd(final Request request) {
+
+    }
+
+    @Override
+    public void onRequestTrailers(final Request request) {
+
+    }
+
+    @Override
+    public void onRequestEnd(final Request request) {
+
+    }
+
+    @Override
+    public void onRequestFailure(final Request request, final Throwable failure) {
+
+    }
+
+    @Override
+    public void onResponseBegin(final Request request) {
+
+    }
+
+    @Override
+    public void onResponseCommit(final Request request) {
+
+    }
+
+    @Override
+    public void onResponseContent(final Request request, final ByteBuffer content) {
+
+    }
+
+    @Override
+    public void onResponseEnd(final Request request) {
+
+    }
+
+    @Override
+    public void onResponseFailure(final Request request, final Throwable failure) {
+
+    }
+
+    @Override
+    public void onComplete(final Request request) {
+
+    }
+
+    private void before(final Request request) {
         activeDispatches.inc();
 
         final long start;
@@ -239,27 +289,44 @@ public class InstrumentedHandler extends HandlerWrapper {
             // resumed request
             start = System.currentTimeMillis();
             activeSuspended.dec();
-            if (state.getState() == DISPATCHED_HACK) {
+            if (state.isAsyncStarted()) {
                 asyncDispatches.mark();
             }
         }
+        request.setAttribute(START_ATTR, start);
+    }
 
-        try {
-            super.handle(path, request, httpRequest, httpResponse);
-        } finally {
-            final long now = System.currentTimeMillis();
-            final long dispatched = now - start;
+    private void after(final Request request) {
+        final long start = (long) request.getAttribute(START_ATTR);
+        final long now = System.currentTimeMillis();
+        final long dispatched = now - start;
 
-            activeDispatches.dec();
-            dispatches.update(dispatched, TimeUnit.MILLISECONDS);
+        activeDispatches.dec();
+        dispatches.update(dispatched, TimeUnit.MILLISECONDS);
 
-            if (state.isSuspended()) {
-                activeSuspended.inc();
-            } else if (state.isInitial()) {
-                updateResponses(httpRequest, httpResponse, start, request.isHandled());
-            }
-            // else onCompletion will handle it.
+        final HttpChannelState state = request.getHttpChannelState();
+        if (state.isSuspended()) {
+            activeSuspended.inc();
+        } else if (state.isInitial()) {
+            updateResponses(request, request.getResponse(), start, request.isHandled());
         }
+        // else onCompletion will handle it.
+    }
+
+    private void updateResponses(HttpServletRequest request, HttpServletResponse response, long start, boolean isHandled) {
+        final int responseStatus;
+        if (isHandled) {
+            responseStatus = response.getStatus() / 100;
+        } else {
+            responseStatus = 4; // will end up with a 404 response sent by HttpChannel.handle
+        }
+        if (responseStatus >= 1 && responseStatus <= 5) {
+            responses[responseStatus - 1].mark();
+        }
+        activeRequests.dec();
+        final long elapsedTime = System.currentTimeMillis() - start;
+        requests.update(elapsedTime, TimeUnit.MILLISECONDS);
+        requestTimer(request.getMethod()).update(elapsedTime, TimeUnit.MILLISECONDS);
     }
 
     private Timer requestTimer(String method) {
@@ -290,21 +357,5 @@ public class InstrumentedHandler extends HandlerWrapper {
                     return otherRequests;
             }
         }
-    }
-
-    private void updateResponses(HttpServletRequest request, HttpServletResponse response, long start, boolean isHandled) {
-        final int responseStatus;
-        if (isHandled) {
-            responseStatus = response.getStatus() / 100;
-        } else {
-            responseStatus = 4; // will end up with a 404 response sent by HttpChannel.handle
-        }
-        if (responseStatus >= 1 && responseStatus <= 5) {
-            responses[responseStatus - 1].mark();
-        }
-        activeRequests.dec();
-        final long elapsedTime = System.currentTimeMillis() - start;
-        requests.update(elapsedTime, TimeUnit.MILLISECONDS);
-        requestTimer(request.getMethod()).update(elapsedTime, TimeUnit.MILLISECONDS);
     }
 }

--- a/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHttpChannelListenerTest.java
+++ b/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHttpChannelListenerTest.java
@@ -1,0 +1,204 @@
+package com.codahale.metrics.jetty9;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.codahale.metrics.MetricRegistry;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstrumentedHttpChannelListenerTest
+{
+    private final HttpClient client = new HttpClient();
+    private final MetricRegistry registry = new MetricRegistry();
+    private final Server server = new Server();
+    private final ServerConnector connector = new ServerConnector(server);
+    private final TestHandler handler = new TestHandler();
+
+    @Before
+    public void setUp() throws Exception {
+        connector.addBean(new InstrumentedHttpChannelListener(registry, MetricRegistry.name(TestHandler.class, "handler")));
+        server.addConnector(connector);
+        server.setHandler(handler);
+        server.start();
+        client.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+        client.stop();
+    }
+
+    @Test
+    public void createsMetricsForTheHandler() throws Exception {
+        final ContentResponse response = client.GET(uri("/hello"));
+
+        assertThat(response.getStatus())
+            .isEqualTo(404);
+
+        assertThat(registry.getNames())
+            .containsOnly(
+                MetricRegistry.name(TestHandler.class, "handler.1xx-responses"),
+                MetricRegistry.name(TestHandler.class, "handler.2xx-responses"),
+                MetricRegistry.name(TestHandler.class, "handler.3xx-responses"),
+                MetricRegistry.name(TestHandler.class, "handler.4xx-responses"),
+                MetricRegistry.name(TestHandler.class, "handler.5xx-responses"),
+                MetricRegistry.name(TestHandler.class, "handler.percent-4xx-1m"),
+                MetricRegistry.name(TestHandler.class, "handler.percent-4xx-5m"),
+                MetricRegistry.name(TestHandler.class, "handler.percent-4xx-15m"),
+                MetricRegistry.name(TestHandler.class, "handler.percent-5xx-1m"),
+                MetricRegistry.name(TestHandler.class, "handler.percent-5xx-5m"),
+                MetricRegistry.name(TestHandler.class, "handler.percent-5xx-15m"),
+                MetricRegistry.name(TestHandler.class, "handler.requests"),
+                MetricRegistry.name(TestHandler.class, "handler.active-suspended"),
+                MetricRegistry.name(TestHandler.class, "handler.async-dispatches"),
+                MetricRegistry.name(TestHandler.class, "handler.async-timeouts"),
+                MetricRegistry.name(TestHandler.class, "handler.get-requests"),
+                MetricRegistry.name(TestHandler.class, "handler.put-requests"),
+                MetricRegistry.name(TestHandler.class, "handler.active-dispatches"),
+                MetricRegistry.name(TestHandler.class, "handler.trace-requests"),
+                MetricRegistry.name(TestHandler.class, "handler.other-requests"),
+                MetricRegistry.name(TestHandler.class, "handler.connect-requests"),
+                MetricRegistry.name(TestHandler.class, "handler.dispatches"),
+                MetricRegistry.name(TestHandler.class, "handler.head-requests"),
+                MetricRegistry.name(TestHandler.class, "handler.post-requests"),
+                MetricRegistry.name(TestHandler.class, "handler.options-requests"),
+                MetricRegistry.name(TestHandler.class, "handler.active-requests"),
+                MetricRegistry.name(TestHandler.class, "handler.delete-requests"),
+                MetricRegistry.name(TestHandler.class, "handler.move-requests")
+            );
+    }
+
+
+    @Test
+    public void responseTimesAreRecordedForBlockingResponses() throws Exception {
+
+        final ContentResponse response = client.GET(uri("/blocking"));
+
+        assertThat(response.getStatus())
+            .isEqualTo(200);
+
+        assertResponseTimesValid();
+    }
+
+    @Test
+    public void responseTimesAreRecordedForAsyncResponses() throws Exception {
+
+        final ContentResponse response = client.GET(uri("/async"));
+
+        assertThat(response.getStatus())
+            .isEqualTo(200);
+
+        assertResponseTimesValid();
+    }
+
+    private void assertResponseTimesValid() {
+        assertThat(registry.getMeters().get(metricName() + ".2xx-responses")
+            .getCount()).isGreaterThan(0L);
+
+
+        assertThat(registry.getTimers().get(metricName() + ".get-requests")
+            .getSnapshot().getMedian()).isGreaterThan(0.0).isLessThan(TimeUnit.SECONDS.toNanos(1));
+
+        assertThat(registry.getTimers().get(metricName() + ".requests")
+            .getSnapshot().getMedian()).isGreaterThan(0.0).isLessThan(TimeUnit.SECONDS.toNanos(1));
+    }
+
+    private String uri(String path) {
+        return "http://localhost:" + connector.getLocalPort() + path;
+    }
+
+    private String metricName() {
+        return MetricRegistry.name(TestHandler.class.getName(), "handler");
+    }
+
+    /**
+     * test handler.
+     * <p>
+     * Supports
+     * <p>
+     * /blocking - uses the standard servlet api
+     * /async - uses the 3.1 async api to complete the request
+     * <p>
+     * all other requests will return 404
+     */
+    private static class TestHandler extends AbstractHandler {
+        @Override
+        public void handle(
+            String path,
+            Request request,
+            final HttpServletRequest httpServletRequest,
+            final HttpServletResponse httpServletResponse
+        ) throws IOException, ServletException {
+            switch (path) {
+                case "/blocking":
+                    request.setHandled(true);
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    httpServletResponse.setStatus(200);
+                    httpServletResponse.setContentType("text/plain");
+                    httpServletResponse.getWriter().write("some content from the blocking request\n");
+                    break;
+                case "/async":
+                    request.setHandled(true);
+                    final AsyncContext context = request.startAsync();
+                    Thread t = new Thread(() -> {
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        httpServletResponse.setStatus(200);
+                        httpServletResponse.setContentType("text/plain");
+                        final ServletOutputStream servletOutputStream;
+                        try {
+                            servletOutputStream = httpServletResponse.getOutputStream();
+                            servletOutputStream.setWriteListener(
+                                new WriteListener() {
+                                    @Override
+                                    public void onWritePossible() throws IOException {
+                                        servletOutputStream.write("some content from the async\n"
+                                            .getBytes(StandardCharsets.UTF_8));
+                                        context.complete();
+                                    }
+
+                                    @Override
+                                    public void onError(Throwable throwable) {
+                                        context.complete();
+                                    }
+                                }
+                            );
+                        } catch (IOException e) {
+                            context.complete();
+                        }
+                    });
+                    t.start();
+                    break;
+                 default:
+                     break;
+            }
+        }
+    }
+}

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <javaModuleName>com.codahale.metrics.servlets</javaModuleName>
-        <jetty9.version>9.4.20.v20190813</jetty9.version>
+        <jetty9.version>9.4.21.v20190926</jetty9.version>
         <papertrail.profiler.version>1.1.1</papertrail.profiler.version>
         <servlet.version>3.1.0</servlet.version>
         <jackson.version>2.9.9.3</jackson.version>


### PR DESCRIPTION
It contains some notable internal changes (most importantly related to
HttpChannel.State):
https://github.com/eclipse/jetty.project/commit/bde86467f4e5df595773ab11ed5e80c615b741f3#diff-68e74a60841dd5ec1f7edc4bd736ce18

Fix InstrumentedHandler to compile and work with pre-9.4.21 and
post-9.4.21 Jetty instances, but using internal API is not a recipe
for longevity.

Also, created a new InstrumentedHttpChannelListener that in turn
does use public API of Jetty, and should not break with minor
releases.