### PR TITLE
Make FileDescriptorRatioGaugeTest not dependent on a specific JDK version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java_version: [11]
+        java_version: [11, 15]
         os:
         - ubuntu-latest
     env:

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/FileDescriptorRatioGaugeTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/FileDescriptorRatioGaugeTest.java
@@ -1,6 +1,7 @@
 package com.codahale.metrics.jvm;
 
 import com.sun.management.UnixOperatingSystemMXBean;
+import org.junit.Before;
 import org.junit.Test;
 
 import javax.management.ObjectName;
@@ -10,93 +11,19 @@ import java.lang.management.OperatingSystemMXBean;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @SuppressWarnings("UnusedDeclaration")
 public class FileDescriptorRatioGaugeTest {
-    private final OperatingSystemMXBean os = new UnixOperatingSystemMXBean() {
-        @Override
-        public String getName() {
-            return null;
-        }
-
-        @Override
-        public String getArch() {
-            return null;
-        }
-
-        @Override
-        public String getVersion() {
-            return null;
-        }
-
-        @Override
-        public int getAvailableProcessors() {
-            return 0;
-        }
-
-        @Override
-        public double getSystemLoadAverage() {
-            return 0;
-        }
-
-        @Override
-        public long getOpenFileDescriptorCount() {
-            return 10;
-        }
-
-        @Override
-        public long getMaxFileDescriptorCount() {
-            return 100;
-        }
-
-        @Override
-        public long getCommittedVirtualMemorySize() {
-            return 0;
-        }
-
-        @Override
-        public long getTotalSwapSpaceSize() {
-            return 0;
-        }
-
-        @Override
-        public long getFreeSwapSpaceSize() {
-            return 0;
-        }
-
-        @Override
-        public long getProcessCpuTime() {
-            return 0;
-        }
-
-        @Override
-        public long getFreePhysicalMemorySize() {
-            return 0;
-        }
-
-        @Override
-        public long getTotalPhysicalMemorySize() {
-            return 0;
-        }
-
-        @Override
-        public double getSystemCpuLoad() {
-            return 0;
-        }
-
-        @Override
-        public double getProcessCpuLoad() {
-            return 0;
-        }
-
-        // overridden on Java 1.7; random crap on Java 1.6
-        @Override
-        public ObjectName getObjectName() {
-            return null;
-        }
-    };
+    private final UnixOperatingSystemMXBean os = mock(UnixOperatingSystemMXBean.class);
 
     private final FileDescriptorRatioGauge gauge = new FileDescriptorRatioGauge(os);
+
+    @Before
+    public void setUp() throws Exception {
+        when(os.getOpenFileDescriptorCount()).thenReturn(10L);
+        when(os.getMaxFileDescriptorCount()).thenReturn(100L);
+    }
 
     @Test
     public void calculatesTheRatioOfUsedToTotalFileDescriptors() {


### PR DESCRIPTION
If a JDK adds more methods to UnixOperatingSystemMXBean, the test shouldn't break


Fixes #1734 
