### PR TITLE
Fix ExponentiallyDecayingReservoir constant rescaling

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingReservoir.java
@@ -32,7 +32,7 @@ public class ExponentiallyDecayingReservoir implements Reservoir {
     private final int size;
     private final AtomicLong count;
     private volatile long startTime;
-    private final AtomicLong nextScaleTime;
+    private final AtomicLong lastScaleTick;
     private final Clock clock;
 
     /**
@@ -71,7 +71,7 @@ public class ExponentiallyDecayingReservoir implements Reservoir {
         this.clock = clock;
         this.count = new AtomicLong(0);
         this.startTime = currentTimeInSeconds();
-        this.nextScaleTime = new AtomicLong(clock.getTick() + RESCALE_THRESHOLD);
+        this.lastScaleTick = new AtomicLong(clock.getTick());
     }
 
     @Override
@@ -117,9 +117,9 @@ public class ExponentiallyDecayingReservoir implements Reservoir {
 
     private void rescaleIfNeeded() {
         final long now = clock.getTick();
-        final long next = nextScaleTime.get();
-        if (now >= next) {
-            rescale(now, next);
+        final long lastScaleTickSnapshot = lastScaleTick.get();
+        if (now - lastScaleTickSnapshot >= RESCALE_THRESHOLD) {
+            rescale(now, lastScaleTickSnapshot);
         }
     }
 
@@ -160,10 +160,10 @@ public class ExponentiallyDecayingReservoir implements Reservoir {
      * landmark L′ (and then use this new L′ at query time). This can be done with
      * a linear pass over whatever data structure is being used."
      */
-    private void rescale(long now, long next) {
+    private void rescale(long now, long lastTick) {
         lockForRescale();
         try {
-            if (nextScaleTime.compareAndSet(next, now + RESCALE_THRESHOLD)) {
+            if (lastScaleTick.compareAndSet(lastTick, now)) {
                 final long oldStartTime = startTime;
                 this.startTime = currentTimeInSeconds();
                 final double scalingFactor = exp(-alpha * (startTime - oldStartTime));

--- a/metrics-core/src/test/java/com/codahale/metrics/ManualClock.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ManualClock.java
@@ -3,7 +3,17 @@ package com.codahale.metrics;
 import java.util.concurrent.TimeUnit;
 
 public class ManualClock extends Clock {
-    long ticksInNanos = 0;
+    private final long initialTicksInNanos;
+    long ticksInNanos;
+
+    public ManualClock(long initialTicksInNanos) {
+        this.initialTicksInNanos = initialTicksInNanos;
+        this.ticksInNanos = initialTicksInNanos;
+    }
+
+    public ManualClock() {
+        this(0L);
+    }
 
     public synchronized void addNanos(long nanos) {
         ticksInNanos += nanos;
@@ -28,7 +38,7 @@ public class ManualClock extends Clock {
 
     @Override
     public synchronized long getTime() {
-        return TimeUnit.NANOSECONDS.toMillis(ticksInNanos);
+        return TimeUnit.NANOSECONDS.toMillis(ticksInNanos - initialTicksInNanos);
     }
 
 }


### PR DESCRIPTION
This fixes a bug in ExponentiallyDecayingReservoir in which the
hour prior to the system precise clock (`System.nanotime()`) rolling
from `Long.MAX_VALUE` to `Long.MIN_VALUE` caused every interaction
with the reservoir to rescale.
It's easy to forget that the tick value is allowed to overflow.

In heavily loaded systems, this results in substantial performance
degredation due to write lock acquisition for each update.