### PR TITLE
Use proper logger in ScheduledReporter

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -273,7 +273,6 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
 
     protected double convertDuration(double duration) {
         return duration / durationFactor;
-
     }
 
     protected double convertRate(double rate) {

--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -200,7 +200,9 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
                     executor.shutdownNow(); // Cancel currently executing tasks
                     // Wait a while for tasks to respond to being cancelled
                     if (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
-                        System.err.println(getClass().getSimpleName() + ": ScheduledExecutorService did not terminate");
+                        LOG.warn("ScheduledExecutorService did not terminate.");
+                    } else {
+                        LOG.info("ScheduledExecutorService terminated.");
                     }
                 }
             } catch (InterruptedException ie) {
@@ -272,7 +274,8 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
     }
 
     protected double convertDuration(double duration) {
-        return duration / durationFactor;
+        return duration / durationFactor;                LOG.error("Exception thrown from {}#report. Exception was suppressed.", ScheduledReporter.this.getClass().getSimpleName(), ex);
+
     }
 
     protected double convertRate(double rate) {

--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -201,8 +201,6 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
                     // Wait a while for tasks to respond to being cancelled
                     if (!executor.awaitTermination(1, TimeUnit.SECONDS)) {
                         LOG.warn("ScheduledExecutorService did not terminate.");
-                    } else {
-                        LOG.info("ScheduledExecutorService terminated.");
                     }
                 }
             } catch (InterruptedException ie) {

--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -272,7 +272,7 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
     }
 
     protected double convertDuration(double duration) {
-        return duration / durationFactor;                LOG.error("Exception thrown from {}#report. Exception was suppressed.", ScheduledReporter.this.getClass().getSimpleName(), ex);
+        return duration / durationFactor;
 
     }
 


### PR DESCRIPTION
Use logger instead of System.err for logging ScheduledExecutorService termination failure.
I think the current code use System.err because this piece was copied from java documentation:
https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ExecutorService.html
```
The following method shuts down an ExecutorService in two phases, first by calling shutdown to reject incoming tasks, and then calling shutdownNow, if necessary, to cancel any lingering tasks:
 void shutdownAndAwaitTermination(ExecutorService pool) {
   pool.shutdown(); // Disable new tasks from being submitted
   try {
     // Wait a while for existing tasks to terminate
     if (!pool.awaitTermination(60, TimeUnit.SECONDS)) {
       pool.shutdownNow(); // Cancel currently executing tasks
       // Wait a while for tasks to respond to being cancelled
       if (!pool.awaitTermination(60, TimeUnit.SECONDS))
           System.err.println("Pool did not terminate");
     }
   } catch (InterruptedException ie) {
     // (Re-)Cancel if current thread also interrupted
     pool.shutdownNow();
     // Preserve interrupt status
     Thread.currentThread().interrupt();
   }
 }
```