### PR TITLE
DO NOT MERGE - Add benchmark for lock free EDR

### DIFF
--- a/metrics-core/new.txt
+++ b/metrics-core/new.txt
@@ -1,0 +1,785 @@
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: com.codahale.metrics.BenchmarkNewEDR.measureThreads_01
+
+# Run progress: 0.00% complete, ETA 00:03:00
+# Fork: 1 of 1
+# Warmup Iteration   1: 8.874 ops/us
+# Warmup Iteration   2: 7.220 ops/us
+Iteration   1: 6.475 ops/us
+Iteration   2: 9.054 ops/us
+Iteration   3: 9.437 ops/us
+Iteration   4: 9.362 ops/us
+
+
+Result "com.codahale.metrics.BenchmarkNewEDR.measureThreads_01":
+  8.582 ±(99.9%) 9.140 ops/us [Average]
+  (min, avg, max) = (6.475, 8.582, 9.437), stdev = 1.414
+  CI (99.9%): [≈ 0, 17.722] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 2 threads, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: com.codahale.metrics.BenchmarkNewEDR.measureThreads_02
+
+# Run progress: 6.67% complete, ETA 00:02:53
+# Fork: 1 of 1
+# Warmup Iteration   1: 13.198 ops/us
+# Warmup Iteration   2: 13.059 ops/us
+Iteration   1: 14.122 ops/us
+Iteration   2: 14.230 ops/us
+Iteration   3: 14.347 ops/us
+Iteration   4: 14.127 ops/us
+
+
+Result "com.codahale.metrics.BenchmarkNewEDR.measureThreads_02":
+  14.207 ±(99.9%) 0.686 ops/us [Average]
+  (min, avg, max) = (14.122, 14.207, 14.347), stdev = 0.106
+  CI (99.9%): [13.521, 14.892] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 4 threads, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: com.codahale.metrics.BenchmarkNewEDR.measureThreads_04
+
+# Run progress: 13.33% complete, ETA 00:02:40
+# Fork: 1 of 1
+# Warmup Iteration   1: 19.426 ops/us
+# Warmup Iteration   2: 18.461 ops/us
+Iteration   1: 22.212 ops/us
+Iteration   2: 22.332 ops/us
+Iteration   3: 22.140 ops/us
+Iteration   4: 21.588 ops/us
+
+
+Result "com.codahale.metrics.BenchmarkNewEDR.measureThreads_04":
+  22.068 ±(99.9%) 2.130 ops/us [Average]
+  (min, avg, max) = (21.588, 22.068, 22.332), stdev = 0.330
+  CI (99.9%): [19.938, 24.198] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 32 threads, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: com.codahale.metrics.BenchmarkNewEDR.measureThreads_32
+
+# Run progress: 20.00% complete, ETA 00:02:27
+# Fork: 1 of 1
+# Warmup Iteration   1: 14.968 ops/us
+# Warmup Iteration   2: 20.394 ops/us
+Iteration   1: 20.881 ops/us
+Iteration   2: 20.984 ops/us
+Iteration   3: 20.635 ops/us
+Iteration   4: 17.773 ops/us
+
+
+Result "com.codahale.metrics.BenchmarkNewEDR.measureThreads_32":
+  20.068 ±(99.9%) 9.934 ops/us [Average]
+  (min, avg, max) = (17.773, 20.068, 20.984), stdev = 1.537
+  CI (99.9%): [10.134, 30.002] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 32 threads, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: com.codahale.metrics.BenchmarkNewEDR.measureThreads_64
+
+# Run progress: 26.67% complete, ETA 00:02:17
+# Fork: 1 of 1
+# Warmup Iteration   1: 17.892 ops/us
+# Warmup Iteration   2: 20.651 ops/us
+Iteration   1: 21.722 ops/us
+Iteration   2: 21.357 ops/us
+Iteration   3: 18.185 ops/us
+Iteration   4: 19.439 ops/us
+
+
+Result "com.codahale.metrics.BenchmarkNewEDR.measureThreads_64":
+  20.176 ±(99.9%) 10.743 ops/us [Average]
+  (min, avg, max) = (18.185, 20.176, 21.722), stdev = 1.663
+  CI (99.9%): [9.432, 30.919] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: com.codahale.metrics.BenchmarkNewEDR.measureThreads_01
+
+# Run progress: 33.33% complete, ETA 00:02:07
+# Fork: 1 of 1
+# Warmup Iteration   1: 0.114 us/op
+# Warmup Iteration   2: 0.110 us/op
+Iteration   1: 0.111 us/op
+Iteration   2: 0.115 us/op
+Iteration   3: 0.115 us/op
+Iteration   4: 0.112 us/op
+
+
+Result "com.codahale.metrics.BenchmarkNewEDR.measureThreads_01":
+  0.114 ±(99.9%) 0.014 us/op [Average]
+  (min, avg, max) = (0.111, 0.114, 0.115), stdev = 0.002
+  CI (99.9%): [0.100, 0.127] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 2 threads, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: com.codahale.metrics.BenchmarkNewEDR.measureThreads_02
+
+# Run progress: 40.00% complete, ETA 00:01:54
+# Fork: 1 of 1
+# Warmup Iteration   1: 0.159 us/op
+# Warmup Iteration   2: 0.163 us/op
+Iteration   1: 0.162 us/op
+Iteration   2: 0.178 us/op
+Iteration   3: 0.164 us/op
+Iteration   4: 0.170 us/op
+
+
+Result "com.codahale.metrics.BenchmarkNewEDR.measureThreads_02":
+  0.169 ±(99.9%) 0.047 us/op [Average]
+  (min, avg, max) = (0.162, 0.169, 0.178), stdev = 0.007
+  CI (99.9%): [0.121, 0.216] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 4 threads, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: com.codahale.metrics.BenchmarkNewEDR.measureThreads_04
+
+# Run progress: 46.67% complete, ETA 00:01:40
+# Fork: 1 of 1
+# Warmup Iteration   1: 0.202 ±(99.9%) 0.006 us/op
+# Warmup Iteration   2: 0.182 ±(99.9%) 0.011 us/op
+Iteration   1: 0.205 ±(99.9%) 0.087 us/op
+Iteration   2: 0.186 ±(99.9%) 0.030 us/op
+Iteration   3: 0.179 ±(99.9%) 0.011 us/op
+Iteration   4: 0.180 ±(99.9%) 0.006 us/op
+
+
+Result "com.codahale.metrics.BenchmarkNewEDR.measureThreads_04":
+  0.187 ±(99.9%) 0.077 us/op [Average]
+  (min, avg, max) = (0.179, 0.187, 0.205), stdev = 0.012
+  CI (99.9%): [0.111, 0.264] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 32 threads, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: com.codahale.metrics.BenchmarkNewEDR.measureThreads_32
+
+# Run progress: 53.33% complete, ETA 00:01:28
+# Fork: 1 of 1
+# Warmup Iteration   1: 1.951 ±(99.9%) 0.105 us/op
+# Warmup Iteration   2: 1.576 ±(99.9%) 0.095 us/op
+Iteration   1: 1.798 ±(99.9%) 0.118 us/op
+Iteration   2: 1.622 ±(99.9%) 0.092 us/op
+Iteration   3: 1.537 ±(99.9%) 0.111 us/op
+Iteration   4: 1.648 ±(99.9%) 0.108 us/op
+
+
+Result "com.codahale.metrics.BenchmarkNewEDR.measureThreads_32":
+  1.651 ±(99.9%) 0.702 us/op [Average]
+  (min, avg, max) = (1.537, 1.651, 1.798), stdev = 0.109
+  CI (99.9%): [0.950, 2.353] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 32 threads, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: com.codahale.metrics.BenchmarkNewEDR.measureThreads_64
+
+# Run progress: 60.00% complete, ETA 00:01:16
+# Fork: 1 of 1
+# Warmup Iteration   1: 1.877 ±(99.9%) 0.106 us/op
+# Warmup Iteration   2: 1.905 ±(99.9%) 0.084 us/op
+Iteration   1: 1.631 ±(99.9%) 0.075 us/op
+Iteration   2: 1.604 ±(99.9%) 0.099 us/op
+Iteration   3: 1.936 ±(99.9%) 0.112 us/op
+Iteration   4: 1.996 ±(99.9%) 0.110 us/op
+
+
+Result "com.codahale.metrics.BenchmarkNewEDR.measureThreads_64":
+  1.792 ±(99.9%) 1.312 us/op [Average]
+  (min, avg, max) = (1.604, 1.792, 1.996), stdev = 0.203
+  CI (99.9%): [0.480, 3.104] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Sampling time
+# Benchmark: com.codahale.metrics.BenchmarkNewEDR.measureThreads_01
+
+# Run progress: 66.67% complete, ETA 00:01:03
+# Fork: 1 of 1
+# Warmup Iteration   1: 1.639 ±(99.9%) 1.776 us/op
+# Warmup Iteration   2: 0.158 ±(99.9%) 0.009 us/op
+Iteration   1: 0.149 ±(99.9%) 0.005 us/op
+                 measureThreads_01·p0.00:   0.129 us/op
+                 measureThreads_01·p0.50:   0.136 us/op
+                 measureThreads_01·p0.90:   0.145 us/op
+                 measureThreads_01·p0.95:   0.148 us/op
+                 measureThreads_01·p0.99:   0.197 us/op
+                 measureThreads_01·p0.999:  1.210 us/op
+                 measureThreads_01·p0.9999: 22.083 us/op
+                 measureThreads_01·p1.00:   34.240 us/op
+
+Iteration   2: 0.147 ±(99.9%) 0.005 us/op
+                 measureThreads_01·p0.00:   0.129 us/op
+                 measureThreads_01·p0.50:   0.136 us/op
+                 measureThreads_01·p0.90:   0.145 us/op
+                 measureThreads_01·p0.95:   0.148 us/op
+                 measureThreads_01·p0.99:   0.208 us/op
+                 measureThreads_01·p0.999:  0.616 us/op
+                 measureThreads_01·p0.9999: 13.542 us/op
+                 measureThreads_01·p1.00:   59.328 us/op
+
+Iteration   3: 0.142 ±(99.9%) 0.003 us/op
+                 measureThreads_01·p0.00:   0.129 us/op
+                 measureThreads_01·p0.50:   0.136 us/op
+                 measureThreads_01·p0.90:   0.145 us/op
+                 measureThreads_01·p0.95:   0.145 us/op
+                 measureThreads_01·p0.99:   0.166 us/op
+                 measureThreads_01·p0.999:  0.465 us/op
+                 measureThreads_01·p0.9999: 12.888 us/op
+                 measureThreads_01·p1.00:   30.496 us/op
+
+Iteration   4: 0.143 ±(99.9%) 0.003 us/op
+                 measureThreads_01·p0.00:   0.129 us/op
+                 measureThreads_01·p0.50:   0.136 us/op
+                 measureThreads_01·p0.90:   0.146 us/op
+                 measureThreads_01·p0.95:   0.148 us/op
+                 measureThreads_01·p0.99:   0.170 us/op
+                 measureThreads_01·p0.999:  0.531 us/op
+                 measureThreads_01·p0.9999: 12.844 us/op
+                 measureThreads_01·p1.00:   30.400 us/op
+
+
+
+Result "com.codahale.metrics.BenchmarkNewEDR.measureThreads_01":
+  N = 271028
+  mean =      0.146 ±(99.9%) 0.002 us/op
+
+  Histogram, us/op:
+    [ 0.000,  5.000) = 270926 
+    [ 5.000, 10.000) = 34 
+    [10.000, 15.000) = 47 
+    [15.000, 20.000) = 4 
+    [20.000, 25.000) = 3 
+    [25.000, 30.000) = 5 
+    [30.000, 35.000) = 7 
+    [35.000, 40.000) = 0 
+    [40.000, 45.000) = 1 
+    [45.000, 50.000) = 0 
+    [50.000, 55.000) = 0 
+
+  Percentiles, us/op:
+      p(0.0000) =      0.129 us/op
+     p(50.0000) =      0.136 us/op
+     p(90.0000) =      0.145 us/op
+     p(95.0000) =      0.147 us/op
+     p(99.0000) =      0.179 us/op
+     p(99.9000) =      0.548 us/op
+     p(99.9900) =     13.374 us/op
+     p(99.9990) =     37.151 us/op
+     p(99.9999) =     59.328 us/op
+    p(100.0000) =     59.328 us/op
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 2 threads, will synchronize iterations
+# Benchmark mode: Sampling time
+# Benchmark: com.codahale.metrics.BenchmarkNewEDR.measureThreads_02
+
+# Run progress: 73.33% complete, ETA 00:00:50
+# Fork: 1 of 1
+# Warmup Iteration   1: 0.467 ±(99.9%) 0.114 us/op
+# Warmup Iteration   2: 0.646 ±(99.9%) 0.682 us/op
+Iteration   1: 0.208 ±(99.9%) 0.025 us/op
+                 measureThreads_02·p0.00:   0.136 us/op
+                 measureThreads_02·p0.50:   0.182 us/op
+                 measureThreads_02·p0.90:   0.202 us/op
+                 measureThreads_02·p0.95:   0.213 us/op
+                 measureThreads_02·p0.99:   0.232 us/op
+                 measureThreads_02·p0.999:  3.044 us/op
+                 measureThreads_02·p0.9999: 30.879 us/op
+                 measureThreads_02·p1.00:   675.840 us/op
+
+Iteration   2: 0.194 ±(99.9%) 0.004 us/op
+                 measureThreads_02·p0.00:   0.147 us/op
+                 measureThreads_02·p0.50:   0.182 us/op
+                 measureThreads_02·p0.90:   0.199 us/op
+                 measureThreads_02·p0.95:   0.211 us/op
+                 measureThreads_02·p0.99:   0.244 us/op
+                 measureThreads_02·p0.999:  0.858 us/op
+                 measureThreads_02·p0.9999: 13.632 us/op
+                 measureThreads_02·p1.00:   35.328 us/op
+
+Iteration   3: 0.210 ±(99.9%) 0.053 us/op
+                 measureThreads_02·p0.00:   0.146 us/op
+                 measureThreads_02·p0.50:   0.182 us/op
+                 measureThreads_02·p0.90:   0.199 us/op
+                 measureThreads_02·p0.95:   0.211 us/op
+                 measureThreads_02·p0.99:   0.246 us/op
+                 measureThreads_02·p0.999:  0.833 us/op
+                 measureThreads_02·p0.9999: 16.614 us/op
+                 measureThreads_02·p1.00:   1482.752 us/op
+
+Iteration   4: 0.210 ±(99.9%) 0.005 us/op
+                 measureThreads_02·p0.00:   0.136 us/op
+                 measureThreads_02·p0.50:   0.194 us/op
+                 measureThreads_02·p0.90:   0.229 us/op
+                 measureThreads_02·p0.95:   0.243 us/op
+                 measureThreads_02·p0.99:   0.320 us/op
+                 measureThreads_02·p0.999:  2.692 us/op
+                 measureThreads_02·p0.9999: 13.760 us/op
+                 measureThreads_02·p1.00:   69.248 us/op
+
+
+
+Result "com.codahale.metrics.BenchmarkNewEDR.measureThreads_02":
+  N = 363219
+  mean =      0.206 ±(99.9%) 0.015 us/op
+
+  Histogram, us/op:
+    [   0.000,  125.000) = 363217 
+    [ 125.000,  250.000) = 0 
+    [ 250.000,  375.000) = 0 
+    [ 375.000,  500.000) = 0 
+    [ 500.000,  625.000) = 0 
+    [ 625.000,  750.000) = 1 
+    [ 750.000,  875.000) = 0 
+    [ 875.000, 1000.000) = 0 
+    [1000.000, 1125.000) = 0 
+    [1125.000, 1250.000) = 0 
+    [1250.000, 1375.000) = 0 
+    [1375.000, 1500.000) = 1 
+    [1500.000, 1625.000) = 0 
+    [1625.000, 1750.000) = 0 
+    [1750.000, 1875.000) = 0 
+
+  Percentiles, us/op:
+      p(0.0000) =      0.136 us/op
+     p(50.0000) =      0.183 us/op
+     p(90.0000) =      0.213 us/op
+     p(95.0000) =      0.223 us/op
+     p(99.0000) =      0.271 us/op
+     p(99.9000) =      1.400 us/op
+     p(99.9900) =     16.514 us/op
+     p(99.9990) =     76.762 us/op
+     p(99.9999) =   1482.752 us/op
+    p(100.0000) =   1482.752 us/op
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 4 threads, will synchronize iterations
+# Benchmark mode: Sampling time
+# Benchmark: com.codahale.metrics.BenchmarkNewEDR.measureThreads_04
+
+# Run progress: 80.00% complete, ETA 00:00:38
+# Fork: 1 of 1
+# Warmup Iteration   1: 2.236 ±(99.9%) 0.832 us/op
+# Warmup Iteration   2: 0.525 ±(99.9%) 0.375 us/op
+Iteration   1: 0.339 ±(99.9%) 0.193 us/op
+                 measureThreads_04·p0.00:   0.141 us/op
+                 measureThreads_04·p0.50:   0.250 us/op
+                 measureThreads_04·p0.90:   0.273 us/op
+                 measureThreads_04·p0.95:   0.279 us/op
+                 measureThreads_04·p0.99:   0.298 us/op
+                 measureThreads_04·p0.999:  0.681 us/op
+                 measureThreads_04·p0.9999: 30.646 us/op
+                 measureThreads_04·p1.00:   16023.552 us/op
+
+Iteration   2: 0.364 ±(99.9%) 0.192 us/op
+                 measureThreads_04·p0.00:   0.135 us/op
+                 measureThreads_04·p0.50:   0.247 us/op
+                 measureThreads_04·p0.90:   0.270 us/op
+                 measureThreads_04·p0.95:   0.276 us/op
+                 measureThreads_04·p0.99:   0.296 us/op
+                 measureThreads_04·p0.999:  0.780 us/op
+                 measureThreads_04·p0.9999: 54.094 us/op
+                 measureThreads_04·p1.00:   14516.224 us/op
+
+Iteration   3: 0.351 ±(99.9%) 0.185 us/op
+                 measureThreads_04·p0.00:   0.154 us/op
+                 measureThreads_04·p0.50:   0.250 us/op
+                 measureThreads_04·p0.90:   0.272 us/op
+                 measureThreads_04·p0.95:   0.277 us/op
+                 measureThreads_04·p0.99:   0.296 us/op
+                 measureThreads_04·p0.999:  0.706 us/op
+                 measureThreads_04·p0.9999: 31.025 us/op
+                 measureThreads_04·p1.00:   15908.864 us/op
+
+Iteration   4: 0.462 ±(99.9%) 0.281 us/op
+                 measureThreads_04·p0.00:   0.149 us/op
+                 measureThreads_04·p0.50:   0.229 us/op
+                 measureThreads_04·p0.90:   0.282 us/op
+                 measureThreads_04·p0.95:   0.296 us/op
+                 measureThreads_04·p0.99:   0.422 us/op
+                 measureThreads_04·p0.999:  1.112 us/op
+                 measureThreads_04·p0.9999: 66.726 us/op
+                 measureThreads_04·p1.00:   11993.088 us/op
+
+
+
+Result "com.codahale.metrics.BenchmarkNewEDR.measureThreads_04":
+  N = 1155805
+  mean =      0.375 ±(99.9%) 0.105 us/op
+
+  Histogram, us/op:
+    [    0.000,  1250.000) = 1155786 
+    [ 1250.000,  2500.000) = 6 
+    [ 2500.000,  3750.000) = 1 
+    [ 3750.000,  5000.000) = 2 
+    [ 5000.000,  6250.000) = 2 
+    [ 6250.000,  7500.000) = 1 
+    [ 7500.000,  8750.000) = 1 
+    [ 8750.000, 10000.000) = 1 
+    [10000.000, 11250.000) = 0 
+    [11250.000, 12500.000) = 2 
+    [12500.000, 13750.000) = 0 
+    [13750.000, 15000.000) = 1 
+    [15000.000, 16250.000) = 2 
+    [16250.000, 17500.000) = 0 
+    [17500.000, 18750.000) = 0 
+
+  Percentiles, us/op:
+      p(0.0000) =      0.135 us/op
+     p(50.0000) =      0.244 us/op
+     p(90.0000) =      0.273 us/op
+     p(95.0000) =      0.281 us/op
+     p(99.0000) =      0.323 us/op
+     p(99.9000) =      0.777 us/op
+     p(99.9900) =     36.492 us/op
+     p(99.9990) =   4339.488 us/op
+     p(99.9999) =  16005.683 us/op
+    p(100.0000) =  16023.552 us/op
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 32 threads, will synchronize iterations
+# Benchmark mode: Sampling time
+# Benchmark: com.codahale.metrics.BenchmarkNewEDR.measureThreads_32
+
+# Run progress: 86.67% complete, ETA 00:00:25
+# Fork: 1 of 1
+# Warmup Iteration   1: 12.582 ±(99.9%) 1.758 us/op
+# Warmup Iteration   2: 5.133 ±(99.9%) 1.124 us/op
+Iteration   1: 4.799 ±(99.9%) 1.018 us/op
+                 measureThreads_32·p0.00:   0.138 us/op
+                 measureThreads_32·p0.50:   0.225 us/op
+                 measureThreads_32·p0.90:   0.257 us/op
+                 measureThreads_32·p0.95:   0.268 us/op
+                 measureThreads_32·p0.99:   0.496 us/op
+                 measureThreads_32·p0.999:  2.136 us/op
+                 measureThreads_32·p0.9999: 19988.480 us/op
+                 measureThreads_32·p1.00:   95944.704 us/op
+
+Iteration   2: 4.690 ±(99.9%) 1.031 us/op
+                 measureThreads_32·p0.00:   0.138 us/op
+                 measureThreads_32·p0.50:   0.225 us/op
+                 measureThreads_32·p0.90:   0.255 us/op
+                 measureThreads_32·p0.95:   0.264 us/op
+                 measureThreads_32·p0.99:   0.282 us/op
+                 measureThreads_32·p0.999:  0.558 us/op
+                 measureThreads_32·p0.9999: 19988.480 us/op
+                 measureThreads_32·p1.00:   163840.000 us/op
+
+Iteration   3: 6.142 ±(99.9%) 1.387 us/op
+                 measureThreads_32·p0.00:   0.135 us/op
+                 measureThreads_32·p0.50:   0.222 us/op
+                 measureThreads_32·p0.90:   0.261 us/op
+                 measureThreads_32·p0.95:   0.283 us/op
+                 measureThreads_32·p0.99:   0.410 us/op
+                 measureThreads_32·p0.999:  0.729 us/op
+                 measureThreads_32·p0.9999: 25509.921 us/op
+                 measureThreads_32·p1.00:   139984.896 us/op
+
+Iteration   4: 5.287 ±(99.9%) 1.166 us/op
+                 measureThreads_32·p0.00:   0.140 us/op
+                 measureThreads_32·p0.50:   0.240 us/op
+                 measureThreads_32·p0.90:   0.261 us/op
+                 measureThreads_32·p0.95:   0.270 us/op
+                 measureThreads_32·p0.99:   0.300 us/op
+                 measureThreads_32·p0.999:  0.585 us/op
+                 measureThreads_32·p0.9999: 23348.838 us/op
+                 measureThreads_32·p1.00:   103940.096 us/op
+
+
+
+Result "com.codahale.metrics.BenchmarkNewEDR.measureThreads_32":
+  N = 7949364
+  mean =      5.195 ±(99.9%) 0.572 us/op
+
+  Histogram, us/op:
+    [     0.000,  12500.000) = 7948397 
+    [ 12500.000,  25000.000) = 262 
+    [ 25000.000,  37500.000) = 316 
+    [ 37500.000,  50000.000) = 171 
+    [ 50000.000,  62500.000) = 97 
+    [ 62500.000,  75000.000) = 52 
+    [ 75000.000,  87500.000) = 32 
+    [ 87500.000, 100000.000) = 25 
+    [100000.000, 112500.000) = 5 
+    [112500.000, 125000.000) = 3 
+    [125000.000, 137500.000) = 1 
+    [137500.000, 150000.000) = 2 
+    [150000.000, 162500.000) = 0 
+    [162500.000, 175000.000) = 1 
+    [175000.000, 187500.000) = 0 
+
+  Percentiles, us/op:
+      p(0.0000) =      0.135 us/op
+     p(50.0000) =      0.227 us/op
+     p(90.0000) =      0.258 us/op
+     p(95.0000) =      0.269 us/op
+     p(99.0000) =      0.391 us/op
+     p(99.9000) =      0.831 us/op
+     p(99.9900) =  23533.666 us/op
+     p(99.9990) =  71958.528 us/op
+     p(99.9999) = 108408.175 us/op
+    p(100.0000) = 163840.000 us/op
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 32 threads, will synchronize iterations
+# Benchmark mode: Sampling time
+# Benchmark: com.codahale.metrics.BenchmarkNewEDR.measureThreads_64
+
+# Run progress: 93.33% complete, ETA 00:00:12
+# Fork: 1 of 1
+# Warmup Iteration   1: 13.392 ±(99.9%) 1.668 us/op
+# Warmup Iteration   2: 5.631 ±(99.9%) 1.210 us/op
+Iteration   1: 6.440 ±(99.9%) 1.283 us/op
+                 measureThreads_64·p0.00:   0.133 us/op
+                 measureThreads_64·p0.50:   0.263 us/op
+                 measureThreads_64·p0.90:   0.363 us/op
+                 measureThreads_64·p0.95:   0.389 us/op
+                 measureThreads_64·p0.99:   0.471 us/op
+                 measureThreads_64·p0.999:  0.907 us/op
+                 measureThreads_64·p0.9999: 27983.872 us/op
+                 measureThreads_64·p1.00:   108003.328 us/op
+
+Iteration   2: 6.948 ±(99.9%) 1.499 us/op
+                 measureThreads_64·p0.00:   0.142 us/op
+                 measureThreads_64·p0.50:   0.249 us/op
+                 measureThreads_64·p0.90:   0.344 us/op
+                 measureThreads_64·p0.95:   0.369 us/op
+                 measureThreads_64·p0.99:   0.457 us/op
+                 measureThreads_64·p0.999:  0.810 us/op
+                 measureThreads_64·p0.9999: 31981.568 us/op
+                 measureThreads_64·p1.00:   115998.720 us/op
+
+Iteration   3: 5.515 ±(99.9%) 1.116 us/op
+                 measureThreads_64·p0.00:   0.133 us/op
+                 measureThreads_64·p0.50:   0.260 us/op
+                 measureThreads_64·p0.90:   0.350 us/op
+                 measureThreads_64·p0.95:   0.369 us/op
+                 measureThreads_64·p0.99:   0.403 us/op
+                 measureThreads_64·p0.999:  0.643 us/op
+                 measureThreads_64·p0.9999: 23986.176 us/op
+                 measureThreads_64·p1.00:   103940.096 us/op
+
+Iteration   4: 5.965 ±(99.9%) 1.248 us/op
+                 measureThreads_64·p0.00:   0.137 us/op
+                 measureThreads_64·p0.50:   0.269 us/op
+                 measureThreads_64·p0.90:   0.348 us/op
+                 measureThreads_64·p0.95:   0.373 us/op
+                 measureThreads_64·p0.99:   0.417 us/op
+                 measureThreads_64·p0.999:  0.702 us/op
+                 measureThreads_64·p0.9999: 26724.631 us/op
+                 measureThreads_64·p1.00:   88997.888 us/op
+
+
+
+Result "com.codahale.metrics.BenchmarkNewEDR.measureThreads_64":
+  N = 7019706
+  mean =      6.203 ±(99.9%) 0.643 us/op
+
+  Histogram, us/op:
+    [     0.000,  12500.000) = 7018641 
+    [ 12500.000,  25000.000) = 310 
+    [ 25000.000,  37500.000) = 340 
+    [ 37500.000,  50000.000) = 193 
+    [ 50000.000,  62500.000) = 99 
+    [ 62500.000,  75000.000) = 69 
+    [ 75000.000,  87500.000) = 27 
+    [ 87500.000, 100000.000) = 17 
+    [100000.000, 112500.000) = 9 
+    [112500.000, 125000.000) = 1 
+    [125000.000, 137500.000) = 0 
+    [137500.000, 150000.000) = 0 
+    [150000.000, 162500.000) = 0 
+    [162500.000, 175000.000) = 0 
+    [175000.000, 187500.000) = 0 
+
+  Percentiles, us/op:
+      p(0.0000) =      0.133 us/op
+     p(50.0000) =      0.263 us/op
+     p(90.0000) =      0.352 us/op
+     p(95.0000) =      0.375 us/op
+     p(99.0000) =      0.433 us/op
+     p(99.9000) =      0.799 us/op
+     p(99.9900) =  27983.872 us/op
+     p(99.9990) =  69184.026 us/op
+     p(99.9999) = 103940.096 us/op
+    p(100.0000) = 115998.720 us/op
+
+
+# Run complete. Total time: 00:03:12
+
+REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
+why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
+experiments, perform baseline and negative tests that provide experimental control, make sure
+the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
+Do not assume the numbers tell you what you want them to tell.
+
+Benchmark                                                      Mode      Cnt       Score    Error   Units
+BenchmarkNewEDR.measureThreads_01                             thrpt        4       8.582 ±  9.140  ops/us
+BenchmarkNewEDR.measureThreads_02                             thrpt        4      14.207 ±  0.686  ops/us
+BenchmarkNewEDR.measureThreads_04                             thrpt        4      22.068 ±  2.130  ops/us
+BenchmarkNewEDR.measureThreads_32                             thrpt        4      20.068 ±  9.934  ops/us
+BenchmarkNewEDR.measureThreads_64                             thrpt        4      20.176 ± 10.743  ops/us
+BenchmarkNewEDR.measureThreads_01                              avgt        4       0.114 ±  0.014   us/op
+BenchmarkNewEDR.measureThreads_02                              avgt        4       0.169 ±  0.047   us/op
+BenchmarkNewEDR.measureThreads_04                              avgt        4       0.187 ±  0.077   us/op
+BenchmarkNewEDR.measureThreads_32                              avgt        4       1.651 ±  0.702   us/op
+BenchmarkNewEDR.measureThreads_64                              avgt        4       1.792 ±  1.312   us/op
+BenchmarkNewEDR.measureThreads_01                            sample   271028       0.146 ±  0.002   us/op
+BenchmarkNewEDR.measureThreads_01:measureThreads_01·p0.00    sample                0.129            us/op
+BenchmarkNewEDR.measureThreads_01:measureThreads_01·p0.50    sample                0.136            us/op
+BenchmarkNewEDR.measureThreads_01:measureThreads_01·p0.90    sample                0.145            us/op
+BenchmarkNewEDR.measureThreads_01:measureThreads_01·p0.95    sample                0.147            us/op
+BenchmarkNewEDR.measureThreads_01:measureThreads_01·p0.99    sample                0.179            us/op
+BenchmarkNewEDR.measureThreads_01:measureThreads_01·p0.999   sample                0.548            us/op
+BenchmarkNewEDR.measureThreads_01:measureThreads_01·p0.9999  sample               13.374            us/op
+BenchmarkNewEDR.measureThreads_01:measureThreads_01·p1.00    sample               59.328            us/op
+BenchmarkNewEDR.measureThreads_02                            sample   363219       0.206 ±  0.015   us/op
+BenchmarkNewEDR.measureThreads_02:measureThreads_02·p0.00    sample                0.136            us/op
+BenchmarkNewEDR.measureThreads_02:measureThreads_02·p0.50    sample                0.183            us/op
+BenchmarkNewEDR.measureThreads_02:measureThreads_02·p0.90    sample                0.213            us/op
+BenchmarkNewEDR.measureThreads_02:measureThreads_02·p0.95    sample                0.223            us/op
+BenchmarkNewEDR.measureThreads_02:measureThreads_02·p0.99    sample                0.271            us/op
+BenchmarkNewEDR.measureThreads_02:measureThreads_02·p0.999   sample                1.400            us/op
+BenchmarkNewEDR.measureThreads_02:measureThreads_02·p0.9999  sample               16.514            us/op
+BenchmarkNewEDR.measureThreads_02:measureThreads_02·p1.00    sample             1482.752            us/op
+BenchmarkNewEDR.measureThreads_04                            sample  1155805       0.375 ±  0.105   us/op
+BenchmarkNewEDR.measureThreads_04:measureThreads_04·p0.00    sample                0.135            us/op
+BenchmarkNewEDR.measureThreads_04:measureThreads_04·p0.50    sample                0.244            us/op
+BenchmarkNewEDR.measureThreads_04:measureThreads_04·p0.90    sample                0.273            us/op
+BenchmarkNewEDR.measureThreads_04:measureThreads_04·p0.95    sample                0.281            us/op
+BenchmarkNewEDR.measureThreads_04:measureThreads_04·p0.99    sample                0.323            us/op
+BenchmarkNewEDR.measureThreads_04:measureThreads_04·p0.999   sample                0.777            us/op
+BenchmarkNewEDR.measureThreads_04:measureThreads_04·p0.9999  sample               36.492            us/op
+BenchmarkNewEDR.measureThreads_04:measureThreads_04·p1.00    sample            16023.552            us/op
+BenchmarkNewEDR.measureThreads_32                            sample  7949364       5.195 ±  0.572   us/op
+BenchmarkNewEDR.measureThreads_32:measureThreads_32·p0.00    sample                0.135            us/op
+BenchmarkNewEDR.measureThreads_32:measureThreads_32·p0.50    sample                0.227            us/op
+BenchmarkNewEDR.measureThreads_32:measureThreads_32·p0.90    sample                0.258            us/op
+BenchmarkNewEDR.measureThreads_32:measureThreads_32·p0.95    sample                0.269            us/op
+BenchmarkNewEDR.measureThreads_32:measureThreads_32·p0.99    sample                0.391            us/op
+BenchmarkNewEDR.measureThreads_32:measureThreads_32·p0.999   sample                0.831            us/op
+BenchmarkNewEDR.measureThreads_32:measureThreads_32·p0.9999  sample            23533.666            us/op
+BenchmarkNewEDR.measureThreads_32:measureThreads_32·p1.00    sample           163840.000            us/op
+BenchmarkNewEDR.measureThreads_64                            sample  7019706       6.203 ±  0.643   us/op
+BenchmarkNewEDR.measureThreads_64:measureThreads_64·p0.00    sample                0.133            us/op
+BenchmarkNewEDR.measureThreads_64:measureThreads_64·p0.50    sample                0.263            us/op
+BenchmarkNewEDR.measureThreads_64:measureThreads_64·p0.90    sample                0.352            us/op
+BenchmarkNewEDR.measureThreads_64:measureThreads_64·p0.95    sample                0.375            us/op
+BenchmarkNewEDR.measureThreads_64:measureThreads_64·p0.99    sample                0.433            us/op
+BenchmarkNewEDR.measureThreads_64:measureThreads_64·p0.999   sample                0.799            us/op
+BenchmarkNewEDR.measureThreads_64:measureThreads_64·p0.9999  sample            27983.872            us/op
+BenchmarkNewEDR.measureThreads_64:measureThreads_64·p1.00    sample           115998.720            us/op

--- a/metrics-core/old.txt
+++ b/metrics-core/old.txt
@@ -1,0 +1,787 @@
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: com.codahale.metrics.BenchmarkOldEDR.measureThreads_01
+
+# Run progress: 0.00% complete, ETA 00:03:00
+# Fork: 1 of 1
+# Warmup Iteration   1: 7.845 ops/us
+# Warmup Iteration   2: 7.852 ops/us
+Iteration   1: 7.873 ops/us
+Iteration   2: 8.209 ops/us
+Iteration   3: 8.185 ops/us
+Iteration   4: 8.169 ops/us
+
+
+Result "com.codahale.metrics.BenchmarkOldEDR.measureThreads_01":
+  8.109 ±(99.9%) 1.022 ops/us [Average]
+  (min, avg, max) = (7.873, 8.109, 8.209), stdev = 0.158
+  CI (99.9%): [7.087, 9.131] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 2 threads, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: com.codahale.metrics.BenchmarkOldEDR.measureThreads_02
+
+# Run progress: 6.67% complete, ETA 00:02:52
+# Fork: 1 of 1
+# Warmup Iteration   1: 4.959 ops/us
+# Warmup Iteration   2: 6.733 ops/us
+Iteration   1: 6.674 ops/us
+Iteration   2: 6.605 ops/us
+Iteration   3: 6.605 ops/us
+Iteration   4: 6.476 ops/us
+
+
+Result "com.codahale.metrics.BenchmarkOldEDR.measureThreads_02":
+  6.590 ±(99.9%) 0.534 ops/us [Average]
+  (min, avg, max) = (6.476, 6.590, 6.674), stdev = 0.083
+  CI (99.9%): [6.056, 7.124] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 4 threads, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: com.codahale.metrics.BenchmarkOldEDR.measureThreads_04
+
+# Run progress: 13.33% complete, ETA 00:02:40
+# Fork: 1 of 1
+# Warmup Iteration   1: 5.086 ops/us
+# Warmup Iteration   2: 5.725 ops/us
+Iteration   1: 5.689 ops/us
+Iteration   2: 5.717 ops/us
+Iteration   3: 5.693 ops/us
+Iteration   4: 5.704 ops/us
+
+
+Result "com.codahale.metrics.BenchmarkOldEDR.measureThreads_04":
+  5.701 ±(99.9%) 0.081 ops/us [Average]
+  (min, avg, max) = (5.689, 5.701, 5.717), stdev = 0.012
+  CI (99.9%): [5.620, 5.782] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 32 threads, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: com.codahale.metrics.BenchmarkOldEDR.measureThreads_32
+
+# Run progress: 20.00% complete, ETA 00:02:27
+# Fork: 1 of 1
+# Warmup Iteration   1: 4.066 ops/us
+# Warmup Iteration   2: 4.836 ops/us
+Iteration   1: 5.858 ops/us
+Iteration   2: 5.755 ops/us
+Iteration   3: 5.698 ops/us
+Iteration   4: 5.501 ops/us
+
+
+Result "com.codahale.metrics.BenchmarkOldEDR.measureThreads_32":
+  5.703 ±(99.9%) 0.970 ops/us [Average]
+  (min, avg, max) = (5.501, 5.703, 5.858), stdev = 0.150
+  CI (99.9%): [4.733, 6.673] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 32 threads, will synchronize iterations
+# Benchmark mode: Throughput, ops/time
+# Benchmark: com.codahale.metrics.BenchmarkOldEDR.measureThreads_64
+
+# Run progress: 26.67% complete, ETA 00:02:19
+# Fork: 1 of 1
+# Warmup Iteration   1: 3.758 ops/us
+# Warmup Iteration   2: 3.230 ops/us
+Iteration   1: 5.357 ops/us
+Iteration   2: 5.281 ops/us
+Iteration   3: 5.299 ops/us
+Iteration   4: 5.342 ops/us
+
+
+Result "com.codahale.metrics.BenchmarkOldEDR.measureThreads_64":
+  5.320 ±(99.9%) 0.233 ops/us [Average]
+  (min, avg, max) = (5.281, 5.320, 5.357), stdev = 0.036
+  CI (99.9%): [5.086, 5.553] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: com.codahale.metrics.BenchmarkOldEDR.measureThreads_01
+
+# Run progress: 33.33% complete, ETA 00:02:10
+# Fork: 1 of 1
+# Warmup Iteration   1: 0.125 us/op
+# Warmup Iteration   2: 0.122 us/op
+Iteration   1: 0.121 us/op
+Iteration   2: 0.129 us/op
+Iteration   3: 0.121 us/op
+Iteration   4: 0.122 us/op
+
+
+Result "com.codahale.metrics.BenchmarkOldEDR.measureThreads_01":
+  0.123 ±(99.9%) 0.026 us/op [Average]
+  (min, avg, max) = (0.121, 0.123, 0.129), stdev = 0.004
+  CI (99.9%): [0.097, 0.149] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 2 threads, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: com.codahale.metrics.BenchmarkOldEDR.measureThreads_02
+
+# Run progress: 40.00% complete, ETA 00:01:56
+# Fork: 1 of 1
+# Warmup Iteration   1: 0.458 us/op
+# Warmup Iteration   2: 0.372 us/op
+Iteration   1: 0.332 us/op
+Iteration   2: 0.382 us/op
+Iteration   3: 0.381 us/op
+Iteration   4: 0.384 us/op
+
+
+Result "com.codahale.metrics.BenchmarkOldEDR.measureThreads_02":
+  0.370 ±(99.9%) 0.163 us/op [Average]
+  (min, avg, max) = (0.332, 0.370, 0.384), stdev = 0.025
+  CI (99.9%): [0.207, 0.533] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 4 threads, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: com.codahale.metrics.BenchmarkOldEDR.measureThreads_04
+
+# Run progress: 46.67% complete, ETA 00:01:42
+# Fork: 1 of 1
+# Warmup Iteration   1: 0.759 ±(99.9%) 0.099 us/op
+# Warmup Iteration   2: 0.722 ±(99.9%) 0.274 us/op
+Iteration   1: 0.712 ±(99.9%) 0.403 us/op
+Iteration   2: 0.717 ±(99.9%) 0.077 us/op
+Iteration   3: 0.721 ±(99.9%) 0.172 us/op
+Iteration   4: 0.724 ±(99.9%) 0.069 us/op
+
+
+Result "com.codahale.metrics.BenchmarkOldEDR.measureThreads_04":
+  0.719 ±(99.9%) 0.033 us/op [Average]
+  (min, avg, max) = (0.712, 0.719, 0.724), stdev = 0.005
+  CI (99.9%): [0.686, 0.751] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 32 threads, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: com.codahale.metrics.BenchmarkOldEDR.measureThreads_32
+
+# Run progress: 53.33% complete, ETA 00:01:29
+# Fork: 1 of 1
+# Warmup Iteration   1: 7.879 ±(99.9%) 0.357 us/op
+# Warmup Iteration   2: 9.885 ±(99.9%) 0.926 us/op
+Iteration   1: 5.569 ±(99.9%) 0.448 us/op
+Iteration   2: 5.509 ±(99.9%) 0.406 us/op
+Iteration   3: 5.651 ±(99.9%) 0.452 us/op
+Iteration   4: 5.619 ±(99.9%) 0.400 us/op
+
+
+Result "com.codahale.metrics.BenchmarkOldEDR.measureThreads_32":
+  5.587 ±(99.9%) 0.400 us/op [Average]
+  (min, avg, max) = (5.509, 5.587, 5.651), stdev = 0.062
+  CI (99.9%): [5.187, 5.988] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 32 threads, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: com.codahale.metrics.BenchmarkOldEDR.measureThreads_64
+
+# Run progress: 60.00% complete, ETA 00:01:17
+# Fork: 1 of 1
+# Warmup Iteration   1: 7.244 ±(99.9%) 0.588 us/op
+# Warmup Iteration   2: 9.402 ±(99.9%) 0.673 us/op
+Iteration   1: 5.714 ±(99.9%) 0.300 us/op
+Iteration   2: 5.677 ±(99.9%) 0.314 us/op
+Iteration   3: 5.764 ±(99.9%) 0.506 us/op
+Iteration   4: 5.830 ±(99.9%) 0.332 us/op
+
+
+Result "com.codahale.metrics.BenchmarkOldEDR.measureThreads_64":
+  5.746 ±(99.9%) 0.429 us/op [Average]
+  (min, avg, max) = (5.677, 5.746, 5.830), stdev = 0.066
+  CI (99.9%): [5.317, 6.175] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Sampling time
+# Benchmark: com.codahale.metrics.BenchmarkOldEDR.measureThreads_01
+
+# Run progress: 66.67% complete, ETA 00:01:04
+# Fork: 1 of 1
+# Warmup Iteration   1: 0.347 ±(99.9%) 0.052 us/op
+# Warmup Iteration   2: 0.168 ±(99.9%) 0.008 us/op
+Iteration   1: 0.172 ±(99.9%) 0.034 us/op
+                 measureThreads_01·p0.00:   0.139 us/op
+                 measureThreads_01·p0.50:   0.153 us/op
+                 measureThreads_01·p0.90:   0.156 us/op
+                 measureThreads_01·p0.95:   0.172 us/op
+                 measureThreads_01·p0.99:   0.235 us/op
+                 measureThreads_01·p0.999:  0.856 us/op
+                 measureThreads_01·p0.9999: 27.205 us/op
+                 measureThreads_01·p1.00:   615.424 us/op
+
+Iteration   2: 0.158 ±(99.9%) 0.006 us/op
+                 measureThreads_01·p0.00:   0.139 us/op
+                 measureThreads_01·p0.50:   0.147 us/op
+                 measureThreads_01·p0.90:   0.156 us/op
+                 measureThreads_01·p0.95:   0.157 us/op
+                 measureThreads_01·p0.99:   0.187 us/op
+                 measureThreads_01·p0.999:  0.622 us/op
+                 measureThreads_01·p0.9999: 18.073 us/op
+                 measureThreads_01·p1.00:   72.192 us/op
+
+Iteration   3: 0.157 ±(99.9%) 0.005 us/op
+                 measureThreads_01·p0.00:   0.139 us/op
+                 measureThreads_01·p0.50:   0.146 us/op
+                 measureThreads_01·p0.90:   0.156 us/op
+                 measureThreads_01·p0.95:   0.158 us/op
+                 measureThreads_01·p0.99:   0.181 us/op
+                 measureThreads_01·p0.999:  0.554 us/op
+                 measureThreads_01·p0.9999: 14.930 us/op
+                 measureThreads_01·p1.00:   41.728 us/op
+
+Iteration   4: 0.169 ±(99.9%) 0.005 us/op
+                 measureThreads_01·p0.00:   0.139 us/op
+                 measureThreads_01·p0.50:   0.157 us/op
+                 measureThreads_01·p0.90:   0.175 us/op
+                 measureThreads_01·p0.95:   0.180 us/op
+                 measureThreads_01·p0.99:   0.216 us/op
+                 measureThreads_01·p0.999:  0.641 us/op
+                 measureThreads_01·p0.9999: 18.599 us/op
+                 measureThreads_01·p1.00:   30.720 us/op
+
+
+
+Result "com.codahale.metrics.BenchmarkOldEDR.measureThreads_01":
+  N = 243235
+  mean =      0.164 ±(99.9%) 0.009 us/op
+
+  Histogram, us/op:
+    [  0.000,  50.000) = 243232 
+    [ 50.000, 100.000) = 2 
+    [100.000, 150.000) = 0 
+    [150.000, 200.000) = 0 
+    [200.000, 250.000) = 0 
+    [250.000, 300.000) = 0 
+    [300.000, 350.000) = 0 
+    [350.000, 400.000) = 0 
+    [400.000, 450.000) = 0 
+    [450.000, 500.000) = 0 
+    [500.000, 550.000) = 0 
+    [550.000, 600.000) = 0 
+    [600.000, 650.000) = 1 
+
+  Percentiles, us/op:
+      p(0.0000) =      0.139 us/op
+     p(50.0000) =      0.154 us/op
+     p(90.0000) =      0.162 us/op
+     p(95.0000) =      0.175 us/op
+     p(99.0000) =      0.210 us/op
+     p(99.9000) =      0.636 us/op
+     p(99.9900) =     18.133 us/op
+     p(99.9990) =     66.575 us/op
+     p(99.9999) =    615.424 us/op
+    p(100.0000) =    615.424 us/op
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 2 threads, will synchronize iterations
+# Benchmark mode: Sampling time
+# Benchmark: com.codahale.metrics.BenchmarkOldEDR.measureThreads_02
+
+# Run progress: 73.33% complete, ETA 00:00:51
+# Fork: 1 of 1
+# Warmup Iteration   1: 0.655 ±(99.9%) 0.048 us/op
+# Warmup Iteration   2: 0.661 ±(99.9%) 0.528 us/op
+Iteration   1: 0.492 ±(99.9%) 0.146 us/op
+                 measureThreads_02·p0.00:   0.152 us/op
+                 measureThreads_02·p0.50:   0.357 us/op
+                 measureThreads_02·p0.90:   0.561 us/op
+                 measureThreads_02·p0.95:   0.622 us/op
+                 measureThreads_02·p0.99:   0.774 us/op
+                 measureThreads_02·p0.999:  5.948 us/op
+                 measureThreads_02·p0.9999: 58.236 us/op
+                 measureThreads_02·p1.00:   4153.344 us/op
+
+Iteration   2: 1.014 ±(99.9%) 0.733 us/op
+                 measureThreads_02·p0.00:   0.164 us/op
+                 measureThreads_02·p0.50:   0.352 us/op
+                 measureThreads_02·p0.90:   0.533 us/op
+                 measureThreads_02·p0.95:   0.601 us/op
+                 measureThreads_02·p0.99:   0.780 us/op
+                 measureThreads_02·p0.999:  13.472 us/op
+                 measureThreads_02·p0.9999: 1046.062 us/op
+                 measureThreads_02·p1.00:   18382.848 us/op
+
+Iteration   3: 0.380 ±(99.9%) 0.026 us/op
+                 measureThreads_02·p0.00:   0.168 us/op
+                 measureThreads_02·p0.50:   0.324 us/op
+                 measureThreads_02·p0.90:   0.522 us/op
+                 measureThreads_02·p0.95:   0.602 us/op
+                 measureThreads_02·p0.99:   0.795 us/op
+                 measureThreads_02·p0.999:  8.801 us/op
+                 measureThreads_02·p0.9999: 30.985 us/op
+                 measureThreads_02·p1.00:   713.728 us/op
+
+Iteration   4: 0.413 ±(99.9%) 0.028 us/op
+                 measureThreads_02·p0.00:   0.168 us/op
+                 measureThreads_02·p0.50:   0.359 us/op
+                 measureThreads_02·p0.90:   0.501 us/op
+                 measureThreads_02·p0.95:   0.549 us/op
+                 measureThreads_02·p0.99:   0.726 us/op
+                 measureThreads_02·p0.999:  7.549 us/op
+                 measureThreads_02·p0.9999: 30.764 us/op
+                 measureThreads_02·p1.00:   658.432 us/op
+
+
+
+Result "com.codahale.metrics.BenchmarkOldEDR.measureThreads_02":
+  N = 439113
+  mean =      0.594 ±(99.9%) 0.204 us/op
+
+  Histogram, us/op:
+    [    0.000,  1250.000) = 439099 
+    [ 1250.000,  2500.000) = 4 
+    [ 2500.000,  3750.000) = 3 
+    [ 3750.000,  5000.000) = 2 
+    [ 5000.000,  6250.000) = 0 
+    [ 6250.000,  7500.000) = 1 
+    [ 7500.000,  8750.000) = 1 
+    [ 8750.000, 10000.000) = 0 
+    [10000.000, 11250.000) = 2 
+    [11250.000, 12500.000) = 0 
+    [12500.000, 13750.000) = 0 
+    [13750.000, 15000.000) = 0 
+    [15000.000, 16250.000) = 0 
+    [16250.000, 17500.000) = 0 
+    [17500.000, 18750.000) = 1 
+
+  Percentiles, us/op:
+      p(0.0000) =      0.152 us/op
+     p(50.0000) =      0.348 us/op
+     p(90.0000) =      0.534 us/op
+     p(95.0000) =      0.601 us/op
+     p(99.0000) =      0.777 us/op
+     p(99.9000) =     11.164 us/op
+     p(99.9900) =     89.015 us/op
+     p(99.9990) =   7780.439 us/op
+     p(99.9999) =  18382.848 us/op
+    p(100.0000) =  18382.848 us/op
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 4 threads, will synchronize iterations
+# Benchmark mode: Sampling time
+# Benchmark: com.codahale.metrics.BenchmarkOldEDR.measureThreads_04
+
+# Run progress: 80.00% complete, ETA 00:00:38
+# Fork: 1 of 1
+# Warmup Iteration   1: 3.389 ±(99.9%) 0.786 us/op
+# Warmup Iteration   2: 2.010 ±(99.9%) 0.737 us/op
+Iteration   1: 1.274 ±(99.9%) 0.527 us/op
+                 measureThreads_04·p0.00:   0.177 us/op
+                 measureThreads_04·p0.50:   0.694 us/op
+                 measureThreads_04·p0.90:   0.960 us/op
+                 measureThreads_04·p0.95:   1.058 us/op
+                 measureThreads_04·p0.99:   1.312 us/op
+                 measureThreads_04·p0.999:  14.047 us/op
+                 measureThreads_04·p0.9999: 325.992 us/op
+                 measureThreads_04·p1.00:   15613.952 us/op
+
+Iteration   2: 0.992 ±(99.9%) 0.357 us/op
+                 measureThreads_04·p0.00:   0.178 us/op
+                 measureThreads_04·p0.50:   0.649 us/op
+                 measureThreads_04·p0.90:   0.938 us/op
+                 measureThreads_04·p0.95:   1.036 us/op
+                 measureThreads_04·p0.99:   1.280 us/op
+                 measureThreads_04·p0.999:  13.724 us/op
+                 measureThreads_04·p0.9999: 158.796 us/op
+                 measureThreads_04·p1.00:   16007.168 us/op
+
+Iteration   3: 1.504 ±(99.9%) 0.639 us/op
+                 measureThreads_04·p0.00:   0.173 us/op
+                 measureThreads_04·p0.50:   0.694 us/op
+                 measureThreads_04·p0.90:   0.974 us/op
+                 measureThreads_04·p0.95:   1.076 us/op
+                 measureThreads_04·p0.99:   1.332 us/op
+                 measureThreads_04·p0.999:  13.692 us/op
+                 measureThreads_04·p0.9999: 616.173 us/op
+                 measureThreads_04·p1.00:   16007.168 us/op
+
+Iteration   4: 1.106 ±(99.9%) 0.408 us/op
+                 measureThreads_04·p0.00:   0.173 us/op
+                 measureThreads_04·p0.50:   0.699 us/op
+                 measureThreads_04·p0.90:   0.962 us/op
+                 measureThreads_04·p0.95:   1.062 us/op
+                 measureThreads_04·p0.99:   1.334 us/op
+                 measureThreads_04·p0.999:  14.416 us/op
+                 measureThreads_04·p0.9999: 183.800 us/op
+                 measureThreads_04·p1.00:   12091.392 us/op
+
+
+
+Result "com.codahale.metrics.BenchmarkOldEDR.measureThreads_04":
+  N = 818224
+  mean =      1.214 ±(99.9%) 0.247 us/op
+
+  Histogram, us/op:
+    [    0.000,  1250.000) = 818175 
+    [ 1250.000,  2500.000) = 10 
+    [ 2500.000,  3750.000) = 5 
+    [ 3750.000,  5000.000) = 5 
+    [ 5000.000,  6250.000) = 3 
+    [ 6250.000,  7500.000) = 3 
+    [ 7500.000,  8750.000) = 1 
+    [ 8750.000, 10000.000) = 5 
+    [10000.000, 11250.000) = 5 
+    [11250.000, 12500.000) = 6 
+    [12500.000, 13750.000) = 0 
+    [13750.000, 15000.000) = 1 
+    [15000.000, 16250.000) = 5 
+    [16250.000, 17500.000) = 0 
+    [17500.000, 18750.000) = 0 
+
+  Percentiles, us/op:
+      p(0.0000) =      0.173 us/op
+     p(50.0000) =      0.684 us/op
+     p(90.0000) =      0.958 us/op
+     p(95.0000) =      1.058 us/op
+     p(99.0000) =      1.312 us/op
+     p(99.9000) =     14.000 us/op
+     p(99.9900) =    200.242 us/op
+     p(99.9990) =  12066.050 us/op
+     p(99.9999) =  16007.168 us/op
+    p(100.0000) =  16007.168 us/op
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 32 threads, will synchronize iterations
+# Benchmark mode: Sampling time
+# Benchmark: com.codahale.metrics.BenchmarkOldEDR.measureThreads_32
+
+# Run progress: 86.67% complete, ETA 00:00:25
+# Fork: 1 of 1
+# Warmup Iteration   1: 24.338 ±(99.9%) 2.675 us/op
+# Warmup Iteration   2: 14.263 ±(99.9%) 2.527 us/op
+Iteration   1: 12.347 ±(99.9%) 2.224 us/op
+                 measureThreads_32·p0.00:   0.199 us/op
+                 measureThreads_32·p0.50:   0.526 us/op
+                 measureThreads_32·p0.90:   0.768 us/op
+                 measureThreads_32·p0.95:   0.869 us/op
+                 measureThreads_32·p0.99:   1.220 us/op
+                 measureThreads_32·p0.999:  7.235 us/op
+                 measureThreads_32·p0.9999: 43974.656 us/op
+                 measureThreads_32·p1.00:   163840.000 us/op
+
+Iteration   2: 11.710 ±(99.9%) 2.085 us/op
+                 measureThreads_32·p0.00:   0.210 us/op
+                 measureThreads_32·p0.50:   0.567 us/op
+                 measureThreads_32·p0.90:   0.800 us/op
+                 measureThreads_32·p0.95:   0.890 us/op
+                 measureThreads_32·p0.99:   1.102 us/op
+                 measureThreads_32·p0.999:  4.949 us/op
+                 measureThreads_32·p0.9999: 39976.960 us/op
+                 measureThreads_32·p1.00:   164102.144 us/op
+
+Iteration   3: 11.033 ±(99.9%) 1.932 us/op
+                 measureThreads_32·p0.00:   0.209 us/op
+                 measureThreads_32·p0.50:   0.577 us/op
+                 measureThreads_32·p0.90:   0.815 us/op
+                 measureThreads_32·p0.95:   0.909 us/op
+                 measureThreads_32·p0.99:   1.130 us/op
+                 measureThreads_32·p0.999:  5.144 us/op
+                 measureThreads_32·p0.9999: 35979.264 us/op
+                 measureThreads_32·p1.00:   149946.368 us/op
+
+Iteration   4: 11.378 ±(99.9%) 1.980 us/op
+                 measureThreads_32·p0.00:   0.211 us/op
+                 measureThreads_32·p0.50:   0.576 us/op
+                 measureThreads_32·p0.90:   0.801 us/op
+                 measureThreads_32·p0.95:   0.890 us/op
+                 measureThreads_32·p0.99:   1.096 us/op
+                 measureThreads_32·p0.999:  5.055 us/op
+                 measureThreads_32·p0.9999: 35979.264 us/op
+                 measureThreads_32·p1.00:   141295.616 us/op
+
+
+
+Result "com.codahale.metrics.BenchmarkOldEDR.measureThreads_32":
+  N = 5752558
+  mean =     11.613 ±(99.9%) 1.028 us/op
+
+  Histogram, us/op:
+    [     0.000,  12500.000) = 5751037 
+    [ 12500.000,  25000.000) = 327 
+    [ 25000.000,  37500.000) = 593 
+    [ 37500.000,  50000.000) = 231 
+    [ 50000.000,  62500.000) = 168 
+    [ 62500.000,  75000.000) = 107 
+    [ 75000.000,  87500.000) = 27 
+    [ 87500.000, 100000.000) = 21 
+    [100000.000, 112500.000) = 24 
+    [112500.000, 125000.000) = 3 
+    [125000.000, 137500.000) = 10 
+    [137500.000, 150000.000) = 8 
+    [150000.000, 162500.000) = 0 
+    [162500.000, 175000.000) = 2 
+    [175000.000, 187500.000) = 0 
+
+  Percentiles, us/op:
+      p(0.0000) =      0.199 us/op
+     p(50.0000) =      0.562 us/op
+     p(90.0000) =      0.798 us/op
+     p(95.0000) =      0.891 us/op
+     p(99.0000) =      1.124 us/op
+     p(99.9000) =      5.752 us/op
+     p(99.9900) =  39583.744 us/op
+     p(99.9990) =  91605.911 us/op
+     p(99.9999) = 141098.337 us/op
+    p(100.0000) = 164102.144 us/op
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_221, Java HotSpot(TM) 64-Bit Server VM, 25.221-b11
+# VM invoker: /usr/lib/jvm/jdk-8-oracle-x64/jre/bin/java
+# VM options: <none>
+# Warmup: 2 iterations, 2 s each
+# Measurement: 4 iterations, 2 s each
+# Timeout: 10 min per iteration
+# Threads: 32 threads, will synchronize iterations
+# Benchmark mode: Sampling time
+# Benchmark: com.codahale.metrics.BenchmarkOldEDR.measureThreads_64
+
+# Run progress: 93.33% complete, ETA 00:00:12
+# Fork: 1 of 1
+# Warmup Iteration   1: 21.958 ±(99.9%) 2.136 us/op
+# Warmup Iteration   2: 11.763 ±(99.9%) 1.834 us/op
+Iteration   1: 13.741 ±(99.9%) 2.151 us/op
+                 measureThreads_64·p0.00:   0.168 us/op
+                 measureThreads_64·p0.50:   0.615 us/op
+                 measureThreads_64·p0.90:   0.877 us/op
+                 measureThreads_64·p0.95:   0.985 us/op
+                 measureThreads_64·p0.99:   1.486 us/op
+                 measureThreads_64·p0.999:  13.425 us/op
+                 measureThreads_64·p0.9999: 40110.850 us/op
+                 measureThreads_64·p1.00:   120324.096 us/op
+
+Iteration   2: 14.715 ±(99.9%) 2.276 us/op
+                 measureThreads_64·p0.00:   0.210 us/op
+                 measureThreads_64·p0.50:   0.589 us/op
+                 measureThreads_64·p0.90:   0.877 us/op
+                 measureThreads_64·p0.95:   1.012 us/op
+                 measureThreads_64·p0.99:   2.580 us/op
+                 measureThreads_64·p0.999:  14.304 us/op
+                 measureThreads_64·p0.9999: 43974.656 us/op
+                 measureThreads_64·p1.00:   147849.216 us/op
+
+Iteration   3: 13.499 ±(99.9%) 2.345 us/op
+                 measureThreads_64·p0.00:   0.202 us/op
+                 measureThreads_64·p0.50:   0.584 us/op
+                 measureThreads_64·p0.90:   0.833 us/op
+                 measureThreads_64·p0.95:   0.931 us/op
+                 measureThreads_64·p0.99:   1.168 us/op
+                 measureThreads_64·p0.999:  13.568 us/op
+                 measureThreads_64·p0.9999: 43974.656 us/op
+                 measureThreads_64·p1.00:   195821.568 us/op
+
+Iteration   4: 14.723 ±(99.9%) 2.371 us/op
+                 measureThreads_64·p0.00:   0.209 us/op
+                 measureThreads_64·p0.50:   0.588 us/op
+                 measureThreads_64·p0.90:   0.842 us/op
+                 measureThreads_64·p0.95:   0.950 us/op
+                 measureThreads_64·p0.99:   1.296 us/op
+                 measureThreads_64·p0.999:  13.600 us/op
+                 measureThreads_64·p0.9999: 46207.218 us/op
+                 measureThreads_64·p1.00:   155189.248 us/op
+
+
+
+Result "com.codahale.metrics.BenchmarkOldEDR.measureThreads_64":
+  N = 5449982
+  mean =     14.166 ±(99.9%) 1.142 us/op
+
+  Histogram, us/op:
+    [     0.000,  12500.000) = 5448176 
+    [ 12500.000,  25000.000) = 411 
+    [ 25000.000,  37500.000) = 668 
+    [ 37500.000,  50000.000) = 324 
+    [ 50000.000,  62500.000) = 182 
+    [ 62500.000,  75000.000) = 102 
+    [ 75000.000,  87500.000) = 60 
+    [ 87500.000, 100000.000) = 31 
+    [100000.000, 112500.000) = 15 
+    [112500.000, 125000.000) = 6 
+    [125000.000, 137500.000) = 3 
+    [137500.000, 150000.000) = 1 
+    [150000.000, 162500.000) = 1 
+    [162500.000, 175000.000) = 0 
+    [175000.000, 187500.000) = 0 
+
+  Percentiles, us/op:
+      p(0.0000) =      0.168 us/op
+     p(50.0000) =      0.594 us/op
+     p(90.0000) =      0.858 us/op
+     p(95.0000) =      0.969 us/op
+     p(99.0000) =      1.422 us/op
+     p(99.9000) =     13.824 us/op
+     p(99.9900) =  43974.656 us/op
+     p(99.9990) =  87949.312 us/op
+     p(99.9999) = 132428.722 us/op
+    p(100.0000) = 195821.568 us/op
+
+
+# Run complete. Total time: 00:03:15
+
+REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
+why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
+experiments, perform baseline and negative tests that provide experimental control, make sure
+the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
+Do not assume the numbers tell you what you want them to tell.
+
+Benchmark                                                      Mode      Cnt       Score   Error   Units
+BenchmarkOldEDR.measureThreads_01                             thrpt        4       8.109 ± 1.022  ops/us
+BenchmarkOldEDR.measureThreads_02                             thrpt        4       6.590 ± 0.534  ops/us
+BenchmarkOldEDR.measureThreads_04                             thrpt        4       5.701 ± 0.081  ops/us
+BenchmarkOldEDR.measureThreads_32                             thrpt        4       5.703 ± 0.970  ops/us
+BenchmarkOldEDR.measureThreads_64                             thrpt        4       5.320 ± 0.233  ops/us
+BenchmarkOldEDR.measureThreads_01                              avgt        4       0.123 ± 0.026   us/op
+BenchmarkOldEDR.measureThreads_02                              avgt        4       0.370 ± 0.163   us/op
+BenchmarkOldEDR.measureThreads_04                              avgt        4       0.719 ± 0.033   us/op
+BenchmarkOldEDR.measureThreads_32                              avgt        4       5.587 ± 0.400   us/op
+BenchmarkOldEDR.measureThreads_64                              avgt        4       5.746 ± 0.429   us/op
+BenchmarkOldEDR.measureThreads_01                            sample   243235       0.164 ± 0.009   us/op
+BenchmarkOldEDR.measureThreads_01:measureThreads_01·p0.00    sample                0.139           us/op
+BenchmarkOldEDR.measureThreads_01:measureThreads_01·p0.50    sample                0.154           us/op
+BenchmarkOldEDR.measureThreads_01:measureThreads_01·p0.90    sample                0.162           us/op
+BenchmarkOldEDR.measureThreads_01:measureThreads_01·p0.95    sample                0.175           us/op
+BenchmarkOldEDR.measureThreads_01:measureThreads_01·p0.99    sample                0.210           us/op
+BenchmarkOldEDR.measureThreads_01:measureThreads_01·p0.999   sample                0.636           us/op
+BenchmarkOldEDR.measureThreads_01:measureThreads_01·p0.9999  sample               18.133           us/op
+BenchmarkOldEDR.measureThreads_01:measureThreads_01·p1.00    sample              615.424           us/op
+BenchmarkOldEDR.measureThreads_02                            sample   439113       0.594 ± 0.204   us/op
+BenchmarkOldEDR.measureThreads_02:measureThreads_02·p0.00    sample                0.152           us/op
+BenchmarkOldEDR.measureThreads_02:measureThreads_02·p0.50    sample                0.348           us/op
+BenchmarkOldEDR.measureThreads_02:measureThreads_02·p0.90    sample                0.534           us/op
+BenchmarkOldEDR.measureThreads_02:measureThreads_02·p0.95    sample                0.601           us/op
+BenchmarkOldEDR.measureThreads_02:measureThreads_02·p0.99    sample                0.777           us/op
+BenchmarkOldEDR.measureThreads_02:measureThreads_02·p0.999   sample               11.164           us/op
+BenchmarkOldEDR.measureThreads_02:measureThreads_02·p0.9999  sample               89.015           us/op
+BenchmarkOldEDR.measureThreads_02:measureThreads_02·p1.00    sample            18382.848           us/op
+BenchmarkOldEDR.measureThreads_04                            sample   818224       1.214 ± 0.247   us/op
+BenchmarkOldEDR.measureThreads_04:measureThreads_04·p0.00    sample                0.173           us/op
+BenchmarkOldEDR.measureThreads_04:measureThreads_04·p0.50    sample                0.684           us/op
+BenchmarkOldEDR.measureThreads_04:measureThreads_04·p0.90    sample                0.958           us/op
+BenchmarkOldEDR.measureThreads_04:measureThreads_04·p0.95    sample                1.058           us/op
+BenchmarkOldEDR.measureThreads_04:measureThreads_04·p0.99    sample                1.312           us/op
+BenchmarkOldEDR.measureThreads_04:measureThreads_04·p0.999   sample               14.000           us/op
+BenchmarkOldEDR.measureThreads_04:measureThreads_04·p0.9999  sample              200.242           us/op
+BenchmarkOldEDR.measureThreads_04:measureThreads_04·p1.00    sample            16007.168           us/op
+BenchmarkOldEDR.measureThreads_32                            sample  5752558      11.613 ± 1.028   us/op
+BenchmarkOldEDR.measureThreads_32:measureThreads_32·p0.00    sample                0.199           us/op
+BenchmarkOldEDR.measureThreads_32:measureThreads_32·p0.50    sample                0.562           us/op
+BenchmarkOldEDR.measureThreads_32:measureThreads_32·p0.90    sample                0.798           us/op
+BenchmarkOldEDR.measureThreads_32:measureThreads_32·p0.95    sample                0.891           us/op
+BenchmarkOldEDR.measureThreads_32:measureThreads_32·p0.99    sample                1.124           us/op
+BenchmarkOldEDR.measureThreads_32:measureThreads_32·p0.999   sample                5.752           us/op
+BenchmarkOldEDR.measureThreads_32:measureThreads_32·p0.9999  sample            39583.744           us/op
+BenchmarkOldEDR.measureThreads_32:measureThreads_32·p1.00    sample           164102.144           us/op
+BenchmarkOldEDR.measureThreads_64                            sample  5449982      14.166 ± 1.142   us/op
+BenchmarkOldEDR.measureThreads_64:measureThreads_64·p0.00    sample                0.168           us/op
+BenchmarkOldEDR.measureThreads_64:measureThreads_64·p0.50    sample                0.594           us/op
+BenchmarkOldEDR.measureThreads_64:measureThreads_64·p0.90    sample                0.858           us/op
+BenchmarkOldEDR.measureThreads_64:measureThreads_64·p0.95    sample                0.969           us/op
+BenchmarkOldEDR.measureThreads_64:measureThreads_64·p0.99    sample                1.422           us/op
+BenchmarkOldEDR.measureThreads_64:measureThreads_64·p0.999   sample               13.824           us/op
+BenchmarkOldEDR.measureThreads_64:measureThreads_64·p0.9999  sample            43974.656           us/op
+BenchmarkOldEDR.measureThreads_64:measureThreads_64·p1.00    sample           195821.568           us/op

--- a/metrics-core/pom.xml
+++ b/metrics-core/pom.xml
@@ -10,7 +10,7 @@
 
     <artifactId>metrics-core</artifactId>
     <name>Metrics Core</name>
-    <packaging>bundle</packaging>
+    <packaging>jar</packaging>
     <description>
         Metrics is a Java library which gives you unparalleled insight into what your code does in
         production. Metrics provides a powerful toolkit of ways to measure the behavior of critical
@@ -20,4 +20,5 @@
     <properties>
         <javaModuleName>com.codahale.metrics</javaModuleName>
     </properties>
+
 </project>

--- a/metrics-core/run.sh
+++ b/metrics-core/run.sh
@@ -1,0 +1,7 @@
+# mvn package
+CP=$(find target|grep jar$|grep -v sources|grep -v javadoc  | tr '\n' ':'):target/test-classes
+
+echo CP: $CP
+java -cp $CP org.openjdk.jmh.Main com.codahale.metrics.BenchmarkNewEDR > new.txt
+java -cp $CP org.openjdk.jmh.Main com.codahale.metrics.BenchmarkOldEDR > old.txt
+

--- a/metrics-core/src/main/java/com/codahale/metrics/LockFreeExponentiallyDecayingReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/LockFreeExponentiallyDecayingReservoir.java
@@ -1,0 +1,210 @@
+package com.codahale.metrics;
+
+import com.codahale.metrics.WeightedSnapshot.WeightedSample;
+
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.lang.Math.exp;
+import static java.lang.Math.min;
+
+/**
+ * An exponentially-decaying random reservoir of {@code long}s. Uses Cormode et al's
+ * forward-decaying priority reservoir sampling method to produce a statistically representative
+ * sampling reservoir, exponentially biased towards newer entries.
+ *
+ * @see <a href="http://dimacs.rutgers.edu/~graham/pubs/papers/fwddecay.pdf">
+ * Cormode et al. Forward Decay: A Practical Time Decay Model for Streaming Systems. ICDE '09:
+ * Proceedings of the 2009 IEEE International Conference on Data Engineering (2009)</a>
+ */
+public class LockFreeExponentiallyDecayingReservoir implements Reservoir {
+    private static final int DEFAULT_SIZE = 1028;
+    private static final double DEFAULT_ALPHA = 0.015;
+    private static final long RESCALE_THRESHOLD = TimeUnit.HOURS.toNanos(1);
+
+    private final double alpha;
+    private final int size;
+    private final AtomicLong nextScaleTime;
+    private final Clock clock;
+
+    private volatile State writerState;
+    private volatile State snapshotState;
+
+
+    /**
+     * Creates a new {@link LockFreeExponentiallyDecayingReservoir} of 1028 elements, which offers a 99.9%
+     * confidence level with a 5% margin of error assuming a normal distribution, and an alpha
+     * factor of 0.015, which heavily biases the reservoir to the past 5 minutes of measurements.
+     */
+    public LockFreeExponentiallyDecayingReservoir() {
+        this(DEFAULT_SIZE, DEFAULT_ALPHA);
+    }
+
+    /**
+     * Creates a new {@link LockFreeExponentiallyDecayingReservoir}.
+     *
+     * @param size  the number of samples to keep in the sampling reservoir
+     * @param alpha the exponential decay factor; the higher this is, the more biased the reservoir
+     *              will be towards newer values
+     */
+    public LockFreeExponentiallyDecayingReservoir(int size, double alpha) {
+        this(size, alpha, Clock.defaultClock());
+    }
+
+    /**
+     * Creates a new {@link LockFreeExponentiallyDecayingReservoir}.
+     *
+     * @param size  the number of samples to keep in the sampling reservoir
+     * @param alpha the exponential decay factor; the higher this is, the more biased the reservoir
+     *              will be towards newer values
+     * @param clock the clock used to timestamp samples and track rescaling
+     */
+    public LockFreeExponentiallyDecayingReservoir(int size, double alpha, Clock clock) {
+        this.alpha = alpha;
+        this.size = size;
+        this.clock = clock;
+        this.writerState = new State(currentTimeInSeconds());
+        this.snapshotState = writerState;
+        this.nextScaleTime = new AtomicLong(clock.getTick() + RESCALE_THRESHOLD);
+    }
+
+    @Override
+    public int size() {
+        return (int) min(size, writerState.count.get());
+    }
+
+    @Override
+    public void update(long value) {
+        update(value, currentTimeInSeconds());
+    }
+
+    /**
+     * Adds an old value with a fixed timestamp to the reservoir.
+     *
+     * @param value     the value to be added
+     * @param timestamp the epoch timestamp of {@code value} in seconds
+     */
+    public void update(long value, long timestamp) {
+        rescaleIfNeeded();
+        final State localState = this.writerState;
+        localState.update(value, timestamp);
+        final State newLocalState = this.writerState;
+        if (localState != newLocalState) {
+            newLocalState.backfill(localState);
+        }
+    }
+
+    private void rescaleIfNeeded() {
+        final long now = clock.getTick();
+        final long next = nextScaleTime.get();
+        if (now >= next) {
+            rescale(now, next);
+        }
+    }
+
+    @Override
+    public Snapshot getSnapshot() {
+        rescaleIfNeeded();
+        return new WeightedSnapshot(snapshotState.values.get().values());
+    }
+
+    private long currentTimeInSeconds() {
+        return TimeUnit.MILLISECONDS.toSeconds(clock.getTime());
+    }
+
+    private double weight(long t) {
+        return exp(alpha * t);
+    }
+
+    /* "A common feature of the above techniques—indeed, the key technique that
+     * allows us to track the decayed weights efficiently—is that they maintain
+     * counts and other quantities based on g(ti − L), and only scale by g(t − L)
+     * at query time. But while g(ti −L)/g(t−L) is guaranteed to lie between zero
+     * and one, the intermediate values of g(ti − L) could become very large. For
+     * polynomial functions, these values should not grow too large, and should be
+     * effectively represented in practice by floating point values without loss of
+     * precision. For exponential functions, these values could grow quite large as
+     * new values of (ti − L) become large, and potentially exceed the capacity of
+     * common floating point types. However, since the values stored by the
+     * algorithms are linear combinations of g values (scaled sums), they can be
+     * rescaled relative to a new landmark. That is, by the analysis of exponential
+     * decay in Section III-A, the choice of L does not affect the final result. We
+     * can therefore multiply each value based on L by a factor of exp(−α(L′ − L)),
+     * and obtain the correct value as if we had instead computed relative to a new
+     * landmark L′ (and then use this new L′ at query time). This can be done with
+     * a linear pass over whatever data structure is being used."
+     */
+    private void rescale(long now, long next) {
+        if (nextScaleTime.compareAndSet(next, now + RESCALE_THRESHOLD)) {
+            State oldState = this.writerState;
+            State newState = new State(currentTimeInSeconds());
+
+            this.writerState = newState;
+            // Snapshot won't see new values until the backfill completes
+            newState.backfill(oldState);
+
+            this.snapshotState = newState;
+        }
+    }
+
+    private class State {
+
+        private final AtomicReference<ConcurrentSkipListMap<Double, WeightedSample>> values =
+                new AtomicReference<>(new ConcurrentSkipListMap<>());
+
+        private final long startTime;
+        private final AtomicLong count = new AtomicLong();
+
+        private State(long startTime) {
+            this.startTime = startTime;
+        }
+
+        private void backfill(State previous) {
+            final double scalingFactor = exp(-alpha * (startTime - previous.startTime));
+
+            final ConcurrentSkipListMap<Double, WeightedSample> oldValues = previous.values.getAndSet(new ConcurrentSkipListMap<>());
+            previous.count.addAndGet(-oldValues.size());
+
+            if (Double.compare(scalingFactor, 0) == 0) {
+                return;
+            }
+
+            // Slightly racy - calls to update() could add values while we iterate over it
+            // but it should not affect the overall statistical correctness
+            for (final WeightedSample sample : oldValues.values()) {
+                final double newWeight = sample.weight * scalingFactor;
+                if (Double.compare(newWeight, 0) != 0) {
+                    update(new WeightedSample(sample.value, newWeight), newWeight);
+                }
+            }
+
+        }
+
+        private void update(long value, long timestamp) {
+            final double itemWeight = weight(timestamp - startTime);
+            final WeightedSample sample = new WeightedSample(value, itemWeight);
+            final double priority = itemWeight / ThreadLocalRandom.current().nextDouble();
+
+            update(sample, priority);
+        }
+
+        private void update(WeightedSample sample, double priority) {
+            ConcurrentSkipListMap<Double, WeightedSample> map = values.get();
+            final long newCount = count.incrementAndGet();
+            if (newCount <= size) {
+                map.put(priority, sample);
+            } else {
+                Double first = map.firstKey();
+                if (first < priority && map.putIfAbsent(priority, sample) == null) {
+                    // ensure we always remove an item
+                    while (map.remove(first) == null) {
+                        first = map.firstKey();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/BenchmarkNewEDR.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/BenchmarkNewEDR.java
@@ -1,0 +1,72 @@
+package com.codahale.metrics;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 2, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, warmups = 0)
+public class BenchmarkNewEDR {
+
+    private Reservoir reservoir;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        reservoir = new LockFreeExponentiallyDecayingReservoir();
+    }
+
+
+    @Benchmark
+    @BenchmarkMode({Mode.AverageTime, Mode.Throughput, Mode.SampleTime})
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    @Threads(1)
+    public void measureThreads_01() {
+        reservoir.update(123);
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.AverageTime, Mode.Throughput, Mode.SampleTime})
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    @Threads(2)
+    public void measureThreads_02() {
+        reservoir.update(123);
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.AverageTime, Mode.Throughput, Mode.SampleTime})
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    @Threads(4)
+    public void measureThreads_04() {
+        reservoir.update(123);
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.AverageTime, Mode.Throughput, Mode.SampleTime})
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    @Threads(32)
+    public void measureThreads_32() {
+        reservoir.update(123);
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.AverageTime, Mode.Throughput, Mode.SampleTime})
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    @Threads(32)
+    public void measureThreads_64() {
+        reservoir.update(123);
+    }
+
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/BenchmarkOldEDR.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/BenchmarkOldEDR.java
@@ -1,0 +1,72 @@
+package com.codahale.metrics;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 2, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 1, warmups = 0)
+public class BenchmarkOldEDR {
+
+    private Reservoir reservoir;
+
+    @Setup(Level.Trial)
+    public void setup() {
+        reservoir = new ExponentiallyDecayingReservoir();
+    }
+
+
+    @Benchmark
+    @BenchmarkMode({Mode.AverageTime, Mode.Throughput, Mode.SampleTime})
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    @Threads(1)
+    public void measureThreads_01() {
+        reservoir.update(123);
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.AverageTime, Mode.Throughput, Mode.SampleTime})
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    @Threads(2)
+    public void measureThreads_02() {
+        reservoir.update(123);
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.AverageTime, Mode.Throughput, Mode.SampleTime})
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    @Threads(4)
+    public void measureThreads_04() {
+        reservoir.update(123);
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.AverageTime, Mode.Throughput, Mode.SampleTime})
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    @Threads(32)
+    public void measureThreads_32() {
+        reservoir.update(123);
+    }
+
+    @Benchmark
+    @BenchmarkMode({Mode.AverageTime, Mode.Throughput, Mode.SampleTime})
+    @OutputTimeUnit(TimeUnit.MICROSECONDS)
+    @Threads(32)
+    public void measureThreads_64() {
+        reservoir.update(123);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,6 @@
         <mockito.version>3.4.6</mockito.version>
         <junit.version>4.12</junit.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
-        <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>
     </properties>
 
     <developers>
@@ -143,64 +142,19 @@
             <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.23</version>
+            <!--scope>test</scope-->
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.23</version>
+            <!--scope>test</scope-->
+        </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>jdk8</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>${maven-compiler-plugin.version}</version>
-                        <configuration>
-                            <fork>true</fork>
-                            <compilerArgs combine.children="append">
-                                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${errorprone.javac.version}/javac-${errorprone.javac.version}.jar</arg>
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>release-sign-artifacts</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <configuration>
-                            <gpgArguments>
-                                <argument>--no-tty</argument>
-                            </gpgArguments>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-    </profiles>
 
     <build>
         <pluginManagement>
@@ -221,40 +175,13 @@
                     <source>1.8</source>
                     <target>1.8</target>
                     <showWarnings>true</showWarnings>
-                    <compilerArgs>
-                        <arg>-Xlint:all</arg>
-                        <arg>-XDcompilePolicy=simple</arg>
-                        <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.*</arg>
-                    </compilerArgs>
                     <annotationProcessorPaths>
-                        <path>
-                            <groupId>com.google.errorprone</groupId>
-                            <artifactId>error_prone_core</artifactId>
-                            <version>2.4.0</version>
-                        </path>
+                        <annotationProcessorPath>
+                            <groupId>org.openjdk.jmh</groupId>
+                            <artifactId>jmh-generator-annprocess</artifactId>
+                            <version>1.23</version>
+                        </annotationProcessorPath>
                     </annotationProcessorPaths>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.felix</groupId>
-                <artifactId>maven-bundle-plugin</artifactId>
-                <version>5.1.1</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <instructions>
-                        <Import-Package><![CDATA[
-                            javax.servlet*;version="[2.5.0,4.0.0)",
-                            org.slf4j*;version="[1.6.0,2.0.0)",
-                            sun.misc.*;resolution:=optional,
-                            com.sun.management.*;resolution:=optional,
-                            *
-                        ]]>
-                        </Import-Package>
-                        <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
-                        <!-- https://stackoverflow.com/a/29853163/49505 -->
-                        <_removeheaders>Bnd-LastModified</_removeheaders>
-                        <_reproducible>true</_reproducible>
-                    </instructions>
                 </configuration>
             </plugin>
             <plugin>
@@ -267,103 +194,50 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
-                <executions>
-                    <execution>
-                        <id>enforce</id>
-                        <configuration>
-                            <rules>
-                                <DependencyConvergence />
-                            </rules>
-                        </configuration>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.1.2</version>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
-                <configuration>
-                    <source>8</source>
-                    <doclint>none</doclint>
-                    <quiet>true</quiet>
-                    <notimestamp>true</notimestamp>
-                </configuration>
+                <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>attach-javadocs</id>
+                        <id>default-jar</id>
+                        <phase>prepare-package</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
-                <configuration>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
-                    <mavenExecutorId>forked-path</mavenExecutorId>
-                    <tagNameFormat>v@{project.version}</tagNameFormat>
-                    <preparationGoals>clean test</preparationGoals>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.0</version>
                 <configuration>
                     <archive>
+                        <addMavenDescriptor>true</addMavenDescriptor>
                         <manifest>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addClasspath>true</addClasspath>
+                            <classpathPrefix>lib/</classpathPrefix>
                         </manifest>
-                        <manifestEntries>
-                            <Automatic-Module-Name>${javaModuleName}</Automatic-Module-Name>
-                        </manifestEntries>
                     </archive>
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.1</version>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
-                    <configLocation>checkstyle.xml</configLocation>
-                    <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    <useBaseVersion>false</useBaseVersion>
+                    <overWriteIfNewer>true</overWriteIfNewer>
+                    <overWriteReleases>false</overWriteReleases>
+                    <overWriteSnapshots>false</overWriteSnapshots>
+                    <includeScope>runtime</includeScope>
+                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                    <ignoreNonCompile>true</ignoreNonCompile>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <version>3.9.1</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>3.1.0</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Benchmark only tests update case - did not test for rescaling case

Tests ran on a 4 core Intel(R) Core(TM) i7-7500U CPU @ 2.70GHz

Main takeaways of benchmark:

Single threaded usecase:
* Slightly better throughput and lower average latency for new code
* Slight improvement to tail latencies

2 threads:
* Almost double the throughput

4 threads:
* Throughput is 4 times higher
* 99.9% percentile is improved from 14.000 us/op to 0.777 us/op

32 threads
* Same performance as for 4 threads