### PR TITLE
Bump jetty10.version from 10.0.0 to 10.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 
         <jackson.version>2.12.1</jackson.version>
         <jetty9.version>9.4.37.v20210219</jetty9.version>
-        <jetty10.version>10.0.0</jetty10.version>
+        <jetty10.version>10.0.1</jetty10.version>
         <jetty11.version>11.0.0</jetty11.version>
         <slf4j.version>1.7.30</slf4j.version>
         <assertj.version>3.19.0</assertj.version>


### PR DESCRIPTION
Bumps `jetty10.version` from 10.0.0 to 10.0.1.

Updates `jetty-bom` from 10.0.0 to 10.0.1
Updates `jetty-servlet` from 10.0.0 to 10.0.1
Updates `jetty-http` from 10.0.0 to 10.0.1
Updates `jetty-servlet` from 10.0.0 to 10.0.1

- [Release notes](https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.1)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-10.0.0...jetty-10.0.1)