### PR TITLE
Upgrade to Jackson 2.9.10.6

### DIFF
--- a/metrics-json/pom.xml
+++ b/metrics-json/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <javaModuleName>com.codahale.metrics.json</javaModuleName>
-        <jackson.version>2.9.10.5</jackson.version>
+        <jackson.version>2.9.10.6</jackson.version>
     </properties>
 
     <dependencyManagement>

--- a/metrics-servlets/pom.xml
+++ b/metrics-servlets/pom.xml
@@ -20,7 +20,7 @@
         <javaModuleName>com.codahale.metrics.servlets</javaModuleName>
         <papertrail.profiler.version>1.1.1</papertrail.profiler.version>
         <servlet.version>3.1.0</servlet.version>
-        <jackson.version>2.9.10.5</jackson.version>
+        <jackson.version>2.9.10.6</jackson.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
This addresses several CVEs:

* https://nvd.nist.gov/vuln/detail/CVE-2020-24750
* https://nvd.nist.gov/vuln/detail/CVE-2020-24616

Release notes: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9#micro-patches

>  jackson-databind 2.9.10.6 (24-Aug-2020) -- with jackson-bom version 2.9.10.20200824
>  * https://github.com/FasterXML/jackson-databind/issues/2798: Block one more gadget type (com.pastdev.httpcomponents, CVE-2020-24750
>  * https://github.com/FasterXML/jackson-databind/issues/2814: Block one more gadget type (Anteros-DBCP, CVE-2020-24616)
>  * https://github.com/FasterXML/jackson-databind/issues/2826: Block one more gadget type (com.nqadmin.rowset)
>  * https://github.com/FasterXML/jackson-databind/issues/2827: Block one more gadget type (org.arrahtec:profiler-core)

Closes #1706