### PR TITLE
Avoid queuing up report tasks in ScheduledReporter

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -166,7 +166,7 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
             throw new IllegalArgumentException("Reporter already started");
         }
 
-        this.scheduledFuture = executor.scheduleAtFixedRate(runnable, initialDelay, period, unit);
+        this.scheduledFuture = executor.scheduleWithFixedDelay(runnable, initialDelay, period, unit);
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/dropwizard/metrics/issues/1524

Discussion does not seem to be active, but it could be merged if no objections.