### PR TITLE
Backport to 4.1.x: Avoid queuing up report tasks in ScheduledReporter (#1590)

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -166,7 +166,7 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
             throw new IllegalArgumentException("Reporter already started");
         }
 
-        this.scheduledFuture = executor.scheduleAtFixedRate(runnable, initialDelay, period, unit);
+        this.scheduledFuture = executor.scheduleWithFixedDelay(runnable, initialDelay, period, unit);
     }
 
     /**


### PR DESCRIPTION
This PR backports #1590 to `release/4.1.x`.

Would love to have this fix in version `4.1`.

Thank you

