### PR TITLE
Implement histograms for double values

### DIFF
--- a/metrics-collectd/src/test/java/com/codahale/metrics/collectd/CollectdReporterTest.java
+++ b/metrics-collectd/src/test/java/com/codahale/metrics/collectd/CollectdReporterTest.java
@@ -1,6 +1,8 @@
 package com.codahale.metrics.collectd;
 
 import com.codahale.metrics.Counter;
+import com.codahale.metrics.DoubleHistogram;
+import com.codahale.metrics.DoubleSnapshot;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricAttribute;
@@ -169,6 +171,36 @@ public class CollectdReporterTest {
         when(snapshot.get999thPercentile()).thenReturn(11.0);
 
         reporter.report(
+                map(),
+                map(),
+                map("histogram", histogram),
+                map(),
+                map());
+
+        for (int i = 1; i <= 11; i++) {
+            assertThat(nextValues(receiver)).containsExactly((double) i);
+        }
+    }
+
+    @Test
+    public void reportsDoubleHistograms() throws Exception {
+        DoubleHistogram histogram = mock(DoubleHistogram.class);
+        DoubleSnapshot snapshot = mock(DoubleSnapshot.class);
+        when(histogram.getCount()).thenReturn(1L);
+        when(histogram.getSnapshot()).thenReturn(snapshot);
+        when(snapshot.getMax()).thenReturn(2.0);
+        when(snapshot.getMean()).thenReturn(3.0);
+        when(snapshot.getMin()).thenReturn(4.0);
+        when(snapshot.getStdDev()).thenReturn(5.0);
+        when(snapshot.getMedian()).thenReturn(6.0);
+        when(snapshot.get75thPercentile()).thenReturn(7.0);
+        when(snapshot.get95thPercentile()).thenReturn(8.0);
+        when(snapshot.get98thPercentile()).thenReturn(9.0);
+        when(snapshot.get99thPercentile()).thenReturn(10.0);
+        when(snapshot.get999thPercentile()).thenReturn(11.0);
+
+        reporter.report(
+                map(),
                 map(),
                 map(),
                 map("histogram", histogram),

--- a/metrics-core/src/main/java/com/codahale/metrics/ChunkedAssociativeDoubleArray.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ChunkedAssociativeDoubleArray.java
@@ -1,0 +1,200 @@
+package com.codahale.metrics;
+
+import java.lang.ref.SoftReference;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Iterator;
+
+import static java.lang.System.arraycopy;
+import static java.util.Arrays.binarySearch;
+
+class ChunkedAssociativeDoubleArray {
+    private static final double[] EMPTY = new double[0];
+    private static final int DEFAULT_CHUNK_SIZE = 512;
+    private static final int MAX_CACHE_SIZE = 128;
+
+    private final int defaultChunkSize;
+
+    /*
+     * We use this ArrayDeque as cache to store chunks that are expired and removed from main data structure.
+     * Then instead of allocating new Chunk immediately we are trying to poll one from this deque.
+     * So if you have constant or slowly changing load ChunkedAssociativeLongArray will never
+     * throw away old chunks or allocate new ones which makes this data structure almost garbage free.
+     */
+    private final ArrayDeque<SoftReference<Chunk>> chunksCache = new ArrayDeque<>();
+
+    private final Deque<Chunk> chunks = new ArrayDeque<>();
+
+    ChunkedAssociativeDoubleArray() {
+        this(DEFAULT_CHUNK_SIZE);
+    }
+
+    ChunkedAssociativeDoubleArray(int chunkSize) {
+        this.defaultChunkSize = chunkSize;
+    }
+
+    private Chunk allocateChunk() {
+        while (true) {
+            final SoftReference<Chunk> chunkRef = chunksCache.pollLast();
+            if (chunkRef == null) {
+                return new Chunk(defaultChunkSize);
+            }
+            final Chunk chunk = chunkRef.get();
+            if (chunk != null) {
+                chunk.cursor = 0;
+                chunk.startIndex = 0;
+                chunk.chunkSize = chunk.keys.length;
+                return chunk;
+            }
+        }
+    }
+
+    private void freeChunk(Chunk chunk) {
+        if (chunksCache.size() < MAX_CACHE_SIZE) {
+            chunksCache.add(new SoftReference<>(chunk));
+        }
+    }
+
+    synchronized boolean put(long key, double value) {
+        Chunk activeChunk = chunks.peekLast();
+        if (activeChunk != null && activeChunk.cursor != 0 && activeChunk.keys[activeChunk.cursor - 1] > key) {
+            // key should be the same as last inserted or bigger
+            return false;
+        }
+        if (activeChunk == null || activeChunk.cursor - activeChunk.startIndex == activeChunk.chunkSize) {
+            // The last chunk doesn't exist or full
+            activeChunk = allocateChunk();
+            chunks.add(activeChunk);
+        }
+        activeChunk.append(key, value);
+        return true;
+    }
+
+    synchronized double[] values() {
+        final int valuesSize = size();
+        if (valuesSize == 0) {
+            return EMPTY;
+        }
+
+        final double[] values = new double[valuesSize];
+        int valuesIndex = 0;
+        for (Chunk chunk : chunks) {
+            int length = chunk.cursor - chunk.startIndex;
+            int itemsToCopy = Math.min(valuesSize - valuesIndex, length);
+            arraycopy(chunk.values, chunk.startIndex, values, valuesIndex, itemsToCopy);
+            valuesIndex += length;
+        }
+        return values;
+    }
+
+    synchronized int size() {
+        int result = 0;
+        for (Chunk chunk : chunks) {
+            result += chunk.cursor - chunk.startIndex;
+        }
+        return result;
+    }
+
+    synchronized String out() {
+        final StringBuilder builder = new StringBuilder();
+        final Iterator<Chunk> iterator = chunks.iterator();
+        while (iterator.hasNext()) {
+            final Chunk chunk = iterator.next();
+            builder.append('[');
+            for (int i = chunk.startIndex; i < chunk.cursor; i++) {
+                builder.append('(').append(chunk.keys[i]).append(": ")
+                        .append(chunk.values[i]).append(')').append(' ');
+            }
+            builder.append(']');
+            if (iterator.hasNext()) {
+                builder.append("->");
+            }
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Try to trim all beyond specified boundaries.
+     *
+     * @param startKey the start value for which all elements less than it should be removed.
+     * @param endKey   the end value for which all elements greater/equals than it should be removed.
+     */
+    synchronized void trim(long startKey, long endKey) {
+        /*
+         * [3, 4, 5, 9] -> [10, 13, 14, 15] -> [21, 24, 29, 30] -> [31] :: start layout
+         *       |5______________________________23|                    :: trim(5, 23)
+         *       [5, 9] -> [10, 13, 14, 15] -> [21]                     :: result layout
+         */
+        final Iterator<Chunk> descendingIterator = chunks.descendingIterator();
+        while (descendingIterator.hasNext()) {
+            final Chunk currentTail = descendingIterator.next();
+            if (isFirstElementIsEmptyOrGreaterEqualThanKey(currentTail, endKey)) {
+                freeChunk(currentTail);
+                descendingIterator.remove();
+            } else {
+                currentTail.cursor = findFirstIndexOfGreaterEqualElements(currentTail.keys, currentTail.startIndex,
+                        currentTail.cursor, endKey);
+                break;
+            }
+        }
+
+        final Iterator<Chunk> iterator = chunks.iterator();
+        while (iterator.hasNext()) {
+            final Chunk currentHead = iterator.next();
+            if (isLastElementIsLessThanKey(currentHead, startKey)) {
+                freeChunk(currentHead);
+                iterator.remove();
+            } else {
+                final int newStartIndex = findFirstIndexOfGreaterEqualElements(currentHead.keys, currentHead.startIndex,
+                        currentHead.cursor, startKey);
+                if (currentHead.startIndex != newStartIndex) {
+                    currentHead.startIndex = newStartIndex;
+                    currentHead.chunkSize = currentHead.cursor - currentHead.startIndex;
+                }
+                break;
+            }
+        }
+    }
+
+    synchronized void clear() {
+        chunks.clear();
+    }
+
+    private boolean isFirstElementIsEmptyOrGreaterEqualThanKey(Chunk chunk, long key) {
+        return chunk.cursor == chunk.startIndex || chunk.keys[chunk.startIndex] >= key;
+    }
+
+    private boolean isLastElementIsLessThanKey(Chunk chunk, long key) {
+        return chunk.cursor == chunk.startIndex || chunk.keys[chunk.cursor - 1] < key;
+    }
+
+    private int findFirstIndexOfGreaterEqualElements(long[] array, int startIndex, int endIndex, long minKey) {
+        if (endIndex == startIndex || array[startIndex] >= minKey) {
+            return startIndex;
+        }
+        final int keyIndex = binarySearch(array, startIndex, endIndex, minKey);
+        return keyIndex < 0 ? -(keyIndex + 1) : keyIndex;
+    }
+
+    private static class Chunk {
+
+        private final long[] keys;
+        private final double[] values;
+
+        private int chunkSize; // can differ from keys.length after half clear()
+        private int startIndex = 0;
+        private int cursor = 0;
+
+        private Chunk(int chunkSize) {
+            this.chunkSize = chunkSize;
+            this.keys = new long[chunkSize];
+            this.values = new double[chunkSize];
+        }
+
+        private void append(long key, double value) {
+            keys[cursor] = key;
+            values[cursor] = value;
+            cursor++;
+        }
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
@@ -228,6 +228,17 @@ public class ConsoleReporter extends ScheduledReporter {
                        SortedMap<String, Histogram> histograms,
                        SortedMap<String, Meter> meters,
                        SortedMap<String, Timer> timers) {
+        report(gauges, counters, histograms, Collections.emptySortedMap(), meters, timers);
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public void report(SortedMap<String, Gauge> gauges,
+                       SortedMap<String, Counter> counters,
+                       SortedMap<String, Histogram> histograms,
+                       SortedMap<String, DoubleHistogram> doubleHistograms,
+                       SortedMap<String, Meter> meters,
+                       SortedMap<String, Timer> timers) {
         final String dateTime = dateFormat.format(new Date(clock.getTime()));
         printWithBanner(dateTime, '=');
         output.println();
@@ -255,6 +266,15 @@ public class ConsoleReporter extends ScheduledReporter {
             for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
                 output.println(entry.getKey());
                 printHistogram(entry.getValue());
+            }
+            output.println();
+        }
+
+        if (!doubleHistograms.isEmpty()) {
+            printWithBanner("-- Double Histograms", '-');
+            for (Map.Entry<String, DoubleHistogram> entry : doubleHistograms.entrySet()) {
+                output.println(entry.getKey());
+                printDoubleHistogram(entry.getValue());
             }
             output.println();
         }
@@ -302,6 +322,21 @@ public class ConsoleReporter extends ScheduledReporter {
         Snapshot snapshot = histogram.getSnapshot();
         printIfEnabled(MetricAttribute.MIN, String.format(locale, "               min = %d", snapshot.getMin()));
         printIfEnabled(MetricAttribute.MAX, String.format(locale, "               max = %d", snapshot.getMax()));
+        printIfEnabled(MetricAttribute.MEAN, String.format(locale, "              mean = %2.2f", snapshot.getMean()));
+        printIfEnabled(MetricAttribute.STDDEV, String.format(locale, "            stddev = %2.2f", snapshot.getStdDev()));
+        printIfEnabled(MetricAttribute.P50, String.format(locale, "            median = %2.2f", snapshot.getMedian()));
+        printIfEnabled(MetricAttribute.P75, String.format(locale, "              75%% <= %2.2f", snapshot.get75thPercentile()));
+        printIfEnabled(MetricAttribute.P95, String.format(locale, "              95%% <= %2.2f", snapshot.get95thPercentile()));
+        printIfEnabled(MetricAttribute.P98, String.format(locale, "              98%% <= %2.2f", snapshot.get98thPercentile()));
+        printIfEnabled(MetricAttribute.P99, String.format(locale, "              99%% <= %2.2f", snapshot.get99thPercentile()));
+        printIfEnabled(MetricAttribute.P999, String.format(locale, "            99.9%% <= %2.2f", snapshot.get999thPercentile()));
+    }
+
+    private void printDoubleHistogram(DoubleHistogram histogram) {
+        printIfEnabled(MetricAttribute.COUNT, String.format(locale, "             count = %d", histogram.getCount()));
+        DoubleSnapshot snapshot = histogram.getSnapshot();
+        printIfEnabled(MetricAttribute.MIN, String.format(locale, "               min = %f", snapshot.getMin()));
+        printIfEnabled(MetricAttribute.MAX, String.format(locale, "               max = %f", snapshot.getMax()));
         printIfEnabled(MetricAttribute.MEAN, String.format(locale, "              mean = %2.2f", snapshot.getMean()));
         printIfEnabled(MetricAttribute.STDDEV, String.format(locale, "            stddev = %2.2f", snapshot.getStdDev()));
         printIfEnabled(MetricAttribute.P50, String.format(locale, "            median = %2.2f", snapshot.getMedian()));

--- a/metrics-core/src/main/java/com/codahale/metrics/DoubleHistogram.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/DoubleHistogram.java
@@ -1,0 +1,67 @@
+package com.codahale.metrics;
+
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * A metric which calculates the distribution of a value.
+ *
+ * @see <a href="http://www.johndcook.com/standard_deviation.html">Accurately computing running
+ * variance</a>
+ */
+public class DoubleHistogram implements Metric, DoubleSampling, Counting {
+    private final DoubleReservoir reservoir;
+    private final LongAdder count;
+
+    /**
+     * Creates a new {@link DoubleHistogram} with the given reservoir.
+     *
+     * @param reservoir the reservoir to create a histogram from
+     */
+    public DoubleHistogram(DoubleReservoir reservoir) {
+        this.reservoir = reservoir;
+        this.count = new LongAdder();
+    }
+
+    /**
+     * Adds a recorded value.
+     *
+     * @param value the length of the value
+     */
+    public void update(int value) {
+        update((double) value);
+    }
+
+    /**
+     * Adds a recorded value.
+     *
+     * @param value the length of the value
+     */
+    public void update(long value) {
+        update((double) value);
+    }
+
+    /**
+     * Adds a recorded value.
+     *
+     * @param value the length of the value
+     */
+    public void update(double value) {
+        count.increment();
+        reservoir.update(value);
+    }
+
+    /**
+     * Returns the number of values recorded.
+     *
+     * @return the number of values recorded
+     */
+    @Override
+    public long getCount() {
+        return count.sum();
+    }
+
+    @Override
+    public DoubleSnapshot getSnapshot() {
+        return reservoir.getSnapshot();
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/DoubleReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/DoubleReservoir.java
@@ -1,0 +1,27 @@
+package com.codahale.metrics;
+
+/**
+ * A statistically representative reservoir of a data stream.
+ */
+public interface DoubleReservoir {
+    /**
+     * Returns the number of values recorded.
+     *
+     * @return the number of values recorded
+     */
+    int size();
+
+    /**
+     * Adds a new recorded value to the reservoir.
+     *
+     * @param value a new recorded value
+     */
+    void update(double value);
+
+    /**
+     * Returns a snapshot of the reservoir's values.
+     *
+     * @return a snapshot of the reservoir's values
+     */
+    DoubleSnapshot getSnapshot();
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/DoubleSampling.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/DoubleSampling.java
@@ -1,0 +1,13 @@
+package com.codahale.metrics;
+
+/**
+ * An object which samples values.
+ */
+public interface DoubleSampling {
+    /**
+     * Returns a snapshot of the values.
+     *
+     * @return a snapshot of the values
+     */
+    DoubleSnapshot getSnapshot();
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/DoubleSnapshot.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/DoubleSnapshot.java
@@ -1,0 +1,121 @@
+package com.codahale.metrics;
+
+import java.io.OutputStream;
+
+/**
+ * A statistical snapshot of a {@link DoubleSnapshot}.
+ */
+public abstract class DoubleSnapshot {
+
+    /**
+     * Returns the value at the given quantile.
+     *
+     * @param quantile a given quantile, in {@code [0..1]}
+     * @return the value in the distribution at {@code quantile}
+     */
+    public abstract double getValue(double quantile);
+
+    /**
+     * Returns the entire set of values in the snapshot.
+     *
+     * @return the entire set of values
+     */
+    public abstract double[] getValues();
+
+    /**
+     * Returns the number of values in the snapshot.
+     *
+     * @return the number of values
+     */
+    public abstract int size();
+
+    /**
+     * Returns the median value in the distribution.
+     *
+     * @return the median value
+     */
+    public double getMedian() {
+        return getValue(0.5);
+    }
+
+    /**
+     * Returns the value at the 75th percentile in the distribution.
+     *
+     * @return the value at the 75th percentile
+     */
+    public double get75thPercentile() {
+        return getValue(0.75);
+    }
+
+    /**
+     * Returns the value at the 95th percentile in the distribution.
+     *
+     * @return the value at the 95th percentile
+     */
+    public double get95thPercentile() {
+        return getValue(0.95);
+    }
+
+    /**
+     * Returns the value at the 98th percentile in the distribution.
+     *
+     * @return the value at the 98th percentile
+     */
+    public double get98thPercentile() {
+        return getValue(0.98);
+    }
+
+    /**
+     * Returns the value at the 99th percentile in the distribution.
+     *
+     * @return the value at the 99th percentile
+     */
+    public double get99thPercentile() {
+        return getValue(0.99);
+    }
+
+    /**
+     * Returns the value at the 99.9th percentile in the distribution.
+     *
+     * @return the value at the 99.9th percentile
+     */
+    public double get999thPercentile() {
+        return getValue(0.999);
+    }
+
+    /**
+     * Returns the highest value in the snapshot.
+     *
+     * @return the highest value
+     */
+    public abstract double getMax();
+
+    /**
+     * Returns the arithmetic mean of the values in the snapshot.
+     *
+     * @return the arithmetic mean
+     */
+    public abstract double getMean();
+
+    /**
+     * Returns the lowest value in the snapshot.
+     *
+     * @return the lowest value
+     */
+    public abstract double getMin();
+
+    /**
+     * Returns the standard deviation of the values in the snapshot.
+     *
+     * @return the standard value
+     */
+    public abstract double getStdDev();
+
+    /**
+     * Writes the values of the snapshot to the given stream.
+     *
+     * @param output an output stream
+     */
+    public abstract void dump(OutputStream output);
+
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingDoubleReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ExponentiallyDecayingDoubleReservoir.java
@@ -1,0 +1,207 @@
+package com.codahale.metrics;
+
+import com.codahale.metrics.WeightedDoubleSnapshot.WeightedDoubleSample;
+
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static java.lang.Math.exp;
+import static java.lang.Math.min;
+
+/**
+ * An exponentially-decaying random reservoir of {@code long}s. Uses Cormode et al's
+ * forward-decaying priority reservoir sampling method to produce a statistically representative
+ * sampling reservoir, exponentially biased towards newer entries.
+ *
+ * @see <a href="http://dimacs.rutgers.edu/~graham/pubs/papers/fwddecay.pdf">
+ * Cormode et al. Forward Decay: A Practical Time Decay Model for Streaming Systems. ICDE '09:
+ * Proceedings of the 2009 IEEE International Conference on Data Engineering (2009)</a>
+ */
+public class ExponentiallyDecayingDoubleReservoir implements DoubleReservoir {
+    private static final int DEFAULT_SIZE = 1028;
+    private static final double DEFAULT_ALPHA = 0.015;
+    private static final long RESCALE_THRESHOLD = TimeUnit.HOURS.toNanos(1);
+
+    private final ConcurrentSkipListMap<Double, WeightedDoubleSample> values;
+    private final ReentrantReadWriteLock lock;
+    private final double alpha;
+    private final int size;
+    private final AtomicLong count;
+    private volatile long startTime;
+    private final AtomicLong lastScaleTick;
+    private final Clock clock;
+
+    /**
+     * Creates a new {@link ExponentiallyDecayingDoubleReservoir} of 1028 elements, which offers a 99.9%
+     * confidence level with a 5% margin of error assuming a normal distribution, and an alpha
+     * factor of 0.015, which heavily biases the reservoir to the past 5 minutes of measurements.
+     */
+    public ExponentiallyDecayingDoubleReservoir() {
+        this(DEFAULT_SIZE, DEFAULT_ALPHA);
+    }
+
+    /**
+     * Creates a new {@link ExponentiallyDecayingDoubleReservoir}.
+     *
+     * @param size  the number of samples to keep in the sampling reservoir
+     * @param alpha the exponential decay factor; the higher this is, the more biased the reservoir
+     *              will be towards newer values
+     */
+    public ExponentiallyDecayingDoubleReservoir(int size, double alpha) {
+        this(size, alpha, Clock.defaultClock());
+    }
+
+    /**
+     * Creates a new {@link ExponentiallyDecayingDoubleReservoir}.
+     *
+     * @param size  the number of samples to keep in the sampling reservoir
+     * @param alpha the exponential decay factor; the higher this is, the more biased the reservoir
+     *              will be towards newer values
+     * @param clock the clock used to timestamp samples and track rescaling
+     */
+    public ExponentiallyDecayingDoubleReservoir(int size, double alpha, Clock clock) {
+        this.values = new ConcurrentSkipListMap<>();
+        this.lock = new ReentrantReadWriteLock();
+        this.alpha = alpha;
+        this.size = size;
+        this.clock = clock;
+        this.count = new AtomicLong(0);
+        this.startTime = currentTimeInSeconds();
+        this.lastScaleTick = new AtomicLong(clock.getTick());
+    }
+
+    @Override
+    public int size() {
+        return (int) min(size, count.get());
+    }
+
+    @Override
+    public void update(double value) {
+        update(value, currentTimeInSeconds());
+    }
+
+    /**
+     * Adds an old value with a fixed timestamp to the reservoir.
+     *
+     * @param value     the value to be added
+     * @param timestamp the epoch timestamp of {@code value} in seconds
+     */
+    public void update(double value, long timestamp) {
+        rescaleIfNeeded();
+        lockForRegularUsage();
+        try {
+            final double itemWeight = weight(timestamp - startTime);
+            final WeightedDoubleSample sample = new WeightedDoubleSample(value, itemWeight);
+            final double priority = itemWeight / ThreadLocalRandom.current().nextDouble();
+
+            final long newCount = count.incrementAndGet();
+            if (newCount <= size || values.isEmpty()) {
+                values.put(priority, sample);
+            } else {
+                Double first = values.firstKey();
+                if (first < priority && values.putIfAbsent(priority, sample) == null) {
+                    // ensure we always remove an item
+                    while (values.remove(first) == null) {
+                        first = values.firstKey();
+                    }
+                }
+            }
+        } finally {
+            unlockForRegularUsage();
+        }
+    }
+
+    private void rescaleIfNeeded() {
+        final long now = clock.getTick();
+        final long lastScaleTickSnapshot = lastScaleTick.get();
+        if (now - lastScaleTickSnapshot >= RESCALE_THRESHOLD) {
+            rescale(now, lastScaleTickSnapshot);
+        }
+    }
+
+    @Override
+    public DoubleSnapshot getSnapshot() {
+        rescaleIfNeeded();
+        lockForRegularUsage();
+        try {
+            return new WeightedDoubleSnapshot(values.values());
+        } finally {
+            unlockForRegularUsage();
+        }
+    }
+
+    private long currentTimeInSeconds() {
+        return TimeUnit.MILLISECONDS.toSeconds(clock.getTime());
+    }
+
+    private double weight(long t) {
+        return exp(alpha * t);
+    }
+
+    /* "A common feature of the above techniques—indeed, the key technique that
+     * allows us to track the decayed weights efficiently—is that they maintain
+     * counts and other quantities based on g(ti − L), and only scale by g(t − L)
+     * at query time. But while g(ti −L)/g(t−L) is guaranteed to lie between zero
+     * and one, the intermediate values of g(ti − L) could become very large. For
+     * polynomial functions, these values should not grow too large, and should be
+     * effectively represented in practice by floating point values without loss of
+     * precision. For exponential functions, these values could grow quite large as
+     * new values of (ti − L) become large, and potentially exceed the capacity of
+     * common floating point types. However, since the values stored by the
+     * algorithms are linear combinations of g values (scaled sums), they can be
+     * rescaled relative to a new landmark. That is, by the analysis of exponential
+     * decay in Section III-A, the choice of L does not affect the final result. We
+     * can therefore multiply each value based on L by a factor of exp(−α(L′ − L)),
+     * and obtain the correct value as if we had instead computed relative to a new
+     * landmark L′ (and then use this new L′ at query time). This can be done with
+     * a linear pass over whatever data structure is being used."
+     */
+    private void rescale(long now, long lastTick) {
+        lockForRescale();
+        try {
+            if (lastScaleTick.compareAndSet(lastTick, now)) {
+                final long oldStartTime = startTime;
+                this.startTime = currentTimeInSeconds();
+                final double scalingFactor = exp(-alpha * (startTime - oldStartTime));
+                if (Double.compare(scalingFactor, 0) == 0) {
+                    values.clear();
+                } else {
+                    final ArrayList<Double> keys = new ArrayList<>(values.keySet());
+                    for (Double key : keys) {
+                        final WeightedDoubleSample sample = values.remove(key);
+                        final WeightedDoubleSample newSample = new WeightedDoubleSample(sample.value, sample.weight * scalingFactor);
+                        if (Double.compare(newSample.weight, 0) == 0) {
+                            continue;
+                        }
+                        values.put(key * scalingFactor, newSample);
+                    }
+                }
+
+                // make sure the counter is in sync with the number of stored samples.
+                count.set(values.size());
+            }
+        } finally {
+            unlockForRescale();
+        }
+    }
+
+    private void unlockForRescale() {
+        lock.writeLock().unlock();
+    }
+
+    private void lockForRescale() {
+        lock.writeLock().lock();
+    }
+
+    private void lockForRegularUsage() {
+        lock.readLock().lock();
+    }
+
+    private void unlockForRegularUsage() {
+        lock.readLock().unlock();
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/LockFreeExponentiallyDecayingDoubleReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/LockFreeExponentiallyDecayingDoubleReservoir.java
@@ -1,0 +1,270 @@
+package com.codahale.metrics;
+
+import com.codahale.metrics.WeightedDoubleSnapshot.WeightedDoubleSample;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.function.BiConsumer;
+
+/**
+ * A lock-free exponentially-decaying random reservoir of {@code long}s. Uses Cormode et al's
+ * forward-decaying priority reservoir sampling method to produce a statistically representative
+ * sampling reservoir, exponentially biased towards newer entries.
+ *
+ * @see <a href="http://dimacs.rutgers.edu/~graham/pubs/papers/fwddecay.pdf">
+ * Cormode et al. Forward Decay: A Practical Time Decay Model for Streaming Systems. ICDE '09:
+ * Proceedings of the 2009 IEEE International Conference on Data Engineering (2009)</a>
+ *
+ * {@link LockFreeExponentiallyDecayingDoubleReservoir} is based closely on the {@link ExponentiallyDecayingReservoir},
+ * however it provides looser guarantees while completely avoiding locks.
+ *
+ * Looser guarantees:
+ * <ul>
+ *     <li> Updates which occur concurrently with rescaling may be discarded if the orphaned state node is updated after
+ *     rescale has replaced it. This condition has a greater probability as the rescale interval is reduced due to the
+ *     increased frequency of rescaling. {@link #rescaleThresholdNanos} values below 30 seconds are not recommended.
+ *     <li> Given a small rescale threshold, updates may attempt to rescale into a new bucket, but lose the CAS race
+ *     and update into a newer bucket than expected. In these cases the measurement weight is reduced accordingly.
+ *     <li>In the worst case, all concurrent threads updating the reservoir may attempt to rescale rather than
+ *     a single thread holding an exclusive write lock. It's expected that the configuration is set such that
+ *     rescaling is substantially less common than updating at peak load. Even so, when size is reasonably small
+ *     it can be more efficient to rescale than to park and context switch.
+ * </ul>
+ *
+ * @author <a href="mailto:ckozak@ckozak.net">Carter Kozak</a>
+ */
+public final class LockFreeExponentiallyDecayingDoubleReservoir implements DoubleReservoir {
+
+    private static final double SECONDS_PER_NANO = .000_000_001D;
+    private static final AtomicReferenceFieldUpdater<LockFreeExponentiallyDecayingDoubleReservoir, State> stateUpdater =
+            AtomicReferenceFieldUpdater.newUpdater(LockFreeExponentiallyDecayingDoubleReservoir.class, State.class, "state");
+
+    private final int size;
+    private final long rescaleThresholdNanos;
+    private final Clock clock;
+
+    private volatile State state;
+
+    private static final class State {
+
+        private static final AtomicIntegerFieldUpdater<State> countUpdater =
+                AtomicIntegerFieldUpdater.newUpdater(State.class, "count");
+
+        private final double alphaNanos;
+        private final int size;
+        private final long startTick;
+        // Count is updated after samples are successfully added to the map.
+        private final ConcurrentSkipListMap<Double, WeightedDoubleSample> values;
+
+        private volatile int count;
+
+        State(
+                double alphaNanos,
+                int size,
+                long startTick,
+                int count,
+                ConcurrentSkipListMap<Double, WeightedDoubleSample> values) {
+            this.alphaNanos = alphaNanos;
+            this.size = size;
+            this.startTick = startTick;
+            this.values = values;
+            this.count = count;
+        }
+
+        private void update(double value, long timestampNanos) {
+            double itemWeight = weight(timestampNanos - startTick);
+            double priority = itemWeight / ThreadLocalRandom.current().nextDouble();
+            boolean mapIsFull = count >= size;
+            if (!mapIsFull || values.firstKey() < priority) {
+                addSample(priority, value, itemWeight, mapIsFull);
+            }
+        }
+
+        private void addSample(double priority, double value, double itemWeight, boolean bypassIncrement) {
+            if (values.putIfAbsent(priority, new WeightedDoubleSample(value, itemWeight)) == null
+                    && (bypassIncrement || countUpdater.incrementAndGet(this) > size)) {
+                values.pollFirstEntry();
+            }
+        }
+
+        /* "A common feature of the above techniques—indeed, the key technique that
+         * allows us to track the decayed weights efficiently—is that they maintain
+         * counts and other quantities based on g(ti − L), and only scale by g(t − L)
+         * at query time. But while g(ti −L)/g(t−L) is guaranteed to lie between zero
+         * and one, the intermediate values of g(ti − L) could become very large. For
+         * polynomial functions, these values should not grow too large, and should be
+         * effectively represented in practice by floating point values without loss of
+         * precision. For exponential functions, these values could grow quite large as
+         * new values of (ti − L) become large, and potentially exceed the capacity of
+         * common floating point types. However, since the values stored by the
+         * algorithms are linear combinations of g values (scaled sums), they can be
+         * rescaled relative to a new landmark. That is, by the analysis of exponential
+         * decay in Section III-A, the choice of L does not affect the final result. We
+         * can therefore multiply each value based on L by a factor of exp(−α(L′ − L)),
+         * and obtain the correct value as if we had instead computed relative to a new
+         * landmark L′ (and then use this new L′ at query time). This can be done with
+         * a linear pass over whatever data structure is being used."
+         */
+        State rescale(long newTick) {
+            long durationNanos = newTick - startTick;
+            double scalingFactor = Math.exp(-alphaNanos * durationNanos);
+            int newCount = 0;
+            ConcurrentSkipListMap<Double, WeightedDoubleSample> newValues = new ConcurrentSkipListMap<>();
+            if (Double.compare(scalingFactor, 0) != 0) {
+                RescalingConsumer consumer = new RescalingConsumer(scalingFactor, newValues);
+                values.forEach(consumer);
+                // make sure the counter is in sync with the number of stored samples.
+                newCount = consumer.count;
+            }
+            // It's possible that more values were added while the map was scanned, those with the
+            // minimum priorities are removed.
+            while (newCount > size) {
+                Objects.requireNonNull(newValues.pollFirstEntry(), "Expected an entry");
+                newCount--;
+            }
+            return new State(alphaNanos, size, newTick, newCount, newValues);
+        }
+
+        private double weight(long durationNanos) {
+            return Math.exp(alphaNanos * durationNanos);
+        }
+    }
+
+    private static final class RescalingConsumer implements BiConsumer<Double, WeightedDoubleSample> {
+        private final double scalingFactor;
+        private final ConcurrentSkipListMap<Double, WeightedDoubleSample> values;
+        private int count;
+
+        RescalingConsumer(double scalingFactor, ConcurrentSkipListMap<Double, WeightedDoubleSample> values) {
+            this.scalingFactor = scalingFactor;
+            this.values = values;
+        }
+
+        @Override
+        public void accept(Double priority, WeightedDoubleSample sample) {
+            double newWeight = sample.weight * scalingFactor;
+            if (Double.compare(newWeight, 0) == 0) {
+                return;
+            }
+            WeightedDoubleSample newSample = new WeightedDoubleSample(sample.value, newWeight);
+            if (values.put(priority * scalingFactor, newSample) == null) {
+                count++;
+            }
+        }
+    }
+
+    private LockFreeExponentiallyDecayingDoubleReservoir(int size, double alpha, Duration rescaleThreshold, Clock clock) {
+        // Scale alpha to nanoseconds
+        double alphaNanos = alpha * SECONDS_PER_NANO;
+        this.size = size;
+        this.clock = clock;
+        this.rescaleThresholdNanos = rescaleThreshold.toNanos();
+        this.state = new State(alphaNanos, size, clock.getTick(), 0, new ConcurrentSkipListMap<>());
+    }
+
+    @Override
+    public int size() {
+        return Math.min(size, state.count);
+    }
+
+    @Override
+    public void update(double value) {
+        long now = clock.getTick();
+        rescaleIfNeeded(now).update(value, now);
+    }
+
+    private State rescaleIfNeeded(long currentTick) {
+        // This method is optimized for size so the check may be quickly inlined.
+        // Rescaling occurs substantially less frequently than the check itself.
+        State stateSnapshot = this.state;
+        if (currentTick - stateSnapshot.startTick >= rescaleThresholdNanos) {
+            return doRescale(currentTick, stateSnapshot);
+        }
+        return stateSnapshot;
+    }
+
+    private State doRescale(long currentTick, State stateSnapshot) {
+        State newState = stateSnapshot.rescale(currentTick);
+        if (stateUpdater.compareAndSet(this, stateSnapshot, newState)) {
+            // newState successfully installed
+            return newState;
+        }
+        // Otherwise another thread has won the race and we can return the result of a volatile read.
+        // It's possible this has taken so long that another update is required, however that's unlikely
+        // and no worse than the standard race between a rescale and update.
+        return this.state;
+    }
+
+    @Override
+    public DoubleSnapshot getSnapshot() {
+        State stateSnapshot = rescaleIfNeeded(clock.getTick());
+        return new WeightedDoubleSnapshot(stateSnapshot.values.values());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * By default this uses a size of 1028 elements, which offers a 99.9%
+     * confidence level with a 5% margin of error assuming a normal distribution, and an alpha
+     * factor of 0.015, which heavily biases the reservoir to the past 5 minutes of measurements.
+     */
+    public static final class Builder {
+        private static final int DEFAULT_SIZE = 1028;
+        private static final double DEFAULT_ALPHA = 0.015D;
+        private static final Duration DEFAULT_RESCALE_THRESHOLD = Duration.ofHours(1);
+
+        private int size = DEFAULT_SIZE;
+        private double alpha = DEFAULT_ALPHA;
+        private Duration rescaleThreshold = DEFAULT_RESCALE_THRESHOLD;
+        private Clock clock = Clock.defaultClock();
+
+        private Builder() {}
+
+        /**
+         * Maximum number of samples to keep in the reservoir. Once this number is reached older samples are
+         * replaced (based on weight, with some amount of random jitter).
+         */
+        public Builder size(int value) {
+            if (value <= 0) {
+                throw new IllegalArgumentException(
+                        "LockFreeExponentiallyDecayingDoubleReservoir size must be positive: " + value);
+            }
+            this.size = value;
+            return this;
+        }
+
+        /**
+         * Alpha is the exponential decay factor. Higher values bias results more heavily toward newer values.
+         */
+        public Builder alpha(double value) {
+            this.alpha = value;
+            return this;
+        }
+
+        /**
+         * Interval at which this reservoir is rescaled.
+         */
+        public Builder rescaleThreshold(Duration value) {
+            this.rescaleThreshold = Objects.requireNonNull(value, "rescaleThreshold is required");
+            return this;
+        }
+
+        /**
+         * Clock instance used for decay.
+         */
+        public Builder clock(Clock value) {
+            this.clock = Objects.requireNonNull(value, "clock is required");
+            return this;
+        }
+
+        public DoubleReservoir build() {
+            return new LockFreeExponentiallyDecayingDoubleReservoir(size, alpha, rescaleThreshold, clock);
+        }
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/MetricRegistryListener.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/MetricRegistryListener.java
@@ -35,6 +35,14 @@ public interface MetricRegistryListener extends EventListener {
         }
 
         @Override
+        public void onDoubleHistogramAdded(String name, DoubleHistogram histogram) {
+        }
+
+        @Override
+        public void onDoubleHistogramRemoved(String name) {
+        }
+
+        @Override
         public void onMeterAdded(String name, Meter meter) {
         }
 
@@ -95,6 +103,21 @@ public interface MetricRegistryListener extends EventListener {
      * @param name the histogram's name
      */
     void onHistogramRemoved(String name);
+
+    /**
+     * Called when a {@link DoubleHistogram} is added to the registry.
+     *
+     * @param name      the histogram's name
+     * @param histogram the histogram
+     */
+    void onDoubleHistogramAdded(String name, DoubleHistogram histogram);
+
+    /**
+     * Called when a {@link Histogram} is removed from the registry.
+     *
+     * @param name the histogram's name
+     */
+    void onDoubleHistogramRemoved(String name);
 
     /**
      * Called when a {@link Meter} is added to the registry.

--- a/metrics-core/src/main/java/com/codahale/metrics/NoopMetricRegistry.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/NoopMetricRegistry.java
@@ -80,6 +80,16 @@ public final class NoopMetricRegistry extends MetricRegistry {
         return NoopHistogram.INSTANCE;
     }
 
+    @Override
+    public DoubleHistogram doubleHistogram(String name) {
+        return NoopDoubleHistogram.INSTANCE;
+    }
+
+    @Override
+    public DoubleHistogram doubleHistogram(String name, MetricSupplier<DoubleHistogram> supplier) {
+        return NoopDoubleHistogram.INSTANCE;
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -211,6 +221,16 @@ public final class NoopMetricRegistry extends MetricRegistry {
         return Collections.emptySortedMap();
     }
 
+    @Override
+    public SortedMap<String, DoubleHistogram> getDoubleHistograms() {
+        return Collections.emptySortedMap();
+    }
+
+    @Override
+    public SortedMap<String, DoubleHistogram> getDoubleHistograms(MetricFilter filter) {
+        return Collections.emptySortedMap();
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -321,6 +341,75 @@ public final class NoopMetricRegistry extends MetricRegistry {
         @Override
         public long getMin() {
             return 0L;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public double getStdDev() {
+            return 0D;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void dump(OutputStream output) {
+            // NOP
+        }
+    }
+
+    private static final class EmptyDoubleSnapshot extends DoubleSnapshot {
+        private static final EmptyDoubleSnapshot INSTANCE = new EmptyDoubleSnapshot();
+        private static final double[] EMPTY_DOUBLE_ARRAY = new double[0];
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public double getValue(double quantile) {
+            return 0D;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public double[] getValues() {
+            return EMPTY_DOUBLE_ARRAY;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public int size() {
+            return 0;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public double getMax() {
+            return 0D;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public double getMean() {
+            return 0D;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public double getMin() {
+            return 0D;
         }
 
         /**
@@ -543,6 +632,71 @@ public final class NoopMetricRegistry extends MetricRegistry {
         @Override
         public Snapshot getSnapshot() {
             return EmptySnapshot.INSTANCE;
+        }
+    }
+
+    static final class NoopDoubleHistogram extends DoubleHistogram {
+        private static final NoopDoubleHistogram INSTANCE = new NoopDoubleHistogram();
+        private static final DoubleReservoir EMPTY_RESERVOIR = new DoubleReservoir() {
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public int size() {
+                return 0;
+            }
+
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public void update(double value) {
+                // NOP
+            }
+
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public DoubleSnapshot getSnapshot() {
+                return EmptyDoubleSnapshot.INSTANCE;
+            }
+        };
+
+        private NoopDoubleHistogram() {
+            super(EMPTY_RESERVOIR);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void update(int value) {
+            // NOP
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void update(long value) {
+            // NOP
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public long getCount() {
+            return 0L;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public DoubleSnapshot getSnapshot() {
+            return EmptyDoubleSnapshot.INSTANCE;
         }
     }
 

--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -253,6 +253,7 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
             report(registry.getGauges(filter),
                     registry.getCounters(filter),
                     registry.getHistograms(filter),
+                    registry.getDoubleHistograms(filter),
                     registry.getMeters(filter),
                     registry.getTimers(filter));
         }
@@ -266,13 +267,37 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
      * @param histograms all of the histograms in the registry
      * @param meters     all of the meters in the registry
      * @param timers     all of the timers in the registry
+     * @deprecated Use {@link #report(SortedMap, SortedMap, SortedMap, SortedMap, SortedMap, SortedMap)}
      */
     @SuppressWarnings("rawtypes")
-    public abstract void report(SortedMap<String, Gauge> gauges,
+    public void report(SortedMap<String, Gauge> gauges,
                                 SortedMap<String, Counter> counters,
                                 SortedMap<String, Histogram> histograms,
                                 SortedMap<String, Meter> meters,
-                                SortedMap<String, Timer> timers);
+                                SortedMap<String, Timer> timers) {
+        // NOP
+    }
+
+    /**
+     * Called periodically by the polling thread. Subclasses should report all the given metrics.
+     *
+     * @param gauges     all of the gauges in the registry
+     * @param counters   all of the counters in the registry
+     * @param histograms all of the histograms in the registry
+     * @param doubleHistograms all of the double histograms in the registry
+     * @param meters     all of the meters in the registry
+     * @param timers     all of the timers in the registry
+     */
+    @SuppressWarnings("rawtypes")
+    public void report(SortedMap<String, Gauge> gauges,
+                       SortedMap<String, Counter> counters,
+                       SortedMap<String, Histogram> histograms,
+                       SortedMap<String, DoubleHistogram> doubleHistograms,
+                       SortedMap<String, Meter> meters,
+                       SortedMap<String, Timer> timers) {
+        LOG.debug("{}#report(...) doesn't support double histograms.", this.getClass());
+        report(gauges, counters, histograms, meters, timers);
+    }
 
     protected String getRateUnit() {
         return rateUnit;

--- a/metrics-core/src/main/java/com/codahale/metrics/SlidingTimeWindowArrayDoubleReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SlidingTimeWindowArrayDoubleReservoir.java
@@ -1,0 +1,101 @@
+package com.codahale.metrics;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A {@link Reservoir} implementation backed by a sliding window that stores only the measurements made
+ * in the last {@code N} seconds (or other time unit).
+ */
+public class SlidingTimeWindowArrayDoubleReservoir implements DoubleReservoir {
+    // allow for this many duplicate ticks before overwriting measurements
+    private static final long COLLISION_BUFFER = 256L;
+    // only trim on updating once every N
+    private static final long TRIM_THRESHOLD = 256L;
+    private static final long CLEAR_BUFFER = TimeUnit.HOURS.toNanos(1) * COLLISION_BUFFER;
+
+    private final Clock clock;
+    private final ChunkedAssociativeDoubleArray measurements;
+    private final long window;
+    private final AtomicLong lastTick;
+    private final AtomicLong count;
+    private final long startTick;
+
+    /**
+     * Creates a new {@link SlidingTimeWindowArrayDoubleReservoir} with the given window of time.
+     *
+     * @param window     the window of time
+     * @param windowUnit the unit of {@code window}
+     */
+    public SlidingTimeWindowArrayDoubleReservoir(long window, TimeUnit windowUnit) {
+        this(window, windowUnit, Clock.defaultClock());
+    }
+
+    /**
+     * Creates a new {@link SlidingTimeWindowArrayDoubleReservoir} with the given clock and window of time.
+     *
+     * @param window     the window of time
+     * @param windowUnit the unit of {@code window}
+     * @param clock      the {@link Clock} to use
+     */
+    public SlidingTimeWindowArrayDoubleReservoir(long window, TimeUnit windowUnit, Clock clock) {
+        this.startTick = clock.getTick();
+        this.clock = clock;
+        this.measurements = new ChunkedAssociativeDoubleArray();
+        this.window = windowUnit.toNanos(window) * COLLISION_BUFFER;
+        this.lastTick = new AtomicLong((clock.getTick() - startTick) * COLLISION_BUFFER);
+        this.count = new AtomicLong();
+    }
+
+    @Override
+    public int size() {
+        trim();
+        return measurements.size();
+    }
+
+    @Override
+    public void update(double value) {
+        long newTick;
+        do {
+            if (count.incrementAndGet() % TRIM_THRESHOLD == 0L) {
+                trim();
+            }
+            long lastTick = this.lastTick.get();
+            newTick = getTick();
+            boolean longOverflow = newTick < lastTick;
+            if (longOverflow) {
+                measurements.clear();
+            }
+        } while (!measurements.put(newTick, value));
+    }
+
+    @Override
+    public DoubleSnapshot getSnapshot() {
+        trim();
+        return new UniformDoubleSnapshot(measurements.values());
+    }
+
+    private long getTick() {
+        for ( ;; ) {
+            final long oldTick = lastTick.get();
+            final long tick = (clock.getTick() - startTick) * COLLISION_BUFFER;
+            // ensure the tick is strictly incrementing even if there are duplicate ticks
+            final long newTick = tick - oldTick > 0L ? tick : oldTick + 1L;
+            if (lastTick.compareAndSet(oldTick, newTick)) {
+                return newTick;
+            }
+        }
+    }
+
+    void trim() {
+        final long now = getTick();
+        final long windowStart = now - window;
+        final long windowEnd = now + CLEAR_BUFFER;
+        if (windowStart < windowEnd) {
+            measurements.trim(windowStart, windowEnd);
+        } else {
+            // long overflow handling that can happen only after 1 year after class loading
+            measurements.clear();
+        }
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/SlidingTimeWindowDoubleReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SlidingTimeWindowDoubleReservoir.java
@@ -1,0 +1,95 @@
+package com.codahale.metrics;
+
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A {@link Reservoir} implementation backed by a sliding window that stores only the measurements made
+ * in the last {@code N} seconds (or other time unit).
+ */
+public class SlidingTimeWindowDoubleReservoir implements DoubleReservoir {
+    // allow for this many duplicate ticks before overwriting measurements
+    private static final int COLLISION_BUFFER = 256;
+    // only trim on updating once every N
+    private static final int TRIM_THRESHOLD = 256;
+    // offsets the front of the time window for the purposes of clearing the buffer in trim
+    private static final long CLEAR_BUFFER = TimeUnit.HOURS.toNanos(1) * COLLISION_BUFFER;
+
+    private final Clock clock;
+    private final ConcurrentSkipListMap<Long, Double> measurements;
+    private final long window;
+    private final AtomicLong lastTick;
+    private final AtomicLong count;
+    private final long startTick;
+
+    /**
+     * Creates a new {@link SlidingTimeWindowDoubleReservoir} with the given window of time.
+     *
+     * @param window     the window of time
+     * @param windowUnit the unit of {@code window}
+     */
+    public SlidingTimeWindowDoubleReservoir(long window, TimeUnit windowUnit) {
+        this(window, windowUnit, Clock.defaultClock());
+    }
+
+    /**
+     * Creates a new {@link SlidingTimeWindowDoubleReservoir} with the given clock and window of time.
+     *
+     * @param window     the window of time
+     * @param windowUnit the unit of {@code window}
+     * @param clock      the {@link Clock} to use
+     */
+    public SlidingTimeWindowDoubleReservoir(long window, TimeUnit windowUnit, Clock clock) {
+        this.startTick = clock.getTick();
+        this.clock = clock;
+        this.measurements = new ConcurrentSkipListMap<>();
+        this.window = windowUnit.toNanos(window) * COLLISION_BUFFER;
+        this.lastTick = new AtomicLong((clock.getTick() - startTick) * COLLISION_BUFFER);
+        this.count = new AtomicLong();
+    }
+
+    @Override
+    public int size() {
+        trim();
+        return measurements.size();
+    }
+
+    @Override
+    public void update(double value) {
+        if (count.incrementAndGet() % TRIM_THRESHOLD == 0) {
+            trim();
+        }
+        measurements.put(getTick(), value);
+    }
+
+    @Override
+    public DoubleSnapshot getSnapshot() {
+        trim();
+        return new UniformDoubleSnapshot(measurements.values());
+    }
+
+    private long getTick() {
+        for ( ;; ) {
+            final long oldTick = lastTick.get();
+            final long tick = (clock.getTick() - startTick) * COLLISION_BUFFER;
+            // ensure the tick is strictly incrementing even if there are duplicate ticks
+            final long newTick = tick - oldTick > 0 ? tick : oldTick + 1;
+            if (lastTick.compareAndSet(oldTick, newTick)) {
+                return newTick;
+            }
+        }
+    }
+
+    private void trim() {
+        final long now = getTick();
+        final long windowStart = now - window;
+        final long windowEnd = now + CLEAR_BUFFER;
+        if (windowStart < windowEnd) {
+            measurements.headMap(windowStart).clear();
+            measurements.tailMap(windowEnd).clear();
+        } else {
+            measurements.subMap(windowEnd, windowStart).clear();
+        }
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/SlidingWindowDoubleReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SlidingWindowDoubleReservoir.java
@@ -1,0 +1,43 @@
+package com.codahale.metrics;
+
+import static java.lang.Math.min;
+
+/**
+ * A {@link Reservoir} implementation backed by a sliding window that stores the last {@code N}
+ * measurements.
+ */
+public class SlidingWindowDoubleReservoir implements DoubleReservoir {
+    private final double[] measurements;
+    private long count;
+
+    /**
+     * Creates a new {@link SlidingWindowDoubleReservoir} which stores the last {@code size} measurements.
+     *
+     * @param size the number of measurements to store
+     */
+    public SlidingWindowDoubleReservoir(int size) {
+        this.measurements = new double[size];
+        this.count = 0;
+    }
+
+    @Override
+    public synchronized int size() {
+        return (int) min(count, measurements.length);
+    }
+
+    @Override
+    public synchronized void update(double value) {
+        measurements[(int) (count++ % measurements.length)] = value;
+    }
+
+    @Override
+    public DoubleSnapshot getSnapshot() {
+        final double[] values = new double[size()];
+        for (int i = 0; i < values.length; i++) {
+            synchronized (this) {
+                values[i] = measurements[i];
+            }
+        }
+        return new UniformDoubleSnapshot(values);
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/UniformDoubleReservoir.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/UniformDoubleReservoir.java
@@ -1,0 +1,70 @@
+package com.codahale.metrics;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
+
+/**
+ * A random sampling reservoir of a stream of {@code long}s. Uses Vitter's Algorithm R to produce a
+ * statistically representative sample.
+ *
+ * @see <a href="http://www.cs.umd.edu/~samir/498/vitter.pdf">Random Sampling with a Reservoir</a>
+ */
+public class UniformDoubleReservoir implements DoubleReservoir {
+    private static final int DEFAULT_SIZE = 1028;
+    private final AtomicLong count = new AtomicLong();
+    private final AtomicLongArray values;
+
+    /**
+     * Creates a new {@link UniformDoubleReservoir} of 1028 elements, which offers a 99.9% confidence level
+     * with a 5% margin of error assuming a normal distribution.
+     */
+    public UniformDoubleReservoir() {
+        this(DEFAULT_SIZE);
+    }
+
+    /**
+     * Creates a new {@link UniformDoubleReservoir}.
+     *
+     * @param size the number of samples to keep in the sampling reservoir
+     */
+    public UniformDoubleReservoir(int size) {
+        this.values = new AtomicLongArray(size);
+        for (int i = 0; i < values.length(); i++) {
+            values.set(i, 0);
+        }
+        count.set(0);
+    }
+
+    @Override
+    public int size() {
+        final long c = count.get();
+        if (c > values.length()) {
+            return values.length();
+        }
+        return (int) c;
+    }
+
+    @Override
+    public void update(double value) {
+        final long c = count.incrementAndGet();
+        if (c <= values.length()) {
+            values.set((int) c - 1, Double.doubleToLongBits(value));
+        } else {
+            final long r = ThreadLocalRandom.current().nextLong(c);
+            if (r < values.length()) {
+                values.set((int) r, Double.doubleToLongBits(value));
+            }
+        }
+    }
+
+    @Override
+    public DoubleSnapshot getSnapshot() {
+        final int s = size();
+        double[] copy = new double[s];
+        for (int i = 0; i < s; i++) {
+            copy[i] = Double.longBitsToDouble(values.get(i));
+        }
+        return new UniformDoubleSnapshot(copy);
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/UniformDoubleSnapshot.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/UniformDoubleSnapshot.java
@@ -1,0 +1,177 @@
+package com.codahale.metrics;
+
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static java.lang.Math.floor;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * A statistical snapshot of a {@link UniformDoubleSnapshot}.
+ */
+public class UniformDoubleSnapshot extends DoubleSnapshot {
+
+    private final double[] values;
+
+    /**
+     * Create a new {@link Snapshot} with the given values.
+     *
+     * @param values an unordered set of values in the reservoir
+     */
+    public UniformDoubleSnapshot(Collection<Double> values) {
+        final Object[] copy = values.toArray();
+        this.values = new double[copy.length];
+        for (int i = 0; i < copy.length; i++) {
+            this.values[i] = (Double) copy[i];
+        }
+        Arrays.sort(this.values);
+    }
+
+    /**
+     * Create a new {@link Snapshot} with the given values.
+     *
+     * @param values an unordered set of values in the reservoir that can be used by this class directly
+     */
+    public UniformDoubleSnapshot(double[] values) {
+        this.values = Arrays.copyOf(values, values.length);
+        Arrays.sort(this.values);
+    }
+
+    /**
+     * Returns the value at the given quantile.
+     *
+     * @param quantile a given quantile, in {@code [0..1]}
+     * @return the value in the distribution at {@code quantile}
+     */
+    @Override
+    public double getValue(double quantile) {
+        if (quantile < 0.0 || quantile > 1.0 || Double.isNaN(quantile)) {
+            throw new IllegalArgumentException(quantile + " is not in [0..1]");
+        }
+
+        if (values.length == 0) {
+            return 0.0;
+        }
+
+        final double pos = quantile * (values.length + 1);
+        final int index = (int) pos;
+
+        if (index < 1) {
+            return values[0];
+        }
+
+        if (index >= values.length) {
+            return values[values.length - 1];
+        }
+
+        final double lower = values[index - 1];
+        final double upper = values[index];
+        return lower + (pos - floor(pos)) * (upper - lower);
+    }
+
+    /**
+     * Returns the number of values in the snapshot.
+     *
+     * @return the number of values
+     */
+    @Override
+    public int size() {
+        return values.length;
+    }
+
+    /**
+     * Returns the entire set of values in the snapshot.
+     *
+     * @return the entire set of values
+     */
+    @Override
+    public double[] getValues() {
+        return Arrays.copyOf(values, values.length);
+    }
+
+    /**
+     * Returns the highest value in the snapshot.
+     *
+     * @return the highest value
+     */
+    @Override
+    public double getMax() {
+        if (values.length == 0) {
+            return 0;
+        }
+        return values[values.length - 1];
+    }
+
+    /**
+     * Returns the lowest value in the snapshot.
+     *
+     * @return the lowest value
+     */
+    @Override
+    public double getMin() {
+        if (values.length == 0) {
+            return 0;
+        }
+        return values[0];
+    }
+
+    /**
+     * Returns the arithmetic mean of the values in the snapshot.
+     *
+     * @return the arithmetic mean
+     */
+    @Override
+    public double getMean() {
+        if (values.length == 0) {
+            return 0;
+        }
+
+        double sum = 0;
+        for (double value : values) {
+            sum += value;
+        }
+        return sum / values.length;
+    }
+
+    /**
+     * Returns the standard deviation of the values in the snapshot.
+     *
+     * @return the standard deviation value
+     */
+    @Override
+    public double getStdDev() {
+        // two-pass algorithm for variance, avoids numeric overflow
+
+        if (values.length <= 1) {
+            return 0;
+        }
+
+        final double mean = getMean();
+        double sum = 0;
+
+        for (double value : values) {
+            final double diff = value - mean;
+            sum += diff * diff;
+        }
+
+        final double variance = sum / (values.length - 1);
+        return Math.sqrt(variance);
+    }
+
+    /**
+     * Writes the values of the snapshot to the given stream.
+     *
+     * @param output an output stream
+     */
+    @Override
+    public void dump(OutputStream output) {
+        try (PrintWriter out = new PrintWriter(new OutputStreamWriter(output, UTF_8))) {
+            for (double value : values) {
+                out.printf("%f%n", value);
+            }
+        }
+    }
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/WeightedDoubleSnapshot.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/WeightedDoubleSnapshot.java
@@ -1,0 +1,195 @@
+package com.codahale.metrics;
+
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * A statistical snapshot of a {@link WeightedDoubleSnapshot}.
+ */
+public class WeightedDoubleSnapshot extends DoubleSnapshot {
+
+    /**
+     * A single sample item with value and its weights for {@link WeightedDoubleSnapshot}.
+     */
+    public static class WeightedDoubleSample {
+        public final double value;
+        public final double weight;
+
+        public WeightedDoubleSample(double value, double weight) {
+            this.value = value;
+            this.weight = weight;
+        }
+    }
+
+    private final double[] values;
+    private final double[] normWeights;
+    private final double[] quantiles;
+
+    /**
+     * Create a new {@link Snapshot} with the given values.
+     *
+     * @param values an unordered set of values in the reservoir
+     */
+    public WeightedDoubleSnapshot(Collection<WeightedDoubleSample> values) {
+        final WeightedDoubleSample[] copy = values.toArray(new WeightedDoubleSample[]{});
+
+        Arrays.sort(copy, Comparator.comparingDouble(w -> w.value));
+
+        this.values = new double[copy.length];
+        this.normWeights = new double[copy.length];
+        this.quantiles = new double[copy.length];
+
+        double sumWeight = 0;
+        for (WeightedDoubleSample sample : copy) {
+            sumWeight += sample.weight;
+        }
+
+        for (int i = 0; i < copy.length; i++) {
+            this.values[i] = copy[i].value;
+            this.normWeights[i] = sumWeight != 0 ? copy[i].weight / sumWeight : 0;
+        }
+
+        for (int i = 1; i < copy.length; i++) {
+            this.quantiles[i] = this.quantiles[i - 1] + this.normWeights[i - 1];
+        }
+    }
+
+    /**
+     * Returns the value at the given quantile.
+     *
+     * @param quantile a given quantile, in {@code [0..1]}
+     * @return the value in the distribution at {@code quantile}
+     */
+    @Override
+    public double getValue(double quantile) {
+        if (quantile < 0.0 || quantile > 1.0 || Double.isNaN(quantile)) {
+            throw new IllegalArgumentException(quantile + " is not in [0..1]");
+        }
+
+        if (values.length == 0) {
+            return 0.0;
+        }
+
+        int posx = Arrays.binarySearch(quantiles, quantile);
+        if (posx < 0)
+            posx = ((-posx) - 1) - 1;
+
+        if (posx < 1) {
+            return values[0];
+        }
+
+        if (posx >= values.length) {
+            return values[values.length - 1];
+        }
+
+        return values[posx];
+    }
+
+    /**
+     * Returns the number of values in the snapshot.
+     *
+     * @return the number of values
+     */
+    @Override
+    public int size() {
+        return values.length;
+    }
+
+    /**
+     * Returns the entire set of values in the snapshot.
+     *
+     * @return the entire set of values
+     */
+    @Override
+    public double[] getValues() {
+        return Arrays.copyOf(values, values.length);
+    }
+
+    /**
+     * Returns the highest value in the snapshot.
+     *
+     * @return the highest value
+     */
+    @Override
+    public double getMax() {
+        if (values.length == 0) {
+            return 0;
+        }
+        return values[values.length - 1];
+    }
+
+    /**
+     * Returns the lowest value in the snapshot.
+     *
+     * @return the lowest value
+     */
+    @Override
+    public double getMin() {
+        if (values.length == 0) {
+            return 0;
+        }
+        return values[0];
+    }
+
+    /**
+     * Returns the weighted arithmetic mean of the values in the snapshot.
+     *
+     * @return the weighted arithmetic mean
+     */
+    @Override
+    public double getMean() {
+        if (values.length == 0) {
+            return 0;
+        }
+
+        double sum = 0;
+        for (int i = 0; i < values.length; i++) {
+            sum += values[i] * normWeights[i];
+        }
+        return sum;
+    }
+
+    /**
+     * Returns the weighted standard deviation of the values in the snapshot.
+     *
+     * @return the weighted standard deviation value
+     */
+    @Override
+    public double getStdDev() {
+        // two-pass algorithm for variance, avoids numeric overflow
+
+        if (values.length <= 1) {
+            return 0;
+        }
+
+        final double mean = getMean();
+        double variance = 0;
+
+        for (int i = 0; i < values.length; i++) {
+            final double diff = values[i] - mean;
+            variance += normWeights[i] * diff * diff;
+        }
+
+        return Math.sqrt(variance);
+    }
+
+    /**
+     * Writes the values of the snapshot to the given stream.
+     *
+     * @param output an output stream
+     */
+    @Override
+    public void dump(OutputStream output) {
+        try (PrintWriter out = new PrintWriter(new OutputStreamWriter(output, UTF_8))) {
+            for (double value : values) {
+                out.printf("%f%n", value);
+            }
+        }
+    }
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/ChunkedAssociativeDoubleArrayTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ChunkedAssociativeDoubleArrayTest.java
@@ -1,0 +1,40 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.BDDAssertions.then;
+
+public class ChunkedAssociativeDoubleArrayTest {
+
+    @Test
+    public void testTrim() {
+        ChunkedAssociativeDoubleArray array = new ChunkedAssociativeDoubleArray(3);
+        array.put(-3, 3D);
+        array.put(-2, 1D);
+        array.put(0, 5D);
+        array.put(3, 0D);
+        array.put(9, 8D);
+        array.put(15, 0D);
+        array.put(19, 5D);
+        array.put(21, 5D);
+        array.put(34, -9D);
+        array.put(109, 5D);
+
+        then(array.out())
+                .isEqualTo("[(-3: 3.0) (-2: 1.0) (0: 5.0) ]->[(3: 0.0) (9: 8.0) (15: 0.0) ]->[(19: 5.0) (21: 5.0) (34: -9.0) ]->[(109: 5.0) ]");
+        then(array.values())
+                .isEqualTo(new double[]{3D, 1D, 5D, 0D, 8D, 0D, 5D, 5D, -9D, 5D});
+        then(array.size())
+                .isEqualTo(10);
+
+        array.trim(-2, 20);
+
+        then(array.out())
+                .isEqualTo("[(-2: 1.0) (0: 5.0) ]->[(3: 0.0) (9: 8.0) (15: 0.0) ]->[(19: 5.0) ]");
+        then(array.values())
+                .isEqualTo(new double[]{1D, 5D, 0D, 8D, 0D, 5D});
+        then(array.size())
+                .isEqualTo(6);
+
+    }
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ConsoleReporterTest.java
@@ -140,6 +140,54 @@ public class ConsoleReporterTest {
     }
 
     @Test
+    public void reportsDoubleHistogramValues() throws Exception {
+        final DoubleHistogram histogram = mock(DoubleHistogram.class);
+        when(histogram.getCount()).thenReturn(1L);
+
+        final DoubleSnapshot snapshot = mock(DoubleSnapshot.class);
+        when(snapshot.getMax()).thenReturn(23.0D);
+        when(snapshot.getMean()).thenReturn(3.0);
+        when(snapshot.getMin()).thenReturn(4.2D);
+        when(snapshot.getStdDev()).thenReturn(5.0);
+        when(snapshot.getMedian()).thenReturn(6.0);
+        when(snapshot.get75thPercentile()).thenReturn(7.0);
+        when(snapshot.get95thPercentile()).thenReturn(8.0);
+        when(snapshot.get98thPercentile()).thenReturn(9.0);
+        when(snapshot.get99thPercentile()).thenReturn(10.0);
+        when(snapshot.get999thPercentile()).thenReturn(11.0);
+
+        when(histogram.getSnapshot()).thenReturn(snapshot);
+
+        reporter.report(map(),
+                map(),
+                map(),
+                map("test.histogram", histogram),
+                map(),
+                map());
+
+        assertThat(consoleOutput())
+                .isEqualTo(lines(
+                        dateHeader,
+                        "",
+                        "-- Double Histograms -----------------------------------------------------------",
+                        "test.histogram",
+                        "             count = 1",
+                        "               min = 4.200000",
+                        "               max = 23.000000",
+                        "              mean = 3.00",
+                        "            stddev = 5.00",
+                        "            median = 6.00",
+                        "              75% <= 7.00",
+                        "              95% <= 8.00",
+                        "              98% <= 9.00",
+                        "              99% <= 10.00",
+                        "            99.9% <= 11.00",
+                        "",
+                        ""
+                ));
+    }
+
+    @Test
     public void reportsMeterValues() throws Exception {
         final Meter meter = mock(Meter.class);
         when(meter.getCount()).thenReturn(1L);

--- a/metrics-core/src/test/java/com/codahale/metrics/CsvReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/CsvReporterTest.java
@@ -112,6 +112,39 @@ public class CsvReporterTest {
     }
 
     @Test
+    public void reportsDoubleHistogramValues() throws Exception {
+        final DoubleHistogram histogram = mock(DoubleHistogram.class);
+        when(histogram.getCount()).thenReturn(1L);
+
+        final DoubleSnapshot snapshot = mock(DoubleSnapshot.class);
+        when(snapshot.getMax()).thenReturn(23.0D);
+        when(snapshot.getMean()).thenReturn(3.0);
+        when(snapshot.getMin()).thenReturn(4.2D);
+        when(snapshot.getStdDev()).thenReturn(5.0);
+        when(snapshot.getMedian()).thenReturn(6.0);
+        when(snapshot.get75thPercentile()).thenReturn(7.0);
+        when(snapshot.get95thPercentile()).thenReturn(8.0);
+        when(snapshot.get98thPercentile()).thenReturn(9.0);
+        when(snapshot.get99thPercentile()).thenReturn(10.0);
+        when(snapshot.get999thPercentile()).thenReturn(11.0);
+
+        when(histogram.getSnapshot()).thenReturn(snapshot);
+
+        reporter.report(map(),
+                map(),
+                map(),
+                map("test.histogram", histogram),
+                map(),
+                map());
+
+        assertThat(fileContents("test.histogram.csv"))
+                .isEqualTo(csv(
+                        "t,count,max,mean,min,stddev,p50,p75,p95,p98,p99,p999",
+                        "19910191,1,23.000000,3.000000,4.200000,5.000000,6.000000,7.000000,8.000000,9.000000,10.000000,11.000000"
+                ));
+    }
+
+    @Test
     public void reportsMeterValues() throws Exception {
         final Meter meter = mockMeter();
 

--- a/metrics-core/src/test/java/com/codahale/metrics/DoubleHistogramTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/DoubleHistogramTest.java
@@ -1,0 +1,40 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DoubleHistogramTest {
+    private final DoubleReservoir reservoir = mock(DoubleReservoir.class);
+    private final DoubleHistogram histogram = new DoubleHistogram(reservoir);
+
+    @Test
+    public void updatesTheCountOnUpdates() {
+        assertThat(histogram.getCount())
+                .isZero();
+
+        histogram.update(1);
+
+        assertThat(histogram.getCount())
+                .isEqualTo(1);
+    }
+
+    @Test
+    public void returnsTheSnapshotFromTheDoubleReservoir() {
+        final DoubleSnapshot snapshot = mock(DoubleSnapshot.class);
+        when(reservoir.getSnapshot()).thenReturn(snapshot);
+
+        assertThat(histogram.getSnapshot())
+                .isEqualTo(snapshot);
+    }
+
+    @Test
+    public void updatesTheDoubleReservoir() throws Exception {
+        histogram.update(1);
+
+        verify(reservoir).update(1);
+    }
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingDoubleReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ExponentiallyDecayingDoubleReservoirTest.java
@@ -1,0 +1,415 @@
+package com.codahale.metrics;
+
+import com.codahale.metrics.Timer.Context;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class ExponentiallyDecayingDoubleReservoirTest {
+
+    public enum ReservoirFactory {
+        EXPONENTIALLY_DECAYING() {
+            @Override
+            DoubleReservoir create(int size, double alpha, Clock clock) {
+                return new ExponentiallyDecayingDoubleReservoir(size, alpha, clock);
+            }
+        },
+
+        LOCK_FREE_EXPONENTIALLY_DECAYING() {
+            @Override
+            DoubleReservoir create(int size, double alpha, Clock clock) {
+                return LockFreeExponentiallyDecayingDoubleReservoir.builder()
+                        .size(size)
+                        .alpha(alpha)
+                        .clock(clock)
+                        .build();
+            }
+        };
+
+        abstract DoubleReservoir create(int size, double alpha, Clock clock);
+
+        DoubleReservoir create(int size, double alpha) {
+            return create(size, alpha, Clock.defaultClock());
+        }
+    }
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> reservoirs() {
+        return Arrays.stream(ReservoirFactory.values())
+                .map(value -> new Object[] {value})
+                .collect(Collectors.toList());
+    }
+
+    private final ReservoirFactory reservoirFactory;
+
+    public ExponentiallyDecayingDoubleReservoirTest(ReservoirFactory reservoirFactory) {
+        this.reservoirFactory = reservoirFactory;
+    }
+
+    @Test
+    public void aReservoirOf100OutOf1000Elements() {
+        final DoubleReservoir reservoir = reservoirFactory.create(100, 0.99);
+        for (int i = 0; i < 1000; i++) {
+            reservoir.update(i);
+        }
+
+        assertThat(reservoir.size())
+                .isEqualTo(100);
+
+        final DoubleSnapshot snapshot = reservoir.getSnapshot();
+
+        assertThat(snapshot.size())
+                .isEqualTo(100);
+
+        assertAllValuesBetween(reservoir, 0, 1000);
+    }
+
+    @Test
+    public void aReservoirOf100OutOf10Elements() {
+        final DoubleReservoir reservoir = reservoirFactory.create(100, 0.99);
+        for (int i = 0; i < 10; i++) {
+            reservoir.update(i);
+        }
+
+        final DoubleSnapshot snapshot = reservoir.getSnapshot();
+
+        assertThat(snapshot.size())
+                .isEqualTo(10);
+
+        assertThat(snapshot.size())
+                .isEqualTo(10);
+
+        assertAllValuesBetween(reservoir, 0, 10);
+    }
+
+    @Test
+    public void aHeavilyBiasedReservoirOf100OutOf1000Elements() {
+        final DoubleReservoir reservoir = reservoirFactory.create(1000, 0.01);
+        for (int i = 0; i < 100; i++) {
+            reservoir.update(i);
+        }
+
+
+        assertThat(reservoir.size())
+                .isEqualTo(100);
+
+        final DoubleSnapshot snapshot = reservoir.getSnapshot();
+
+        assertThat(snapshot.size())
+                .isEqualTo(100);
+
+        assertAllValuesBetween(reservoir, 0, 100);
+    }
+
+    @Test
+    public void longPeriodsOfInactivityShouldNotCorruptSamplingState() {
+        final ManualClock clock = new ManualClock();
+        final DoubleReservoir reservoir = reservoirFactory.create(10, 0.15, clock);
+
+        // add 1000 values at a rate of 10 values/second
+        for (int i = 0; i < 1000; i++) {
+            reservoir.update(1000 + i);
+            clock.addMillis(100);
+        }
+        assertThat(reservoir.getSnapshot().size())
+                .isEqualTo(10);
+        assertAllValuesBetween(reservoir, 1000, 2000);
+
+        // wait for 15 hours and add another value.
+        // this should trigger a rescale. Note that the number of samples will be reduced to 1
+        // because scaling factor equal to zero will remove all existing entries after rescale.
+        clock.addHours(15);
+        reservoir.update(2000);
+        assertThat(reservoir.getSnapshot().size())
+                .isEqualTo(1);
+        assertAllValuesBetween(reservoir, 1000, 2001);
+
+
+        // add 1000 values at a rate of 10 values/second
+        for (int i = 0; i < 1000; i++) {
+            reservoir.update(3000 + i);
+            clock.addMillis(100);
+        }
+        assertThat(reservoir.getSnapshot().size())
+                .isEqualTo(10);
+        assertAllValuesBetween(reservoir, 3000, 4000);
+    }
+
+    @Test
+    public void longPeriodsOfInactivity_fetchShouldResample() {
+        final ManualClock clock = new ManualClock();
+        final DoubleReservoir reservoir = reservoirFactory.create(10,
+                0.015,
+                clock);
+
+        // add 1000 values at a rate of 10 values/second
+        for (int i = 0; i < 1000; i++) {
+            reservoir.update(1000 + i);
+            clock.addMillis(100);
+        }
+        assertThat(reservoir.getSnapshot().size())
+                .isEqualTo(10);
+        assertAllValuesBetween(reservoir, 1000, 2000);
+
+        // wait for 20 hours and take snapshot.
+        // this should trigger a rescale. Note that the number of samples will be reduced to 0
+        // because scaling factor equal to zero will remove all existing entries after rescale.
+        clock.addHours(20);
+        DoubleSnapshot snapshot = reservoir.getSnapshot();
+        assertThat(snapshot.getMax()).isEqualTo(0);
+        assertThat(snapshot.getMean()).isEqualTo(0);
+        assertThat(snapshot.getMedian()).isEqualTo(0);
+        assertThat(snapshot.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void emptyReservoirSnapshot_shouldReturnZeroForAllValues() {
+        final DoubleReservoir reservoir = reservoirFactory.create(100, 0.015,
+                new ManualClock());
+
+        DoubleSnapshot snapshot = reservoir.getSnapshot();
+        assertThat(snapshot.getMax()).isEqualTo(0);
+        assertThat(snapshot.getMean()).isEqualTo(0);
+        assertThat(snapshot.getMedian()).isEqualTo(0);
+        assertThat(snapshot.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void removeZeroWeightsInSamplesToPreventNaNInMeanValues() {
+        final ManualClock clock = new ManualClock();
+        final DoubleReservoir reservoir = reservoirFactory.create(1028, 0.015, clock);
+
+        clock.addMillis(100);
+        reservoir.update(TimeUnit.MILLISECONDS.toNanos(100L));
+
+        for (int i = 1; i < 48; i++) {
+            clock.addHours(1);
+            assertThat(reservoir.getSnapshot().getMean()).isBetween(0.0, Double.MAX_VALUE);
+        }
+    }
+
+    @Test
+    public void multipleUpdatesAfterlongPeriodsOfInactivityShouldNotCorruptSamplingState() throws Exception {
+        // This test illustrates the potential race condition in rescale that
+        // can lead to a corrupt state.  Note that while this test uses updates
+        // exclusively to trigger the race condition, two concurrent updates
+        // may be made much more likely to trigger this behavior if executed
+        // while another thread is constructing a snapshot of the reservoir;
+        // that thread then holds the read lock when the two competing updates
+        // are executed and the race condition's window is substantially
+        // expanded.
+
+        // Run the test several times.
+        for (int attempt = 0; attempt < 10; attempt++) {
+            final ManualClock clock = new ManualClock();
+            final DoubleReservoir reservoir = reservoirFactory.create(10,
+                    0.015,
+                    clock);
+
+            // Various atomics used to communicate between this thread and the
+            // thread created below.
+            final AtomicBoolean running = new AtomicBoolean(true);
+            final AtomicInteger threadUpdates = new AtomicInteger(0);
+            final AtomicInteger testUpdates = new AtomicInteger(0);
+
+            final Thread thread = new Thread(() -> {
+                int previous = 0;
+                while (running.get()) {
+                    // Wait for the test thread to update it's counter
+                    // before updaing the reservoir.
+                    while (true) {
+                        int next = testUpdates.get();
+                        if (previous < next) {
+                            previous = next;
+                            break;
+                        }
+                    }
+
+                    // Update the reservoir.  This needs to occur at the
+                    // same time as the test thread's update.
+                    reservoir.update(1000);
+
+                    // Signal the main thread; allows the next update
+                    // attempt to begin.
+                    threadUpdates.incrementAndGet();
+                }
+            });
+
+            thread.start();
+
+            int sum = 0;
+            int previous = -1;
+            for (int i = 0; i < 100; i++) {
+                // Wait for 15 hours before attempting the next concurrent
+                // update.  The delay here needs to be sufficiently long to
+                // overflow if an update attempt is allowed to add a value to
+                // the reservoir without rescaling.  Note that:
+                // e(alpha*(15*60*60)) =~ 10^351 >> Double.MAX_VALUE =~ 1.8*10^308.
+                clock.addHours(15);
+
+                // Signal the other thread; asynchronously updates the reservoir.
+                testUpdates.incrementAndGet();
+
+                // Delay a variable length of time.  Without a delay here this
+                // thread is heavily favored and the race condition is almost
+                // never observed.
+                for (int j = 0; j < i; j++)
+                    sum += j;
+
+                // Competing reservoir update.
+                reservoir.update(1000);
+
+                // Wait for the other thread to finish it's update.
+                while (true) {
+                    int next = threadUpdates.get();
+                    if (previous < next) {
+                        previous = next;
+                        break;
+                    }
+                }
+            }
+
+            // Terminate the thread.
+            running.set(false);
+            testUpdates.incrementAndGet();
+            thread.join();
+
+            // Test failures will result in normWeights that are not finite;
+            // checking the mean value here is sufficient.
+            assertThat(reservoir.getSnapshot().getMean()).isBetween(0.0, Double.MAX_VALUE);
+
+            // Check the value of sum; should prevent the JVM from optimizing
+            // out the delay loop entirely.
+            assertThat(sum).isEqualTo(161700);
+        }
+    }
+
+    @Test
+    public void spotLift() {
+        final ManualClock clock = new ManualClock();
+        final DoubleReservoir reservoir = reservoirFactory.create(1000,
+                0.015,
+                clock);
+
+        final int valuesRatePerMinute = 10;
+        final int valuesIntervalMillis = (int) (TimeUnit.MINUTES.toMillis(1) / valuesRatePerMinute);
+        // mode 1: steady regime for 120 minutes
+        for (int i = 0; i < 120 * valuesRatePerMinute; i++) {
+            reservoir.update(177);
+            clock.addMillis(valuesIntervalMillis);
+        }
+
+        // switching to mode 2: 10 minutes more with the same rate, but larger value
+        for (int i = 0; i < 10 * valuesRatePerMinute; i++) {
+            reservoir.update(9999);
+            clock.addMillis(valuesIntervalMillis);
+        }
+
+        // expect that quantiles should be more about mode 2 after 10 minutes
+        assertThat(reservoir.getSnapshot().getMedian())
+                .isEqualTo(9999);
+    }
+
+    @Test
+    public void spotFall() {
+        final ManualClock clock = new ManualClock();
+        final DoubleReservoir reservoir = reservoirFactory.create(1000,
+                0.015,
+                clock);
+
+        final int valuesRatePerMinute = 10;
+        final int valuesIntervalMillis = (int) (TimeUnit.MINUTES.toMillis(1) / valuesRatePerMinute);
+        // mode 1: steady regime for 120 minutes
+        for (int i = 0; i < 120 * valuesRatePerMinute; i++) {
+            reservoir.update(9998);
+            clock.addMillis(valuesIntervalMillis);
+        }
+
+        // switching to mode 2: 10 minutes more with the same rate, but smaller value
+        for (int i = 0; i < 10 * valuesRatePerMinute; i++) {
+            reservoir.update(178);
+            clock.addMillis(valuesIntervalMillis);
+        }
+
+        // expect that quantiles should be more about mode 2 after 10 minutes
+        assertThat(reservoir.getSnapshot().get95thPercentile())
+                .isEqualTo(178);
+    }
+
+    @Test
+    public void quantiliesShouldBeBasedOnWeights() {
+        final ManualClock clock = new ManualClock();
+        final DoubleReservoir reservoir = reservoirFactory.create(1000,
+                0.015,
+                clock);
+        for (int i = 0; i < 40; i++) {
+            reservoir.update(177);
+        }
+
+        clock.addSeconds(120);
+
+        for (int i = 0; i < 10; i++) {
+            reservoir.update(9999);
+        }
+
+        assertThat(reservoir.getSnapshot().size())
+                .isEqualTo(50);
+
+        // the first added 40 items (177) have weights 1 
+        // the next added 10 items (9999) have weights ~6 
+        // so, it's 40 vs 60 distribution, not 40 vs 10
+        assertThat(reservoir.getSnapshot().getMedian())
+                .isEqualTo(9999);
+        assertThat(reservoir.getSnapshot().get75thPercentile())
+                .isEqualTo(9999);
+    }
+
+    @Test
+    public void clockWrapShouldNotRescale() {
+        // First verify the test works as expected given low values
+        testShortPeriodShouldNotRescale(0);
+        // Now revalidate using an edge case nanoTime value just prior to wrapping
+        testShortPeriodShouldNotRescale(Long.MAX_VALUE - TimeUnit.MINUTES.toNanos(30));
+    }
+
+    private void testShortPeriodShouldNotRescale(long startTimeNanos) {
+        final ManualClock clock = new ManualClock(startTimeNanos);
+        final DoubleReservoir reservoir = reservoirFactory.create(10, 1, clock);
+
+        reservoir.update(1000);
+        assertThat(reservoir.getSnapshot().size()).isEqualTo(1);
+
+        assertAllValuesBetween(reservoir, 1000, 1001);
+
+        // wait for 10 millis and take snapshot.
+        // this should not trigger a rescale. Note that the number of samples will be reduced to 0
+        // because scaling factor equal to zero will remove all existing entries after rescale.
+        clock.addSeconds(20 * 60);
+        DoubleSnapshot snapshot = reservoir.getSnapshot();
+        assertThat(snapshot.getMax()).isEqualTo(1000);
+        assertThat(snapshot.getMean()).isEqualTo(1000);
+        assertThat(snapshot.getMedian()).isEqualTo(1000);
+        assertThat(snapshot.size()).isEqualTo(1);
+    }
+
+    private static void assertAllValuesBetween(DoubleReservoir reservoir,
+                                               double min,
+                                               double max) {
+        for (double i : reservoir.getSnapshot().getValues()) {
+            assertThat(i)
+                    .isLessThan(max)
+                    .isGreaterThanOrEqualTo(min);
+        }
+    }
+
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryListenerTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/MetricRegistryListenerTest.java
@@ -3,15 +3,15 @@ package com.codahale.metrics;
 import org.junit.Test;
 
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 public class MetricRegistryListenerTest {
     private final Counter counter = mock(Counter.class);
     private final Histogram histogram = mock(Histogram.class);
+    private final DoubleHistogram doubleHistogram = mock(DoubleHistogram.class);
     private final Meter meter = mock(Meter.class);
     private final Timer timer = mock(Timer.class);
     private final MetricRegistryListener listener = new MetricRegistryListener.Base() {
-
     };
 
     @Test
@@ -25,28 +25,35 @@ public class MetricRegistryListenerTest {
     public void noOpsOnCounterAdded() {
         listener.onCounterAdded("blah", counter);
 
-        verifyZeroInteractions(counter);
+        verifyNoMoreInteractions(counter);
     }
 
     @Test
     public void noOpsOnHistogramAdded() {
         listener.onHistogramAdded("blah", histogram);
 
-        verifyZeroInteractions(histogram);
+        verifyNoMoreInteractions(histogram);
+    }
+
+    @Test
+    public void noOpsOnDoubleHistogramAdded() {
+        listener.onDoubleHistogramAdded("blah", doubleHistogram);
+
+        verifyNoMoreInteractions(histogram);
     }
 
     @Test
     public void noOpsOnMeterAdded() {
         listener.onMeterAdded("blah", meter);
 
-        verifyZeroInteractions(meter);
+        verifyNoMoreInteractions(meter);
     }
 
     @Test
     public void noOpsOnTimerAdded() {
         listener.onTimerAdded("blah", timer);
 
-        verifyZeroInteractions(timer);
+        verifyNoMoreInteractions(timer);
     }
 
     @Test
@@ -54,6 +61,7 @@ public class MetricRegistryListenerTest {
         listener.onGaugeRemoved("blah");
         listener.onCounterRemoved("blah");
         listener.onHistogramRemoved("blah");
+        listener.onDoubleHistogramRemoved("blah");
         listener.onMeterRemoved("blah");
         listener.onTimerRemoved("blah");
     }

--- a/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowArrayDoubleReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowArrayDoubleReservoirTest.java
@@ -1,0 +1,150 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("Duplicates")
+public class SlidingTimeWindowArrayDoubleReservoirTest {
+
+    @Test
+    public void storesMeasurementsWithDuplicateTicks() {
+        final Clock clock = mock(Clock.class);
+        final SlidingTimeWindowArrayDoubleReservoir reservoir = new SlidingTimeWindowArrayDoubleReservoir(10, NANOSECONDS, clock);
+
+        when(clock.getTick()).thenReturn(20L);
+
+        reservoir.update(1);
+        reservoir.update(2);
+
+        assertThat(reservoir.getSnapshot().getValues())
+                .containsOnly(1, 2);
+    }
+
+    @Test
+    public void boundsMeasurementsToATimeWindow() {
+        final Clock clock = mock(Clock.class);
+        final SlidingTimeWindowArrayDoubleReservoir reservoir = new SlidingTimeWindowArrayDoubleReservoir(10, NANOSECONDS, clock);
+
+        when(clock.getTick()).thenReturn(0L);
+        reservoir.update(1);
+
+        when(clock.getTick()).thenReturn(5L);
+        reservoir.update(2);
+
+        when(clock.getTick()).thenReturn(10L);
+        reservoir.update(3);
+
+        when(clock.getTick()).thenReturn(15L);
+        reservoir.update(4);
+
+        when(clock.getTick()).thenReturn(20L);
+        reservoir.update(5);
+
+        assertThat(reservoir.getSnapshot().getValues())
+                .containsOnly(4, 5);
+    }
+
+    @Test
+    public void comparisonResultsTest() {
+        int cycles = 1000000;
+        long time = (Long.MAX_VALUE / 256) - (long) (cycles * 0.5);
+        ManualClock manualClock = new ManualClock();
+        manualClock.addNanos(time);
+        int window = 300;
+        Random random = new Random(ThreadLocalRandom.current().nextInt());
+
+        SlidingTimeWindowDoubleReservoir treeReservoir = new SlidingTimeWindowDoubleReservoir(window, NANOSECONDS, manualClock);
+        SlidingTimeWindowArrayDoubleReservoir arrayReservoir = new SlidingTimeWindowArrayDoubleReservoir(window, NANOSECONDS, manualClock);
+
+        for (int i = 0; i < cycles; i++) {
+            manualClock.addNanos(1);
+            treeReservoir.update(i);
+            arrayReservoir.update(i);
+            if (random.nextDouble() < 0.01) {
+                double[] treeValues = treeReservoir.getSnapshot().getValues();
+                double[] arrValues = arrayReservoir.getSnapshot().getValues();
+                assertThat(arrValues).isEqualTo(treeValues);
+            }
+            if (random.nextDouble() < 0.05) {
+                assertThat(arrayReservoir.size()).isEqualTo(treeReservoir.size());
+            }
+        }
+    }
+
+    @Test
+    public void testGetTickOverflow() {
+        final Random random = new Random(0);
+        final int window = 128;
+        AtomicLong counter = new AtomicLong(0L);
+
+        // Note: 'threshold' defines the number of updates submitted to the reservoir after overflowing
+        for (int threshold : Arrays.asList(0, 1, 2, 127, 128, 129, 255, 256, 257)) {
+
+            // Note: 'updatePerTick' defines the number of updates submitted to the reservoir between each tick
+            for (int updatesPerTick : Arrays.asList(1, 2, 127, 128, 129, 255, 256, 257)) {
+                //logger.info("Executing test: threshold={}, updatesPerTick={}", threshold, updatesPerTick);
+
+                // Set the clock to overflow in (2*window+1)ns
+                final ManualClock clock = new ManualClock();
+                clock.addNanos(Long.MAX_VALUE / 256 - 2 * window - clock.getTick());
+                assertThat(clock.getTick() * 256).isGreaterThan(0);
+
+                // Create the reservoir
+                final SlidingTimeWindowArrayDoubleReservoir reservoir = new SlidingTimeWindowArrayDoubleReservoir(window, NANOSECONDS, clock);
+                int updatesAfterThreshold = 0;
+                while (true) {
+                    // Update the reservoir
+                    for (int i = 0; i < updatesPerTick; i++) {
+                        long l = counter.incrementAndGet();
+                        reservoir.update(l);
+                    }
+
+                    // Randomly check the reservoir size
+                    if (random.nextDouble() < 0.1) {
+                        assertThat(reservoir.size())
+                                .as("Bad reservoir size with: threshold=%d, updatesPerTick=%d", threshold, updatesPerTick)
+                                .isLessThanOrEqualTo(window * 256);
+                    }
+
+                    // Update the clock
+                    clock.addNanos(1);
+
+                    // If the clock has overflowed start counting updates
+                    if ((clock.getTick() * 256) < 0) {
+                        if (updatesAfterThreshold++ >= threshold) {
+                            break;
+                        }
+                    }
+                }
+
+                // Check the final reservoir size
+                assertThat(reservoir.size())
+                        .as("Bad final reservoir size with: threshold=%d, updatesPerTick=%d", threshold, updatesPerTick)
+                        .isLessThanOrEqualTo(window * 256);
+
+                // Advance the clock far enough to clear the reservoir.  Note that here the window only loosely defines
+                // the reservoir window; when updatesPerTick is greater than 128 the sliding window will always be well
+                // ahead of the current clock time, and advances in getTick while in trim (called randomly above from
+                // size and every 256 updates).  Until the clock "catches up" advancing the clock will have no effect on
+                // the reservoir, and reservoir.size() will merely move the window forward 1/256th of a ns - as such, an
+                // arbitrary increment of 1s here was used instead to advance the clock well beyond any updates recorded
+                // above.
+                clock.addSeconds(1);
+
+                // The reservoir should now be empty
+                assertThat(reservoir.size())
+                        .as("Bad reservoir size after delay with: threshold=%d, updatesPerTick=%d", threshold, updatesPerTick)
+                        .isEqualTo(0);
+            }
+        }
+    }
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowDoubleReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SlidingTimeWindowDoubleReservoirTest.java
@@ -1,0 +1,119 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SlidingTimeWindowDoubleReservoirTest {
+    @Test
+    public void storesMeasurementsWithDuplicateTicks() {
+        final Clock clock = mock(Clock.class);
+        final SlidingTimeWindowDoubleReservoir reservoir = new SlidingTimeWindowDoubleReservoir(10, NANOSECONDS, clock);
+
+        when(clock.getTick()).thenReturn(20L);
+
+        reservoir.update(1);
+        reservoir.update(2);
+
+        assertThat(reservoir.getSnapshot().getValues())
+                .containsOnly(1, 2);
+    }
+
+    @Test
+    public void boundsMeasurementsToATimeWindow() {
+        final Clock clock = mock(Clock.class);
+        when(clock.getTick()).thenReturn(0L);
+
+        final SlidingTimeWindowDoubleReservoir reservoir = new SlidingTimeWindowDoubleReservoir(10, NANOSECONDS, clock);
+
+        when(clock.getTick()).thenReturn(0L);
+        reservoir.update(1);
+
+        when(clock.getTick()).thenReturn(5L);
+        reservoir.update(2);
+
+        when(clock.getTick()).thenReturn(10L);
+        reservoir.update(3);
+
+        when(clock.getTick()).thenReturn(15L);
+        reservoir.update(4);
+
+        when(clock.getTick()).thenReturn(20L);
+        reservoir.update(5);
+
+        assertThat(reservoir.getSnapshot().getValues())
+                .containsOnly(4, 5);
+    }
+
+    @Test
+    public void testGetTickOverflow() {
+        final Random random = new Random(0);
+        final int window = 128;
+
+        // Note: 'threshold' defines the number of updates submitted to the reservoir after overflowing
+        for (int threshold : Arrays.asList(0, 1, 2, 127, 128, 129, 255, 256, 257)) {
+
+            // Note: 'updatePerTick' defines the number of updates submitted to the reservoir between each tick
+            for (int updatesPerTick : Arrays.asList(1, 2, 127, 128, 129, 255, 256, 257)) {
+                //logger.info("Executing test: threshold={}, updatesPerTick={}", threshold, updatesPerTick);
+
+                final ManualClock clock = new ManualClock();
+
+                // Create the reservoir
+                final SlidingTimeWindowDoubleReservoir reservoir = new SlidingTimeWindowDoubleReservoir(window, NANOSECONDS, clock);
+
+                // Set the clock to overflow in (2*window+1)ns
+                clock.addNanos(Long.MAX_VALUE / 256 - 2 * window - clock.getTick());
+                assertThat(clock.getTick() * 256).isGreaterThan(0);
+
+                int updatesAfterThreshold = 0;
+                while (true) {
+                    // Update the reservoir
+                    for (int i = 0; i < updatesPerTick; i++)
+                        reservoir.update(0);
+
+                    // Randomly check the reservoir size
+                    if (random.nextDouble() < 0.1) {
+                        assertThat(reservoir.size())
+                                .as("Bad reservoir size with: threshold=%d, updatesPerTick=%d", threshold, updatesPerTick)
+                                .isLessThanOrEqualTo(window * 256);
+                    }
+
+                    // Update the clock
+                    clock.addNanos(1);
+
+                    // If the clock has overflowed start counting updates
+                    if ((clock.getTick() * 256) < 0) {
+                        if (updatesAfterThreshold++ >= threshold)
+                            break;
+                    }
+                }
+
+                // Check the final reservoir size
+                assertThat(reservoir.size())
+                        .as("Bad final reservoir size with: threshold=%d, updatesPerTick=%d", threshold, updatesPerTick)
+                        .isLessThanOrEqualTo(window * 256);
+
+                // Advance the clock far enough to clear the reservoir.  Note that here the window only loosely defines
+                // the reservoir window; when updatesPerTick is greater than 128 the sliding window will always be well
+                // ahead of the current clock time, and advances in getTick while in trim (called randomly above from
+                // size and every 256 updates).  Until the clock "catches up" advancing the clock will have no effect on
+                // the reservoir, and reservoir.size() will merely move the window forward 1/256th of a ns - as such, an
+                // arbitrary increment of 1s here was used instead to advance the clock well beyond any updates recorded
+                // above.
+                clock.addSeconds(1);
+
+                // The reservoir should now be empty
+                assertThat(reservoir.size())
+                        .as("Bad reservoir size after delay with: threshold=%d, updatesPerTick=%d", threshold, updatesPerTick)
+                        .isEqualTo(0);
+            }
+        }
+    }
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/SlidingWindowDoubleReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/SlidingWindowDoubleReservoirTest.java
@@ -1,0 +1,29 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SlidingWindowDoubleReservoirTest {
+    private final SlidingWindowDoubleReservoir reservoir = new SlidingWindowDoubleReservoir(3);
+
+    @Test
+    public void handlesSmallDataStreams() {
+        reservoir.update(1);
+        reservoir.update(2);
+
+        assertThat(reservoir.getSnapshot().getValues())
+                .containsOnly(1, 2);
+    }
+
+    @Test
+    public void onlyKeepsTheMostRecentFromBigDataStreams() {
+        reservoir.update(1);
+        reservoir.update(2);
+        reservoir.update(3);
+        reservoir.update(4);
+
+        assertThat(reservoir.getSnapshot().getValues())
+                .containsOnly(2, 3, 4);
+    }
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/UniformDoubleReservoirTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/UniformDoubleReservoirTest.java
@@ -1,0 +1,31 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UniformDoubleReservoirTest {
+    @Test
+    @SuppressWarnings("unchecked")
+    public void aReservoirOf100OutOf1000Elements() {
+        final UniformDoubleReservoir reservoir = new UniformDoubleReservoir(100);
+        for (int i = 0; i < 1000; i++) {
+            reservoir.update(i);
+        }
+
+        final DoubleSnapshot snapshot = reservoir.getSnapshot();
+
+        assertThat(reservoir.size())
+                .isEqualTo(100);
+
+        assertThat(snapshot.size())
+                .isEqualTo(100);
+
+        for (double i : snapshot.getValues()) {
+            assertThat(i)
+                    .isLessThan(1000)
+                    .isGreaterThanOrEqualTo(0);
+        }
+    }
+
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/UniformDoubleSnapshotTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/UniformDoubleSnapshotTest.java
@@ -1,0 +1,198 @@
+package com.codahale.metrics;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Random;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+public class UniformDoubleSnapshotTest {
+    private final DoubleSnapshot DoubleSnapshot = new UniformDoubleSnapshot(new double[]{5, 1, 2, 3, 4});
+
+    @Test
+    public void smallQuantilesAreTheFirstValue() {
+        assertThat(DoubleSnapshot.getValue(0.0))
+                .isEqualTo(1, offset(0.1));
+    }
+
+    @Test
+    public void bigQuantilesAreTheLastValue() {
+        assertThat(DoubleSnapshot.getValue(1.0))
+                .isEqualTo(5, offset(0.1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void disallowsNotANumberQuantile() {
+        DoubleSnapshot.getValue(Double.NaN);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void disallowsNegativeQuantile() {
+        DoubleSnapshot.getValue(-0.5);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void disallowsQuantileOverOne() {
+        DoubleSnapshot.getValue(1.5);
+    }
+
+    @Test
+    public void hasAMedian() {
+        assertThat(DoubleSnapshot.getMedian()).isEqualTo(3, offset(0.1));
+    }
+
+    @Test
+    public void hasAp75() {
+        assertThat(DoubleSnapshot.get75thPercentile()).isEqualTo(4.5, offset(0.1));
+    }
+
+    @Test
+    public void hasAp95() {
+        assertThat(DoubleSnapshot.get95thPercentile()).isEqualTo(5.0, offset(0.1));
+    }
+
+    @Test
+    public void hasAp98() {
+        assertThat(DoubleSnapshot.get98thPercentile()).isEqualTo(5.0, offset(0.1));
+    }
+
+    @Test
+    public void hasAp99() {
+        assertThat(DoubleSnapshot.get99thPercentile()).isEqualTo(5.0, offset(0.1));
+    }
+
+    @Test
+    public void hasAp999() {
+        assertThat(DoubleSnapshot.get999thPercentile()).isEqualTo(5.0, offset(0.1));
+    }
+
+    @Test
+    public void hasValues() {
+        assertThat(DoubleSnapshot.getValues())
+                .containsOnly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void hasASize() {
+        assertThat(DoubleSnapshot.size())
+                .isEqualTo(5);
+    }
+
+    @Test
+    public void canAlsoBeCreatedFromACollectionOfLongs() {
+        final DoubleSnapshot other = new UniformDoubleSnapshot(asList(5D, 1D, 2D, 3D, 4D));
+
+        assertThat(other.getValues())
+                .containsOnly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void correctlyCreatedFromCollectionWithWeakIterator() throws Exception {
+        final ConcurrentSkipListSet<Double> values = new ConcurrentSkipListSet<>();
+
+        // Create a latch to make sure that the background thread has started and
+        // pushed some data to the collection.
+        final CountDownLatch latch = new CountDownLatch(10);
+        final Thread backgroundThread = new Thread(() -> {
+            final Random random = new Random();
+            // Update the collection in the loop to trigger a potential `ArrayOutOfBoundException`
+            // and verify that the DoubleSnapshot doesn't make assumptions about the size of the iterator.
+            while (!Thread.currentThread().isInterrupted()) {
+                values.add(random.nextDouble());
+                latch.countDown();
+            }
+        });
+        backgroundThread.start();
+
+        try {
+            latch.await(5, TimeUnit.SECONDS);
+            assertThat(latch.getCount()).isEqualTo(0);
+
+            // Create a DoubleSnapshot while the  collection is being updated.
+            final DoubleSnapshot DoubleSnapshot = new UniformDoubleSnapshot(values);
+            assertThat(DoubleSnapshot.getValues().length).isGreaterThanOrEqualTo(10);
+        } finally {
+            backgroundThread.interrupt();
+        }
+    }
+
+    @Test
+    public void dumpsToAStream() {
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        DoubleSnapshot.dump(output);
+
+        assertThat(output.toString())
+                .isEqualTo(String.format("1.000000%n2.000000%n3.000000%n4.000000%n5.000000%n"));
+    }
+
+    @Test
+    public void calculatesTheMinimumValue() {
+        assertThat(DoubleSnapshot.getMin())
+                .isEqualTo(1);
+    }
+
+    @Test
+    public void calculatesTheMaximumValue() {
+        assertThat(DoubleSnapshot.getMax())
+                .isEqualTo(5);
+    }
+
+    @Test
+    public void calculatesTheMeanValue() {
+        assertThat(DoubleSnapshot.getMean())
+                .isEqualTo(3.0);
+    }
+
+    @Test
+    public void calculatesTheStdDev() {
+        assertThat(DoubleSnapshot.getStdDev())
+                .isEqualTo(1.5811, offset(0.0001));
+    }
+
+    @Test
+    public void calculatesAMinOfZeroForAnEmptyDoubleSnapshot() {
+        final DoubleSnapshot emptyDoubleSnapshot = new UniformDoubleSnapshot(new double[0]);
+
+        assertThat(emptyDoubleSnapshot.getMin())
+                .isZero();
+    }
+
+    @Test
+    public void calculatesAMaxOfZeroForAnEmptyDoubleSnapshot() {
+        final DoubleSnapshot emptyDoubleSnapshot = new UniformDoubleSnapshot(new double[0]);
+
+        assertThat(emptyDoubleSnapshot.getMax())
+                .isZero();
+    }
+
+    @Test
+    public void calculatesAMeanOfZeroForAnEmptyDoubleSnapshot() {
+        final DoubleSnapshot emptyDoubleSnapshot = new UniformDoubleSnapshot(new double[0]);
+
+        assertThat(emptyDoubleSnapshot.getMean())
+                .isZero();
+    }
+
+    @Test
+    public void calculatesAStdDevOfZeroForAnEmptyDoubleSnapshot() {
+        final DoubleSnapshot emptyDoubleSnapshot = new UniformDoubleSnapshot(new double[0]);
+
+        assertThat(emptyDoubleSnapshot.getStdDev())
+                .isZero();
+    }
+
+    @Test
+    public void calculatesAStdDevOfZeroForASingletonDoubleSnapshot() {
+        final DoubleSnapshot singleItemDoubleSnapshot = new UniformDoubleSnapshot(new double[0]);
+
+        assertThat(singleItemDoubleSnapshot.getStdDev())
+                .isZero();
+    }
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/WeightedDoubleSnapshotTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/WeightedDoubleSnapshotTest.java
@@ -1,0 +1,223 @@
+package com.codahale.metrics;
+
+import com.codahale.metrics.WeightedDoubleSnapshot.WeightedDoubleSample;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class WeightedDoubleSnapshotTest {
+
+    private static List<WeightedDoubleSample> weightedArray(long[] values, double[] weights) {
+        if (values.length != weights.length) {
+            throw new IllegalArgumentException("Mismatched lengths: " + values.length + " vs " + weights.length);
+        }
+
+        final List<WeightedDoubleSample> samples = new ArrayList<>();
+        for (int i = 0; i < values.length; i++) {
+            samples.add(new WeightedDoubleSample(values[i], weights[i]));
+        }
+
+        return samples;
+    }
+
+    private final DoubleSnapshot snapshot = new WeightedDoubleSnapshot(
+            weightedArray(new long[]{5, 1, 2, 3, 4}, new double[]{1, 2, 3, 2, 2}));
+
+    @Test
+    public void smallQuantilesAreTheFirstValue() {
+        assertThat(snapshot.getValue(0.0))
+                .isEqualTo(1.0, offset(0.1));
+    }
+
+    @Test
+    public void bigQuantilesAreTheLastValue() {
+        assertThat(snapshot.getValue(1.0))
+                .isEqualTo(5.0, offset(0.1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void disallowsNotANumberQuantile() {
+        snapshot.getValue(Double.NaN);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void disallowsNegativeQuantile() {
+        snapshot.getValue(-0.5);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void disallowsQuantileOverOne() {
+        snapshot.getValue(1.5);
+    }
+
+    @Test
+    public void hasAMedian() {
+        assertThat(snapshot.getMedian()).isEqualTo(3.0, offset(0.1));
+    }
+
+    @Test
+    public void hasAp75() {
+        assertThat(snapshot.get75thPercentile()).isEqualTo(4.0, offset(0.1));
+    }
+
+    @Test
+    public void hasAp95() {
+        assertThat(snapshot.get95thPercentile()).isEqualTo(5.0, offset(0.1));
+    }
+
+    @Test
+    public void hasAp98() {
+        assertThat(snapshot.get98thPercentile()).isEqualTo(5.0, offset(0.1));
+    }
+
+    @Test
+    public void hasAp99() {
+        assertThat(snapshot.get99thPercentile()).isEqualTo(5.0, offset(0.1));
+    }
+
+    @Test
+    public void hasAp999() {
+        assertThat(snapshot.get999thPercentile()).isEqualTo(5.0, offset(0.1));
+    }
+
+    @Test
+    public void hasValues() {
+        assertThat(snapshot.getValues())
+                .containsOnly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void hasASize() {
+        assertThat(snapshot.size())
+                .isEqualTo(5);
+    }
+
+    @Test
+    public void worksWithUnderestimatedCollections() {
+        final List<WeightedDoubleSample> items = spy(weightedArray(new long[]{5, 1, 2, 3, 4}, new double[]{1, 2, 3, 2, 2}));
+        when(items.size()).thenReturn(4, 5);
+
+        final DoubleSnapshot other = new WeightedDoubleSnapshot(items);
+
+        assertThat(other.getValues())
+                .containsOnly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void worksWithOverestimatedCollections() {
+        final List<WeightedDoubleSample> items = spy(weightedArray(new long[]{5, 1, 2, 3, 4}, new double[]{1, 2, 3, 2, 2}));
+        when(items.size()).thenReturn(6, 5);
+
+        final DoubleSnapshot other = new WeightedDoubleSnapshot(items);
+
+        assertThat(other.getValues())
+                .containsOnly(1, 2, 3, 4, 5);
+    }
+
+    @Test
+    public void dumpsToAStream() {
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        snapshot.dump(output);
+
+        assertThat(output.toString())
+                .isEqualTo(String.format("1.000000%n2.000000%n3.000000%n4.000000%n5.000000%n"));
+    }
+
+    @Test
+    public void calculatesTheMinimumValue() {
+        assertThat(snapshot.getMin())
+                .isEqualTo(1);
+    }
+
+    @Test
+    public void calculatesTheMaximumValue() {
+        assertThat(snapshot.getMax())
+                .isEqualTo(5);
+    }
+
+    @Test
+    public void calculatesTheMeanValue() {
+        assertThat(snapshot.getMean())
+                .isEqualTo(2.7);
+    }
+
+    @Test
+    public void calculatesTheStdDev() {
+        assertThat(snapshot.getStdDev())
+                .isEqualTo(1.2688, offset(0.0001));
+    }
+
+    @Test
+    public void calculatesAMinOfZeroForAnEmptySnapshot() {
+        final DoubleSnapshot emptySnapshot = new WeightedDoubleSnapshot(
+                weightedArray(new long[]{}, new double[]{}));
+
+        assertThat(emptySnapshot.getMin())
+                .isZero();
+    }
+
+    @Test
+    public void calculatesAMaxOfZeroForAnEmptySnapshot() {
+        final DoubleSnapshot emptySnapshot = new WeightedDoubleSnapshot(
+                weightedArray(new long[]{}, new double[]{}));
+
+        assertThat(emptySnapshot.getMax())
+                .isZero();
+    }
+
+    @Test
+    public void calculatesAMeanOfZeroForAnEmptySnapshot() {
+        final DoubleSnapshot emptySnapshot = new WeightedDoubleSnapshot(
+                weightedArray(new long[]{}, new double[]{}));
+
+        assertThat(emptySnapshot.getMean())
+                .isZero();
+    }
+
+    @Test
+    public void calculatesAStdDevOfZeroForAnEmptySnapshot() {
+        final DoubleSnapshot emptySnapshot = new WeightedDoubleSnapshot(
+                weightedArray(new long[]{}, new double[]{}));
+
+        assertThat(emptySnapshot.getStdDev())
+                .isZero();
+    }
+
+    @Test
+    public void calculatesAStdDevOfZeroForASingletonSnapshot() {
+        final DoubleSnapshot singleItemSnapshot = new WeightedDoubleSnapshot(
+                weightedArray(new long[]{1}, new double[]{1.0}));
+
+        assertThat(singleItemSnapshot.getStdDev())
+                .isZero();
+    }
+
+    @Test
+    public void expectNoOverflowForLowWeights() {
+        final DoubleSnapshot scatteredSnapshot = new WeightedDoubleSnapshot(
+                weightedArray(
+                        new long[]{1, 2, 3},
+                        new double[]{Double.MIN_VALUE, Double.MIN_VALUE, Double.MIN_VALUE}
+                )
+        );
+
+        assertThat(scatteredSnapshot.getMean())
+                .isEqualTo(2);
+    }
+
+    @Test
+    public void doesNotProduceNaNValues() {
+        WeightedDoubleSnapshot WeightedDoubleSnapshot = new WeightedDoubleSnapshot(
+                weightedArray(new long[]{1, 2, 3}, new double[]{0, 0, 0}));
+        assertThat(WeightedDoubleSnapshot.getMean()).isEqualTo(0);
+    }
+
+}

--- a/metrics-core/src/test/java/com/codahale/metrics/WeightedDoubleSnapshotTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/WeightedDoubleSnapshotTest.java
@@ -2,6 +2,7 @@ package com.codahale.metrics;
 
 import com.codahale.metrics.WeightedDoubleSnapshot.WeightedDoubleSample;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 
 import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
@@ -9,6 +10,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.offset;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
@@ -101,10 +103,12 @@ public class WeightedDoubleSnapshotTest {
 
     @Test
     public void worksWithUnderestimatedCollections() {
-        final List<WeightedDoubleSample> items = spy(weightedArray(new long[]{5, 1, 2, 3, 4}, new double[]{1, 2, 3, 2, 2}));
-        when(items.size()).thenReturn(4, 5);
+        final List<WeightedDoubleSample> originalItems = weightedArray(new long[]{5, 1, 2, 3, 4}, new double[]{1, 2, 3, 2, 2});
+        final List<WeightedDoubleSample> spyItems = spy(originalItems);
+        doReturn(originalItems.toArray(new WeightedDoubleSample[]{})).when(spyItems).toArray(ArgumentMatchers.any(WeightedDoubleSample[].class));
+        when(spyItems.size()).thenReturn(4, 5);
 
-        final DoubleSnapshot other = new WeightedDoubleSnapshot(items);
+        final DoubleSnapshot other = new WeightedDoubleSnapshot(spyItems);
 
         assertThat(other.getValues())
                 .containsOnly(1, 2, 3, 4, 5);
@@ -112,10 +116,12 @@ public class WeightedDoubleSnapshotTest {
 
     @Test
     public void worksWithOverestimatedCollections() {
-        final List<WeightedDoubleSample> items = spy(weightedArray(new long[]{5, 1, 2, 3, 4}, new double[]{1, 2, 3, 2, 2}));
-        when(items.size()).thenReturn(6, 5);
+        final List<WeightedDoubleSample> originalItems = weightedArray(new long[]{5, 1, 2, 3, 4}, new double[]{1, 2, 3, 2, 2});
+        final List<WeightedDoubleSample> spyItems = spy(originalItems);
+        doReturn(originalItems.toArray(new WeightedDoubleSample[]{})).when(spyItems).toArray(ArgumentMatchers.any(WeightedDoubleSample[].class));
+        when(spyItems.size()).thenReturn(6, 5);
 
-        final DoubleSnapshot other = new WeightedDoubleSnapshot(items);
+        final DoubleSnapshot other = new WeightedDoubleSnapshot(spyItems);
 
         assertThat(other.getValues())
                 .containsOnly(1, 2, 3, 4, 5);

--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
                 <configuration>
-                    <argLine>-Djava.net.preferIPv4Stack=true</argLine>
+                    <argLine>-Djava.net.preferIPv4Stack=true -Duser.language=en -Duser.region=US -Duser.timezone=UTC</argLine>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Naive implementation of histograms for `double` values.

The PR introduces a new type of metric: `DoubleHistogram` and its associated types `DoubleSampling`,  `DoubleSnapshot`, `DoubleReservoir`, and their concrete implementations which are pretty much just copies of their counterparts with `long` values.

Any `Reporter` or `ScheduledReporter` classes will have to explicitly add support for these new types of histograms. Older reporters should be compatible in the way that they don't break but also won't report the new histogram types.

I thought this was preferable over making `Histogram`, `Snapshot`, `Reservoir`, `Sampling` generic which would introduce some breaking changes for all consumers of these classes and wouldn't allow us to keep using primitive number types (`long` and `double`) which would increase memory requirements for the related types (histograms, timers).

Refs #863
Refs #1525