### PR TITLE
Change graphite connect logic to lookup dns names on reconnect

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteUDP.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteUDP.java
@@ -2,6 +2,7 @@ package com.codahale.metrics.graphite;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.InetAddress;
 import java.nio.ByteBuffer;
 import java.nio.channels.DatagramChannel;
 
@@ -50,7 +51,7 @@ public class GraphiteUDP implements GraphiteSender {
 
         // Resolve hostname
         if (hostname != null) {
-            address = new InetSocketAddress(hostname, port);
+            address = new InetSocketAddress(InetAddress.getByName(hostname), port);
         }
 
         datagramChannel = DatagramChannel.open();


### PR DESCRIPTION
We had various issues with dns names for our graphite host changing (its an aws ALB and the ip addresses rotate fairly frequently).  I have tracked down the issue to the hostname not being re-resolved by InetSockAddress once it has an address.  This code will now always attempt to re-resolve (with default java jvm ttl of 30s, or dns resolve cache ttl applying) 