### PR TITLE
Improve tick overflow handling in SlidingTimeWindowReservoir

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/SlidingTimeWindowReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SlidingTimeWindowReservoir.java
@@ -21,6 +21,7 @@ public class SlidingTimeWindowReservoir implements Reservoir {
     private final long window;
     private final AtomicLong lastTick;
     private final AtomicLong count;
+    private final long startTick;
 
     /**
      * Creates a new {@link SlidingTimeWindowReservoir} with the given window of time.
@@ -40,10 +41,11 @@ public class SlidingTimeWindowReservoir implements Reservoir {
      * @param clock      the {@link Clock} to use
      */
     public SlidingTimeWindowReservoir(long window, TimeUnit windowUnit, Clock clock) {
+        this.startTick = clock.getTick();
         this.clock = clock;
         this.measurements = new ConcurrentSkipListMap<>();
         this.window = windowUnit.toNanos(window) * COLLISION_BUFFER;
-        this.lastTick = new AtomicLong(clock.getTick() * COLLISION_BUFFER);
+        this.lastTick = new AtomicLong((clock.getTick() - startTick) * COLLISION_BUFFER);
         this.count = new AtomicLong();
     }
 
@@ -70,7 +72,7 @@ public class SlidingTimeWindowReservoir implements Reservoir {
     private long getTick() {
         for ( ;; ) {
             final long oldTick = lastTick.get();
-            final long tick = clock.getTick() * COLLISION_BUFFER;
+            final long tick = (clock.getTick() - startTick) * COLLISION_BUFFER;
             // ensure the tick is strictly incrementing even if there are duplicate ticks
             final long newTick = tick - oldTick > 0 ? tick : oldTick + 1;
             if (lastTick.compareAndSet(oldTick, newTick)) {

--- a/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowReservoirTest.java
@@ -28,6 +28,8 @@ public class SlidingTimeWindowReservoirTest {
     @Test
     public void boundsMeasurementsToATimeWindow() {
         final Clock clock = mock(Clock.class);
+        when(clock.getTick()).thenReturn(0L);
+
         final SlidingTimeWindowReservoir reservoir = new SlidingTimeWindowReservoir(10, NANOSECONDS, clock);
 
         when(clock.getTick()).thenReturn(0L);
@@ -61,13 +63,14 @@ public class SlidingTimeWindowReservoirTest {
             for (int updatesPerTick : Arrays.asList(1, 2, 127, 128, 129, 255, 256, 257)) {
                 //logger.info("Executing test: threshold={}, updatesPerTick={}", threshold, updatesPerTick);
 
-                // Set the clock to overflow in (2*window+1)ns
                 final ManualClock clock = new ManualClock();
-                clock.addNanos(Long.MAX_VALUE / 256 - 2 * window - clock.getTick());
-                assertThat(clock.getTick() * 256).isGreaterThan(0);
 
                 // Create the reservoir
                 final SlidingTimeWindowReservoir reservoir = new SlidingTimeWindowReservoir(window, NANOSECONDS, clock);
+
+                // Set the clock to overflow in (2*window+1)ns
+                clock.addNanos(Long.MAX_VALUE / 256 - 2 * window - clock.getTick());
+                assertThat(clock.getTick() * 256).isGreaterThan(0);
 
                 int updatesAfterThreshold = 0;
                 while (true) {


### PR DESCRIPTION
The current implementation of `SlidingTimeWindowArrayReservoir` handles clock tick overflows much better, than `SlidingTimeWindowReservoir`. This is a change for `SlidingTimeWindowReservoir` to postpone tick overflow as much as possible, as it is done in `SlidingTimeWindowArrayReservoir`.

Maybe it would be even better to clear all measurements in case of overflow as it is done in `SlidingTimeWindowArrayReservoir`, but this may be treated as a backward-incompatible change from an end-user perspective.