### PR TITLE
CachedGauge: Fix reloading when Clock's time is negative

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/CachedGauge.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/CachedGauge.java
@@ -34,7 +34,7 @@ public abstract class CachedGauge<T> implements Gauge<T> {
      */
     protected CachedGauge(Clock clock, long timeout, TimeUnit timeoutUnit) {
         this.clock = clock;
-        this.reloadAt = new AtomicLong(0);
+        this.reloadAt = new AtomicLong(clock.getTick());
         this.timeoutNS = timeoutUnit.toNanos(timeout);
         this.value = new AtomicReference<>();
     }


### PR DESCRIPTION
The UserTimeClock returns System.nanoTime(), which is allowed to be negative.
CachedGauge's initialization assumes 0 is before all time, which is not always true -
leading to a gauge that never updates, until your clock rolls past 0