### PR TITLE
Override healthcheck HTTP status

### DIFF
--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
@@ -124,7 +124,8 @@ public class HealthCheckServlet extends HttpServlet {
         if (results.isEmpty()) {
             resp.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
         } else {
-            if (isAllHealthy(results)) {
+            final boolean alwaysOk = Boolean.parseBoolean(req.getParameter("alwaysOk"));
+            if (alwaysOk || isAllHealthy(results)) {
                 resp.setStatus(HttpServletResponse.SC_OK);
             } else {
                 resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
Some monitoring tools only parse responses with status 200. With this change status 500 can be disabled.