### PR TITLE
Bumps `jetty9.version` from 9.4.38.v20210224 to 9.4.39.v20210325.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <jackson.version>2.9.10.8</jackson.version>
-        <jetty9.version>9.4.38.v20210224</jetty9.version>
+        <jetty9.version>9.4.39.v20210325</jetty9.version>
         <slf4j.version>1.7.30</slf4j.version>
         <assertj.version>3.19.0</assertj.version>
         <mockito.version>3.8.0</mockito.version>


### PR DESCRIPTION
Updates `jetty-bom` from 9.4.38.v20210224 to 9.4.39.v20210325
- [Release notes](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.39.v20210325)
- [Commits](eclipse/jetty.project@jetty-9.4.38.v20210224...jetty-9.4.39.v20210325)

Updates `jetty-servlet` from 9.4.38.v20210224 to 9.4.39.v20210325
- [Release notes](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.39.v20210325)
- [Commits](eclipse/jetty.project@jetty-9.4.38.v20210224...jetty-9.4.39.v20210325)

Updates `jetty-http` from 9.4.38.v20210224 to 9.4.39.v20210325
- [Release notes](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.39.v20210325)
- [Commits](eclipse/jetty.project@jetty-9.4.38.v20210224...jetty-9.4.39.v20210325)

Updates `jetty-servlet` from 9.4.38.v20210224 to 9.4.39.v20210325
- [Release notes](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.39.v20210325)
- [Commits](eclipse/jetty.project@jetty-9.4.38.v20210224...jetty-9.4.39.v20210325)

Closes https://github.com/dropwizard/metrics/pull/1832