### PR TITLE
Don't overwrite start time in InstrumentedHandler with concurrent async requests

### DIFF
--- a/metrics-jetty10/src/main/java/io/dropwizard/metrics5/jetty10/InstrumentedHandler.java
+++ b/metrics-jetty10/src/main/java/io/dropwizard/metrics5/jetty10/InstrumentedHandler.java
@@ -210,36 +210,7 @@ public class InstrumentedHandler extends HandlerWrapper {
         });
 
 
-        this.listener = new AsyncListener() {
-            private long startTime;
-
-            @Override
-            public void onTimeout(AsyncEvent event) throws IOException {
-                asyncTimeouts.mark();
-            }
-
-            @Override
-            public void onStartAsync(AsyncEvent event) throws IOException {
-                startTime = System.currentTimeMillis();
-                event.getAsyncContext().addListener(this);
-            }
-
-            @Override
-            public void onError(AsyncEvent event) throws IOException {
-            }
-
-            @Override
-            public void onComplete(AsyncEvent event) throws IOException {
-                final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
-                final HttpServletRequest request = (HttpServletRequest) state.getRequest();
-                final HttpServletResponse response = (HttpServletResponse) state.getResponse();
-                updateResponses(request, response, startTime, true);
-                if (state.getHttpChannelState().getState() != HttpChannelState.State.HANDLING &&
-                        state.getHttpChannelState().isSuspended()) {
-                    activeSuspended.dec();
-                }
-            }
-        };
+        this.listener = new AsyncAttachingListener();
     }
 
     @Override
@@ -368,5 +339,54 @@ public class InstrumentedHandler extends HandlerWrapper {
 
     private MetricName getMetricPrefix() {
         return this.prefix == null ? name(getHandler().getClass(), name) : name(this.prefix, name);
+    }
+
+    private class AsyncAttachingListener implements AsyncListener {
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+            event.getAsyncContext().addListener(new InstrumentedAsyncListener());
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {}
+    };
+
+    private class InstrumentedAsyncListener implements AsyncListener {
+        private final long startTime;
+
+        InstrumentedAsyncListener() {
+            this.startTime = System.currentTimeMillis();
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {
+            asyncTimeouts.mark();
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {
+            final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
+            final HttpServletRequest request = (HttpServletRequest) state.getRequest();
+            final HttpServletResponse response = (HttpServletResponse) state.getResponse();
+            updateResponses(request, response, startTime, true);
+            if (!state.getHttpChannelState().isSuspended()) {
+                activeSuspended.dec();
+            }
+        }
     }
 }

--- a/metrics-jetty10/src/main/java/io/dropwizard/metrics5/jetty10/InstrumentedHttpChannelListener.java
+++ b/metrics-jetty10/src/main/java/io/dropwizard/metrics5/jetty10/InstrumentedHttpChannelListener.java
@@ -166,35 +166,7 @@ public class InstrumentedHttpChannelListener
             }
         });
 
-        this.listener = new AsyncListener() {
-            private long startTime;
-
-            @Override
-            public void onTimeout(AsyncEvent event) throws IOException {
-                asyncTimeouts.mark();
-            }
-
-            @Override
-            public void onStartAsync(AsyncEvent event) throws IOException {
-                startTime = System.currentTimeMillis();
-                event.getAsyncContext().addListener(this);
-            }
-
-            @Override
-            public void onError(AsyncEvent event) throws IOException {
-            }
-
-            @Override
-            public void onComplete(AsyncEvent event) throws IOException {
-                final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
-                final HttpServletRequest request = (HttpServletRequest) state.getRequest();
-                final HttpServletResponse response = (HttpServletResponse) state.getResponse();
-                updateResponses(request, response, startTime, true);
-                if (!state.getHttpChannelState().isSuspended()) {
-                    activeSuspended.dec();
-                }
-            }
-        };
+        this.listener = new AsyncAttachingListener();
     }
 
     @Override
@@ -352,6 +324,55 @@ public class InstrumentedHttpChannelListener
                     return moveRequests;
                 default:
                     return otherRequests;
+            }
+        }
+    }
+
+    private class AsyncAttachingListener implements AsyncListener {
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+            event.getAsyncContext().addListener(new InstrumentedAsyncListener());
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {}
+    };
+
+    private class InstrumentedAsyncListener implements AsyncListener {
+        private final long startTime;
+
+        InstrumentedAsyncListener() {
+            this.startTime = System.currentTimeMillis();
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {
+            asyncTimeouts.mark();
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {
+            final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
+            final HttpServletRequest request = (HttpServletRequest) state.getRequest();
+            final HttpServletResponse response = (HttpServletResponse) state.getResponse();
+            updateResponses(request, response, startTime, true);
+            if (!state.getHttpChannelState().isSuspended()) {
+                activeSuspended.dec();
             }
         }
     }

--- a/metrics-jetty11/src/main/java/io/dropwizard/metrics5/jetty11/InstrumentedHandler.java
+++ b/metrics-jetty11/src/main/java/io/dropwizard/metrics5/jetty11/InstrumentedHandler.java
@@ -209,38 +209,7 @@ public class InstrumentedHandler extends HandlerWrapper {
             }
         });
 
-
-
-        this.listener = new AsyncListener() {
-            private long startTime;
-
-            @Override
-            public void onTimeout(AsyncEvent event) throws IOException {
-                asyncTimeouts.mark();
-            }
-
-            @Override
-            public void onStartAsync(AsyncEvent event) throws IOException {
-                startTime = System.currentTimeMillis();
-                event.getAsyncContext().addListener(this);
-            }
-
-            @Override
-            public void onError(AsyncEvent event) throws IOException {
-            }
-
-            @Override
-            public void onComplete(AsyncEvent event) throws IOException {
-                final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
-                final HttpServletRequest request = (HttpServletRequest) state.getRequest();
-                final HttpServletResponse response = (HttpServletResponse) state.getResponse();
-                updateResponses(request, response, startTime, true);
-                if (state.getHttpChannelState().getState() != HttpChannelState.State.HANDLING &&
-                        state.getHttpChannelState().isSuspended()) {
-                    activeSuspended.dec();
-                }
-            }
-        };
+        this.listener = new AsyncAttachingListener();
     }
 
     @Override
@@ -369,5 +338,54 @@ public class InstrumentedHandler extends HandlerWrapper {
 
     private MetricName getMetricPrefix() {
         return this.prefix == null ? name(getHandler().getClass(), name) : name(this.prefix, name);
+    }
+
+    private class AsyncAttachingListener implements AsyncListener {
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+            event.getAsyncContext().addListener(new InstrumentedAsyncListener());
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {}
+    };
+
+    private class InstrumentedAsyncListener implements AsyncListener {
+        private final long startTime;
+
+        InstrumentedAsyncListener() {
+            this.startTime = System.currentTimeMillis();
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {
+            asyncTimeouts.mark();
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {
+            final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
+            final HttpServletRequest request = (HttpServletRequest) state.getRequest();
+            final HttpServletResponse response = (HttpServletResponse) state.getResponse();
+            updateResponses(request, response, startTime, true);
+            if (!state.getHttpChannelState().isSuspended()) {
+                activeSuspended.dec();
+            }
+        }
     }
 }

--- a/metrics-jetty11/src/main/java/io/dropwizard/metrics5/jetty11/InstrumentedHttpChannelListener.java
+++ b/metrics-jetty11/src/main/java/io/dropwizard/metrics5/jetty11/InstrumentedHttpChannelListener.java
@@ -166,35 +166,7 @@ public class InstrumentedHttpChannelListener
             }
         });
 
-        this.listener = new AsyncListener() {
-            private long startTime;
-
-            @Override
-            public void onTimeout(AsyncEvent event) throws IOException {
-                asyncTimeouts.mark();
-            }
-
-            @Override
-            public void onStartAsync(AsyncEvent event) throws IOException {
-                startTime = System.currentTimeMillis();
-                event.getAsyncContext().addListener(this);
-            }
-
-            @Override
-            public void onError(AsyncEvent event) throws IOException {
-            }
-
-            @Override
-            public void onComplete(AsyncEvent event) throws IOException {
-                final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
-                final HttpServletRequest request = (HttpServletRequest) state.getRequest();
-                final HttpServletResponse response = (HttpServletResponse) state.getResponse();
-                updateResponses(request, response, startTime, true);
-                if (!state.getHttpChannelState().isSuspended()) {
-                    activeSuspended.dec();
-                }
-            }
-        };
+        this.listener = new AsyncAttachingListener();
     }
 
     @Override
@@ -352,6 +324,55 @@ public class InstrumentedHttpChannelListener
                     return moveRequests;
                 default:
                     return otherRequests;
+            }
+        }
+    }
+
+    private class AsyncAttachingListener implements AsyncListener {
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+            event.getAsyncContext().addListener(new InstrumentedAsyncListener());
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {}
+    };
+
+    private class InstrumentedAsyncListener implements AsyncListener {
+        private final long startTime;
+
+        InstrumentedAsyncListener() {
+            this.startTime = System.currentTimeMillis();
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {
+            asyncTimeouts.mark();
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {
+            final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
+            final HttpServletRequest request = (HttpServletRequest) state.getRequest();
+            final HttpServletResponse response = (HttpServletResponse) state.getResponse();
+            updateResponses(request, response, startTime, true);
+            if (!state.getHttpChannelState().isSuspended()) {
+                activeSuspended.dec();
             }
         }
     }

--- a/metrics-jetty9/src/main/java/io/dropwizard/metrics5/jetty9/InstrumentedHttpChannelListener.java
+++ b/metrics-jetty9/src/main/java/io/dropwizard/metrics5/jetty9/InstrumentedHttpChannelListener.java
@@ -170,35 +170,7 @@ public class InstrumentedHttpChannelListener
             }
         });
 
-        this.listener = new AsyncListener() {
-            private long startTime;
-
-            @Override
-            public void onTimeout(AsyncEvent event) throws IOException {
-                asyncTimeouts.mark();
-            }
-
-            @Override
-            public void onStartAsync(AsyncEvent event) throws IOException {
-                startTime = System.currentTimeMillis();
-                event.getAsyncContext().addListener(this);
-            }
-
-            @Override
-            public void onError(AsyncEvent event) throws IOException {
-            }
-
-            @Override
-            public void onComplete(AsyncEvent event) throws IOException {
-                final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
-                final HttpServletRequest request = (HttpServletRequest) state.getRequest();
-                final HttpServletResponse response = (HttpServletResponse) state.getResponse();
-                updateResponses(request, response, startTime, true);
-                if (!state.getHttpChannelState().isSuspended()) {
-                    activeSuspended.dec();
-                }
-            }
-        };
+        this.listener = new AsyncAttachingListener();
     }
 
     @Override
@@ -356,6 +328,55 @@ public class InstrumentedHttpChannelListener
                     return moveRequests;
                 default:
                     return otherRequests;
+            }
+        }
+    }
+
+    private class AsyncAttachingListener implements AsyncListener {
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+            event.getAsyncContext().addListener(new InstrumentedAsyncListener());
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {}
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {}
+    };
+
+    private class InstrumentedAsyncListener implements AsyncListener {
+        private final long startTime;
+
+        InstrumentedAsyncListener() {
+            this.startTime = System.currentTimeMillis();
+        }
+
+        @Override
+        public void onTimeout(AsyncEvent event) throws IOException {
+            asyncTimeouts.mark();
+        }
+
+        @Override
+        public void onStartAsync(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onError(AsyncEvent event) throws IOException {
+        }
+
+        @Override
+        public void onComplete(AsyncEvent event) throws IOException {
+            final AsyncContextState state = (AsyncContextState) event.getAsyncContext();
+            final HttpServletRequest request = (HttpServletRequest) state.getRequest();
+            final HttpServletResponse response = (HttpServletResponse) state.getResponse();
+            updateResponses(request, response, startTime, true);
+            if (!state.getHttpChannelState().isSuspended()) {
+                activeSuspended.dec();
             }
         }
     }


### PR DESCRIPTION
Forward port of #2413 to Dropwizard Metrics 5.x.

Conflicts:
	metrics-jetty11/src/main/java/io/dropwizard/metrics5/jetty11/InstrumentedHandler.java

Closes #2121
Refs #2413

(cherry picked from commit 533cac7124a186ce46c819f0a0806c1ba3210955)