### PR TITLE
Upgrade metrics-jersey2 to Jersey 2.33

### DIFF
--- a/metrics-jersey2/pom.xml
+++ b/metrics-jersey2/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <javaModuleName>com.codahale.metrics.jersey2</javaModuleName>
-        <jersey.version>2.32</jersey.version>
+        <jersey.version>2.33</jersey.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <slf4j.version>1.7.30</slf4j.version>
         <assertj.version>3.19.0</assertj.version>
         <mockito.version>3.7.7</mockito.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.1</junit.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <errorprone.javac.version>9+181-r4173-1</errorprone.javac.version>
 


### PR DESCRIPTION
Release notes: https://github.com/eclipse-ee4j/jersey/releases/tag/2.33

Additional change: Upgrade to JUnit 4.13.1

Jersey 2.33 is not using JUnit 4.12 anymore, so we can (and have to)
update our dependency too:
```
Failed while enforcing releasability the error(s) are [
Dependency convergence error for junit:junit:4.13.1 paths to dependency are:
+-io.dropwizard.metrics:metrics-jersey2:4.1.18-SNAPSHOT
  +-org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:2.33
    +-org.glassfish.jersey.test-framework:jersey-test-framework-core:2.33
      +-junit:junit:4.13.1
and
+-io.dropwizard.metrics:metrics-jersey2:4.1.18-SNAPSHOT
  +-org.glassfish.jersey.test-framework.providers:jersey-test-framework-provider-inmemory:2.33
    +-junit:junit:4.13.1
and
+-io.dropwizard.metrics:metrics-jersey2:4.1.18-SNAPSHOT
  +-junit:junit:4.12
```

Release notes:
- https://github.com/junit-team/junit4/blob/64634e1c3e357251a84278c26b73b04fc3450ea3/doc/ReleaseNotes4.13.md
- https://github.com/junit-team/junit4/blob/64634e1c3e357251a84278c26b73b04fc3450ea3/doc/ReleaseNotes4.13.1.md