### PR TITLE
Enforce lower/upper limit on frequency parameter of CPU profile servlet

### DIFF
--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/CpuProfileServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/CpuProfileServlet.java
@@ -39,6 +39,7 @@ public class CpuProfileServlet extends HttpServlet {
         if (req.getParameter("frequency") != null) {
             try {
                 frequency = Integer.parseInt(req.getParameter("frequency"));
+                frequency = Math.min(Math.max(frequency, 1), 1000);
             } catch (NumberFormatException e) {
                 frequency = 100;
             }


### PR DESCRIPTION
Currently, a request to the CPU profile servlet with a negative frequency, e.g. `http://localhost:8071/pprof?frequency=-1`, causes the request to hang due to an endless loop within `CpuProfile.record()`. The underlying `profiler` library doesn't seem to receive too much attention these days (cf. https://github.com/phax/profiler/pull/1) so I'd like to propose the following safeguard in the servlet. Given that the code already handles non-numeric inputs by simply using defaults, it seems in line with that existing philosophy to equally ignore out of range values and restrict the frequency to the allowed values.