### PR TITLE
fix counting suspended requests

### DIFF
--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -213,7 +213,8 @@ public class InstrumentedHandler extends HandlerWrapper {
                 final HttpServletRequest request = (HttpServletRequest) state.getRequest();
                 final HttpServletResponse response = (HttpServletResponse) state.getResponse();
                 updateResponses(request, response, startTime, true);
-                if (state.getHttpChannelState().getState() != DISPATCHED_HACK) {
+                if (state.getHttpChannelState().getState() != DISPATCHED_HACK &&
+                        state.getHttpChannelState().isSuspended()) {
                     activeSuspended.dec();
                 }
             }


### PR DESCRIPTION
There is a small bug with async requests, metrics dec even if requests no-suspended. 