### PR TITLE
Ensure that start times aren't overwritten by concurrent asynchronous…

### DIFF
--- a/metrics-jetty10/src/main/java/io/dropwizard/metrics/jetty10/InstrumentedHandler.java
+++ b/metrics-jetty10/src/main/java/io/dropwizard/metrics/jetty10/InstrumentedHandler.java
@@ -209,36 +209,7 @@ public class InstrumentedHandler extends HandlerWrapper {
         });
 
 
-        this.listener = new AsyncListener() {
-            private long startTime;
-
-            @Override
-            public void onTimeout(AsyncEvent event) throws IOException {
-                asyncTimeouts.mark();
-            }
-
-            @Override
-            public void onStartAsync(AsyncEvent event) throws IOException {
-                startTime = System.currentTimeMillis();
-                event.getAsyncContext().addListener(this);
-            }
-
-            @Override
-            public void onError(AsyncEvent event) throws IOException {
-            }
-
-            @Override
-            public void onComplete(AsyncEvent event) throws IOException {
-                final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
-                final HttpServletRequest request = (HttpServletRequest) state.getRequest();
-                final HttpServletResponse response = (HttpServletResponse) state.getResponse();
-                updateResponses(request, response, startTime, true);
-                if (state.getHttpChannelState().getState() != HttpChannelState.State.HANDLING &&
-                        state.getHttpChannelState().isSuspended()) {
-                    activeSuspended.dec();
-                }
-            }
-        };
+        this.listener = new AsyncAttachingListener();
     }
 
     @Override
@@ -367,5 +338,54 @@ public class InstrumentedHandler extends HandlerWrapper {
 
     private String getMetricPrefix() {
         return this.prefix == null ? name(getHandler().getClass(), name) : name(this.prefix, name);
+    }
+
+    private class AsyncAttachingListener implements AsyncListener {
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+            event.getAsyncContext().addListener(new InstrumentedAsyncListener());
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {}
+    };
+
+    private class InstrumentedAsyncListener implements AsyncListener {
+        private final long startTime;
+
+        InstrumentedAsyncListener() {
+            this.startTime = System.currentTimeMillis();
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {
+            asyncTimeouts.mark();
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {
+            final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
+            final HttpServletRequest request = (HttpServletRequest) state.getRequest();
+            final HttpServletResponse response = (HttpServletResponse) state.getResponse();
+            updateResponses(request, response, startTime, true);
+            if (!state.getHttpChannelState().isSuspended()) {
+                activeSuspended.dec();
+            }
+        }
     }
 }

--- a/metrics-jetty11/src/main/java/io/dropwizard/metrics/jetty11/InstrumentedHandler.java
+++ b/metrics-jetty11/src/main/java/io/dropwizard/metrics/jetty11/InstrumentedHandler.java
@@ -209,36 +209,7 @@ public class InstrumentedHandler extends HandlerWrapper {
         });
 
 
-        this.listener = new AsyncListener() {
-            private long startTime;
-
-            @Override
-            public void onTimeout(AsyncEvent event) throws IOException {
-                asyncTimeouts.mark();
-            }
-
-            @Override
-            public void onStartAsync(AsyncEvent event) throws IOException {
-                startTime = System.currentTimeMillis();
-                event.getAsyncContext().addListener(this);
-            }
-
-            @Override
-            public void onError(AsyncEvent event) throws IOException {
-            }
-
-            @Override
-            public void onComplete(AsyncEvent event) throws IOException {
-                final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
-                final HttpServletRequest request = (HttpServletRequest) state.getRequest();
-                final HttpServletResponse response = (HttpServletResponse) state.getResponse();
-                updateResponses(request, response, startTime, true);
-                if (state.getHttpChannelState().getState() != HttpChannelState.State.HANDLING &&
-                        state.getHttpChannelState().isSuspended()) {
-                    activeSuspended.dec();
-                }
-            }
-        };
+        this.listener = new AsyncAttachingListener();
     }
 
     @Override
@@ -367,5 +338,54 @@ public class InstrumentedHandler extends HandlerWrapper {
 
     private String getMetricPrefix() {
         return this.prefix == null ? name(getHandler().getClass(), name) : name(this.prefix, name);
+    }
+
+    private class AsyncAttachingListener implements AsyncListener {
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+            event.getAsyncContext().addListener(new InstrumentedAsyncListener());
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {}
+    };
+
+    private class InstrumentedAsyncListener implements AsyncListener {
+        private final long startTime;
+
+        InstrumentedAsyncListener() {
+            this.startTime = System.currentTimeMillis();
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {
+            asyncTimeouts.mark();
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {
+            final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
+            final HttpServletRequest request = (HttpServletRequest) state.getRequest();
+            final HttpServletResponse response = (HttpServletResponse) state.getResponse();
+            updateResponses(request, response, startTime, true);
+            if (!state.getHttpChannelState().isSuspended()) {
+                activeSuspended.dec();
+            }
+        }
     }
 }

--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -217,36 +217,7 @@ public class InstrumentedHandler extends HandlerWrapper {
         });
 
 
-        this.listener = new AsyncListener() {
-            private long startTime;
-
-            @Override
-            public void onTimeout(AsyncEvent event) throws IOException {
-                asyncTimeouts.mark();
-            }
-
-            @Override
-            public void onStartAsync(AsyncEvent event) throws IOException {
-                startTime = System.currentTimeMillis();
-                event.getAsyncContext().addListener(this);
-            }
-
-            @Override
-            public void onError(AsyncEvent event) throws IOException {
-            }
-
-            @Override
-            public void onComplete(AsyncEvent event) throws IOException {
-                final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
-                final HttpServletRequest request = (HttpServletRequest) state.getRequest();
-                final HttpServletResponse response = (HttpServletResponse) state.getResponse();
-                updateResponses(request, response, startTime, true);
-                if (state.getHttpChannelState().getState() != DISPATCHED_HACK &&
-                        state.getHttpChannelState().isSuspended()) {
-                    activeSuspended.dec();
-                }
-            }
-        };
+        this.listener = new AsyncAttachingListener();
     }
 
     @Override
@@ -375,5 +346,54 @@ public class InstrumentedHandler extends HandlerWrapper {
 
     private String getMetricPrefix() {
         return this.prefix == null ? name(getHandler().getClass(), name) : name(this.prefix, name);
+    }
+
+    private class AsyncAttachingListener implements AsyncListener {
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+            event.getAsyncContext().addListener(new InstrumentedAsyncListener());
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {}
+    };
+
+    private class InstrumentedAsyncListener implements AsyncListener {
+        private final long startTime;
+
+        InstrumentedAsyncListener() {
+            this.startTime = System.currentTimeMillis();
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {
+            asyncTimeouts.mark();
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {
+            final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
+            final HttpServletRequest request = (HttpServletRequest) state.getRequest();
+            final HttpServletResponse response = (HttpServletResponse) state.getResponse();
+            updateResponses(request, response, startTime, true);
+            if (!state.getHttpChannelState().isSuspended()) {
+                activeSuspended.dec();
+            }
+        }
     }
 }

--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHttpChannelListener.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHttpChannelListener.java
@@ -169,35 +169,7 @@ public class InstrumentedHttpChannelListener
             }
         });
 
-        this.listener = new AsyncListener() {
-            private long startTime;
-
-            @Override
-            public void onTimeout(AsyncEvent event) throws IOException {
-                asyncTimeouts.mark();
-            }
-
-            @Override
-            public void onStartAsync(AsyncEvent event) throws IOException {
-                startTime = System.currentTimeMillis();
-                event.getAsyncContext().addListener(this);
-            }
-
-            @Override
-            public void onError(AsyncEvent event) throws IOException {
-            }
-
-            @Override
-            public void onComplete(AsyncEvent event) throws IOException {
-                final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
-                final HttpServletRequest request = (HttpServletRequest) state.getRequest();
-                final HttpServletResponse response = (HttpServletResponse) state.getResponse();
-                updateResponses(request, response, startTime, true);
-                if (!state.getHttpChannelState().isSuspended()) {
-                    activeSuspended.dec();
-                }
-            }
-        };
+        this.listener = new AsyncAttachingListener();
     }
 
     @Override
@@ -355,6 +327,55 @@ public class InstrumentedHttpChannelListener
                     return moveRequests;
                 default:
                     return otherRequests;
+            }
+        }
+    }
+
+    private class AsyncAttachingListener implements AsyncListener {
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+            event.getAsyncContext().addListener(new InstrumentedAsyncListener());
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {}
+    };
+
+    private class InstrumentedAsyncListener implements AsyncListener {
+        private final long startTime;
+
+        InstrumentedAsyncListener() {
+            this.startTime = System.currentTimeMillis();
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {
+            asyncTimeouts.mark();
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {
+            final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
+            final HttpServletRequest request = (HttpServletRequest) state.getRequest();
+            final HttpServletResponse response = (HttpServletResponse) state.getResponse();
+            updateResponses(request, response, startTime, true);
+            if (!state.getHttpChannelState().isSuspended()) {
+                activeSuspended.dec();
             }
         }
     }


### PR DESCRIPTION
… requests.

Resolves https://github.com/dropwizard/metrics/issues/2121

To limit increasing the memory footprint, I added an `AsyncAttachingListener` to replace the old anonymous `AsyncListener`. Which creates a new listener if an async request is actually processed, which has a final `startTime` that cannot be overwritten. I made the change in `InstrumentedHandler` and `InstrumentedHttpChannelListener` for each of the jetty versions, since the race condition exists in each one. The tests seem to be passing, but I can probably add something if the current tests aren't viewed as sufficient. I do notice the async tests are marked with ignore.