### PR TITLE
Run SonarCloud analysis only when SONAR_TOKEN is available

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,7 +32,9 @@ jobs:
           ${{ runner.os }}-maven-
     - name: Cache SonarCloud packages
       uses: actions/cache@v2.1.2
-      if: ${{ github.repository == 'dropwizard/metrics' && matrix.java_version == '11' }}
+      if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       with:
         path: ~/.sonar/cache
         key: ${{ runner.os }}-sonar
@@ -40,7 +42,7 @@ jobs:
     - name: Build
       run: ./mvnw -B -V -ff -s .github/settings.xml -ntp install
     - name: Analyze with SonarCloud
-      if: ${{ github.repository == 'dropwizard/metrics' && matrix.java_version == '11' }}
+      if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java_version == '11' }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Forked repositories don't have access to the `SONAR_TOKEN` secret and thus cannot run the SonarCloud analysis as part of the build.

The changes in b9ad643c4133e1ad5ee75c4e19cf8e2869c601cf unfortunately weren't working as expected because `github.repository` seems to always be set to the repository the GitHub workflow is running in and not the "source" repository of a branch/PR.