### PR TITLE
HealthCheckServlet object mapper and status indicator

### DIFF
--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
@@ -187,4 +187,9 @@ public class HealthCheckServlet extends HttpServlet {
         }
         return true;
     }
+
+    // visible for testing
+    ObjectMapper getMapper() {
+        return mapper;
+    }
 }

--- a/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
+++ b/metrics-servlets/src/main/java/com/codahale/metrics/servlets/HealthCheckServlet.java
@@ -1,10 +1,11 @@
 package com.codahale.metrics.servlets;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.util.Map;
-import java.util.SortedMap;
-import java.util.concurrent.ExecutorService;
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckFilter;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.codahale.metrics.json.HealthCheckModule;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
@@ -14,13 +15,11 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import com.codahale.metrics.health.HealthCheck;
-import com.codahale.metrics.health.HealthCheckFilter;
-import com.codahale.metrics.health.HealthCheckRegistry;
-import com.codahale.metrics.json.HealthCheckModule;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.ExecutorService;
 
 public class HealthCheckServlet extends HttpServlet {
     public static abstract class ContextListener implements ServletContextListener {
@@ -46,11 +45,21 @@ public class HealthCheckServlet extends HttpServlet {
             return HealthCheckFilter.ALL;
         }
 
+        /**
+         * @return the {@link ObjectMapper} that shall be used to render health checks,
+         * or {@code null} if the default object mapper should be used.
+         */
+        protected ObjectMapper getObjectMapper() {
+            // don't use an object mapper by default
+            return null;
+        }
+
         @Override
         public void contextInitialized(ServletContextEvent event) {
             final ServletContext context = event.getServletContext();
             context.setAttribute(HEALTH_CHECK_REGISTRY, getHealthCheckRegistry());
             context.setAttribute(HEALTH_CHECK_EXECUTOR, getExecutorService());
+            context.setAttribute(HEALTH_CHECK_MAPPER, getObjectMapper());
         }
 
         @Override
@@ -62,14 +71,18 @@ public class HealthCheckServlet extends HttpServlet {
     public static final String HEALTH_CHECK_REGISTRY = HealthCheckServlet.class.getCanonicalName() + ".registry";
     public static final String HEALTH_CHECK_EXECUTOR = HealthCheckServlet.class.getCanonicalName() + ".executor";
     public static final String HEALTH_CHECK_FILTER = HealthCheckServlet.class.getCanonicalName() + ".healthCheckFilter";
+    public static final String HEALTH_CHECK_MAPPER = HealthCheckServlet.class.getCanonicalName() + ".mapper";
+    public static final String HEALTH_CHECK_HTTP_STATUS_INDICATOR = HealthCheckServlet.class.getCanonicalName() + ".httpStatusIndicator";
 
     private static final long serialVersionUID = -8432996484889177321L;
     private static final String CONTENT_TYPE = "application/json";
+    private static final String HTTP_STATUS_INDICATOR_PARAM = "httpStatusIndicator";
 
     private transient HealthCheckRegistry registry;
     private transient ExecutorService executorService;
     private transient HealthCheckFilter filter;
     private transient ObjectMapper mapper;
+    private transient boolean httpStatusIndicator;
 
     public HealthCheckServlet() {
     }
@@ -97,7 +110,6 @@ public class HealthCheckServlet extends HttpServlet {
             this.executorService = (ExecutorService) executorAttr;
         }
 
-
         final Object filterAttr = context.getAttribute(HEALTH_CHECK_FILTER);
         if (filterAttr instanceof HealthCheckFilter) {
             filter = (HealthCheckFilter) filterAttr;
@@ -106,7 +118,20 @@ public class HealthCheckServlet extends HttpServlet {
             filter = HealthCheckFilter.ALL;
         }
 
-        this.mapper = new ObjectMapper().registerModule(new HealthCheckModule());
+        final Object mapperAttr = context.getAttribute(HEALTH_CHECK_MAPPER);
+        if (mapperAttr instanceof ObjectMapper) {
+            this.mapper = (ObjectMapper) mapperAttr;
+        } else {
+            this.mapper = new ObjectMapper();
+        }
+        this.mapper.registerModule(new HealthCheckModule());
+
+        final Object httpStatusIndicatorAttr = context.getAttribute(HEALTH_CHECK_HTTP_STATUS_INDICATOR);
+        if (httpStatusIndicatorAttr instanceof Boolean) {
+            this.httpStatusIndicator = (Boolean) httpStatusIndicatorAttr;
+        } else {
+            this.httpStatusIndicator = true;
+        }
     }
 
     @Override
@@ -124,7 +149,10 @@ public class HealthCheckServlet extends HttpServlet {
         if (results.isEmpty()) {
             resp.setStatus(HttpServletResponse.SC_NOT_IMPLEMENTED);
         } else {
-            if (isAllHealthy(results)) {
+            final String reqParameter = req.getParameter(HTTP_STATUS_INDICATOR_PARAM);
+            final boolean httpStatusIndicatorParam = Boolean.parseBoolean(reqParameter);
+            final boolean useHttpStatusForHealthCheck = reqParameter == null ? httpStatusIndicator : httpStatusIndicatorParam;
+            if (!useHttpStatusForHealthCheck || isAllHealthy(results)) {
                 resp.setStatus(HttpServletResponse.SC_OK);
             } else {
                 resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
@@ -189,7 +189,7 @@ public class HealthCheckServletTest extends AbstractServletTest {
         healthCheckServlet.init(servletConfig);
 
         verify(servletConfig, times(1)).getServletContext();
-        verify(servletContext, never()).getAttribute(eq(HealthCheckServlet.HEALTH_CHECK_REGISTRY));
+        verify(servletContext, never()).getAttribute(HealthCheckServlet.HEALTH_CHECK_REGISTRY);
     }
 
     @Test
@@ -198,14 +198,14 @@ public class HealthCheckServletTest extends AbstractServletTest {
         final ServletContext servletContext = mock(ServletContext.class);
         final ServletConfig servletConfig = mock(ServletConfig.class);
         when(servletConfig.getServletContext()).thenReturn(servletContext);
-        when(servletContext.getAttribute(eq(HealthCheckServlet.HEALTH_CHECK_REGISTRY)))
+        when(servletContext.getAttribute(HealthCheckServlet.HEALTH_CHECK_REGISTRY))
                 .thenReturn(healthCheckRegistry);
 
         final HealthCheckServlet healthCheckServlet = new HealthCheckServlet(null);
         healthCheckServlet.init(servletConfig);
 
         verify(servletConfig, times(1)).getServletContext();
-        verify(servletContext, times(1)).getAttribute(eq(HealthCheckServlet.HEALTH_CHECK_REGISTRY));
+        verify(servletContext, times(1)).getAttribute(HealthCheckServlet.HEALTH_CHECK_REGISTRY);
     }
 
     @Test(expected = ServletException.class)
@@ -213,7 +213,7 @@ public class HealthCheckServletTest extends AbstractServletTest {
         final ServletContext servletContext = mock(ServletContext.class);
         final ServletConfig servletConfig = mock(ServletConfig.class);
         when(servletConfig.getServletContext()).thenReturn(servletContext);
-        when(servletContext.getAttribute(eq(HealthCheckServlet.HEALTH_CHECK_REGISTRY)))
+        when(servletContext.getAttribute(HealthCheckServlet.HEALTH_CHECK_REGISTRY))
                 .thenReturn("IRELLEVANT_STRING");
 
         final HealthCheckServlet healthCheckServlet = new HealthCheckServlet(null);
@@ -225,11 +225,15 @@ public class HealthCheckServletTest extends AbstractServletTest {
         final ServletContext servletContext = mock(ServletContext.class);
         final ServletConfig servletConfig = mock(ServletConfig.class);
         when(servletConfig.getServletContext()).thenReturn(servletContext);
-        when(servletContext.getAttribute(eq(HealthCheckServlet.HEALTH_CHECK_REGISTRY))).thenReturn(registry);
-        when(servletContext.getAttribute(eq(HealthCheckServlet.HEALTH_CHECK_MAPPER))).thenReturn("IRELLEVANT_STRING");
+        when(servletContext.getAttribute(HealthCheckServlet.HEALTH_CHECK_REGISTRY)).thenReturn(registry);
+        when(servletContext.getAttribute(HealthCheckServlet.HEALTH_CHECK_MAPPER)).thenReturn("IRELLEVANT_STRING");
 
         final HealthCheckServlet healthCheckServlet = new HealthCheckServlet(null);
         healthCheckServlet.init(servletConfig);
+
+        assertThat(healthCheckServlet.getMapper())
+                .isNotNull()
+                .isInstanceOf(ObjectMapper.class);
     }
 
     static class TestHealthCheck extends HealthCheck {

--- a/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
+++ b/metrics-servlets/src/test/java/com/codahale/metrics/servlets/HealthCheckServletTest.java
@@ -1,5 +1,25 @@
 package com.codahale.metrics.servlets;
 
+import com.codahale.metrics.Clock;
+import com.codahale.metrics.health.HealthCheck;
+import com.codahale.metrics.health.HealthCheckFilter;
+import com.codahale.metrics.health.HealthCheckRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.servlet.ServletTester;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -7,26 +27,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-
-import com.codahale.metrics.Clock;
-import org.eclipse.jetty.http.HttpHeader;
-import org.eclipse.jetty.servlet.ServletTester;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import com.codahale.metrics.health.HealthCheck;
-import com.codahale.metrics.health.HealthCheckFilter;
-import com.codahale.metrics.health.HealthCheckRegistry;
 
 public class HealthCheckServletTest extends AbstractServletTest {
 
@@ -51,12 +51,14 @@ public class HealthCheckServletTest extends AbstractServletTest {
 
     private final HealthCheckRegistry registry = new HealthCheckRegistry();
     private final ExecutorService threadPool = Executors.newCachedThreadPool();
+    private final ObjectMapper mapper = new ObjectMapper();
 
     @Override
     protected void setUp(ServletTester tester) {
         tester.addServlet(HealthCheckServlet.class, "/healthchecks");
         tester.setAttribute("com.codahale.metrics.servlets.HealthCheckServlet.registry", registry);
         tester.setAttribute("com.codahale.metrics.servlets.HealthCheckServlet.executor", threadPool);
+        tester.setAttribute("com.codahale.metrics.servlets.HealthCheckServlet.mapper", mapper);
         tester.setAttribute("com.codahale.metrics.servlets.HealthCheckServlet.healthCheckFilter",
                 (HealthCheckFilter) (name, healthCheck) -> !"filtered".equals(name));
     }
@@ -77,136 +79,79 @@ public class HealthCheckServletTest extends AbstractServletTest {
     public void returns501IfNoHealthChecksAreRegistered() throws Exception {
         processRequest();
 
-        assertThat(response.getStatus())
-                .isEqualTo(501);
-        assertThat(response.getContent())
-                .isEqualTo("{}");
-        assertThat(response.get(HttpHeader.CONTENT_TYPE))
-                .isEqualTo("application/json");
+        assertThat(response.getStatus()).isEqualTo(501);
+        assertThat(response.get(HttpHeader.CONTENT_TYPE)).isEqualTo("application/json");
+        assertThat(response.getContent()).isEqualTo("{}");
     }
 
     @Test
     public void returnsA200IfAllHealthChecksAreHealthy() throws Exception {
-        registry.register("fun", new HealthCheck() {
-            @Override
-            protected Result check() {
-                return healthyResultUsingFixedClockWithMessage("whee");
-            }
-
-            @Override
-            protected Clock clock() {
-                return FIXED_CLOCK;
-            }
-        });
+        registry.register("fun", new TestHealthCheck(() -> healthyResultWithMessage("whee")));
 
         processRequest();
 
-        assertThat(response.getStatus())
-                .isEqualTo(200);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.get(HttpHeader.CONTENT_TYPE)).isEqualTo("application/json");
         assertThat(response.getContent())
                 .isEqualTo("{\"fun\":{\"healthy\":true,\"message\":\"whee\",\"duration\":0,\"timestamp\":\"" +
                         EXPECTED_TIMESTAMP +
                         "\"}}");
-        assertThat(response.get(HttpHeader.CONTENT_TYPE))
-                .isEqualTo("application/json");
     }
 
     @Test
     public void returnsASubsetOfHealthChecksIfFiltered() throws Exception {
-        registry.register("fun", new HealthCheck() {
-            @Override
-            protected Result check() {
-                return healthyResultUsingFixedClockWithMessage("whee");
-            }
-
-            @Override
-            protected Clock clock() {
-                return FIXED_CLOCK;
-            }
-        });
-
-        registry.register("filtered", new HealthCheck() {
-            @Override
-            protected Result check() {
-                return Result.unhealthy("whee");
-            }
-
-            @Override
-            protected Clock clock() {
-                return FIXED_CLOCK;
-            }
-        });
+        registry.register("fun", new TestHealthCheck(() -> healthyResultWithMessage("whee")));
+        registry.register("filtered", new TestHealthCheck(() -> unhealthyResultWithMessage("whee")));
 
         processRequest();
 
-        assertThat(response.getStatus())
-                .isEqualTo(200);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.get(HttpHeader.CONTENT_TYPE)).isEqualTo("application/json");
         assertThat(response.getContent())
                 .isEqualTo("{\"fun\":{\"healthy\":true,\"message\":\"whee\",\"duration\":0,\"timestamp\":\"" +
                         EXPECTED_TIMESTAMP +
                         "\"}}");
-        assertThat(response.get(HttpHeader.CONTENT_TYPE))
-                .isEqualTo("application/json");
     }
 
     @Test
     public void returnsA500IfAnyHealthChecksAreUnhealthy() throws Exception {
-        registry.register("fun", new HealthCheck() {
-            @Override
-            protected Result check() {
-                return healthyResultUsingFixedClockWithMessage("whee");
-            }
-
-            @Override
-            protected Clock clock() {
-                return FIXED_CLOCK;
-            }
-        });
-
-        registry.register("notFun", new HealthCheck() {
-            @Override
-            protected Result check() {
-                return Result.builder().usingClock(FIXED_CLOCK).unhealthy().withMessage("whee").build();
-            }
-
-            @Override
-            protected Clock clock() {
-                return FIXED_CLOCK;
-            }
-        });
+        registry.register("fun", new TestHealthCheck(() -> healthyResultWithMessage("whee")));
+        registry.register("notFun", new TestHealthCheck(() -> unhealthyResultWithMessage("whee")));
 
         processRequest();
 
-        assertThat(response.getStatus())
-                .isEqualTo(500);
-        assertThat(response.getContent())
-                .contains(
+        assertThat(response.getStatus()).isEqualTo(500);
+        assertThat(response.get(HttpHeader.CONTENT_TYPE)).isEqualTo("application/json");
+        assertThat(response.getContent()).contains(
                         "{\"fun\":{\"healthy\":true,\"message\":\"whee\",\"duration\":0,\"timestamp\":\"" + EXPECTED_TIMESTAMP + "\"}",
                         ",\"notFun\":{\"healthy\":false,\"message\":\"whee\",\"duration\":0,\"timestamp\":\"" + EXPECTED_TIMESTAMP + "\"}}");
-        assertThat(response.get(HttpHeader.CONTENT_TYPE))
-                .isEqualTo("application/json");
+    }
+
+    @Test
+    public void returnsA200IfAnyHealthChecksAreUnhealthyAndHttpStatusIndicatorIsDisabled() throws Exception {
+        registry.register("fun", new TestHealthCheck(() -> healthyResultWithMessage("whee")));
+        registry.register("notFun", new TestHealthCheck(() -> unhealthyResultWithMessage("whee")));
+        request.setURI("/healthchecks?httpStatusIndicator=false");
+
+        processRequest();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.get(HttpHeader.CONTENT_TYPE)).isEqualTo("application/json");
+        assertThat(response.getContent()).contains(
+                "{\"fun\":{\"healthy\":true,\"message\":\"whee\",\"duration\":0,\"timestamp\":\"" + EXPECTED_TIMESTAMP + "\"}",
+                ",\"notFun\":{\"healthy\":false,\"message\":\"whee\",\"duration\":0,\"timestamp\":\"" + EXPECTED_TIMESTAMP + "\"}}");
     }
 
     @Test
     public void optionallyPrettyPrintsTheJson() throws Exception {
-        registry.register("fun", new HealthCheck() {
-            @Override
-            protected Result check() {
-                return healthyResultUsingFixedClockWithMessage("foo bar 123");
-            }
-
-            @Override
-            protected Clock clock() {
-                return FIXED_CLOCK;
-            }
-        });
+        registry.register("fun", new TestHealthCheck(() -> healthyResultWithMessage("foo bar 123")));
 
         request.setURI("/healthchecks?pretty=true");
 
         processRequest();
 
-        assertThat(response.getStatus())
-                .isEqualTo(200);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.get(HttpHeader.CONTENT_TYPE)).isEqualTo("application/json");
         assertThat(response.getContent())
                 .isEqualTo(String.format("{%n" +
                         "  \"fun\" : {%n" +
@@ -215,13 +160,19 @@ public class HealthCheckServletTest extends AbstractServletTest {
                         "    \"duration\" : 0,%n" +
                         "    \"timestamp\" : \"" + EXPECTED_TIMESTAMP + "\"" +
                         "%n  }%n}"));
-        assertThat(response.get(HttpHeader.CONTENT_TYPE))
-                .isEqualTo("application/json");
     }
 
-    private static HealthCheck.Result healthyResultUsingFixedClockWithMessage(String message) {
+    private static HealthCheck.Result healthyResultWithMessage(String message) {
         return HealthCheck.Result.builder()
                 .healthy()
+                .withMessage(message)
+                .usingClock(FIXED_CLOCK)
+                .build();
+    }
+
+    private static HealthCheck.Result unhealthyResultWithMessage(String message) {
+        return HealthCheck.Result.builder()
+                .unhealthy()
                 .withMessage(message)
                 .usingClock(FIXED_CLOCK)
                 .build();
@@ -267,5 +218,35 @@ public class HealthCheckServletTest extends AbstractServletTest {
 
         final HealthCheckServlet healthCheckServlet = new HealthCheckServlet(null);
         healthCheckServlet.init(servletConfig);
+    }
+
+    @Test
+    public void constructorWithObjectMapperAsArgumentUsesServletConfigWhenNullButWrongTypeInContext() throws Exception {
+        final ServletContext servletContext = mock(ServletContext.class);
+        final ServletConfig servletConfig = mock(ServletConfig.class);
+        when(servletConfig.getServletContext()).thenReturn(servletContext);
+        when(servletContext.getAttribute(eq(HealthCheckServlet.HEALTH_CHECK_REGISTRY))).thenReturn(registry);
+        when(servletContext.getAttribute(eq(HealthCheckServlet.HEALTH_CHECK_MAPPER))).thenReturn("IRELLEVANT_STRING");
+
+        final HealthCheckServlet healthCheckServlet = new HealthCheckServlet(null);
+        healthCheckServlet.init(servletConfig);
+    }
+
+    static class TestHealthCheck extends HealthCheck {
+        private final Callable<Result> check;
+
+        public TestHealthCheck(Callable<Result> check) {
+            this.check = check;
+        }
+
+        @Override
+        protected Result check() throws Exception {
+            return check.call();
+        }
+
+        @Override
+        protected Clock clock() {
+            return FIXED_CLOCK;
+        }
     }
 }


### PR DESCRIPTION
- Allow overriding the `ObjectMapper` instance used in `HealthCheckServlet` with the servlet attribute `com.codahale.metrics.servlets.HealthCheckServlet.mapper`
- Allow setting the HTTP status code used to indicate health to 200 (OK) with the servlet attribute `com.codahale.metrics.servlets.HealthCheckServlet.httpStatusIndicator`, or with the HTTP query parameter `httpStatusIndicator` per request

Refs #1821