### PR TITLE
Report metrics when stopping ScheduledReporter

### DIFF
--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -447,7 +447,10 @@ public class GraphiteReporterTest {
     public void closesConnectionOnReporterStop() throws Exception {
         reporter.stop();
 
-        verify(graphite).close();
+        final InOrder inOrder = inOrder(graphite);
+        inOrder.verify(graphite).connect();
+        inOrder.verify(graphite).flush();
+        inOrder.verify(graphite, times(2)).close();
 
         verifyNoMoreInteractions(graphite);
     }


### PR DESCRIPTION
When stopping a ScheduledReporter, it should report the metrics in the metrics registry one final time.

Fixes #1461