### PR TITLE
Use Gauge<String> values as metric names

### DIFF
--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -474,9 +474,18 @@ public class GraphiteReporter extends ScheduledReporter {
     }
 
     private void reportGauge(String name, Gauge<?> gauge, long timestamp) throws IOException {
-        final String value = format(gauge.getValue());
+        Object value = gauge.getValue();
+        String finalMetricName;
+        String finalValue;
+        if(value instanceof String) {
+            finalMetricName = MetricRegistry.name(prefix, name, (String) value);
+            finalValue = format(1);
+        } else {
+            finalMetricName = prefix(name);
+            finalValue = format(value);
+        }
         if (value != null) {
-            graphite.send(prefix(name), value, timestamp);
+            graphite.send(finalMetricName, finalValue, timestamp);
         }
     }
 

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -477,7 +477,7 @@ public class GraphiteReporter extends ScheduledReporter {
         Object value = gauge.getValue();
         String finalMetricName;
         String finalValue;
-        if(value instanceof String) {
+        if (value instanceof String) {
             finalMetricName = MetricRegistry.name(prefix, name, (String) value);
             finalValue = format(1);
         } else {

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -63,23 +63,6 @@ public class GraphiteReporterTest {
     }
 
     @Test
-    public void doesNotReportStringGaugeValues() throws Exception {
-        reporter.report(map("gauge", gauge("value")),
-            map(),
-            map(),
-            map(),
-            map());
-
-        final InOrder inOrder = inOrder(graphite);
-        inOrder.verify(graphite).connect();
-        inOrder.verify(graphite, never()).send("prefix.gauge", "value", timestamp);
-        inOrder.verify(graphite).flush();
-        inOrder.verify(graphite).close();
-
-        verifyNoMoreInteractions(graphite);
-    }
-
-    @Test
     public void reportsByteGaugeValues() throws Exception {
         reporter.report(map("gauge", gauge((byte) 1)),
             map(),

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -165,6 +165,23 @@ public class GraphiteReporterTest {
     }
 
     @Test
+    public void reportsStringGaugeValues() throws Exception {
+        reporter.report(map("gauge", gauge("statusOk")),
+                map(),
+                map(),
+                map(),
+                map());
+
+        final InOrder inOrder = inOrder(graphite);
+        inOrder.verify(graphite).connect();
+        inOrder.verify(graphite).send("prefix.gauge.statusOk", "1", timestamp);
+        inOrder.verify(graphite).flush();
+        inOrder.verify(graphite).close();
+
+        verifyNoMoreInteractions(graphite);
+    }
+
+    @Test
     public void reportsDoubleGaugeValues() throws Exception {
         reporter.report(map("gauge", gauge(1.1)),
             map(),


### PR DESCRIPTION
A lot of metric use gauges of type String to report the status of a component (e.g. failed / running). Currently all those values are discared since they are not numeric. This commit appends the value of the gauge to the metric name and sends it with a constant value of 1.

<a href="https://gitpod.io/#https://github.com/dropwizard/metrics/pull/2639"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

