### PR TITLE
Revert "Bump jackson-databind from 2.9.10.8 to 2.12.2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jackson.version>2.12.2</jackson.version>
+        <jackson.version>2.9.10.8</jackson.version>
         <jetty9.version>9.4.38.v20210224</jetty9.version>
         <slf4j.version>1.7.30</slf4j.version>
         <assertj.version>3.19.0</assertj.version>


### PR DESCRIPTION
Reverts dropwizard/metrics#1779

Let's not bump the Jackson version in a patch version.

Metrics 4.2.0 is already using Jackson 2.12.x (see https://github.com/dropwizard/metrics/pull/1782).