### PR TITLE
Adding explicit version for sphinx-maven-plugin to fix warning on build

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -73,6 +73,7 @@
                 <configuration>
                     <sourceDirectory>${project.build.directory}/source</sourceDirectory>
                 </configuration>
+                <version>2.9.0</version>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
Fixes this Maven warning, shown when building docs.

```
[WARNING] Report plugin kr.motd.maven:sphinx-maven-plugin has an empty version.
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```