### PR TITLE
Metrics from Caffeine caches

### DIFF
--- a/docs/source/manual/caffeine.rst
+++ b/docs/source/manual/caffeine.rst
@@ -1,0 +1,36 @@
+.. _manual-caffeine:
+
+#####################
+Instrumenting Caffeine
+#####################
+
+.. highlight:: text
+
+.. rubric:: The ``metrics-caffeine`` module provides ``MetricsStatsCounter``, a metrics listener for
+            Caffeine_ caches:
+
+.. _Caffeine: https://github.com/ben-manes/caffeine
+
+.. code-block:: java
+
+    LoadingCache<Integer, Integer> cache = Caffeine.newBuilder()
+        .recordStats(() -> new MetricsStatsCounter(registry, "cache"))
+        .build(key -> key);
+
+The listener publishes these metrics:
+
++---------------------------+----------------------------------------------------------------------+
+| ``hits``                  | Number of times a requested item was found in the cache.             |
++---------------------------+----------------------------------------------------------------------+
+| ``misses``                | Number of times a requested item was not found in the cache.         |
++---------------------------+----------------------------------------------------------------------+
+| ``loads-success``         | Timer for successful loads into cache.                               |
++---------------------------+----------------------------------------------------------------------+
+| ``loads-failure``         | Timer for failed loads into cache.                                   |
++---------------------------+----------------------------------------------------------------------+
+| ``evictions``             | Histogram of eviction weights      .                                 |
++---------------------------+----------------------------------------------------------------------+
+| ``evictions-weight``      | Total weight of evicted entries.                                     |
++---------------------------+----------------------------------------------------------------------+
+| ``evictions.<CAUSE>``     | Histogram of eviction weights for each RemovalCause                  |
++---------------------------+----------------------------------------------------------------------+

--- a/docs/source/manual/index.rst
+++ b/docs/source/manual/index.rst
@@ -14,6 +14,7 @@ User Manual
     core
     healthchecks
     ehcache
+    caffeine
     collectd
     graphite
     httpclient

--- a/metrics-caffeine/pom.xml
+++ b/metrics-caffeine/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-parent</artifactId>
+        <version>4.1.10-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>metrics-caffeine</artifactId>
+    <name>Metrics Integration for Caffeine</name>
+    <packaging>bundle</packaging>
+    <description>
+        Metrics Integration for Caffeine.
+    </description>
+
+    <properties>
+        <javaModuleName>com.codahale.metrics.caffeine</javaModuleName>
+        <caffeine.version>2.8.4</caffeine.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>${caffeine.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/metrics-caffeine/src/main/java/com/codahale/metrics/caffeine/MetricsStatsCounter.java
+++ b/metrics-caffeine/src/main/java/com/codahale/metrics/caffeine/MetricsStatsCounter.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2016 Ben Manes. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.codahale.metrics.caffeine;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.TimeUnit;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.github.benmanes.caffeine.cache.stats.StatsCounter;
+
+/**
+ * A {@link StatsCounter} instrumented with Dropwizard Metrics.
+ *
+ * @author ben.manes@gmail.com (Ben Manes)
+ */
+public final class MetricsStatsCounter implements StatsCounter {
+  private final Counter hitCount;
+  private final Counter missCount;
+  private final Counter loadSuccessCount;
+  private final Counter loadFailureCount;
+  private final Timer totalLoadTime;
+  private final Counter evictionCount;
+  private final Counter evictionWeight;
+
+  /**
+   * Constructs an instance for use by a single cache.
+   *
+   * @param registry the registry of metric instances
+   * @param metricsPrefix the prefix name for the metrics
+   */
+  public MetricsStatsCounter(MetricRegistry registry, String metricsPrefix) {
+    requireNonNull(metricsPrefix);
+    hitCount = registry.counter(metricsPrefix + ".hits");
+    missCount = registry.counter(metricsPrefix + ".misses");
+    totalLoadTime = registry.timer(metricsPrefix + ".loads");
+    loadSuccessCount = registry.counter(metricsPrefix + ".loads-success");
+    loadFailureCount = registry.counter(metricsPrefix + ".loads-failure");
+    evictionCount = registry.counter(metricsPrefix + ".evictions");
+    evictionWeight = registry.counter(metricsPrefix + ".evictions-weight");
+  }
+
+  @Override
+  public void recordHits(int count) {
+    hitCount.inc(count);
+  }
+
+  @Override
+  public void recordMisses(int count) {
+    missCount.inc(count);
+  }
+
+  @Override
+  public void recordLoadSuccess(long loadTime) {
+    loadSuccessCount.inc();
+    totalLoadTime.update(loadTime, TimeUnit.NANOSECONDS);
+  }
+
+  @Override
+  public void recordLoadFailure(long loadTime) {
+    loadFailureCount.inc();
+    totalLoadTime.update(loadTime, TimeUnit.NANOSECONDS);
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public void recordEviction() {
+    // This method is scheduled for removal in version 3.0 in favor of recordEviction(weight)
+    recordEviction(1);
+  }
+
+  @Override
+  public void recordEviction(int weight) {
+    evictionCount.inc();
+    evictionWeight.inc(weight);
+  }
+
+  @Override
+  public CacheStats snapshot() {
+    return new CacheStats(
+        hitCount.getCount(),
+        missCount.getCount(),
+        loadSuccessCount.getCount(),
+        loadFailureCount.getCount(),
+        totalLoadTime.getCount(),
+        evictionCount.getCount(),
+        evictionWeight.getCount());
+  }
+
+  @Override
+  public String toString() {
+    return snapshot().toString();
+  }
+}

--- a/metrics-caffeine/src/main/java/com/codahale/metrics/caffeine/MetricsStatsCounter.java
+++ b/metrics-caffeine/src/main/java/com/codahale/metrics/caffeine/MetricsStatsCounter.java
@@ -47,13 +47,13 @@ public final class MetricsStatsCounter implements StatsCounter {
    */
   public MetricsStatsCounter(MetricRegistry registry, String metricsPrefix) {
     requireNonNull(metricsPrefix);
-    hitCount = registry.counter(metricsPrefix + ".hits");
-    missCount = registry.counter(metricsPrefix + ".misses");
-    totalLoadTime = registry.timer(metricsPrefix + ".loads");
-    loadSuccessCount = registry.counter(metricsPrefix + ".loads-success");
-    loadFailureCount = registry.counter(metricsPrefix + ".loads-failure");
-    evictionCount = registry.counter(metricsPrefix + ".evictions");
-    evictionWeight = registry.counter(metricsPrefix + ".evictions-weight");
+    hitCount = registry.counter(MetricRegistry.name(metricsPrefix, "hits"));
+    missCount = registry.counter(MetricRegistry.name(metricsPrefix, "misses"));
+    totalLoadTime = registry.timer(MetricRegistry.name(metricsPrefix, "loads"));
+    loadSuccessCount = registry.counter(MetricRegistry.name(metricsPrefix, "loads-success"));
+    loadFailureCount = registry.counter(MetricRegistry.name(metricsPrefix, "loads-failure"));
+    evictionCount = registry.counter(MetricRegistry.name(metricsPrefix, "evictions"));
+    evictionWeight = registry.counter(MetricRegistry.name(metricsPrefix, "evictions-weight"));
   }
 
   @Override

--- a/metrics-caffeine/src/test/java/com/codahale/metrics/caffeine/MetricsStatsCounterTest.java
+++ b/metrics-caffeine/src/test/java/com/codahale/metrics/caffeine/MetricsStatsCounterTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Ben Manes. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.codahale.metrics.caffeine;
+
+import static org.junit.Assert.assertEquals;
+
+import com.codahale.metrics.MetricRegistry;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import org.junit.Test;
+
+/**
+ * An example of exporting stats to Dropwizard Metrics (http://metrics.dropwizard.io).
+ *
+ * @author ben.manes@gmail.com (Ben Manes)
+ */
+public final class MetricsStatsCounterTest {
+
+  @Test
+  public void metrics() {
+    // Use a registry that is exported using a Reporter (via console, JMX, Graphite, etc)
+    MetricRegistry registry = new MetricRegistry();
+
+    // Create the cache with a dedicated, uniquely named stats counter
+    LoadingCache<Integer, Integer> cache = Caffeine.newBuilder()
+        .recordStats(() -> new MetricsStatsCounter(registry, "example"))
+        .build(key -> key);
+
+    // Perform application work
+    for (int i = 0; i < 4; i++) {
+      cache.get(1);
+    }
+
+    // Statistics can be queried and reported on
+    assertEquals(cache.stats().hitCount(), 3L);
+    assertEquals(registry.counter("example.hits").getCount(), 3L);
+  }
+}

--- a/metrics-caffeine/src/test/java/com/codahale/metrics/caffeine/MetricsStatsCounterTest.java
+++ b/metrics-caffeine/src/test/java/com/codahale/metrics/caffeine/MetricsStatsCounterTest.java
@@ -74,26 +74,26 @@ public final class MetricsStatsCounterTest {
   @Test
   public void loadSuccess() {
     stats.recordLoadSuccess(256);
-    assertThat(registry.counter(PREFIX + ".loads-success").getCount()).isEqualTo(1);
+    assertThat(registry.timer(PREFIX + ".loads-success").getCount()).isEqualTo(1);
   }
 
   @Test
   public void loadFailure() {
     stats.recordLoadFailure(256);
-    assertThat(registry.counter(PREFIX + ".loads-failure").getCount()).isEqualTo(1);
+    assertThat(registry.timer(PREFIX + ".loads-failure").getCount()).isEqualTo(1);
   }
 
   @Test
   public void eviction() {
     stats.recordEviction();
-    assertThat(registry.counter(PREFIX + ".evictions").getCount()).isEqualTo(1);
+    assertThat(registry.histogram(PREFIX + ".evictions").getCount()).isEqualTo(1);
     assertThat(registry.counter(PREFIX + ".evictions-weight").getCount()).isEqualTo(1);
   }
 
   @Test
   public void evictionWithWeight() {
     stats.recordEviction(3);
-    assertThat(registry.counter(PREFIX + ".evictions").getCount()).isEqualTo(1);
+    assertThat(registry.histogram(PREFIX + ".evictions").getCount()).isEqualTo(1);
     assertThat(registry.counter(PREFIX + ".evictions-weight").getCount()).isEqualTo(3);
   }
 
@@ -102,8 +102,7 @@ public final class MetricsStatsCounterTest {
     // With JUnit 5, this would be better done with @ParameterizedTest + @EnumSource
     for (RemovalCause cause : RemovalCause.values()) {
       stats.recordEviction(3, cause);
-      assertThat(registry.counter(PREFIX + ".evictions." + cause.name()).getCount()).isEqualTo(1);
-      assertThat(registry.counter(PREFIX + ".evictions-weight." + cause.name()).getCount()).isEqualTo(3);
+      assertThat(registry.histogram(PREFIX + ".evictions." + cause.name()).getCount()).isEqualTo(1);
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <module>metrics-bom</module>
         <module>metrics-annotation</module>
         <module>metrics-benchmarks</module>
+        <module>metrics-caffeine</module>
         <module>metrics-core</module>
         <module>metrics-collectd</module>
         <module>metrics-ehcache</module>


### PR DESCRIPTION
Add ability to gather metrics from Caffeine cache library. An instance of `MetricsStatsCounter` should be passed to the Caffeine cache builder, resulting in Caffeine using that class to publish metrics to the desired metrics registry. (An example of this usage is in the UT.)

Code was taken from example given by Caffeine library author provided at https://github.com/ben-manes/caffeine/blob/master/examples/stats-metrics/src/test/java/com/github/benmanes/caffeine/examples/stats/metrics/MetricsStatsCounterTest.java

Adding it into official dropwizard metrics repo should make it easier for dependent projects to take advantage of.

It has the Apache Public License 2.0, same as this project, so I assume it is okay to integrate?

Changes made to copied sources:
 - Package names made consistent rest of project
 - Switched UT to use JUnit, added more UT
 - Used Histogram/Timer where possible
 - Break down evictions by RemovalCause
 - Documentation