### PR TITLE
Make CachedGauge thread-safe

### DIFF
--- a/metrics-benchmarks/src/main/java/com/codahale/metrics/benchmarks/CachedGaugeBenchmark.java
+++ b/metrics-benchmarks/src/main/java/com/codahale/metrics/benchmarks/CachedGaugeBenchmark.java
@@ -1,0 +1,46 @@
+package com.codahale.metrics.benchmarks;
+
+import com.codahale.metrics.CachedGauge;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+public class CachedGaugeBenchmark {
+
+    private CachedGauge<Integer> cachedGauge = new CachedGauge<Integer>(100, TimeUnit.MILLISECONDS) {
+        @Override
+        protected Integer loadValue() {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Thread was interrupted", e);
+            }
+            return 12345;
+        }
+    };
+
+    @Benchmark
+    public void perfGetValue(Blackhole blackhole) {
+        blackhole.consume(cachedGauge.getValue());
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(".*" + CachedGaugeBenchmark.class.getSimpleName() + ".*")
+                .warmupIterations(3)
+                .measurementIterations(5)
+                .threads(4)
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/CachedGaugeTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/CachedGaugeTest.java
@@ -1,13 +1,21 @@
 package com.codahale.metrics;
 
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.TimeUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class CachedGaugeTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CachedGaugeTest.class);
+    private static final int THREAD_COUNT = 10;
+
     private final AtomicInteger value = new AtomicInteger(0);
     private final Gauge<Integer> gauge = new CachedGauge<Integer>(100, TimeUnit.MILLISECONDS) {
         @Override
@@ -15,9 +23,21 @@ public class CachedGaugeTest {
             return value.incrementAndGet();
         }
     };
+    private final Gauge<Integer> shortTimeoutGauge = new CachedGauge<Integer>(1, TimeUnit.MILLISECONDS) {
+        @Override
+        protected Integer loadValue() {
+            try {
+                Thread.sleep(5);
+            } catch (InterruptedException e) {
+                throw new RuntimeException("Thread was interrupted", e);
+            }
+            return value.incrementAndGet();
+        }
+    };
+    private final ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
 
     @Test
-    public void cachesTheValueForTheGivenPeriod() throws Exception {
+    public void cachesTheValueForTheGivenPeriod() {
         assertThat(gauge.getValue())
                 .isEqualTo(1);
         assertThat(gauge.getValue())
@@ -36,5 +56,45 @@ public class CachedGaugeTest {
 
         assertThat(gauge.getValue())
                 .isEqualTo(2);
+    }
+
+    @Test
+    public void multipleThreadAccessReturnsConsistentResults() throws Exception {
+        List<Future<Boolean>> futures = new ArrayList<>(THREAD_COUNT);
+        long runningTimeMillis = TimeUnit.SECONDS.toMillis(10);
+
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            Future<Boolean> future = executor.submit(() -> {
+                long startTime = System.currentTimeMillis();
+                int lastValue = 0;
+
+                do {
+                    Integer newValue = shortTimeoutGauge.getValue();
+
+                    if (newValue == null) {
+                        LOGGER.warn("Cached gauge returned null value");
+                        return false;
+                    }
+
+                    if (newValue < lastValue) {
+                        LOGGER.error("Cached gauge returned stale value, last: {}, new: {}", lastValue, newValue);
+                        return false;
+                    }
+
+                    lastValue = newValue;
+                } while (System.currentTimeMillis() - startTime <= runningTimeMillis);
+
+                return true;
+            });
+
+            futures.add(future);
+        }
+
+        for (int i = 0; i < futures.size(); i++) {
+            assertTrue("Future " + i + " failed", futures.get(i).get());
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(1, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
https://github.com/dropwizard/metrics/issues/1565

I was able to recreate failures with a unit tests and I came up with this non blocking implementation. The issue was already pointed out before - https://github.com/dropwizard/metrics/issues/711

**Changes**

- non blocking, thread safe cached gauge implemented
- added multithreaded unit test
- added cached gauge benchmark

**Benchmark**

Caption			: Intel64 Family 6 Model 60 Stepping 3
MaxClockSpeed	: 4001
Name			: Intel(R) Core(TM) i7-4790K CPU @ 4.00GHz
NumberOfCores	: 4 

**Non blocking**

```
Benchmark                           Mode  Cnt          Score         Error  Units
CachedGaugeBenchmark.perfGetValue  thrpt    5  171858323.080 ± 5082330.853  ops/s
```

**Synchronized**

```
Benchmark                           Mode  Cnt         Score        Error  Units
CachedGaugeBenchmark.perfGetValue  thrpt    5  15644559.909 ± 792061.174  ops/s
```

Seems that non blocking implementation is order of magnitude faster (based on timeout == 100ms and loading time == 10ms).

```
171858323 (non blocking)
 15644559 (synchronized)
```