### PR TITLE
Update repository URLs for new OSSRH Sonatype instance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,12 +113,12 @@
         <snapshotRepository>
             <id>ossrh</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>ossrh</id>
             <name>Nexus Release Repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 
@@ -215,7 +215,7 @@
                         <version>1.6.8</version>
                         <configuration>
                             <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
                             <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                         <executions>


### PR DESCRIPTION
After the migration to the new OSSRH Sonatype instance releases will hopefully be more reliable.

https://central.sonatype.org/news/20210223_new-users-on-s01/
https://issues.sonatype.org/browse/OSSRH-76149