### PR TITLE
Bump jetty11.version from 11.0.0 to 11.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <jackson.version>2.12.1</jackson.version>
         <jetty9.version>9.4.37.v20210219</jetty9.version>
         <jetty10.version>10.0.0</jetty10.version>
-        <jetty11.version>11.0.0</jetty11.version>
+        <jetty11.version>11.0.1</jetty11.version>
         <slf4j.version>1.7.30</slf4j.version>
         <assertj.version>3.19.0</assertj.version>
         <mockito.version>3.8.0</mockito.version>


### PR DESCRIPTION
Bumps `jetty11.version` from 11.0.0 to 11.0.1.

Updates `jetty-bom` from 11.0.0 to 11.0.1
Updates `jetty-servlet` from 11.0.0 to 11.0.1
Updates `jetty-http` from 11.0.0 to 11.0.1
Updates `jetty-servlet` from 11.0.0 to 11.0.1

- [Release notes](https://github.com/eclipse/jetty.project/releases/tag/jetty-11.0.1)
- [Commits](https://github.com/eclipse/jetty.project/compare/jetty-11.0.0...jetty-11.0.1)