### PR TITLE
Add support for Jetty 10.0.0 and 11.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     environment:
       JAVA_TOOL_OPTIONS: -Xms512m -Xmx2g
     docker:
-      - image: circleci/openjdk:8-jdk-stretch
+      - image: circleci/openjdk:11-jdk-buster
     steps:
       - checkout
       - restore_cache:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java_version: [8, 11]
+        java_version: [11]
         os:
         - ubuntu-latest
     env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,16 @@
-test_script:
-  - ./mvnw -B verify
+matrix:
+  fast_finish: true
+environment:
+  JAVA_OPTS: '-Xms512m -Xmx2g -XX:+TieredCompilation -XX:TieredStopAtLevel=1'
+  matrix:
+  - JAVA_HOME: 'C:\Program Files\Java\jdk11'
+    PATH: '%JAVA_HOME%\bin;%PATH%'
+image:
+- 'Visual Studio 2019'
+cache:
+- '%USERPROFILE%\.m2\repository'
+install:
+- cmd: 'java -version'
 build: off
+test_script:
+- mvnw.cmd -B -V -ff -ntp -Dmaven.javadoc.skip=true -Dmaven.source.skip=true verify

--- a/metrics-jetty10/pom.xml
+++ b/metrics-jetty10/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-parent</artifactId>
+        <version>4.1.17-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>metrics-jetty10</artifactId>
+    <name>Metrics Integration for Jetty 10.x and higher</name>
+    <packaging>bundle</packaging>
+    <description>
+        A set of extensions for Jetty 10.x and higher which provide instrumentation of thread pools, connector
+        metrics, and application latency and utilization.
+    </description>
+
+    <properties>
+        <javaModuleName>io.dropwizard.metrics.jetty10</javaModuleName>
+
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+
+        <slf4j.version>2.0.0-alpha1</slf4j.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>${jetty10.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/metrics-jetty10/src/main/java/io/dropwizard/metrics/jetty10/InstrumentedConnectionFactory.java
+++ b/metrics-jetty10/src/main/java/io/dropwizard/metrics/jetty10/InstrumentedConnectionFactory.java
@@ -1,0 +1,63 @@
+package io.dropwizard.metrics.jetty10;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Timer;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.util.component.ContainerLifeCycle;
+
+import java.util.List;
+
+public class InstrumentedConnectionFactory extends ContainerLifeCycle implements ConnectionFactory {
+    private final ConnectionFactory connectionFactory;
+    private final Timer timer;
+    private final Counter counter;
+
+    public InstrumentedConnectionFactory(ConnectionFactory connectionFactory, Timer timer) {
+        this(connectionFactory, timer, null);
+    }
+
+    public InstrumentedConnectionFactory(ConnectionFactory connectionFactory, Timer timer, Counter counter) {
+        this.connectionFactory = connectionFactory;
+        this.timer = timer;
+        this.counter = counter;
+        addBean(connectionFactory);
+    }
+
+    @Override
+    public String getProtocol() {
+        return connectionFactory.getProtocol();
+    }
+
+    @Override
+    public List<String> getProtocols() {
+        return connectionFactory.getProtocols();
+    }
+
+    @Override
+    public Connection newConnection(Connector connector, EndPoint endPoint) {
+        final Connection connection = connectionFactory.newConnection(connector, endPoint);
+        connection.addEventListener(new Connection.Listener() {
+            private Timer.Context context;
+
+            @Override
+            public void onOpened(Connection connection) {
+                this.context = timer.time();
+                if (counter != null) {
+                    counter.inc();
+                }
+            }
+
+            @Override
+            public void onClosed(Connection connection) {
+                context.stop();
+                if (counter != null) {
+                    counter.dec();
+                }
+            }
+        });
+        return connection;
+    }
+}

--- a/metrics-jetty10/src/main/java/io/dropwizard/metrics/jetty10/InstrumentedHandler.java
+++ b/metrics-jetty10/src/main/java/io/dropwizard/metrics/jetty10/InstrumentedHandler.java
@@ -1,0 +1,379 @@
+package io.dropwizard.metrics.jetty10;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.RatioGauge;
+import com.codahale.metrics.Timer;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.server.AsyncContextState;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpChannelState;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.HandlerWrapper;
+
+import javax.servlet.AsyncEvent;
+import javax.servlet.AsyncListener;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+/**
+ * A Jetty {@link Handler} which records various metrics about an underlying {@link Handler}
+ * instance.
+ */
+public class InstrumentedHandler extends HandlerWrapper {
+    private static final String NAME_REQUESTS = "requests";
+    private static final String NAME_DISPATCHES = "dispatches";
+    private static final String NAME_ACTIVE_REQUESTS = "active-requests";
+    private static final String NAME_ACTIVE_DISPATCHES = "active-dispatches";
+    private static final String NAME_ACTIVE_SUSPENDED = "active-suspended";
+    private static final String NAME_ASYNC_DISPATCHES = "async-dispatches";
+    private static final String NAME_ASYNC_TIMEOUTS = "async-timeouts";
+    private static final String NAME_1XX_RESPONSES = "1xx-responses";
+    private static final String NAME_2XX_RESPONSES = "2xx-responses";
+    private static final String NAME_3XX_RESPONSES = "3xx-responses";
+    private static final String NAME_4XX_RESPONSES = "4xx-responses";
+    private static final String NAME_5XX_RESPONSES = "5xx-responses";
+    private static final String NAME_GET_REQUESTS = "get-requests";
+    private static final String NAME_POST_REQUESTS = "post-requests";
+    private static final String NAME_HEAD_REQUESTS = "head-requests";
+    private static final String NAME_PUT_REQUESTS = "put-requests";
+    private static final String NAME_DELETE_REQUESTS = "delete-requests";
+    private static final String NAME_OPTIONS_REQUESTS = "options-requests";
+    private static final String NAME_TRACE_REQUESTS = "trace-requests";
+    private static final String NAME_CONNECT_REQUESTS = "connect-requests";
+    private static final String NAME_MOVE_REQUESTS = "move-requests";
+    private static final String NAME_OTHER_REQUESTS = "other-requests";
+    private static final String NAME_PERCENT_4XX_1M = "percent-4xx-1m";
+    private static final String NAME_PERCENT_4XX_5M = "percent-4xx-5m";
+    private static final String NAME_PERCENT_4XX_15M = "percent-4xx-15m";
+    private static final String NAME_PERCENT_5XX_1M = "percent-5xx-1m";
+    private static final String NAME_PERCENT_5XX_5M = "percent-5xx-5m";
+    private static final String NAME_PERCENT_5XX_15M = "percent-5xx-15m";
+
+    private final MetricRegistry metricRegistry;
+
+    private String name;
+    private final String prefix;
+
+    // the requests handled by this handler, excluding active
+    private Timer requests;
+
+    // the number of dispatches seen by this handler, excluding active
+    private Timer dispatches;
+
+    // the number of active requests
+    private Counter activeRequests;
+
+    // the number of active dispatches
+    private Counter activeDispatches;
+
+    // the number of requests currently suspended.
+    private Counter activeSuspended;
+
+    // the number of requests that have been asynchronously dispatched
+    private Meter asyncDispatches;
+
+    // the number of requests that expired while suspended
+    private Meter asyncTimeouts;
+
+    private Meter[] responses;
+
+    private Timer getRequests;
+    private Timer postRequests;
+    private Timer headRequests;
+    private Timer putRequests;
+    private Timer deleteRequests;
+    private Timer optionsRequests;
+    private Timer traceRequests;
+    private Timer connectRequests;
+    private Timer moveRequests;
+    private Timer otherRequests;
+
+    private AsyncListener listener;
+
+    private HttpChannelState.State DISPATCHED_HACK;
+
+    /**
+     * Create a new instrumented handler using a given metrics registry.
+     *
+     * @param registry the registry for the metrics
+     */
+    public InstrumentedHandler(MetricRegistry registry) {
+        this(registry, null);
+    }
+
+    /**
+     * Create a new instrumented handler using a given metrics registry.
+     *
+     * @param registry the registry for the metrics
+     * @param prefix   the prefix to use for the metrics names
+     */
+    public InstrumentedHandler(MetricRegistry registry, String prefix) {
+        this.metricRegistry = registry;
+        this.prefix = prefix;
+
+        try {
+            DISPATCHED_HACK = HttpChannelState.State.valueOf("HANDLING");
+        } catch (IllegalArgumentException e) {
+            DISPATCHED_HACK = HttpChannelState.State.valueOf("DISPATCHED");
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+
+        final String prefix = getMetricPrefix();
+
+        this.requests = metricRegistry.timer(name(prefix, NAME_REQUESTS));
+        this.dispatches = metricRegistry.timer(name(prefix, NAME_DISPATCHES));
+
+        this.activeRequests = metricRegistry.counter(name(prefix, NAME_ACTIVE_REQUESTS));
+        this.activeDispatches = metricRegistry.counter(name(prefix, NAME_ACTIVE_DISPATCHES));
+        this.activeSuspended = metricRegistry.counter(name(prefix, NAME_ACTIVE_SUSPENDED));
+
+        this.asyncDispatches = metricRegistry.meter(name(prefix, NAME_ASYNC_DISPATCHES));
+        this.asyncTimeouts = metricRegistry.meter(name(prefix, NAME_ASYNC_TIMEOUTS));
+
+        this.responses = new Meter[]{
+                metricRegistry.meter(name(prefix, NAME_1XX_RESPONSES)), // 1xx
+                metricRegistry.meter(name(prefix, NAME_2XX_RESPONSES)), // 2xx
+                metricRegistry.meter(name(prefix, NAME_3XX_RESPONSES)), // 3xx
+                metricRegistry.meter(name(prefix, NAME_4XX_RESPONSES)), // 4xx
+                metricRegistry.meter(name(prefix, NAME_5XX_RESPONSES))  // 5xx
+        };
+
+        this.getRequests = metricRegistry.timer(name(prefix, NAME_GET_REQUESTS));
+        this.postRequests = metricRegistry.timer(name(prefix, NAME_POST_REQUESTS));
+        this.headRequests = metricRegistry.timer(name(prefix, NAME_HEAD_REQUESTS));
+        this.putRequests = metricRegistry.timer(name(prefix, NAME_PUT_REQUESTS));
+        this.deleteRequests = metricRegistry.timer(name(prefix, NAME_DELETE_REQUESTS));
+        this.optionsRequests = metricRegistry.timer(name(prefix, NAME_OPTIONS_REQUESTS));
+        this.traceRequests = metricRegistry.timer(name(prefix, NAME_TRACE_REQUESTS));
+        this.connectRequests = metricRegistry.timer(name(prefix, NAME_CONNECT_REQUESTS));
+        this.moveRequests = metricRegistry.timer(name(prefix, NAME_MOVE_REQUESTS));
+        this.otherRequests = metricRegistry.timer(name(prefix, NAME_OTHER_REQUESTS));
+
+        metricRegistry.register(name(prefix, NAME_PERCENT_4XX_1M), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[3].getOneMinuteRate(),
+                        requests.getOneMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, NAME_PERCENT_4XX_5M), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[3].getFiveMinuteRate(),
+                        requests.getFiveMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, NAME_PERCENT_4XX_15M), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[3].getFifteenMinuteRate(),
+                        requests.getFifteenMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, NAME_PERCENT_5XX_1M), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[4].getOneMinuteRate(),
+                        requests.getOneMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, NAME_PERCENT_5XX_5M), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[4].getFiveMinuteRate(),
+                        requests.getFiveMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, NAME_PERCENT_5XX_15M), new RatioGauge() {
+            @Override
+            public Ratio getRatio() {
+                return Ratio.of(responses[4].getFifteenMinuteRate(),
+                        requests.getFifteenMinuteRate());
+            }
+        });
+
+
+        this.listener = new AsyncListener() {
+            private long startTime;
+
+            @Override
+            public void onTimeout(AsyncEvent event) throws IOException {
+                asyncTimeouts.mark();
+            }
+
+            @Override
+            public void onStartAsync(AsyncEvent event) throws IOException {
+                startTime = System.currentTimeMillis();
+                event.getAsyncContext().addListener(this);
+            }
+
+            @Override
+            public void onError(AsyncEvent event) throws IOException {
+            }
+
+            @Override
+            public void onComplete(AsyncEvent event) throws IOException {
+                final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
+                final HttpServletRequest request = (HttpServletRequest) state.getRequest();
+                final HttpServletResponse response = (HttpServletResponse) state.getResponse();
+                updateResponses(request, response, startTime, true);
+                if (state.getHttpChannelState().getState() != DISPATCHED_HACK &&
+                        state.getHttpChannelState().isSuspended()) {
+                    activeSuspended.dec();
+                }
+            }
+        };
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        final String prefix = getMetricPrefix();
+
+        metricRegistry.remove(name(prefix, NAME_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_DISPATCHES));
+        metricRegistry.remove(name(prefix, NAME_ACTIVE_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_ACTIVE_DISPATCHES));
+        metricRegistry.remove(name(prefix, NAME_ACTIVE_SUSPENDED));
+        metricRegistry.remove(name(prefix, NAME_ASYNC_DISPATCHES));
+        metricRegistry.remove(name(prefix, NAME_ASYNC_TIMEOUTS));
+        metricRegistry.remove(name(prefix, NAME_1XX_RESPONSES));
+        metricRegistry.remove(name(prefix, NAME_2XX_RESPONSES));
+        metricRegistry.remove(name(prefix, NAME_3XX_RESPONSES));
+        metricRegistry.remove(name(prefix, NAME_4XX_RESPONSES));
+        metricRegistry.remove(name(prefix, NAME_5XX_RESPONSES));
+        metricRegistry.remove(name(prefix, NAME_GET_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_POST_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_HEAD_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_PUT_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_DELETE_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_OPTIONS_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_TRACE_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_CONNECT_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_MOVE_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_OTHER_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_PERCENT_4XX_1M));
+        metricRegistry.remove(name(prefix, NAME_PERCENT_4XX_5M));
+        metricRegistry.remove(name(prefix, NAME_PERCENT_4XX_15M));
+        metricRegistry.remove(name(prefix, NAME_PERCENT_5XX_1M));
+        metricRegistry.remove(name(prefix, NAME_PERCENT_5XX_5M));
+        metricRegistry.remove(name(prefix, NAME_PERCENT_5XX_15M));
+
+        super.doStop();
+    }
+
+    @Override
+    public void handle(String path,
+                       Request request,
+                       HttpServletRequest httpRequest,
+                       HttpServletResponse httpResponse) throws IOException, ServletException {
+
+        activeDispatches.inc();
+
+        final long start;
+        final HttpChannelState state = request.getHttpChannelState();
+        if (state.isInitial()) {
+            // new request
+            activeRequests.inc();
+            start = request.getTimeStamp();
+            state.addListener(listener);
+        } else {
+            // resumed request
+            start = System.currentTimeMillis();
+            activeSuspended.dec();
+            if (state.getState() == DISPATCHED_HACK) {
+                asyncDispatches.mark();
+            }
+        }
+
+        try {
+            super.handle(path, request, httpRequest, httpResponse);
+        } finally {
+            final long now = System.currentTimeMillis();
+            final long dispatched = now - start;
+
+            activeDispatches.dec();
+            dispatches.update(dispatched, TimeUnit.MILLISECONDS);
+
+            if (state.isSuspended()) {
+                activeSuspended.inc();
+            } else if (state.isInitial()) {
+                updateResponses(httpRequest, httpResponse, start, request.isHandled());
+            }
+            // else onCompletion will handle it.
+        }
+    }
+
+    private Timer requestTimer(String method) {
+        final HttpMethod m = HttpMethod.fromString(method);
+        if (m == null) {
+            return otherRequests;
+        } else {
+            switch (m) {
+                case GET:
+                    return getRequests;
+                case POST:
+                    return postRequests;
+                case PUT:
+                    return putRequests;
+                case HEAD:
+                    return headRequests;
+                case DELETE:
+                    return deleteRequests;
+                case OPTIONS:
+                    return optionsRequests;
+                case TRACE:
+                    return traceRequests;
+                case CONNECT:
+                    return connectRequests;
+                case MOVE:
+                    return moveRequests;
+                default:
+                    return otherRequests;
+            }
+        }
+    }
+
+    private void updateResponses(HttpServletRequest request, HttpServletResponse response, long start, boolean isHandled) {
+        final int responseStatus;
+        if (isHandled) {
+            responseStatus = response.getStatus() / 100;
+        } else {
+            responseStatus = 4; // will end up with a 404 response sent by HttpChannel.handle
+        }
+        if (responseStatus >= 1 && responseStatus <= 5) {
+            responses[responseStatus - 1].mark();
+        }
+        activeRequests.dec();
+        final long elapsedTime = System.currentTimeMillis() - start;
+        requests.update(elapsedTime, TimeUnit.MILLISECONDS);
+        requestTimer(request.getMethod()).update(elapsedTime, TimeUnit.MILLISECONDS);
+    }
+
+    private String getMetricPrefix() {
+        return this.prefix == null ? name(getHandler().getClass(), name) : name(this.prefix, name);
+    }
+}

--- a/metrics-jetty10/src/main/java/io/dropwizard/metrics/jetty10/InstrumentedHandler.java
+++ b/metrics-jetty10/src/main/java/io/dropwizard/metrics/jetty10/InstrumentedHandler.java
@@ -97,8 +97,6 @@ public class InstrumentedHandler extends HandlerWrapper {
 
     private AsyncListener listener;
 
-    private HttpChannelState.State DISPATCHED_HACK;
-
     /**
      * Create a new instrumented handler using a given metrics registry.
      *
@@ -117,12 +115,6 @@ public class InstrumentedHandler extends HandlerWrapper {
     public InstrumentedHandler(MetricRegistry registry, String prefix) {
         this.metricRegistry = registry;
         this.prefix = prefix;
-
-        try {
-            DISPATCHED_HACK = HttpChannelState.State.valueOf("HANDLING");
-        } catch (IllegalArgumentException e) {
-            DISPATCHED_HACK = HttpChannelState.State.valueOf("DISPATCHED");
-        }
     }
 
     public String getName() {
@@ -241,7 +233,7 @@ public class InstrumentedHandler extends HandlerWrapper {
                 final HttpServletRequest request = (HttpServletRequest) state.getRequest();
                 final HttpServletResponse response = (HttpServletResponse) state.getResponse();
                 updateResponses(request, response, startTime, true);
-                if (state.getHttpChannelState().getState() != DISPATCHED_HACK &&
+                if (state.getHttpChannelState().getState() != HttpChannelState.State.HANDLING &&
                         state.getHttpChannelState().isSuspended()) {
                     activeSuspended.dec();
                 }
@@ -304,7 +296,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             // resumed request
             start = System.currentTimeMillis();
             activeSuspended.dec();
-            if (state.getState() == DISPATCHED_HACK) {
+            if (state.getState() == HttpChannelState.State.HANDLING) {
                 asyncDispatches.mark();
             }
         }

--- a/metrics-jetty10/src/main/java/io/dropwizard/metrics/jetty10/InstrumentedHttpChannelListener.java
+++ b/metrics-jetty10/src/main/java/io/dropwizard/metrics/jetty10/InstrumentedHttpChannelListener.java
@@ -1,0 +1,359 @@
+package io.dropwizard.metrics.jetty10;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.RatioGauge;
+import com.codahale.metrics.Timer;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.server.AsyncContextState;
+import org.eclipse.jetty.server.HttpChannel.Listener;
+import org.eclipse.jetty.server.HttpChannelState;
+import org.eclipse.jetty.server.Request;
+
+import javax.servlet.AsyncEvent;
+import javax.servlet.AsyncListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+/**
+ * A Jetty {@link org.eclipse.jetty.server.HttpChannel.Listener} implementation which records various metrics about
+ * underlying channel instance. Unlike {@link InstrumentedHandler} that uses internal API, this class should be
+ * future proof. To install it, just add instance of this class to {@link org.eclipse.jetty.server.Connector} as bean.
+ *
+ * @since TBD
+ */
+public class InstrumentedHttpChannelListener
+        implements Listener {
+    private static final String START_ATTR = InstrumentedHttpChannelListener.class.getName() + ".start";
+
+    private final MetricRegistry metricRegistry;
+
+    // the requests handled by this handler, excluding active
+    private final Timer requests;
+
+    // the number of dispatches seen by this handler, excluding active
+    private final Timer dispatches;
+
+    // the number of active requests
+    private final Counter activeRequests;
+
+    // the number of active dispatches
+    private final Counter activeDispatches;
+
+    // the number of requests currently suspended.
+    private final Counter activeSuspended;
+
+    // the number of requests that have been asynchronously dispatched
+    private final Meter asyncDispatches;
+
+    // the number of requests that expired while suspended
+    private final Meter asyncTimeouts;
+
+    private final Meter[] responses;
+
+    private final Timer getRequests;
+    private final Timer postRequests;
+    private final Timer headRequests;
+    private final Timer putRequests;
+    private final Timer deleteRequests;
+    private final Timer optionsRequests;
+    private final Timer traceRequests;
+    private final Timer connectRequests;
+    private final Timer moveRequests;
+    private final Timer otherRequests;
+
+    private final AsyncListener listener;
+
+    /**
+     * Create a new instrumented handler using a given metrics registry.
+     *
+     * @param registry the registry for the metrics
+     */
+    public InstrumentedHttpChannelListener(MetricRegistry registry) {
+        this(registry, null);
+    }
+
+    /**
+     * Create a new instrumented handler using a given metrics registry.
+     *
+     * @param registry the registry for the metrics
+     * @param pref     the prefix to use for the metrics names
+     */
+    public InstrumentedHttpChannelListener(MetricRegistry registry, String pref) {
+        this.metricRegistry = registry;
+
+        String prefix = (pref == null) ? getClass().getName() : pref;
+
+        this.requests = metricRegistry.timer(name(prefix, "requests"));
+        this.dispatches = metricRegistry.timer(name(prefix, "dispatches"));
+
+        this.activeRequests = metricRegistry.counter(name(prefix, "active-requests"));
+        this.activeDispatches = metricRegistry.counter(name(prefix, "active-dispatches"));
+        this.activeSuspended = metricRegistry.counter(name(prefix, "active-suspended"));
+
+        this.asyncDispatches = metricRegistry.meter(name(prefix, "async-dispatches"));
+        this.asyncTimeouts = metricRegistry.meter(name(prefix, "async-timeouts"));
+
+        this.responses = new Meter[]{
+                metricRegistry.meter(name(prefix, "1xx-responses")), // 1xx
+                metricRegistry.meter(name(prefix, "2xx-responses")), // 2xx
+                metricRegistry.meter(name(prefix, "3xx-responses")), // 3xx
+                metricRegistry.meter(name(prefix, "4xx-responses")), // 4xx
+                metricRegistry.meter(name(prefix, "5xx-responses"))  // 5xx
+        };
+
+        this.getRequests = metricRegistry.timer(name(prefix, "get-requests"));
+        this.postRequests = metricRegistry.timer(name(prefix, "post-requests"));
+        this.headRequests = metricRegistry.timer(name(prefix, "head-requests"));
+        this.putRequests = metricRegistry.timer(name(prefix, "put-requests"));
+        this.deleteRequests = metricRegistry.timer(name(prefix, "delete-requests"));
+        this.optionsRequests = metricRegistry.timer(name(prefix, "options-requests"));
+        this.traceRequests = metricRegistry.timer(name(prefix, "trace-requests"));
+        this.connectRequests = metricRegistry.timer(name(prefix, "connect-requests"));
+        this.moveRequests = metricRegistry.timer(name(prefix, "move-requests"));
+        this.otherRequests = metricRegistry.timer(name(prefix, "other-requests"));
+
+        metricRegistry.register(name(prefix, "percent-4xx-1m"), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[3].getOneMinuteRate(),
+                        requests.getOneMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, "percent-4xx-5m"), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[3].getFiveMinuteRate(),
+                        requests.getFiveMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, "percent-4xx-15m"), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[3].getFifteenMinuteRate(),
+                        requests.getFifteenMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, "percent-5xx-1m"), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[4].getOneMinuteRate(),
+                        requests.getOneMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, "percent-5xx-5m"), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[4].getFiveMinuteRate(),
+                        requests.getFiveMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, "percent-5xx-15m"), new RatioGauge() {
+            @Override
+            public Ratio getRatio() {
+                return Ratio.of(responses[4].getFifteenMinuteRate(),
+                        requests.getFifteenMinuteRate());
+            }
+        });
+
+        this.listener = new AsyncListener() {
+            private long startTime;
+
+            @Override
+            public void onTimeout(AsyncEvent event) throws IOException {
+                asyncTimeouts.mark();
+            }
+
+            @Override
+            public void onStartAsync(AsyncEvent event) throws IOException {
+                startTime = System.currentTimeMillis();
+                event.getAsyncContext().addListener(this);
+            }
+
+            @Override
+            public void onError(AsyncEvent event) throws IOException {
+            }
+
+            @Override
+            public void onComplete(AsyncEvent event) throws IOException {
+                final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
+                final HttpServletRequest request = (HttpServletRequest) state.getRequest();
+                final HttpServletResponse response = (HttpServletResponse) state.getResponse();
+                updateResponses(request, response, startTime, true);
+                if (!state.getHttpChannelState().isSuspended()) {
+                    activeSuspended.dec();
+                }
+            }
+        };
+    }
+
+    @Override
+    public void onRequestBegin(final Request request) {
+
+    }
+
+    @Override
+    public void onBeforeDispatch(final Request request) {
+        before(request);
+    }
+
+    @Override
+    public void onDispatchFailure(final Request request, final Throwable failure) {
+
+    }
+
+    @Override
+    public void onAfterDispatch(final Request request) {
+        after(request);
+    }
+
+    @Override
+    public void onRequestContent(final Request request, final ByteBuffer content) {
+
+    }
+
+    @Override
+    public void onRequestContentEnd(final Request request) {
+
+    }
+
+    @Override
+    public void onRequestTrailers(final Request request) {
+
+    }
+
+    @Override
+    public void onRequestEnd(final Request request) {
+
+    }
+
+    @Override
+    public void onRequestFailure(final Request request, final Throwable failure) {
+
+    }
+
+    @Override
+    public void onResponseBegin(final Request request) {
+
+    }
+
+    @Override
+    public void onResponseCommit(final Request request) {
+
+    }
+
+    @Override
+    public void onResponseContent(final Request request, final ByteBuffer content) {
+
+    }
+
+    @Override
+    public void onResponseEnd(final Request request) {
+
+    }
+
+    @Override
+    public void onResponseFailure(final Request request, final Throwable failure) {
+
+    }
+
+    @Override
+    public void onComplete(final Request request) {
+
+    }
+
+    private void before(final Request request) {
+        activeDispatches.inc();
+
+        final long start;
+        final HttpChannelState state = request.getHttpChannelState();
+        if (state.isInitial()) {
+            // new request
+            activeRequests.inc();
+            start = request.getTimeStamp();
+            state.addListener(listener);
+        } else {
+            // resumed request
+            start = System.currentTimeMillis();
+            activeSuspended.dec();
+            if (state.isAsyncStarted()) {
+                asyncDispatches.mark();
+            }
+        }
+        request.setAttribute(START_ATTR, start);
+    }
+
+    private void after(final Request request) {
+        final long start = (long) request.getAttribute(START_ATTR);
+        final long now = System.currentTimeMillis();
+        final long dispatched = now - start;
+
+        activeDispatches.dec();
+        dispatches.update(dispatched, TimeUnit.MILLISECONDS);
+
+        final HttpChannelState state = request.getHttpChannelState();
+        if (state.isSuspended()) {
+            activeSuspended.inc();
+        } else if (state.isInitial()) {
+            updateResponses(request, request.getResponse(), start, request.isHandled());
+        }
+        // else onCompletion will handle it.
+    }
+
+    private void updateResponses(HttpServletRequest request, HttpServletResponse response, long start, boolean isHandled) {
+        final int responseStatus;
+        if (isHandled) {
+            responseStatus = response.getStatus() / 100;
+        } else {
+            responseStatus = 4; // will end up with a 404 response sent by HttpChannel.handle
+        }
+        if (responseStatus >= 1 && responseStatus <= 5) {
+            responses[responseStatus - 1].mark();
+        }
+        activeRequests.dec();
+        final long elapsedTime = System.currentTimeMillis() - start;
+        requests.update(elapsedTime, TimeUnit.MILLISECONDS);
+        requestTimer(request.getMethod()).update(elapsedTime, TimeUnit.MILLISECONDS);
+    }
+
+    private Timer requestTimer(String method) {
+        final HttpMethod m = HttpMethod.fromString(method);
+        if (m == null) {
+            return otherRequests;
+        } else {
+            switch (m) {
+                case GET:
+                    return getRequests;
+                case POST:
+                    return postRequests;
+                case PUT:
+                    return putRequests;
+                case HEAD:
+                    return headRequests;
+                case DELETE:
+                    return deleteRequests;
+                case OPTIONS:
+                    return optionsRequests;
+                case TRACE:
+                    return traceRequests;
+                case CONNECT:
+                    return connectRequests;
+                case MOVE:
+                    return moveRequests;
+                default:
+                    return otherRequests;
+            }
+        }
+    }
+}

--- a/metrics-jetty10/src/main/java/io/dropwizard/metrics/jetty10/InstrumentedQueuedThreadPool.java
+++ b/metrics-jetty10/src/main/java/io/dropwizard/metrics/jetty10/InstrumentedQueuedThreadPool.java
@@ -1,0 +1,121 @@
+package io.dropwizard.metrics.jetty10;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.RatioGauge;
+import org.eclipse.jetty.util.annotation.Name;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+
+import java.util.concurrent.BlockingQueue;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+public class InstrumentedQueuedThreadPool extends QueuedThreadPool {
+    private static final String NAME_UTILIZATION = "utilization";
+    private static final String NAME_UTILIZATION_MAX = "utilization-max";
+    private static final String NAME_SIZE = "size";
+    private static final String NAME_JOBS = "jobs";
+    private static final String NAME_JOBS_QUEUE_UTILIZATION = "jobs-queue-utilization";
+
+    private final MetricRegistry metricRegistry;
+    private String prefix;
+
+    public InstrumentedQueuedThreadPool(@Name("registry") MetricRegistry registry) {
+        this(registry, 200);
+    }
+
+    public InstrumentedQueuedThreadPool(@Name("registry") MetricRegistry registry,
+                                        @Name("maxThreads") int maxThreads) {
+        this(registry, maxThreads, 8);
+    }
+
+    public InstrumentedQueuedThreadPool(@Name("registry") MetricRegistry registry,
+                                        @Name("maxThreads") int maxThreads,
+                                        @Name("minThreads") int minThreads) {
+        this(registry, maxThreads, minThreads, 60000);
+    }
+
+    public InstrumentedQueuedThreadPool(@Name("registry") MetricRegistry registry,
+                                        @Name("maxThreads") int maxThreads,
+                                        @Name("minThreads") int minThreads,
+                                        @Name("idleTimeout") int idleTimeout) {
+        this(registry, maxThreads, minThreads, idleTimeout, null);
+    }
+
+    public InstrumentedQueuedThreadPool(@Name("registry") MetricRegistry registry,
+                                        @Name("maxThreads") int maxThreads,
+                                        @Name("minThreads") int minThreads,
+                                        @Name("idleTimeout") int idleTimeout,
+                                        @Name("queue") BlockingQueue<Runnable> queue) {
+        this(registry, maxThreads, minThreads, idleTimeout, queue, null);
+    }
+
+    public InstrumentedQueuedThreadPool(@Name("registry") MetricRegistry registry,
+                                        @Name("maxThreads") int maxThreads,
+                                        @Name("minThreads") int minThreads,
+                                        @Name("idleTimeout") int idleTimeout,
+                                        @Name("queue") BlockingQueue<Runnable> queue,
+                                        @Name("prefix") String prefix) {
+        super(maxThreads, minThreads, idleTimeout, queue);
+        this.metricRegistry = registry;
+        this.prefix = prefix;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+
+        final String prefix = getMetricPrefix();
+
+        metricRegistry.register(name(prefix, NAME_UTILIZATION), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(getThreads() - getIdleThreads(), getThreads());
+            }
+        });
+        metricRegistry.register(name(prefix, NAME_UTILIZATION_MAX), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(getThreads() - getIdleThreads(), getMaxThreads());
+            }
+        });
+        metricRegistry.register(name(prefix, NAME_SIZE), (Gauge<Integer>) this::getThreads);
+        metricRegistry.register(name(prefix, NAME_JOBS), (Gauge<Integer>) () -> {
+            // This assumes the QueuedThreadPool is using a BlockingArrayQueue or
+            // ArrayBlockingQueue for its queue, and is therefore a constant-time operation.
+            return getQueue().size();
+        });
+        metricRegistry.register(name(prefix, NAME_JOBS_QUEUE_UTILIZATION), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                BlockingQueue<Runnable> queue = getQueue();
+                return Ratio.of(queue.size(), queue.size() + queue.remainingCapacity());
+            }
+        });
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        final String prefix = getMetricPrefix();
+
+        metricRegistry.remove(name(prefix, NAME_UTILIZATION));
+        metricRegistry.remove(name(prefix, NAME_UTILIZATION_MAX));
+        metricRegistry.remove(name(prefix, NAME_SIZE));
+        metricRegistry.remove(name(prefix, NAME_JOBS));
+        metricRegistry.remove(name(prefix, NAME_JOBS_QUEUE_UTILIZATION));
+
+        super.doStop();
+    }
+
+    private String getMetricPrefix() {
+        return this.prefix == null ? name(QueuedThreadPool.class, getName()) : name(this.prefix, getName());
+    }
+}

--- a/metrics-jetty10/src/test/java/io/dropwizard/metrics/jetty10/InstrumentedConnectionFactoryTest.java
+++ b/metrics-jetty10/src/test/java/io/dropwizard/metrics/jetty10/InstrumentedConnectionFactoryTest.java
@@ -1,0 +1,93 @@
+package io.dropwizard.metrics.jetty10;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstrumentedConnectionFactoryTest {
+    private final MetricRegistry registry = new MetricRegistry();
+    private final Server server = new Server();
+    private final ServerConnector connector =
+            new ServerConnector(server, new InstrumentedConnectionFactory(new HttpConnectionFactory(),
+                    registry.timer("http.connections"),
+                    registry.counter("http.active-connections")));
+    private final HttpClient client = new HttpClient();
+
+    @Before
+    public void setUp() throws Exception {
+        server.setHandler(new AbstractHandler() {
+            @Override
+            public void handle(String target,
+                               Request baseRequest,
+                               HttpServletRequest request,
+                               HttpServletResponse response) throws IOException, ServletException {
+                try (PrintWriter writer = response.getWriter()) {
+                    writer.println("OK");
+                }
+            }
+        });
+
+        server.addConnector(connector);
+        server.start();
+
+        client.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+        client.stop();
+    }
+
+    @Test
+    public void instrumentsConnectionTimes() throws Exception {
+        final ContentResponse response = client.GET("http://localhost:" + connector.getLocalPort() + "/hello");
+        assertThat(response.getStatus())
+                .isEqualTo(200);
+
+        client.stop(); // close the connection
+
+        Thread.sleep(100); // make sure the connection is closed
+
+        final Timer timer = registry.timer(MetricRegistry.name("http.connections"));
+        assertThat(timer.getCount())
+                .isEqualTo(1);
+    }
+
+    @Test
+    public void instrumentsActiveConnections() throws Exception {
+        final Counter counter = registry.counter("http.active-connections");
+
+        final ContentResponse response = client.GET("http://localhost:" + connector.getLocalPort() + "/hello");
+        assertThat(response.getStatus())
+                .isEqualTo(200);
+
+        assertThat(counter.getCount())
+                .isEqualTo(1);
+
+        client.stop(); // close the connection
+
+        Thread.sleep(100); // make sure the connection is closed
+
+        assertThat(counter.getCount())
+                .isEqualTo(0);
+    }
+}

--- a/metrics-jetty10/src/test/java/io/dropwizard/metrics/jetty10/InstrumentedHandlerTest.java
+++ b/metrics-jetty10/src/test/java/io/dropwizard/metrics/jetty10/InstrumentedHandlerTest.java
@@ -1,0 +1,214 @@
+package io.dropwizard.metrics.jetty10;
+
+import com.codahale.metrics.MetricRegistry;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstrumentedHandlerTest {
+    private final HttpClient client = new HttpClient();
+    private final MetricRegistry registry = new MetricRegistry();
+    private final Server server = new Server();
+    private final ServerConnector connector = new ServerConnector(server);
+    private final InstrumentedHandler handler = new InstrumentedHandler(registry);
+
+    @Before
+    public void setUp() throws Exception {
+        handler.setName("handler");
+        handler.setHandler(new TestHandler());
+        server.addConnector(connector);
+        server.setHandler(handler);
+        server.start();
+        client.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+        client.stop();
+    }
+
+    @Test
+    public void hasAName() throws Exception {
+        assertThat(handler.getName())
+                .isEqualTo("handler");
+    }
+
+    @Test
+    public void createsAndRemovesMetricsForTheHandler() throws Exception {
+        final ContentResponse response = client.GET(uri("/hello"));
+
+        assertThat(response.getStatus())
+                .isEqualTo(404);
+
+        assertThat(registry.getNames())
+                .containsOnly(
+                        MetricRegistry.name(TestHandler.class, "handler.1xx-responses"),
+                        MetricRegistry.name(TestHandler.class, "handler.2xx-responses"),
+                        MetricRegistry.name(TestHandler.class, "handler.3xx-responses"),
+                        MetricRegistry.name(TestHandler.class, "handler.4xx-responses"),
+                        MetricRegistry.name(TestHandler.class, "handler.5xx-responses"),
+                        MetricRegistry.name(TestHandler.class, "handler.percent-4xx-1m"),
+                        MetricRegistry.name(TestHandler.class, "handler.percent-4xx-5m"),
+                        MetricRegistry.name(TestHandler.class, "handler.percent-4xx-15m"),
+                        MetricRegistry.name(TestHandler.class, "handler.percent-5xx-1m"),
+                        MetricRegistry.name(TestHandler.class, "handler.percent-5xx-5m"),
+                        MetricRegistry.name(TestHandler.class, "handler.percent-5xx-15m"),
+                        MetricRegistry.name(TestHandler.class, "handler.requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.active-suspended"),
+                        MetricRegistry.name(TestHandler.class, "handler.async-dispatches"),
+                        MetricRegistry.name(TestHandler.class, "handler.async-timeouts"),
+                        MetricRegistry.name(TestHandler.class, "handler.get-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.put-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.active-dispatches"),
+                        MetricRegistry.name(TestHandler.class, "handler.trace-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.other-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.connect-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.dispatches"),
+                        MetricRegistry.name(TestHandler.class, "handler.head-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.post-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.options-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.active-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.delete-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.move-requests")
+                );
+
+        server.stop();
+
+        assertThat(registry.getNames())
+                .isEmpty();
+    }
+
+    @Test
+    public void responseTimesAreRecordedForBlockingResponses() throws Exception {
+
+        final ContentResponse response = client.GET(uri("/blocking"));
+
+        assertThat(response.getStatus())
+                .isEqualTo(200);
+
+        assertResponseTimesValid();
+    }
+
+    @Test
+    @Ignore("flaky on virtual machines")
+    public void responseTimesAreRecordedForAsyncResponses() throws Exception {
+
+        final ContentResponse response = client.GET(uri("/async"));
+
+        assertThat(response.getStatus())
+                .isEqualTo(200);
+
+        assertResponseTimesValid();
+    }
+
+    private void assertResponseTimesValid() {
+        assertThat(registry.getMeters().get(metricName() + ".2xx-responses")
+                .getCount()).isGreaterThan(0L);
+
+
+        assertThat(registry.getTimers().get(metricName() + ".get-requests")
+                .getSnapshot().getMedian()).isGreaterThan(0.0).isLessThan(TimeUnit.SECONDS.toNanos(1));
+
+        assertThat(registry.getTimers().get(metricName() + ".requests")
+                .getSnapshot().getMedian()).isGreaterThan(0.0).isLessThan(TimeUnit.SECONDS.toNanos(1));
+    }
+
+    private String uri(String path) {
+        return "http://localhost:" + connector.getLocalPort() + path;
+    }
+
+    private String metricName() {
+        return MetricRegistry.name(TestHandler.class.getName(), "handler");
+    }
+
+    /**
+     * test handler.
+     * <p>
+     * Supports
+     * <p>
+     * /blocking - uses the standard servlet api
+     * /async - uses the 3.1 async api to complete the request
+     * <p>
+     * all other requests will return 404
+     */
+    private static class TestHandler extends AbstractHandler {
+        @Override
+        public void handle(
+                String path,
+                Request request,
+                final HttpServletRequest httpServletRequest,
+                final HttpServletResponse httpServletResponse
+        ) throws IOException, ServletException {
+            switch (path) {
+                case "/blocking":
+                    request.setHandled(true);
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    httpServletResponse.setStatus(200);
+                    httpServletResponse.setContentType("text/plain");
+                    httpServletResponse.getWriter().write("some content from the blocking request\n");
+                    break;
+                case "/async":
+                    request.setHandled(true);
+                    final AsyncContext context = request.startAsync();
+                    Thread t = new Thread(() -> {
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        httpServletResponse.setStatus(200);
+                        httpServletResponse.setContentType("text/plain");
+                        final ServletOutputStream servletOutputStream;
+                        try {
+                            servletOutputStream = httpServletResponse.getOutputStream();
+                            servletOutputStream.setWriteListener(
+                                    new WriteListener() {
+                                        @Override
+                                        public void onWritePossible() throws IOException {
+                                            servletOutputStream.write("some content from the async\n"
+                                                    .getBytes(StandardCharsets.UTF_8));
+                                            context.complete();
+                                        }
+
+                                        @Override
+                                        public void onError(Throwable throwable) {
+                                            context.complete();
+                                        }
+                                    }
+                            );
+                        } catch (IOException e) {
+                            context.complete();
+                        }
+                    });
+                    t.start();
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/metrics-jetty10/src/test/java/io/dropwizard/metrics/jetty10/InstrumentedHttpChannelListenerTest.java
+++ b/metrics-jetty10/src/test/java/io/dropwizard/metrics/jetty10/InstrumentedHttpChannelListenerTest.java
@@ -1,0 +1,208 @@
+package io.dropwizard.metrics.jetty10;
+
+import com.codahale.metrics.MetricRegistry;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstrumentedHttpChannelListenerTest {
+    private final HttpClient client = new HttpClient();
+    private final Server server = new Server();
+    private final ServerConnector connector = new ServerConnector(server);
+    private final TestHandler handler = new TestHandler();
+    private MetricRegistry registry;
+
+    @Before
+    public void setUp() throws Exception {
+        registry = new MetricRegistry();
+        connector.addBean(new InstrumentedHttpChannelListener(registry, MetricRegistry.name(TestHandler.class, "handler")));
+        server.addConnector(connector);
+        server.setHandler(handler);
+        server.start();
+        client.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+        client.stop();
+    }
+
+    @Test
+    public void createsMetricsForTheHandler() throws Exception {
+        final ContentResponse response = client.GET(uri("/hello"));
+
+        assertThat(response.getStatus())
+                .isEqualTo(404);
+
+        assertThat(registry.getNames())
+                .containsOnly(
+                        metricName("1xx-responses"),
+                        metricName("2xx-responses"),
+                        metricName("3xx-responses"),
+                        metricName("4xx-responses"),
+                        metricName("5xx-responses"),
+                        metricName("percent-4xx-1m"),
+                        metricName("percent-4xx-5m"),
+                        metricName("percent-4xx-15m"),
+                        metricName("percent-5xx-1m"),
+                        metricName("percent-5xx-5m"),
+                        metricName("percent-5xx-15m"),
+                        metricName("requests"),
+                        metricName("active-suspended"),
+                        metricName("async-dispatches"),
+                        metricName("async-timeouts"),
+                        metricName("get-requests"),
+                        metricName("put-requests"),
+                        metricName("active-dispatches"),
+                        metricName("trace-requests"),
+                        metricName("other-requests"),
+                        metricName("connect-requests"),
+                        metricName("dispatches"),
+                        metricName("head-requests"),
+                        metricName("post-requests"),
+                        metricName("options-requests"),
+                        metricName("active-requests"),
+                        metricName("delete-requests"),
+                        metricName("move-requests")
+                );
+    }
+
+
+    @Test
+    public void responseTimesAreRecordedForBlockingResponses() throws Exception {
+
+        final ContentResponse response = client.GET(uri("/blocking"));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getMediaType()).isEqualTo("text/plain");
+        assertThat(response.getContentAsString()).isEqualTo("some content from the blocking request");
+
+        assertResponseTimesValid();
+    }
+
+    @Test
+    public void responseTimesAreRecordedForAsyncResponses() throws Exception {
+
+        final ContentResponse response = client.GET(uri("/async"));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getMediaType()).isEqualTo("text/plain");
+        assertThat(response.getContentAsString()).isEqualTo("some content from the async");
+
+        assertResponseTimesValid();
+    }
+
+    private void assertResponseTimesValid() {
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        assertThat(registry.getMeters().get(metricName("2xx-responses"))
+                .getCount()).isPositive();
+
+        assertThat(registry.getTimers().get(metricName("get-requests"))
+                .getSnapshot().getMedian()).isPositive();
+
+        assertThat(registry.getTimers().get(metricName("requests"))
+                .getSnapshot().getMedian()).isPositive();
+    }
+
+    private String uri(String path) {
+        return "http://localhost:" + connector.getLocalPort() + path;
+    }
+
+    private String metricName(String metricName) {
+        return MetricRegistry.name(TestHandler.class.getName(), "handler", metricName);
+    }
+
+    /**
+     * test handler.
+     * <p>
+     * Supports
+     * <p>
+     * /blocking - uses the standard servlet api
+     * /async - uses the 3.1 async api to complete the request
+     * <p>
+     * all other requests will return 404
+     */
+    private static class TestHandler extends AbstractHandler {
+        @Override
+        public void handle(
+                String path,
+                Request request,
+                final HttpServletRequest httpServletRequest,
+                final HttpServletResponse httpServletResponse) throws IOException {
+            switch (path) {
+                case "/blocking":
+                    request.setHandled(true);
+                    httpServletResponse.setStatus(200);
+                    httpServletResponse.setContentType("text/plain");
+                    httpServletResponse.getWriter().write("some content from the blocking request");
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        httpServletResponse.setStatus(500);
+                        Thread.currentThread().interrupt();
+                    }
+                    break;
+                case "/async":
+                    request.setHandled(true);
+                    final AsyncContext context = request.startAsync();
+                    Thread t = new Thread(() -> {
+                        httpServletResponse.setStatus(200);
+                        httpServletResponse.setContentType("text/plain");
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException e) {
+                            httpServletResponse.setStatus(500);
+                            Thread.currentThread().interrupt();
+                        }
+                        final ServletOutputStream servletOutputStream;
+                        try {
+                            servletOutputStream = httpServletResponse.getOutputStream();
+                            servletOutputStream.setWriteListener(
+                                    new WriteListener() {
+                                        @Override
+                                        public void onWritePossible() throws IOException {
+                                            servletOutputStream.write("some content from the async"
+                                                    .getBytes(StandardCharsets.UTF_8));
+                                            context.complete();
+                                        }
+
+                                        @Override
+                                        public void onError(Throwable throwable) {
+                                            context.complete();
+                                        }
+                                    }
+                            );
+                        } catch (IOException e) {
+                            context.complete();
+                        }
+                    });
+                    t.start();
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/metrics-jetty10/src/test/java/io/dropwizard/metrics/jetty10/InstrumentedQueuedThreadPoolTest.java
+++ b/metrics-jetty10/src/test/java/io/dropwizard/metrics/jetty10/InstrumentedQueuedThreadPoolTest.java
@@ -1,0 +1,49 @@
+package io.dropwizard.metrics.jetty10;
+
+import com.codahale.metrics.MetricRegistry;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstrumentedQueuedThreadPoolTest {
+    private static final String PREFIX = "prefix";
+
+    private MetricRegistry metricRegistry;
+    private InstrumentedQueuedThreadPool iqtp;
+
+    @Before
+    public void setUp() {
+        metricRegistry = new MetricRegistry();
+        iqtp = new InstrumentedQueuedThreadPool(metricRegistry);
+    }
+
+    @Test
+    public void customMetricsPrefix() throws Exception {
+        iqtp.setPrefix(PREFIX);
+        iqtp.start();
+
+        assertThat(metricRegistry.getNames())
+                .overridingErrorMessage("Custom metrics prefix doesn't match")
+                .allSatisfy(name -> assertThat(name).startsWith(PREFIX));
+
+        iqtp.stop();
+        assertThat(metricRegistry.getMetrics())
+                .overridingErrorMessage("The default metrics prefix was changed")
+                .isEmpty();
+    }
+
+    @Test
+    public void metricsPrefixBackwardCompatible() throws Exception {
+        iqtp.start();
+        assertThat(metricRegistry.getNames())
+                .overridingErrorMessage("The default metrics prefix was changed")
+                .allSatisfy(name -> assertThat(name).startsWith(QueuedThreadPool.class.getName()));
+
+        iqtp.stop();
+        assertThat(metricRegistry.getMetrics())
+                .overridingErrorMessage("The default metrics prefix was changed")
+                .isEmpty();
+    }
+}

--- a/metrics-jetty11/pom.xml
+++ b/metrics-jetty11/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-parent</artifactId>
+        <version>4.1.17-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>metrics-jetty11</artifactId>
+    <name>Metrics Integration for Jetty 11.x and higher</name>
+    <packaging>bundle</packaging>
+    <description>
+        A set of extensions for Jetty 11.x and higher which provide instrumentation of thread pools, connector
+        metrics, and application latency and utilization.
+    </description>
+
+    <properties>
+        <javaModuleName>io.dropwizard.metrics.jetty11</javaModuleName>
+
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+
+        <slf4j.version>2.0.0-alpha1</slf4j.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>${jetty11.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/metrics-jetty11/src/main/java/io/dropwizard/metrics/jetty11/InstrumentedConnectionFactory.java
+++ b/metrics-jetty11/src/main/java/io/dropwizard/metrics/jetty11/InstrumentedConnectionFactory.java
@@ -1,0 +1,63 @@
+package io.dropwizard.metrics.jetty11;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Timer;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.util.component.ContainerLifeCycle;
+
+import java.util.List;
+
+public class InstrumentedConnectionFactory extends ContainerLifeCycle implements ConnectionFactory {
+    private final ConnectionFactory connectionFactory;
+    private final Timer timer;
+    private final Counter counter;
+
+    public InstrumentedConnectionFactory(ConnectionFactory connectionFactory, Timer timer) {
+        this(connectionFactory, timer, null);
+    }
+
+    public InstrumentedConnectionFactory(ConnectionFactory connectionFactory, Timer timer, Counter counter) {
+        this.connectionFactory = connectionFactory;
+        this.timer = timer;
+        this.counter = counter;
+        addBean(connectionFactory);
+    }
+
+    @Override
+    public String getProtocol() {
+        return connectionFactory.getProtocol();
+    }
+
+    @Override
+    public List<String> getProtocols() {
+        return connectionFactory.getProtocols();
+    }
+
+    @Override
+    public Connection newConnection(Connector connector, EndPoint endPoint) {
+        final Connection connection = connectionFactory.newConnection(connector, endPoint);
+        connection.addEventListener(new Connection.Listener() {
+            private Timer.Context context;
+
+            @Override
+            public void onOpened(Connection connection) {
+                this.context = timer.time();
+                if (counter != null) {
+                    counter.inc();
+                }
+            }
+
+            @Override
+            public void onClosed(Connection connection) {
+                context.stop();
+                if (counter != null) {
+                    counter.dec();
+                }
+            }
+        });
+        return connection;
+    }
+}

--- a/metrics-jetty11/src/main/java/io/dropwizard/metrics/jetty11/InstrumentedHandler.java
+++ b/metrics-jetty11/src/main/java/io/dropwizard/metrics/jetty11/InstrumentedHandler.java
@@ -1,0 +1,379 @@
+package io.dropwizard.metrics.jetty11;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.RatioGauge;
+import com.codahale.metrics.Timer;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.server.AsyncContextState;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpChannelState;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.HandlerWrapper;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+/**
+ * A Jetty {@link Handler} which records various metrics about an underlying {@link Handler}
+ * instance.
+ */
+public class InstrumentedHandler extends HandlerWrapper {
+    private static final String NAME_REQUESTS = "requests";
+    private static final String NAME_DISPATCHES = "dispatches";
+    private static final String NAME_ACTIVE_REQUESTS = "active-requests";
+    private static final String NAME_ACTIVE_DISPATCHES = "active-dispatches";
+    private static final String NAME_ACTIVE_SUSPENDED = "active-suspended";
+    private static final String NAME_ASYNC_DISPATCHES = "async-dispatches";
+    private static final String NAME_ASYNC_TIMEOUTS = "async-timeouts";
+    private static final String NAME_1XX_RESPONSES = "1xx-responses";
+    private static final String NAME_2XX_RESPONSES = "2xx-responses";
+    private static final String NAME_3XX_RESPONSES = "3xx-responses";
+    private static final String NAME_4XX_RESPONSES = "4xx-responses";
+    private static final String NAME_5XX_RESPONSES = "5xx-responses";
+    private static final String NAME_GET_REQUESTS = "get-requests";
+    private static final String NAME_POST_REQUESTS = "post-requests";
+    private static final String NAME_HEAD_REQUESTS = "head-requests";
+    private static final String NAME_PUT_REQUESTS = "put-requests";
+    private static final String NAME_DELETE_REQUESTS = "delete-requests";
+    private static final String NAME_OPTIONS_REQUESTS = "options-requests";
+    private static final String NAME_TRACE_REQUESTS = "trace-requests";
+    private static final String NAME_CONNECT_REQUESTS = "connect-requests";
+    private static final String NAME_MOVE_REQUESTS = "move-requests";
+    private static final String NAME_OTHER_REQUESTS = "other-requests";
+    private static final String NAME_PERCENT_4XX_1M = "percent-4xx-1m";
+    private static final String NAME_PERCENT_4XX_5M = "percent-4xx-5m";
+    private static final String NAME_PERCENT_4XX_15M = "percent-4xx-15m";
+    private static final String NAME_PERCENT_5XX_1M = "percent-5xx-1m";
+    private static final String NAME_PERCENT_5XX_5M = "percent-5xx-5m";
+    private static final String NAME_PERCENT_5XX_15M = "percent-5xx-15m";
+
+    private final MetricRegistry metricRegistry;
+
+    private String name;
+    private final String prefix;
+
+    // the requests handled by this handler, excluding active
+    private Timer requests;
+
+    // the number of dispatches seen by this handler, excluding active
+    private Timer dispatches;
+
+    // the number of active requests
+    private Counter activeRequests;
+
+    // the number of active dispatches
+    private Counter activeDispatches;
+
+    // the number of requests currently suspended.
+    private Counter activeSuspended;
+
+    // the number of requests that have been asynchronously dispatched
+    private Meter asyncDispatches;
+
+    // the number of requests that expired while suspended
+    private Meter asyncTimeouts;
+
+    private Meter[] responses;
+
+    private Timer getRequests;
+    private Timer postRequests;
+    private Timer headRequests;
+    private Timer putRequests;
+    private Timer deleteRequests;
+    private Timer optionsRequests;
+    private Timer traceRequests;
+    private Timer connectRequests;
+    private Timer moveRequests;
+    private Timer otherRequests;
+
+    private AsyncListener listener;
+
+    private HttpChannelState.State DISPATCHED_HACK;
+
+    /**
+     * Create a new instrumented handler using a given metrics registry.
+     *
+     * @param registry the registry for the metrics
+     */
+    public InstrumentedHandler(MetricRegistry registry) {
+        this(registry, null);
+    }
+
+    /**
+     * Create a new instrumented handler using a given metrics registry.
+     *
+     * @param registry the registry for the metrics
+     * @param prefix   the prefix to use for the metrics names
+     */
+    public InstrumentedHandler(MetricRegistry registry, String prefix) {
+        this.metricRegistry = registry;
+        this.prefix = prefix;
+
+        try {
+            DISPATCHED_HACK = HttpChannelState.State.valueOf("HANDLING");
+        } catch (IllegalArgumentException e) {
+            DISPATCHED_HACK = HttpChannelState.State.valueOf("DISPATCHED");
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+
+        final String prefix = getMetricPrefix();
+
+        this.requests = metricRegistry.timer(name(prefix, NAME_REQUESTS));
+        this.dispatches = metricRegistry.timer(name(prefix, NAME_DISPATCHES));
+
+        this.activeRequests = metricRegistry.counter(name(prefix, NAME_ACTIVE_REQUESTS));
+        this.activeDispatches = metricRegistry.counter(name(prefix, NAME_ACTIVE_DISPATCHES));
+        this.activeSuspended = metricRegistry.counter(name(prefix, NAME_ACTIVE_SUSPENDED));
+
+        this.asyncDispatches = metricRegistry.meter(name(prefix, NAME_ASYNC_DISPATCHES));
+        this.asyncTimeouts = metricRegistry.meter(name(prefix, NAME_ASYNC_TIMEOUTS));
+
+        this.responses = new Meter[]{
+                metricRegistry.meter(name(prefix, NAME_1XX_RESPONSES)), // 1xx
+                metricRegistry.meter(name(prefix, NAME_2XX_RESPONSES)), // 2xx
+                metricRegistry.meter(name(prefix, NAME_3XX_RESPONSES)), // 3xx
+                metricRegistry.meter(name(prefix, NAME_4XX_RESPONSES)), // 4xx
+                metricRegistry.meter(name(prefix, NAME_5XX_RESPONSES))  // 5xx
+        };
+
+        this.getRequests = metricRegistry.timer(name(prefix, NAME_GET_REQUESTS));
+        this.postRequests = metricRegistry.timer(name(prefix, NAME_POST_REQUESTS));
+        this.headRequests = metricRegistry.timer(name(prefix, NAME_HEAD_REQUESTS));
+        this.putRequests = metricRegistry.timer(name(prefix, NAME_PUT_REQUESTS));
+        this.deleteRequests = metricRegistry.timer(name(prefix, NAME_DELETE_REQUESTS));
+        this.optionsRequests = metricRegistry.timer(name(prefix, NAME_OPTIONS_REQUESTS));
+        this.traceRequests = metricRegistry.timer(name(prefix, NAME_TRACE_REQUESTS));
+        this.connectRequests = metricRegistry.timer(name(prefix, NAME_CONNECT_REQUESTS));
+        this.moveRequests = metricRegistry.timer(name(prefix, NAME_MOVE_REQUESTS));
+        this.otherRequests = metricRegistry.timer(name(prefix, NAME_OTHER_REQUESTS));
+
+        metricRegistry.register(name(prefix, NAME_PERCENT_4XX_1M), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[3].getOneMinuteRate(),
+                        requests.getOneMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, NAME_PERCENT_4XX_5M), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[3].getFiveMinuteRate(),
+                        requests.getFiveMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, NAME_PERCENT_4XX_15M), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[3].getFifteenMinuteRate(),
+                        requests.getFifteenMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, NAME_PERCENT_5XX_1M), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[4].getOneMinuteRate(),
+                        requests.getOneMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, NAME_PERCENT_5XX_5M), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[4].getFiveMinuteRate(),
+                        requests.getFiveMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, NAME_PERCENT_5XX_15M), new RatioGauge() {
+            @Override
+            public Ratio getRatio() {
+                return Ratio.of(responses[4].getFifteenMinuteRate(),
+                        requests.getFifteenMinuteRate());
+            }
+        });
+
+
+        this.listener = new AsyncListener() {
+            private long startTime;
+
+            @Override
+            public void onTimeout(AsyncEvent event) throws IOException {
+                asyncTimeouts.mark();
+            }
+
+            @Override
+            public void onStartAsync(AsyncEvent event) throws IOException {
+                startTime = System.currentTimeMillis();
+                event.getAsyncContext().addListener(this);
+            }
+
+            @Override
+            public void onError(AsyncEvent event) throws IOException {
+            }
+
+            @Override
+            public void onComplete(AsyncEvent event) throws IOException {
+                final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
+                final HttpServletRequest request = (HttpServletRequest) state.getRequest();
+                final HttpServletResponse response = (HttpServletResponse) state.getResponse();
+                updateResponses(request, response, startTime, true);
+                if (state.getHttpChannelState().getState() != DISPATCHED_HACK &&
+                        state.getHttpChannelState().isSuspended()) {
+                    activeSuspended.dec();
+                }
+            }
+        };
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        final String prefix = getMetricPrefix();
+
+        metricRegistry.remove(name(prefix, NAME_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_DISPATCHES));
+        metricRegistry.remove(name(prefix, NAME_ACTIVE_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_ACTIVE_DISPATCHES));
+        metricRegistry.remove(name(prefix, NAME_ACTIVE_SUSPENDED));
+        metricRegistry.remove(name(prefix, NAME_ASYNC_DISPATCHES));
+        metricRegistry.remove(name(prefix, NAME_ASYNC_TIMEOUTS));
+        metricRegistry.remove(name(prefix, NAME_1XX_RESPONSES));
+        metricRegistry.remove(name(prefix, NAME_2XX_RESPONSES));
+        metricRegistry.remove(name(prefix, NAME_3XX_RESPONSES));
+        metricRegistry.remove(name(prefix, NAME_4XX_RESPONSES));
+        metricRegistry.remove(name(prefix, NAME_5XX_RESPONSES));
+        metricRegistry.remove(name(prefix, NAME_GET_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_POST_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_HEAD_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_PUT_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_DELETE_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_OPTIONS_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_TRACE_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_CONNECT_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_MOVE_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_OTHER_REQUESTS));
+        metricRegistry.remove(name(prefix, NAME_PERCENT_4XX_1M));
+        metricRegistry.remove(name(prefix, NAME_PERCENT_4XX_5M));
+        metricRegistry.remove(name(prefix, NAME_PERCENT_4XX_15M));
+        metricRegistry.remove(name(prefix, NAME_PERCENT_5XX_1M));
+        metricRegistry.remove(name(prefix, NAME_PERCENT_5XX_5M));
+        metricRegistry.remove(name(prefix, NAME_PERCENT_5XX_15M));
+
+        super.doStop();
+    }
+
+    @Override
+    public void handle(String path,
+                       Request request,
+                       HttpServletRequest httpRequest,
+                       HttpServletResponse httpResponse) throws IOException, ServletException {
+
+        activeDispatches.inc();
+
+        final long start;
+        final HttpChannelState state = request.getHttpChannelState();
+        if (state.isInitial()) {
+            // new request
+            activeRequests.inc();
+            start = request.getTimeStamp();
+            state.addListener(listener);
+        } else {
+            // resumed request
+            start = System.currentTimeMillis();
+            activeSuspended.dec();
+            if (state.getState() == DISPATCHED_HACK) {
+                asyncDispatches.mark();
+            }
+        }
+
+        try {
+            super.handle(path, request, httpRequest, httpResponse);
+        } finally {
+            final long now = System.currentTimeMillis();
+            final long dispatched = now - start;
+
+            activeDispatches.dec();
+            dispatches.update(dispatched, TimeUnit.MILLISECONDS);
+
+            if (state.isSuspended()) {
+                activeSuspended.inc();
+            } else if (state.isInitial()) {
+                updateResponses(httpRequest, httpResponse, start, request.isHandled());
+            }
+            // else onCompletion will handle it.
+        }
+    }
+
+    private Timer requestTimer(String method) {
+        final HttpMethod m = HttpMethod.fromString(method);
+        if (m == null) {
+            return otherRequests;
+        } else {
+            switch (m) {
+                case GET:
+                    return getRequests;
+                case POST:
+                    return postRequests;
+                case PUT:
+                    return putRequests;
+                case HEAD:
+                    return headRequests;
+                case DELETE:
+                    return deleteRequests;
+                case OPTIONS:
+                    return optionsRequests;
+                case TRACE:
+                    return traceRequests;
+                case CONNECT:
+                    return connectRequests;
+                case MOVE:
+                    return moveRequests;
+                default:
+                    return otherRequests;
+            }
+        }
+    }
+
+    private void updateResponses(HttpServletRequest request, HttpServletResponse response, long start, boolean isHandled) {
+        final int responseStatus;
+        if (isHandled) {
+            responseStatus = response.getStatus() / 100;
+        } else {
+            responseStatus = 4; // will end up with a 404 response sent by HttpChannel.handle
+        }
+        if (responseStatus >= 1 && responseStatus <= 5) {
+            responses[responseStatus - 1].mark();
+        }
+        activeRequests.dec();
+        final long elapsedTime = System.currentTimeMillis() - start;
+        requests.update(elapsedTime, TimeUnit.MILLISECONDS);
+        requestTimer(request.getMethod()).update(elapsedTime, TimeUnit.MILLISECONDS);
+    }
+
+    private String getMetricPrefix() {
+        return this.prefix == null ? name(getHandler().getClass(), name) : name(this.prefix, name);
+    }
+}

--- a/metrics-jetty11/src/main/java/io/dropwizard/metrics/jetty11/InstrumentedHandler.java
+++ b/metrics-jetty11/src/main/java/io/dropwizard/metrics/jetty11/InstrumentedHandler.java
@@ -97,8 +97,6 @@ public class InstrumentedHandler extends HandlerWrapper {
 
     private AsyncListener listener;
 
-    private HttpChannelState.State DISPATCHED_HACK;
-
     /**
      * Create a new instrumented handler using a given metrics registry.
      *
@@ -117,12 +115,6 @@ public class InstrumentedHandler extends HandlerWrapper {
     public InstrumentedHandler(MetricRegistry registry, String prefix) {
         this.metricRegistry = registry;
         this.prefix = prefix;
-
-        try {
-            DISPATCHED_HACK = HttpChannelState.State.valueOf("HANDLING");
-        } catch (IllegalArgumentException e) {
-            DISPATCHED_HACK = HttpChannelState.State.valueOf("DISPATCHED");
-        }
     }
 
     public String getName() {
@@ -241,7 +233,7 @@ public class InstrumentedHandler extends HandlerWrapper {
                 final HttpServletRequest request = (HttpServletRequest) state.getRequest();
                 final HttpServletResponse response = (HttpServletResponse) state.getResponse();
                 updateResponses(request, response, startTime, true);
-                if (state.getHttpChannelState().getState() != DISPATCHED_HACK &&
+                if (state.getHttpChannelState().getState() != HttpChannelState.State.HANDLING &&
                         state.getHttpChannelState().isSuspended()) {
                     activeSuspended.dec();
                 }
@@ -304,7 +296,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             // resumed request
             start = System.currentTimeMillis();
             activeSuspended.dec();
-            if (state.getState() == DISPATCHED_HACK) {
+            if (state.getState() == HttpChannelState.State.HANDLING) {
                 asyncDispatches.mark();
             }
         }

--- a/metrics-jetty11/src/main/java/io/dropwizard/metrics/jetty11/InstrumentedHttpChannelListener.java
+++ b/metrics-jetty11/src/main/java/io/dropwizard/metrics/jetty11/InstrumentedHttpChannelListener.java
@@ -1,0 +1,359 @@
+package io.dropwizard.metrics.jetty11;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.RatioGauge;
+import com.codahale.metrics.Timer;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.server.AsyncContextState;
+import org.eclipse.jetty.server.HttpChannel.Listener;
+import org.eclipse.jetty.server.HttpChannelState;
+import org.eclipse.jetty.server.Request;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+/**
+ * A Jetty {@link org.eclipse.jetty.server.HttpChannel.Listener} implementation which records various metrics about
+ * underlying channel instance. Unlike {@link InstrumentedHandler} that uses internal API, this class should be
+ * future proof. To install it, just add instance of this class to {@link org.eclipse.jetty.server.Connector} as bean.
+ *
+ * @since TBD
+ */
+public class InstrumentedHttpChannelListener
+        implements Listener {
+    private static final String START_ATTR = InstrumentedHttpChannelListener.class.getName() + ".start";
+
+    private final MetricRegistry metricRegistry;
+
+    // the requests handled by this handler, excluding active
+    private final Timer requests;
+
+    // the number of dispatches seen by this handler, excluding active
+    private final Timer dispatches;
+
+    // the number of active requests
+    private final Counter activeRequests;
+
+    // the number of active dispatches
+    private final Counter activeDispatches;
+
+    // the number of requests currently suspended.
+    private final Counter activeSuspended;
+
+    // the number of requests that have been asynchronously dispatched
+    private final Meter asyncDispatches;
+
+    // the number of requests that expired while suspended
+    private final Meter asyncTimeouts;
+
+    private final Meter[] responses;
+
+    private final Timer getRequests;
+    private final Timer postRequests;
+    private final Timer headRequests;
+    private final Timer putRequests;
+    private final Timer deleteRequests;
+    private final Timer optionsRequests;
+    private final Timer traceRequests;
+    private final Timer connectRequests;
+    private final Timer moveRequests;
+    private final Timer otherRequests;
+
+    private final AsyncListener listener;
+
+    /**
+     * Create a new instrumented handler using a given metrics registry.
+     *
+     * @param registry the registry for the metrics
+     */
+    public InstrumentedHttpChannelListener(MetricRegistry registry) {
+        this(registry, null);
+    }
+
+    /**
+     * Create a new instrumented handler using a given metrics registry.
+     *
+     * @param registry the registry for the metrics
+     * @param pref     the prefix to use for the metrics names
+     */
+    public InstrumentedHttpChannelListener(MetricRegistry registry, String pref) {
+        this.metricRegistry = registry;
+
+        String prefix = (pref == null) ? getClass().getName() : pref;
+
+        this.requests = metricRegistry.timer(name(prefix, "requests"));
+        this.dispatches = metricRegistry.timer(name(prefix, "dispatches"));
+
+        this.activeRequests = metricRegistry.counter(name(prefix, "active-requests"));
+        this.activeDispatches = metricRegistry.counter(name(prefix, "active-dispatches"));
+        this.activeSuspended = metricRegistry.counter(name(prefix, "active-suspended"));
+
+        this.asyncDispatches = metricRegistry.meter(name(prefix, "async-dispatches"));
+        this.asyncTimeouts = metricRegistry.meter(name(prefix, "async-timeouts"));
+
+        this.responses = new Meter[]{
+                metricRegistry.meter(name(prefix, "1xx-responses")), // 1xx
+                metricRegistry.meter(name(prefix, "2xx-responses")), // 2xx
+                metricRegistry.meter(name(prefix, "3xx-responses")), // 3xx
+                metricRegistry.meter(name(prefix, "4xx-responses")), // 4xx
+                metricRegistry.meter(name(prefix, "5xx-responses"))  // 5xx
+        };
+
+        this.getRequests = metricRegistry.timer(name(prefix, "get-requests"));
+        this.postRequests = metricRegistry.timer(name(prefix, "post-requests"));
+        this.headRequests = metricRegistry.timer(name(prefix, "head-requests"));
+        this.putRequests = metricRegistry.timer(name(prefix, "put-requests"));
+        this.deleteRequests = metricRegistry.timer(name(prefix, "delete-requests"));
+        this.optionsRequests = metricRegistry.timer(name(prefix, "options-requests"));
+        this.traceRequests = metricRegistry.timer(name(prefix, "trace-requests"));
+        this.connectRequests = metricRegistry.timer(name(prefix, "connect-requests"));
+        this.moveRequests = metricRegistry.timer(name(prefix, "move-requests"));
+        this.otherRequests = metricRegistry.timer(name(prefix, "other-requests"));
+
+        metricRegistry.register(name(prefix, "percent-4xx-1m"), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[3].getOneMinuteRate(),
+                        requests.getOneMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, "percent-4xx-5m"), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[3].getFiveMinuteRate(),
+                        requests.getFiveMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, "percent-4xx-15m"), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[3].getFifteenMinuteRate(),
+                        requests.getFifteenMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, "percent-5xx-1m"), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[4].getOneMinuteRate(),
+                        requests.getOneMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, "percent-5xx-5m"), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(responses[4].getFiveMinuteRate(),
+                        requests.getFiveMinuteRate());
+            }
+        });
+
+        metricRegistry.register(name(prefix, "percent-5xx-15m"), new RatioGauge() {
+            @Override
+            public Ratio getRatio() {
+                return Ratio.of(responses[4].getFifteenMinuteRate(),
+                        requests.getFifteenMinuteRate());
+            }
+        });
+
+        this.listener = new AsyncListener() {
+            private long startTime;
+
+            @Override
+            public void onTimeout(AsyncEvent event) throws IOException {
+                asyncTimeouts.mark();
+            }
+
+            @Override
+            public void onStartAsync(AsyncEvent event) throws IOException {
+                startTime = System.currentTimeMillis();
+                event.getAsyncContext().addListener(this);
+            }
+
+            @Override
+            public void onError(AsyncEvent event) throws IOException {
+            }
+
+            @Override
+            public void onComplete(AsyncEvent event) throws IOException {
+                final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
+                final HttpServletRequest request = (HttpServletRequest) state.getRequest();
+                final HttpServletResponse response = (HttpServletResponse) state.getResponse();
+                updateResponses(request, response, startTime, true);
+                if (!state.getHttpChannelState().isSuspended()) {
+                    activeSuspended.dec();
+                }
+            }
+        };
+    }
+
+    @Override
+    public void onRequestBegin(final Request request) {
+
+    }
+
+    @Override
+    public void onBeforeDispatch(final Request request) {
+        before(request);
+    }
+
+    @Override
+    public void onDispatchFailure(final Request request, final Throwable failure) {
+
+    }
+
+    @Override
+    public void onAfterDispatch(final Request request) {
+        after(request);
+    }
+
+    @Override
+    public void onRequestContent(final Request request, final ByteBuffer content) {
+
+    }
+
+    @Override
+    public void onRequestContentEnd(final Request request) {
+
+    }
+
+    @Override
+    public void onRequestTrailers(final Request request) {
+
+    }
+
+    @Override
+    public void onRequestEnd(final Request request) {
+
+    }
+
+    @Override
+    public void onRequestFailure(final Request request, final Throwable failure) {
+
+    }
+
+    @Override
+    public void onResponseBegin(final Request request) {
+
+    }
+
+    @Override
+    public void onResponseCommit(final Request request) {
+
+    }
+
+    @Override
+    public void onResponseContent(final Request request, final ByteBuffer content) {
+
+    }
+
+    @Override
+    public void onResponseEnd(final Request request) {
+
+    }
+
+    @Override
+    public void onResponseFailure(final Request request, final Throwable failure) {
+
+    }
+
+    @Override
+    public void onComplete(final Request request) {
+
+    }
+
+    private void before(final Request request) {
+        activeDispatches.inc();
+
+        final long start;
+        final HttpChannelState state = request.getHttpChannelState();
+        if (state.isInitial()) {
+            // new request
+            activeRequests.inc();
+            start = request.getTimeStamp();
+            state.addListener(listener);
+        } else {
+            // resumed request
+            start = System.currentTimeMillis();
+            activeSuspended.dec();
+            if (state.isAsyncStarted()) {
+                asyncDispatches.mark();
+            }
+        }
+        request.setAttribute(START_ATTR, start);
+    }
+
+    private void after(final Request request) {
+        final long start = (long) request.getAttribute(START_ATTR);
+        final long now = System.currentTimeMillis();
+        final long dispatched = now - start;
+
+        activeDispatches.dec();
+        dispatches.update(dispatched, TimeUnit.MILLISECONDS);
+
+        final HttpChannelState state = request.getHttpChannelState();
+        if (state.isSuspended()) {
+            activeSuspended.inc();
+        } else if (state.isInitial()) {
+            updateResponses(request, request.getResponse(), start, request.isHandled());
+        }
+        // else onCompletion will handle it.
+    }
+
+    private void updateResponses(HttpServletRequest request, HttpServletResponse response, long start, boolean isHandled) {
+        final int responseStatus;
+        if (isHandled) {
+            responseStatus = response.getStatus() / 100;
+        } else {
+            responseStatus = 4; // will end up with a 404 response sent by HttpChannel.handle
+        }
+        if (responseStatus >= 1 && responseStatus <= 5) {
+            responses[responseStatus - 1].mark();
+        }
+        activeRequests.dec();
+        final long elapsedTime = System.currentTimeMillis() - start;
+        requests.update(elapsedTime, TimeUnit.MILLISECONDS);
+        requestTimer(request.getMethod()).update(elapsedTime, TimeUnit.MILLISECONDS);
+    }
+
+    private Timer requestTimer(String method) {
+        final HttpMethod m = HttpMethod.fromString(method);
+        if (m == null) {
+            return otherRequests;
+        } else {
+            switch (m) {
+                case GET:
+                    return getRequests;
+                case POST:
+                    return postRequests;
+                case PUT:
+                    return putRequests;
+                case HEAD:
+                    return headRequests;
+                case DELETE:
+                    return deleteRequests;
+                case OPTIONS:
+                    return optionsRequests;
+                case TRACE:
+                    return traceRequests;
+                case CONNECT:
+                    return connectRequests;
+                case MOVE:
+                    return moveRequests;
+                default:
+                    return otherRequests;
+            }
+        }
+    }
+}

--- a/metrics-jetty11/src/main/java/io/dropwizard/metrics/jetty11/InstrumentedQueuedThreadPool.java
+++ b/metrics-jetty11/src/main/java/io/dropwizard/metrics/jetty11/InstrumentedQueuedThreadPool.java
@@ -1,0 +1,121 @@
+package io.dropwizard.metrics.jetty11;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.RatioGauge;
+import org.eclipse.jetty.util.annotation.Name;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+
+import java.util.concurrent.BlockingQueue;
+
+import static com.codahale.metrics.MetricRegistry.name;
+
+public class InstrumentedQueuedThreadPool extends QueuedThreadPool {
+    private static final String NAME_UTILIZATION = "utilization";
+    private static final String NAME_UTILIZATION_MAX = "utilization-max";
+    private static final String NAME_SIZE = "size";
+    private static final String NAME_JOBS = "jobs";
+    private static final String NAME_JOBS_QUEUE_UTILIZATION = "jobs-queue-utilization";
+
+    private final MetricRegistry metricRegistry;
+    private String prefix;
+
+    public InstrumentedQueuedThreadPool(@Name("registry") MetricRegistry registry) {
+        this(registry, 200);
+    }
+
+    public InstrumentedQueuedThreadPool(@Name("registry") MetricRegistry registry,
+                                        @Name("maxThreads") int maxThreads) {
+        this(registry, maxThreads, 8);
+    }
+
+    public InstrumentedQueuedThreadPool(@Name("registry") MetricRegistry registry,
+                                        @Name("maxThreads") int maxThreads,
+                                        @Name("minThreads") int minThreads) {
+        this(registry, maxThreads, minThreads, 60000);
+    }
+
+    public InstrumentedQueuedThreadPool(@Name("registry") MetricRegistry registry,
+                                        @Name("maxThreads") int maxThreads,
+                                        @Name("minThreads") int minThreads,
+                                        @Name("idleTimeout") int idleTimeout) {
+        this(registry, maxThreads, minThreads, idleTimeout, null);
+    }
+
+    public InstrumentedQueuedThreadPool(@Name("registry") MetricRegistry registry,
+                                        @Name("maxThreads") int maxThreads,
+                                        @Name("minThreads") int minThreads,
+                                        @Name("idleTimeout") int idleTimeout,
+                                        @Name("queue") BlockingQueue<Runnable> queue) {
+        this(registry, maxThreads, minThreads, idleTimeout, queue, null);
+    }
+
+    public InstrumentedQueuedThreadPool(@Name("registry") MetricRegistry registry,
+                                        @Name("maxThreads") int maxThreads,
+                                        @Name("minThreads") int minThreads,
+                                        @Name("idleTimeout") int idleTimeout,
+                                        @Name("queue") BlockingQueue<Runnable> queue,
+                                        @Name("prefix") String prefix) {
+        super(maxThreads, minThreads, idleTimeout, queue);
+        this.metricRegistry = registry;
+        this.prefix = prefix;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public void setPrefix(String prefix) {
+        this.prefix = prefix;
+    }
+
+    @Override
+    protected void doStart() throws Exception {
+        super.doStart();
+
+        final String prefix = getMetricPrefix();
+
+        metricRegistry.register(name(prefix, NAME_UTILIZATION), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(getThreads() - getIdleThreads(), getThreads());
+            }
+        });
+        metricRegistry.register(name(prefix, NAME_UTILIZATION_MAX), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                return Ratio.of(getThreads() - getIdleThreads(), getMaxThreads());
+            }
+        });
+        metricRegistry.register(name(prefix, NAME_SIZE), (Gauge<Integer>) this::getThreads);
+        metricRegistry.register(name(prefix, NAME_JOBS), (Gauge<Integer>) () -> {
+            // This assumes the QueuedThreadPool is using a BlockingArrayQueue or
+            // ArrayBlockingQueue for its queue, and is therefore a constant-time operation.
+            return getQueue().size();
+        });
+        metricRegistry.register(name(prefix, NAME_JOBS_QUEUE_UTILIZATION), new RatioGauge() {
+            @Override
+            protected Ratio getRatio() {
+                BlockingQueue<Runnable> queue = getQueue();
+                return Ratio.of(queue.size(), queue.size() + queue.remainingCapacity());
+            }
+        });
+    }
+
+    @Override
+    protected void doStop() throws Exception {
+        final String prefix = getMetricPrefix();
+
+        metricRegistry.remove(name(prefix, NAME_UTILIZATION));
+        metricRegistry.remove(name(prefix, NAME_UTILIZATION_MAX));
+        metricRegistry.remove(name(prefix, NAME_SIZE));
+        metricRegistry.remove(name(prefix, NAME_JOBS));
+        metricRegistry.remove(name(prefix, NAME_JOBS_QUEUE_UTILIZATION));
+
+        super.doStop();
+    }
+
+    private String getMetricPrefix() {
+        return this.prefix == null ? name(QueuedThreadPool.class, getName()) : name(this.prefix, getName());
+    }
+}

--- a/metrics-jetty11/src/test/java/io/dropwizard/metrics/jetty11/InstrumentedConnectionFactoryTest.java
+++ b/metrics-jetty11/src/test/java/io/dropwizard/metrics/jetty11/InstrumentedConnectionFactoryTest.java
@@ -1,0 +1,93 @@
+package io.dropwizard.metrics.jetty11;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstrumentedConnectionFactoryTest {
+    private final MetricRegistry registry = new MetricRegistry();
+    private final Server server = new Server();
+    private final ServerConnector connector =
+            new ServerConnector(server, new InstrumentedConnectionFactory(new HttpConnectionFactory(),
+                    registry.timer("http.connections"),
+                    registry.counter("http.active-connections")));
+    private final HttpClient client = new HttpClient();
+
+    @Before
+    public void setUp() throws Exception {
+        server.setHandler(new AbstractHandler() {
+            @Override
+            public void handle(String target,
+                               Request baseRequest,
+                               HttpServletRequest request,
+                               HttpServletResponse response) throws IOException, ServletException {
+                try (PrintWriter writer = response.getWriter()) {
+                    writer.println("OK");
+                }
+            }
+        });
+
+        server.addConnector(connector);
+        server.start();
+
+        client.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+        client.stop();
+    }
+
+    @Test
+    public void instrumentsConnectionTimes() throws Exception {
+        final ContentResponse response = client.GET("http://localhost:" + connector.getLocalPort() + "/hello");
+        assertThat(response.getStatus())
+                .isEqualTo(200);
+
+        client.stop(); // close the connection
+
+        Thread.sleep(100); // make sure the connection is closed
+
+        final Timer timer = registry.timer(MetricRegistry.name("http.connections"));
+        assertThat(timer.getCount())
+                .isEqualTo(1);
+    }
+
+    @Test
+    public void instrumentsActiveConnections() throws Exception {
+        final Counter counter = registry.counter("http.active-connections");
+
+        final ContentResponse response = client.GET("http://localhost:" + connector.getLocalPort() + "/hello");
+        assertThat(response.getStatus())
+                .isEqualTo(200);
+
+        assertThat(counter.getCount())
+                .isEqualTo(1);
+
+        client.stop(); // close the connection
+
+        Thread.sleep(100); // make sure the connection is closed
+
+        assertThat(counter.getCount())
+                .isEqualTo(0);
+    }
+}

--- a/metrics-jetty11/src/test/java/io/dropwizard/metrics/jetty11/InstrumentedHandlerTest.java
+++ b/metrics-jetty11/src/test/java/io/dropwizard/metrics/jetty11/InstrumentedHandlerTest.java
@@ -1,0 +1,214 @@
+package io.dropwizard.metrics.jetty11;
+
+import com.codahale.metrics.MetricRegistry;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstrumentedHandlerTest {
+    private final HttpClient client = new HttpClient();
+    private final MetricRegistry registry = new MetricRegistry();
+    private final Server server = new Server();
+    private final ServerConnector connector = new ServerConnector(server);
+    private final InstrumentedHandler handler = new InstrumentedHandler(registry);
+
+    @Before
+    public void setUp() throws Exception {
+        handler.setName("handler");
+        handler.setHandler(new TestHandler());
+        server.addConnector(connector);
+        server.setHandler(handler);
+        server.start();
+        client.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+        client.stop();
+    }
+
+    @Test
+    public void hasAName() throws Exception {
+        assertThat(handler.getName())
+                .isEqualTo("handler");
+    }
+
+    @Test
+    public void createsAndRemovesMetricsForTheHandler() throws Exception {
+        final ContentResponse response = client.GET(uri("/hello"));
+
+        assertThat(response.getStatus())
+                .isEqualTo(404);
+
+        assertThat(registry.getNames())
+                .containsOnly(
+                        MetricRegistry.name(TestHandler.class, "handler.1xx-responses"),
+                        MetricRegistry.name(TestHandler.class, "handler.2xx-responses"),
+                        MetricRegistry.name(TestHandler.class, "handler.3xx-responses"),
+                        MetricRegistry.name(TestHandler.class, "handler.4xx-responses"),
+                        MetricRegistry.name(TestHandler.class, "handler.5xx-responses"),
+                        MetricRegistry.name(TestHandler.class, "handler.percent-4xx-1m"),
+                        MetricRegistry.name(TestHandler.class, "handler.percent-4xx-5m"),
+                        MetricRegistry.name(TestHandler.class, "handler.percent-4xx-15m"),
+                        MetricRegistry.name(TestHandler.class, "handler.percent-5xx-1m"),
+                        MetricRegistry.name(TestHandler.class, "handler.percent-5xx-5m"),
+                        MetricRegistry.name(TestHandler.class, "handler.percent-5xx-15m"),
+                        MetricRegistry.name(TestHandler.class, "handler.requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.active-suspended"),
+                        MetricRegistry.name(TestHandler.class, "handler.async-dispatches"),
+                        MetricRegistry.name(TestHandler.class, "handler.async-timeouts"),
+                        MetricRegistry.name(TestHandler.class, "handler.get-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.put-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.active-dispatches"),
+                        MetricRegistry.name(TestHandler.class, "handler.trace-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.other-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.connect-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.dispatches"),
+                        MetricRegistry.name(TestHandler.class, "handler.head-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.post-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.options-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.active-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.delete-requests"),
+                        MetricRegistry.name(TestHandler.class, "handler.move-requests")
+                );
+
+        server.stop();
+
+        assertThat(registry.getNames())
+                .isEmpty();
+    }
+
+    @Test
+    public void responseTimesAreRecordedForBlockingResponses() throws Exception {
+
+        final ContentResponse response = client.GET(uri("/blocking"));
+
+        assertThat(response.getStatus())
+                .isEqualTo(200);
+
+        assertResponseTimesValid();
+    }
+
+    @Test
+    @Ignore("flaky on virtual machines")
+    public void responseTimesAreRecordedForAsyncResponses() throws Exception {
+
+        final ContentResponse response = client.GET(uri("/async"));
+
+        assertThat(response.getStatus())
+                .isEqualTo(200);
+
+        assertResponseTimesValid();
+    }
+
+    private void assertResponseTimesValid() {
+        assertThat(registry.getMeters().get(metricName() + ".2xx-responses")
+                .getCount()).isGreaterThan(0L);
+
+
+        assertThat(registry.getTimers().get(metricName() + ".get-requests")
+                .getSnapshot().getMedian()).isGreaterThan(0.0).isLessThan(TimeUnit.SECONDS.toNanos(1));
+
+        assertThat(registry.getTimers().get(metricName() + ".requests")
+                .getSnapshot().getMedian()).isGreaterThan(0.0).isLessThan(TimeUnit.SECONDS.toNanos(1));
+    }
+
+    private String uri(String path) {
+        return "http://localhost:" + connector.getLocalPort() + path;
+    }
+
+    private String metricName() {
+        return MetricRegistry.name(TestHandler.class.getName(), "handler");
+    }
+
+    /**
+     * test handler.
+     * <p>
+     * Supports
+     * <p>
+     * /blocking - uses the standard servlet api
+     * /async - uses the 3.1 async api to complete the request
+     * <p>
+     * all other requests will return 404
+     */
+    private static class TestHandler extends AbstractHandler {
+        @Override
+        public void handle(
+                String path,
+                Request request,
+                final HttpServletRequest httpServletRequest,
+                final HttpServletResponse httpServletResponse
+        ) throws IOException, ServletException {
+            switch (path) {
+                case "/blocking":
+                    request.setHandled(true);
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    httpServletResponse.setStatus(200);
+                    httpServletResponse.setContentType("text/plain");
+                    httpServletResponse.getWriter().write("some content from the blocking request\n");
+                    break;
+                case "/async":
+                    request.setHandled(true);
+                    final AsyncContext context = request.startAsync();
+                    Thread t = new Thread(() -> {
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        httpServletResponse.setStatus(200);
+                        httpServletResponse.setContentType("text/plain");
+                        final ServletOutputStream servletOutputStream;
+                        try {
+                            servletOutputStream = httpServletResponse.getOutputStream();
+                            servletOutputStream.setWriteListener(
+                                    new WriteListener() {
+                                        @Override
+                                        public void onWritePossible() throws IOException {
+                                            servletOutputStream.write("some content from the async\n"
+                                                    .getBytes(StandardCharsets.UTF_8));
+                                            context.complete();
+                                        }
+
+                                        @Override
+                                        public void onError(Throwable throwable) {
+                                            context.complete();
+                                        }
+                                    }
+                            );
+                        } catch (IOException e) {
+                            context.complete();
+                        }
+                    });
+                    t.start();
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/metrics-jetty11/src/test/java/io/dropwizard/metrics/jetty11/InstrumentedHttpChannelListenerTest.java
+++ b/metrics-jetty11/src/test/java/io/dropwizard/metrics/jetty11/InstrumentedHttpChannelListenerTest.java
@@ -1,0 +1,208 @@
+package io.dropwizard.metrics.jetty11;
+
+import com.codahale.metrics.MetricRegistry;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstrumentedHttpChannelListenerTest {
+    private final HttpClient client = new HttpClient();
+    private final Server server = new Server();
+    private final ServerConnector connector = new ServerConnector(server);
+    private final TestHandler handler = new TestHandler();
+    private MetricRegistry registry;
+
+    @Before
+    public void setUp() throws Exception {
+        registry = new MetricRegistry();
+        connector.addBean(new InstrumentedHttpChannelListener(registry, MetricRegistry.name(TestHandler.class, "handler")));
+        server.addConnector(connector);
+        server.setHandler(handler);
+        server.start();
+        client.start();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.stop();
+        client.stop();
+    }
+
+    @Test
+    public void createsMetricsForTheHandler() throws Exception {
+        final ContentResponse response = client.GET(uri("/hello"));
+
+        assertThat(response.getStatus())
+                .isEqualTo(404);
+
+        assertThat(registry.getNames())
+                .containsOnly(
+                        metricName("1xx-responses"),
+                        metricName("2xx-responses"),
+                        metricName("3xx-responses"),
+                        metricName("4xx-responses"),
+                        metricName("5xx-responses"),
+                        metricName("percent-4xx-1m"),
+                        metricName("percent-4xx-5m"),
+                        metricName("percent-4xx-15m"),
+                        metricName("percent-5xx-1m"),
+                        metricName("percent-5xx-5m"),
+                        metricName("percent-5xx-15m"),
+                        metricName("requests"),
+                        metricName("active-suspended"),
+                        metricName("async-dispatches"),
+                        metricName("async-timeouts"),
+                        metricName("get-requests"),
+                        metricName("put-requests"),
+                        metricName("active-dispatches"),
+                        metricName("trace-requests"),
+                        metricName("other-requests"),
+                        metricName("connect-requests"),
+                        metricName("dispatches"),
+                        metricName("head-requests"),
+                        metricName("post-requests"),
+                        metricName("options-requests"),
+                        metricName("active-requests"),
+                        metricName("delete-requests"),
+                        metricName("move-requests")
+                );
+    }
+
+
+    @Test
+    public void responseTimesAreRecordedForBlockingResponses() throws Exception {
+
+        final ContentResponse response = client.GET(uri("/blocking"));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getMediaType()).isEqualTo("text/plain");
+        assertThat(response.getContentAsString()).isEqualTo("some content from the blocking request");
+
+        assertResponseTimesValid();
+    }
+
+    @Test
+    public void responseTimesAreRecordedForAsyncResponses() throws Exception {
+
+        final ContentResponse response = client.GET(uri("/async"));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getMediaType()).isEqualTo("text/plain");
+        assertThat(response.getContentAsString()).isEqualTo("some content from the async");
+
+        assertResponseTimesValid();
+    }
+
+    private void assertResponseTimesValid() {
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        assertThat(registry.getMeters().get(metricName("2xx-responses"))
+                .getCount()).isPositive();
+
+        assertThat(registry.getTimers().get(metricName("get-requests"))
+                .getSnapshot().getMedian()).isPositive();
+
+        assertThat(registry.getTimers().get(metricName("requests"))
+                .getSnapshot().getMedian()).isPositive();
+    }
+
+    private String uri(String path) {
+        return "http://localhost:" + connector.getLocalPort() + path;
+    }
+
+    private String metricName(String metricName) {
+        return MetricRegistry.name(TestHandler.class.getName(), "handler", metricName);
+    }
+
+    /**
+     * test handler.
+     * <p>
+     * Supports
+     * <p>
+     * /blocking - uses the standard servlet api
+     * /async - uses the 3.1 async api to complete the request
+     * <p>
+     * all other requests will return 404
+     */
+    private static class TestHandler extends AbstractHandler {
+        @Override
+        public void handle(
+                String path,
+                Request request,
+                final HttpServletRequest httpServletRequest,
+                final HttpServletResponse httpServletResponse) throws IOException {
+            switch (path) {
+                case "/blocking":
+                    request.setHandled(true);
+                    httpServletResponse.setStatus(200);
+                    httpServletResponse.setContentType("text/plain");
+                    httpServletResponse.getWriter().write("some content from the blocking request");
+                    try {
+                        Thread.sleep(100);
+                    } catch (InterruptedException e) {
+                        httpServletResponse.setStatus(500);
+                        Thread.currentThread().interrupt();
+                    }
+                    break;
+                case "/async":
+                    request.setHandled(true);
+                    final AsyncContext context = request.startAsync();
+                    Thread t = new Thread(() -> {
+                        httpServletResponse.setStatus(200);
+                        httpServletResponse.setContentType("text/plain");
+                        try {
+                            Thread.sleep(100);
+                        } catch (InterruptedException e) {
+                            httpServletResponse.setStatus(500);
+                            Thread.currentThread().interrupt();
+                        }
+                        final ServletOutputStream servletOutputStream;
+                        try {
+                            servletOutputStream = httpServletResponse.getOutputStream();
+                            servletOutputStream.setWriteListener(
+                                    new WriteListener() {
+                                        @Override
+                                        public void onWritePossible() throws IOException {
+                                            servletOutputStream.write("some content from the async"
+                                                    .getBytes(StandardCharsets.UTF_8));
+                                            context.complete();
+                                        }
+
+                                        @Override
+                                        public void onError(Throwable throwable) {
+                                            context.complete();
+                                        }
+                                    }
+                            );
+                        } catch (IOException e) {
+                            context.complete();
+                        }
+                    });
+                    t.start();
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+}

--- a/metrics-jetty11/src/test/java/io/dropwizard/metrics/jetty11/InstrumentedQueuedThreadPoolTest.java
+++ b/metrics-jetty11/src/test/java/io/dropwizard/metrics/jetty11/InstrumentedQueuedThreadPoolTest.java
@@ -1,0 +1,49 @@
+package io.dropwizard.metrics.jetty11;
+
+import com.codahale.metrics.MetricRegistry;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class InstrumentedQueuedThreadPoolTest {
+    private static final String PREFIX = "prefix";
+
+    private MetricRegistry metricRegistry;
+    private InstrumentedQueuedThreadPool iqtp;
+
+    @Before
+    public void setUp() {
+        metricRegistry = new MetricRegistry();
+        iqtp = new InstrumentedQueuedThreadPool(metricRegistry);
+    }
+
+    @Test
+    public void customMetricsPrefix() throws Exception {
+        iqtp.setPrefix(PREFIX);
+        iqtp.start();
+
+        assertThat(metricRegistry.getNames())
+                .overridingErrorMessage("Custom metrics prefix doesn't match")
+                .allSatisfy(name -> assertThat(name).startsWith(PREFIX));
+
+        iqtp.stop();
+        assertThat(metricRegistry.getMetrics())
+                .overridingErrorMessage("The default metrics prefix was changed")
+                .isEmpty();
+    }
+
+    @Test
+    public void metricsPrefixBackwardCompatible() throws Exception {
+        iqtp.start();
+        assertThat(metricRegistry.getNames())
+                .overridingErrorMessage("The default metrics prefix was changed")
+                .allSatisfy(name -> assertThat(name).startsWith(QueuedThreadPool.class.getName()));
+
+        iqtp.stop();
+        assertThat(metricRegistry.getMetrics())
+                .overridingErrorMessage("The default metrics prefix was changed")
+                .isEmpty();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,8 @@
         <module>metrics-jersey2</module>
         <module>metrics-jersey3</module>
         <module>metrics-jetty9</module>
+        <module>metrics-jetty10</module>
+        <module>metrics-jetty11</module>
         <module>metrics-jmx</module>
         <module>metrics-json</module>
         <module>metrics-jvm</module>
@@ -48,6 +50,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <jetty9.version>9.4.35.v20201120</jetty9.version>
+        <jetty10.version>10.0.0</jetty10.version>
+        <jetty11.version>11.0.0</jetty11.version>
         <slf4j.version>1.7.30</slf4j.version>
         <assertj.version>3.18.1</assertj.version>
         <mockito.version>3.6.28</mockito.version>


### PR DESCRIPTION
* https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.0
* https://github.com/eclipse/jetty.project/releases/tag/jetty-11.0.0

Both, Jetty 10.0.0 and 11.0.0, are targeting Java 11 as their baseline, so that the Metrics project has to be built with JDK 11 or higher.

The target version for  `metrics-jetty10` and `metrics-jetty11` is Java 11 while keeping the other modules on Java 8.