### PR TITLE
Add missing modules to `metrics-bom`

### DIFF
--- a/metrics-bom/pom.xml
+++ b/metrics-bom/pom.xml
@@ -27,6 +27,11 @@
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-caffeine3</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-core</artifactId>
                 <version>${project.version}</version>
             </dependency>
@@ -53,6 +58,11 @@
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-httpclient</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-httpclient5</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
In the `metrics-bom` module there are no specifications for `metrics-httpclient5` and `metrics-caffeine3`. As Jetty and Jersey have different versions in the bom too, I think these modules can be added as well.