### PR TITLE
Add SettableGauge interface and an implementation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/metrics-benchmarks/pom.xml
+++ b/metrics-benchmarks/pom.xml
@@ -56,7 +56,7 @@
                 <!-- generate an uber .jar for standalone benchmarking -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -310,10 +310,10 @@ public class MetricRegistry implements MetricSet {
      * @return a new or pre-existing {@link Gauge}
      */
     @SuppressWarnings("rawtypes")
-    public Gauge gauge(String name, final MetricSupplier<Gauge> supplier) {
-        return getOrAdd(name, new MetricBuilder<Gauge>() {
+    public <T extends  Gauge> T gauge(String name, final MetricSupplier<T> supplier) {
+        return getOrAdd(name, new MetricBuilder<T>() {
             @Override
-            public Gauge newMetric() {
+            public T newMetric() {
                 return supplier.newMetric();
             }
 

--- a/metrics-core/src/main/java/com/codahale/metrics/SettableGauge.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SettableGauge.java
@@ -1,0 +1,14 @@
+package com.codahale.metrics;
+
+/**
+ * <p>
+ * Similar to {@link Gauge}, but metric value is updated via calling {@link #setValue(T)} instead.
+ * See {@link SimpleSettableGauge}.
+ * </p>
+ */
+public interface SettableGauge<T> extends Gauge<T> {
+    /**
+     * Set the metric to a new value.
+     */
+    void setValue(T value);
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/SimpleSettableGauge.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SimpleSettableGauge.java
@@ -1,0 +1,44 @@
+package com.codahale.metrics;
+
+/**
+ * <p>
+ * Similar to {@link Gauge}, but metric value is updated via calling {@link #setValue(T)} instead.
+ * Thread-safety is ensured via storing metric value as a volatile member variable.
+ * </p>
+ */
+public class SimpleSettableGauge<T> implements SettableGauge<T> {
+    /**
+     * Current value.
+     * Volatile so that assignment is thread-safe.
+     * <a href="http://docs.oracle.com/javase/specs/jls/se14/html/jls-17.html#jls-17.7">See 17.7</a>
+     */
+    private volatile T value;
+
+    /**
+     * Create an instance with a default value.
+     *
+     * @param defaultValue default value
+     */
+    public SimpleSettableGauge(T defaultValue) {
+        this.value = defaultValue;
+    }
+
+    /**
+     * Set the metric to a new value.
+     */
+    @Override
+    public void setValue(T value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the metric's current value.
+     *
+     * @return the metric's current value
+     */
+    @Override
+    public T getValue() {
+        return value;
+    }
+
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryTest.java
@@ -20,6 +20,7 @@ public class MetricRegistryTest {
     private final MetricRegistryListener listener = mock(MetricRegistryListener.class);
     private final MetricRegistry registry = new MetricRegistry();
     private final Gauge<String> gauge = () -> "";
+    private final SettableGauge<String> settableGauge = new SimpleSettableGauge<>("");
     private final Counter counter = mock(Counter.class);
     private final Histogram histogram = mock(Histogram.class);
     private final Meter meter = mock(Meter.class);
@@ -227,6 +228,18 @@ public class MetricRegistryTest {
         verify(listener).onGaugeAdded("thing", gauge1);
     }
 
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void settableGaugeIsTreatedLikeAGuage() {
+        final MetricRegistry.MetricSupplier<SettableGauge> supplier = () -> settableGauge;
+        final SettableGauge gauge1 = registry.gauge("thing", supplier);
+        final SettableGauge gauge2 = registry.gauge("thing", supplier);
+
+        assertThat(gauge1)
+                .isSameAs(gauge2);
+
+        verify(listener).onGaugeAdded("thing", gauge1);
+    }
 
     @Test
     public void addingAListenerWithExistingMetricsCatchesItUp() {

--- a/metrics-core/src/test/java/com/codahale/metrics/SimpleSettableGaugeTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SimpleSettableGaugeTest.java
@@ -1,0 +1,28 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SimpleSettableGaugeTest {
+
+    @Test
+    public void defaultValue() {
+        SimpleSettableGauge<Integer> settable = new SimpleSettableGauge<>(1);
+
+        assertThat(settable.getValue()).isEqualTo(1);
+    }
+
+    @Test
+    public void setValueAndThenGetValue() {
+        SimpleSettableGauge<String> settable = new SimpleSettableGauge<>("default");
+
+        settable.setValue("first");
+        assertThat(settable.getValue())
+                .isEqualTo("first");
+
+        settable.setValue("second");
+        assertThat(settable.getValue())
+                .isEqualTo("second");
+    }
+}

--- a/metrics-jcstress/pom.xml
+++ b/metrics-jcstress/pom.xml
@@ -58,7 +58,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.3</version>
+                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <id>main</id>

--- a/pom.xml
+++ b/pom.xml
@@ -374,7 +374,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.0</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
This PR attempts to address https://github.com/dropwizard/metrics/issues/1126.

Example usage:
```
MetricRegistry registry = new MetricRegistry();
SettableGauge<Integer> settable = registry.register("example1", new SimpleSettableGauge<>(0));
settable.setValue(123);
```
Some things I want to point out that I'm not sure about:
1. Whats a better name than `SimpleSettableGauge`?
2. I'm not sure if we need a `MetricRegistry.settableGauge`.