### PR TITLE
Add a more type safe way of registering gauges in 5.0.x

### DIFF
--- a/metrics-core/src/main/java/io/dropwizard/metrics5/InstrumentedExecutorService.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics5/InstrumentedExecutorService.java
@@ -58,31 +58,31 @@ public class InstrumentedExecutorService implements ExecutorService {
 
         if (delegate instanceof ThreadPoolExecutor) {
             ThreadPoolExecutor executor = (ThreadPoolExecutor) delegate;
-            registry.register(MetricRegistry.name(name, "pool.size"),
-                    (Gauge<Integer>) executor::getPoolSize);
-            registry.register(MetricRegistry.name(name, "pool.core"),
-                    (Gauge<Integer>) executor::getCorePoolSize);
-            registry.register(MetricRegistry.name(name, "pool.max"),
-                    (Gauge<Integer>) executor::getMaximumPoolSize);
+            registry.registerGauge(MetricRegistry.name(name, "pool.size"),
+                    executor::getPoolSize);
+            registry.registerGauge(MetricRegistry.name(name, "pool.core"),
+                    executor::getCorePoolSize);
+            registry.registerGauge(MetricRegistry.name(name, "pool.max"),
+                    executor::getMaximumPoolSize);
             final BlockingQueue<Runnable> queue = executor.getQueue();
-            registry.register(MetricRegistry.name(name, "tasks.active"),
-                    (Gauge<Integer>) executor::getActiveCount);
-            registry.register(MetricRegistry.name(name, "tasks.completed"),
-                    (Gauge<Long>) executor::getCompletedTaskCount);
-            registry.register(MetricRegistry.name(name, "tasks.queued"),
-                    (Gauge<Integer>) queue::size);
-            registry.register(MetricRegistry.name(name, "tasks.capacity"),
-                    (Gauge<Integer>) queue::remainingCapacity);
+            registry.registerGauge(MetricRegistry.name(name, "tasks.active"),
+                    executor::getActiveCount);
+            registry.registerGauge(MetricRegistry.name(name, "tasks.completed"),
+                    executor::getCompletedTaskCount);
+            registry.registerGauge(MetricRegistry.name(name, "tasks.queued"),
+                    queue::size);
+            registry.registerGauge(MetricRegistry.name(name, "tasks.capacity"),
+                    queue::remainingCapacity);
         } else if (delegate instanceof ForkJoinPool) {
             ForkJoinPool forkJoinPool = (ForkJoinPool) delegate;
-            registry.register(MetricRegistry.name(name, "tasks.stolen"),
-                    (Gauge<Long>) forkJoinPool::getStealCount);
-            registry.register(MetricRegistry.name(name, "tasks.queued"),
-                    (Gauge<Long>) forkJoinPool::getQueuedTaskCount);
-            registry.register(MetricRegistry.name(name, "threads.active"),
-                    (Gauge<Integer>) forkJoinPool::getActiveThreadCount);
-            registry.register(MetricRegistry.name(name, "threads.running"),
-                    (Gauge<Integer>) forkJoinPool::getRunningThreadCount);
+            registry.registerGauge(MetricRegistry.name(name, "tasks.stolen"),
+                    forkJoinPool::getStealCount);
+            registry.registerGauge(MetricRegistry.name(name, "tasks.queued"),
+                    forkJoinPool::getQueuedTaskCount);
+            registry.registerGauge(MetricRegistry.name(name, "threads.active"),
+                    forkJoinPool::getActiveThreadCount);
+            registry.registerGauge(MetricRegistry.name(name, "threads.running"),
+                    forkJoinPool::getRunningThreadCount);
         }
     }
 

--- a/metrics-core/src/main/java/io/dropwizard/metrics5/MetricRegistry.java
+++ b/metrics-core/src/main/java/io/dropwizard/metrics5/MetricRegistry.java
@@ -69,6 +69,25 @@ public class MetricRegistry implements MetricSet {
     }
 
     /**
+     * See {@link #registerGauge(MetricName, Gauge)}
+     */
+    public <T> Gauge<T> registerGauge(String name, Gauge<T> metric) throws IllegalArgumentException {
+        return register(MetricName.build(name), metric);
+    }
+
+    /**
+     * Given a {@link Gauge}, registers it under the given name and returns it
+     *
+     * @param name the name of the gauge
+     * @param <T>  the type of the gauge's value
+     * @return the registered {@link Gauge}
+     * @since 4.2.10
+     */
+    public <T> Gauge<T> registerGauge(MetricName name, Gauge<T> metric) throws IllegalArgumentException {
+        return register(name, metric);
+    }
+
+    /**
      * See {@link #register(MetricName, Metric)}
      */
     public <T extends Metric> T register(String name, T metric) throws IllegalArgumentException {
@@ -91,7 +110,7 @@ public class MetricRegistry implements MetricSet {
         }
 
         if (metric instanceof MetricRegistry) {
-            final MetricRegistry childRegistry = (MetricRegistry)metric;
+            final MetricRegistry childRegistry = (MetricRegistry) metric;
             final MetricName childName = name;
             childRegistry.addListener(new MetricRegistryListener() {
                 @Override

--- a/metrics-core/src/test/java/io/dropwizard/metrics5/MetricRegistryTest.java
+++ b/metrics-core/src/test/java/io/dropwizard/metrics5/MetricRegistryTest.java
@@ -664,4 +664,18 @@ public class MetricRegistryTest {
         assertThatThrownBy(() -> registry.register("any_name", null))
                 .hasMessage("metric == null");
     }
+
+    @Test
+    public void infersGaugeType() {
+        Gauge<Long> gauge = registry.registerGauge(GAUGE, () -> 10_000_000_000L);
+
+        assertThat(gauge.getValue()).isEqualTo(10_000_000_000L);
+    }
+
+    @Test
+    public void registersGaugeAsLambda() {
+        registry.registerGauge(GAUGE, () -> 3.14);
+
+        assertThat(registry.gauge(GAUGE).getValue()).isEqualTo(3.14);
+    }
 }

--- a/metrics-ehcache/src/main/java/io/dropwizard/metrics5/ehcache/InstrumentedEhcache.java
+++ b/metrics-ehcache/src/main/java/io/dropwizard/metrics5/ehcache/InstrumentedEhcache.java
@@ -1,6 +1,5 @@
 package io.dropwizard.metrics5.ehcache;
 
-import io.dropwizard.metrics5.Gauge;
 import io.dropwizard.metrics5.MetricName;
 import io.dropwizard.metrics5.MetricRegistry;
 import io.dropwizard.metrics5.Timer;
@@ -11,6 +10,8 @@ import net.sf.ehcache.constructs.EhcacheDecoratorAdapter;
 import net.sf.ehcache.statistics.StatisticsGateway;
 
 import java.io.Serializable;
+
+import static io.dropwizard.metrics5.MetricRegistry.name;
 
 /**
  * An instrumented {@link Ehcache} instance.
@@ -116,57 +117,57 @@ public class InstrumentedEhcache extends EhcacheDecoratorAdapter {
      */
     public static Ehcache instrument(MetricRegistry registry, final Ehcache cache) {
 
-        final MetricName prefix = MetricRegistry.name(cache.getClass(), cache.getName());
-        registry.register(prefix.resolve("hits"),
-                (Gauge<Long>) () -> cache.getStatistics().cacheHitCount());
+        final MetricName prefix = name(cache.getClass(), cache.getName());
+        registry.registerGauge(prefix.resolve("hits"),
+                () -> cache.getStatistics().cacheHitCount());
 
-        registry.register(prefix.resolve("in-memory-hits"),
-                (Gauge<Long>) () -> cache.getStatistics().localHeapHitCount());
+        registry.registerGauge(prefix.resolve("in-memory-hits"),
+                () -> cache.getStatistics().localHeapHitCount());
 
-        registry.register(prefix.resolve("off-heap-hits"),
-                (Gauge<Long>) () -> cache.getStatistics().localOffHeapHitCount());
+        registry.registerGauge(prefix.resolve("off-heap-hits"),
+                () -> cache.getStatistics().localOffHeapHitCount());
 
-        registry.register(prefix.resolve("on-disk-hits"),
-                (Gauge<Long>) () -> cache.getStatistics().localDiskHitCount());
+        registry.registerGauge(prefix.resolve("on-disk-hits"),
+                () -> cache.getStatistics().localDiskHitCount());
 
-        registry.register(prefix.resolve("misses"),
-                (Gauge<Long>) () -> cache.getStatistics().cacheMissCount());
+        registry.registerGauge(prefix.resolve("misses"),
+                () -> cache.getStatistics().cacheMissCount());
 
-        registry.register(prefix.resolve("in-memory-misses"),
-                (Gauge<Long>) () -> cache.getStatistics().localHeapMissCount());
+        registry.registerGauge(prefix.resolve("in-memory-misses"),
+                () -> cache.getStatistics().localHeapMissCount());
 
-        registry.register(prefix.resolve("off-heap-misses"),
-                (Gauge<Long>) () -> cache.getStatistics().localOffHeapMissCount());
+        registry.registerGauge(prefix.resolve("off-heap-misses"),
+                () -> cache.getStatistics().localOffHeapMissCount());
 
-        registry.register(prefix.resolve("on-disk-misses"),
-                (Gauge<Long>) () -> cache.getStatistics().localDiskMissCount());
+        registry.registerGauge(prefix.resolve("on-disk-misses"),
+                () -> cache.getStatistics().localDiskMissCount());
 
-        registry.register(prefix.resolve("objects"),
-                (Gauge<Long>) () -> cache.getStatistics().getSize());
+        registry.registerGauge(prefix.resolve("objects"),
+                () -> cache.getStatistics().getSize());
 
-        registry.register(prefix.resolve("in-memory-objects"),
-                (Gauge<Long>) () -> cache.getStatistics().getLocalHeapSize());
+        registry.registerGauge(prefix.resolve("in-memory-objects"),
+                () -> cache.getStatistics().getLocalHeapSize());
 
-        registry.register(prefix.resolve("off-heap-objects"),
-                (Gauge<Long>) () -> cache.getStatistics().getLocalOffHeapSize());
+        registry.registerGauge(prefix.resolve("off-heap-objects"),
+                () -> cache.getStatistics().getLocalOffHeapSize());
 
-        registry.register(prefix.resolve("on-disk-objects"),
-                (Gauge<Long>) () -> cache.getStatistics().getLocalDiskSize());
+        registry.registerGauge(prefix.resolve("on-disk-objects"),
+                () -> cache.getStatistics().getLocalDiskSize());
 
-        registry.register(prefix.resolve("mean-get-time"),
-                (Gauge<Double>) () -> cache.getStatistics().cacheGetOperation().latency().average().value());
+        registry.registerGauge(prefix.resolve("mean-get-time"),
+                () -> cache.getStatistics().cacheGetOperation().latency().average().value());
 
-        registry.register(prefix.resolve("mean-search-time"),
-                (Gauge<Double>) () -> cache.getStatistics().cacheSearchOperation().latency().average().value());
+        registry.registerGauge(prefix.resolve("mean-search-time"),
+                () -> cache.getStatistics().cacheSearchOperation().latency().average().value());
 
-        registry.register(prefix.resolve("eviction-count"),
-                (Gauge<Long>) () -> cache.getStatistics().cacheEvictionOperation().count().value());
+        registry.registerGauge(prefix.resolve("eviction-count"),
+                () -> cache.getStatistics().cacheEvictionOperation().count().value());
 
-        registry.register(prefix.resolve("searches-per-second"),
-                (Gauge<Double>) () -> cache.getStatistics().cacheSearchOperation().rate().value());
+        registry.registerGauge(prefix.resolve("searches-per-second"),
+                () -> cache.getStatistics().cacheSearchOperation().rate().value());
 
-        registry.register(prefix.resolve("writer-queue-size"),
-                (Gauge<Long>) () -> cache.getStatistics().getWriterQueueLength());
+        registry.registerGauge(prefix.resolve("writer-queue-size"),
+                () -> cache.getStatistics().getWriterQueueLength());
 
         return new InstrumentedEhcache(registry, cache);
     }

--- a/metrics-ehcache/src/test/java/io/dropwizard/metrics5/ehcache/InstrumentedEhcacheTest.java
+++ b/metrics-ehcache/src/test/java/io/dropwizard/metrics5/ehcache/InstrumentedEhcacheTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 public class InstrumentedEhcacheTest {
     private static final CacheManager MANAGER = CacheManager.create();
@@ -23,6 +24,27 @@ public class InstrumentedEhcacheTest {
         final Cache c = new Cache(new CacheConfiguration("test", 100));
         MANAGER.addCache(c);
         this.cache = InstrumentedEhcache.instrument(registry, c);
+        assertThat(registry.getGauges().entrySet().stream()
+                .map(e -> entry(e.getKey().getKey(), (Number) e.getValue().getValue())))
+                .containsOnly(
+                        entry("net.sf.ehcache.Cache.test.eviction-count", 0L),
+                        entry("net.sf.ehcache.Cache.test.hits", 0L),
+                        entry("net.sf.ehcache.Cache.test.in-memory-hits", 0L),
+                        entry("net.sf.ehcache.Cache.test.in-memory-misses", 0L),
+                        entry("net.sf.ehcache.Cache.test.in-memory-objects", 0L),
+                        entry("net.sf.ehcache.Cache.test.mean-get-time", Double.NaN),
+                        entry("net.sf.ehcache.Cache.test.mean-search-time", Double.NaN),
+                        entry("net.sf.ehcache.Cache.test.misses", 0L),
+                        entry("net.sf.ehcache.Cache.test.objects", 0L),
+                        entry("net.sf.ehcache.Cache.test.off-heap-hits", 0L),
+                        entry("net.sf.ehcache.Cache.test.off-heap-misses", 0L),
+                        entry("net.sf.ehcache.Cache.test.off-heap-objects", 0L),
+                        entry("net.sf.ehcache.Cache.test.on-disk-hits", 0L),
+                        entry("net.sf.ehcache.Cache.test.on-disk-misses", 0L),
+                        entry("net.sf.ehcache.Cache.test.on-disk-objects", 0L),
+                        entry("net.sf.ehcache.Cache.test.searches-per-second", 0.0),
+                        entry("net.sf.ehcache.Cache.test.writer-queue-size", 0L)
+                );
     }
 
     @Test

--- a/metrics-httpasyncclient/src/main/java/io/dropwizard/metrics5/httpasyncclient/InstrumentedNClientConnManager.java
+++ b/metrics-httpasyncclient/src/main/java/io/dropwizard/metrics5/httpasyncclient/InstrumentedNClientConnManager.java
@@ -1,6 +1,5 @@
 package io.dropwizard.metrics5.httpasyncclient;
 
-import io.dropwizard.metrics5.Gauge;
 import io.dropwizard.metrics5.MetricRegistry;
 import org.apache.http.config.Registry;
 import org.apache.http.conn.DnsResolver;
@@ -20,26 +19,18 @@ public class InstrumentedNClientConnManager extends PoolingNHttpClientConnection
 
     public InstrumentedNClientConnManager(final ConnectingIOReactor ioreactor, final NHttpConnectionFactory<ManagedNHttpClientConnection> connFactory, final SchemePortResolver schemePortResolver, final MetricRegistry metricRegistry, final Registry<SchemeIOSessionStrategy> iosessionFactoryRegistry, final long timeToLive, final TimeUnit tunit, final DnsResolver dnsResolver, final String name) {
         super(ioreactor, connFactory, iosessionFactoryRegistry, schemePortResolver, dnsResolver, timeToLive, tunit);
-        metricRegistry.register(name(NHttpClientConnectionManager.class, name, "available-connections"),
-            (Gauge<Integer>) () -> {
-                // this acquires a lock on the connection pool; remove if contention sucks
-                return getTotalStats().getAvailable();
-            });
-        metricRegistry.register(name(NHttpClientConnectionManager.class, name, "leased-connections"),
-            (Gauge<Integer>) () -> {
-                // this acquires a lock on the connection pool; remove if contention sucks
-                return getTotalStats().getLeased();
-            });
-        metricRegistry.register(name(NHttpClientConnectionManager.class, name, "max-connections"),
-            (Gauge<Integer>) () -> {
-                // this acquires a lock on the connection pool; remove if contention sucks
-                return getTotalStats().getMax();
-            });
-        metricRegistry.register(name(NHttpClientConnectionManager.class, name, "pending-connections"),
-            (Gauge<Integer>) () -> {
-                // this acquires a lock on the connection pool; remove if contention sucks
-                return getTotalStats().getPending();
-            });
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricRegistry.registerGauge(name(NHttpClientConnectionManager.class, name, "available-connections"),
+                () -> getTotalStats().getAvailable());
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricRegistry.registerGauge(name(NHttpClientConnectionManager.class, name, "leased-connections"),
+                () -> getTotalStats().getLeased());
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricRegistry.registerGauge(name(NHttpClientConnectionManager.class, name, "max-connections"),
+                () -> getTotalStats().getMax());
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricRegistry.registerGauge(name(NHttpClientConnectionManager.class, name, "pending-connections"),
+                () -> getTotalStats().getPending());
     }
 
 }

--- a/metrics-httpclient/src/main/java/io/dropwizard/metrics5/httpclient/InstrumentedHttpClientConnectionManager.java
+++ b/metrics-httpclient/src/main/java/io/dropwizard/metrics5/httpclient/InstrumentedHttpClientConnectionManager.java
@@ -1,6 +1,5 @@
 package io.dropwizard.metrics5.httpclient;
 
-import io.dropwizard.metrics5.Gauge;
 import io.dropwizard.metrics5.MetricRegistry;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
@@ -104,26 +103,18 @@ public class InstrumentedHttpClientConnectionManager extends PoolingHttpClientCo
         this.metricsRegistry = metricsRegistry;
         this.name = name;
 
-        metricsRegistry.register(name(HttpClientConnectionManager.class, name, "available-connections"),
-            (Gauge<Integer>) () -> {
-                // this acquires a lock on the connection pool; remove if contention sucks
-                return getTotalStats().getAvailable();
-            });
-        metricsRegistry.register(name(HttpClientConnectionManager.class, name, "leased-connections"),
-            (Gauge<Integer>) () -> {
-                // this acquires a lock on the connection pool; remove if contention sucks
-                return getTotalStats().getLeased();
-            });
-        metricsRegistry.register(name(HttpClientConnectionManager.class, name, "max-connections"),
-            (Gauge<Integer>) () -> {
-                // this acquires a lock on the connection pool; remove if contention sucks
-                return getTotalStats().getMax();
-            });
-        metricsRegistry.register(name(HttpClientConnectionManager.class, name, "pending-connections"),
-            (Gauge<Integer>) () -> {
-                // this acquires a lock on the connection pool; remove if contention sucks
-                return getTotalStats().getPending();
-            });
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricsRegistry.registerGauge(name(HttpClientConnectionManager.class, name, "available-connections"),
+                () -> getTotalStats().getAvailable());
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricsRegistry.registerGauge(name(HttpClientConnectionManager.class, name, "leased-connections"),
+                () -> getTotalStats().getLeased());
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricsRegistry.registerGauge(name(HttpClientConnectionManager.class, name, "max-connections"),
+                () -> getTotalStats().getMax());
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricsRegistry.registerGauge(name(HttpClientConnectionManager.class, name, "pending-connections"),
+                () -> getTotalStats().getPending());
     }
 
     @Override

--- a/metrics-httpclient5/src/main/java/io/dropwizard/metrics5/httpclient5/InstrumentedAsyncClientConnectionManager.java
+++ b/metrics-httpclient5/src/main/java/io/dropwizard/metrics5/httpclient5/InstrumentedAsyncClientConnectionManager.java
@@ -1,6 +1,5 @@
 package io.dropwizard.metrics5.httpclient5;
 
-import io.dropwizard.metrics5.Gauge;
 import io.dropwizard.metrics5.MetricRegistry;
 import org.apache.hc.client5.http.DnsResolver;
 import org.apache.hc.client5.http.SchemePortResolver;
@@ -49,26 +48,18 @@ public class InstrumentedAsyncClientConnectionManager extends PoolingAsyncClient
         this.metricsRegistry = requireNonNull(metricRegistry, "metricRegistry");
         this.name = name;
 
-        metricRegistry.register(name(METRICS_PREFIX, name, "available-connections"),
-                (Gauge<Integer>) () -> {
-                    // this acquires a lock on the connection pool; remove if contention sucks
-                    return getTotalStats().getAvailable();
-                });
-        metricRegistry.register(name(METRICS_PREFIX, name, "leased-connections"),
-                (Gauge<Integer>) () -> {
-                    // this acquires a lock on the connection pool; remove if contention sucks
-                    return getTotalStats().getLeased();
-                });
-        metricRegistry.register(name(METRICS_PREFIX, name, "max-connections"),
-                (Gauge<Integer>) () -> {
-                    // this acquires a lock on the connection pool; remove if contention sucks
-                    return getTotalStats().getMax();
-                });
-        metricRegistry.register(name(METRICS_PREFIX, name, "pending-connections"),
-                (Gauge<Integer>) () -> {
-                    // this acquires a lock on the connection pool; remove if contention sucks
-                    return getTotalStats().getPending();
-                });
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricRegistry.registerGauge(name(METRICS_PREFIX, name, "available-connections"),
+                () -> getTotalStats().getAvailable());
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricRegistry.registerGauge(name(METRICS_PREFIX, name, "leased-connections"),
+                () -> getTotalStats().getLeased());
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricRegistry.registerGauge(name(METRICS_PREFIX, name, "max-connections"),
+                () -> getTotalStats().getMax());
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricRegistry.registerGauge(name(METRICS_PREFIX, name, "pending-connections"),
+                () -> getTotalStats().getPending());
     }
 
     /**

--- a/metrics-httpclient5/src/main/java/io/dropwizard/metrics5/httpclient5/InstrumentedHttpClientConnectionManager.java
+++ b/metrics-httpclient5/src/main/java/io/dropwizard/metrics5/httpclient5/InstrumentedHttpClientConnectionManager.java
@@ -1,6 +1,5 @@
 package io.dropwizard.metrics5.httpclient5;
 
-import io.dropwizard.metrics5.Gauge;
 import io.dropwizard.metrics5.MetricRegistry;
 import org.apache.hc.client5.http.DnsResolver;
 import org.apache.hc.client5.http.SchemePortResolver;
@@ -52,26 +51,18 @@ public class InstrumentedHttpClientConnectionManager extends PoolingHttpClientCo
         this.metricsRegistry = requireNonNull(metricRegistry, "metricRegistry");
         this.name = name;
 
-        metricRegistry.register(name(METRICS_PREFIX, name, "available-connections"),
-                (Gauge<Integer>) () -> {
-                    // this acquires a lock on the connection pool; remove if contention sucks
-                    return getTotalStats().getAvailable();
-                });
-        metricRegistry.register(name(METRICS_PREFIX, name, "leased-connections"),
-                (Gauge<Integer>) () -> {
-                    // this acquires a lock on the connection pool; remove if contention sucks
-                    return getTotalStats().getLeased();
-                });
-        metricRegistry.register(name(METRICS_PREFIX, name, "max-connections"),
-                (Gauge<Integer>) () -> {
-                    // this acquires a lock on the connection pool; remove if contention sucks
-                    return getTotalStats().getMax();
-                });
-        metricRegistry.register(name(METRICS_PREFIX, name, "pending-connections"),
-                (Gauge<Integer>) () -> {
-                    // this acquires a lock on the connection pool; remove if contention sucks
-                    return getTotalStats().getPending();
-                });
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricRegistry.registerGauge(name(METRICS_PREFIX, name, "available-connections"),
+                () -> getTotalStats().getAvailable());
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricRegistry.registerGauge(name(METRICS_PREFIX, name, "leased-connections"),
+                () -> getTotalStats().getLeased());
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricRegistry.registerGauge(name(METRICS_PREFIX, name, "max-connections"),
+                () -> getTotalStats().getMax());
+        // this acquires a lock on the connection pool; remove if contention sucks
+        metricRegistry.registerGauge(name(METRICS_PREFIX, name, "pending-connections"),
+                () -> getTotalStats().getPending());
     }
 
     /**

--- a/metrics-httpclient5/src/test/java/io/dropwizard/metrics5/httpclient5/InstrumentedAsyncClientConnectionManagerTest.java
+++ b/metrics-httpclient5/src/test/java/io/dropwizard/metrics5/httpclient5/InstrumentedAsyncClientConnectionManagerTest.java
@@ -8,6 +8,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
 
 public class InstrumentedAsyncClientConnectionManagerTest {
@@ -16,7 +18,12 @@ public class InstrumentedAsyncClientConnectionManagerTest {
     @Test
     public void shouldRemoveGauges() {
         final InstrumentedAsyncClientConnectionManager instrumentedHttpClientConnectionManager = InstrumentedAsyncClientConnectionManager.builder(metricRegistry).build();
-        Assert.assertEquals(4, metricRegistry.getGauges().size());
+        assertThat(metricRegistry.getGauges().entrySet().stream()
+                .map(e -> entry(e.getKey().getKey(), (Integer) e.getValue().getValue())))
+                .containsOnly(entry("org.apache.hc.client5.http.nio.AsyncClientConnectionManager.available-connections", 0),
+                        entry("org.apache.hc.client5.http.nio.AsyncClientConnectionManager.leased-connections", 0),
+                        entry("org.apache.hc.client5.http.nio.AsyncClientConnectionManager.max-connections", 25),
+                        entry("org.apache.hc.client5.http.nio.AsyncClientConnectionManager.pending-connections", 0));
 
         instrumentedHttpClientConnectionManager.close();
         Assert.assertEquals(0, metricRegistry.getGauges().size());
@@ -36,7 +43,7 @@ public class InstrumentedAsyncClientConnectionManagerTest {
                 .close();
 
         ArgumentCaptor<MetricName> argumentCaptor = ArgumentCaptor.forClass(MetricName.class);
-        Mockito.verify(registry, Mockito.atLeast(1)).register(argumentCaptor.capture(), any());
+        Mockito.verify(registry, Mockito.atLeast(1)).registerGauge(argumentCaptor.capture(), any());
         assertTrue(argumentCaptor.getValue().getKey().contains("some-other-name"));
     }
 }

--- a/metrics-httpclient5/src/test/java/io/dropwizard/metrics5/httpclient5/InstrumentedHttpClientConnectionManagerTest.java
+++ b/metrics-httpclient5/src/test/java/io/dropwizard/metrics5/httpclient5/InstrumentedHttpClientConnectionManagerTest.java
@@ -8,6 +8,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.ArgumentMatchers.any;
 
 public class InstrumentedHttpClientConnectionManagerTest {
@@ -16,7 +18,12 @@ public class InstrumentedHttpClientConnectionManagerTest {
     @Test
     public void shouldRemoveGauges() {
         final InstrumentedHttpClientConnectionManager instrumentedHttpClientConnectionManager = InstrumentedHttpClientConnectionManager.builder(metricRegistry).build();
-        Assert.assertEquals(4, metricRegistry.getGauges().size());
+        assertThat(metricRegistry.getGauges().entrySet().stream()
+                .map(e -> entry(e.getKey().getKey(), (Integer) e.getValue().getValue())))
+                .containsOnly(entry("org.apache.hc.client5.http.io.HttpClientConnectionManager.available-connections", 0),
+                        entry("org.apache.hc.client5.http.io.HttpClientConnectionManager.leased-connections", 0),
+                        entry("org.apache.hc.client5.http.io.HttpClientConnectionManager.max-connections", 25),
+                        entry("org.apache.hc.client5.http.io.HttpClientConnectionManager.pending-connections", 0));
 
         instrumentedHttpClientConnectionManager.close();
         Assert.assertEquals(0, metricRegistry.getGauges().size());
@@ -36,7 +43,7 @@ public class InstrumentedHttpClientConnectionManagerTest {
                 .close();
 
         ArgumentCaptor<MetricName> argumentCaptor = ArgumentCaptor.forClass(MetricName.class);
-        Mockito.verify(registry, Mockito.atLeast(1)).register(argumentCaptor.capture(), any());
+        Mockito.verify(registry, Mockito.atLeast(1)).registerGauge(argumentCaptor.capture(), any());
         assertTrue(argumentCaptor.getValue().getKey().contains("some-other-name"));
     }
 }

--- a/metrics-jetty10/src/main/java/io/dropwizard/metrics5/jetty10/InstrumentedQueuedThreadPool.java
+++ b/metrics-jetty10/src/main/java/io/dropwizard/metrics5/jetty10/InstrumentedQueuedThreadPool.java
@@ -1,6 +1,5 @@
 package io.dropwizard.metrics5.jetty10;
 
-import io.dropwizard.metrics5.Gauge;
 import io.dropwizard.metrics5.MetricName;
 import io.dropwizard.metrics5.MetricRegistry;
 import io.dropwizard.metrics5.RatioGauge;
@@ -88,13 +87,11 @@ public class InstrumentedQueuedThreadPool extends QueuedThreadPool {
                 return Ratio.of(getThreads() - getIdleThreads(), getMaxThreads());
             }
         });
-        metricRegistry.register(prefix.resolve("size"), (Gauge<Integer>) this::getThreads);
-        metricRegistry.register(prefix.resolve("jobs"), (Gauge<Integer>) () -> {
-            // This assumes the QueuedThreadPool is using a BlockingArrayQueue or
-            // ArrayBlockingQueue for its queue, and is therefore a constant-time operation.
-            return getQueue().size();
-        });
-        metricRegistry.register(prefix.resolve("jobs-queue-utilization"), new RatioGauge() {
+        // This assumes the QueuedThreadPool is using a BlockingArrayQueue or
+        // ArrayBlockingQueue for its queue, and is therefore a constant-time operation.
+        metricRegistry.registerGauge(prefix.resolve(NAME_SIZE), this::getThreads);
+        metricRegistry.registerGauge(prefix.resolve(NAME_JOBS), () -> getQueue().size());
+        metricRegistry.register(prefix.resolve(NAME_JOBS_QUEUE_UTILIZATION), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 BlockingQueue<Runnable> queue = getQueue();

--- a/metrics-jetty11/src/main/java/io/dropwizard/metrics5/jetty11/InstrumentedQueuedThreadPool.java
+++ b/metrics-jetty11/src/main/java/io/dropwizard/metrics5/jetty11/InstrumentedQueuedThreadPool.java
@@ -1,6 +1,5 @@
 package io.dropwizard.metrics5.jetty11;
 
-import io.dropwizard.metrics5.Gauge;
 import io.dropwizard.metrics5.MetricName;
 import io.dropwizard.metrics5.MetricRegistry;
 import io.dropwizard.metrics5.RatioGauge;
@@ -88,13 +87,11 @@ public class InstrumentedQueuedThreadPool extends QueuedThreadPool {
                 return Ratio.of(getThreads() - getIdleThreads(), getMaxThreads());
             }
         });
-        metricRegistry.register(prefix.resolve("size"), (Gauge<Integer>) this::getThreads);
-        metricRegistry.register(prefix.resolve("jobs"), (Gauge<Integer>) () -> {
-            // This assumes the QueuedThreadPool is using a BlockingArrayQueue or
-            // ArrayBlockingQueue for its queue, and is therefore a constant-time operation.
-            return getQueue().size();
-        });
-        metricRegistry.register(prefix.resolve("jobs-queue-utilization"), new RatioGauge() {
+        metricRegistry.registerGauge(prefix.resolve(NAME_SIZE), this::getThreads);
+        // This assumes the QueuedThreadPool is using a BlockingArrayQueue or
+        // ArrayBlockingQueue for its queue, and is therefore a constant-time operation.
+        metricRegistry.registerGauge(prefix.resolve(NAME_JOBS), () -> getQueue().size());
+        metricRegistry.register(prefix.resolve(NAME_JOBS_QUEUE_UTILIZATION), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 BlockingQueue<Runnable> queue = getQueue();

--- a/metrics-jetty9/src/main/java/io/dropwizard/metrics5/jetty9/InstrumentedQueuedThreadPool.java
+++ b/metrics-jetty9/src/main/java/io/dropwizard/metrics5/jetty9/InstrumentedQueuedThreadPool.java
@@ -1,6 +1,5 @@
 package io.dropwizard.metrics5.jetty9;
 
-import io.dropwizard.metrics5.Gauge;
 import io.dropwizard.metrics5.MetricName;
 import io.dropwizard.metrics5.MetricRegistry;
 import io.dropwizard.metrics5.RatioGauge;
@@ -86,13 +85,11 @@ public class InstrumentedQueuedThreadPool extends QueuedThreadPool {
                 return Ratio.of(getThreads() - getIdleThreads(), getMaxThreads());
             }
         });
-        metricRegistry.register(prefix.resolve("size"), (Gauge<Integer>) this::getThreads);
-        metricRegistry.register(prefix.resolve("jobs"), (Gauge<Integer>) () -> {
-            // This assumes the QueuedThreadPool is using a BlockingArrayQueue or
-            // ArrayBlockingQueue for its queue, and is therefore a constant-time operation.
-            return getQueue().size();
-        });
-        metricRegistry.register(prefix.resolve("jobs-queue-utilization"), new RatioGauge() {
+        metricRegistry.registerGauge(prefix.resolve(NAME_SIZE), this::getThreads);
+        // This assumes the QueuedThreadPool is using a BlockingArrayQueue or
+        // ArrayBlockingQueue for its queue, and is therefore a constant-time operation.
+        metricRegistry.registerGauge(prefix.resolve(NAME_JOBS), () -> getQueue().size());
+        metricRegistry.register(prefix.resolve(NAME_JOBS_QUEUE_UTILIZATION), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
                 BlockingQueue<Runnable> queue = getQueue();

--- a/metrics-jmx/src/test/java/io/dropwizard/metrics5/jmx/JmxReporterTest.java
+++ b/metrics-jmx/src/test/java/io/dropwizard/metrics5/jmx/JmxReporterTest.java
@@ -130,15 +130,12 @@ public class JmxReporterTest {
         try {
             String widgetName = "something";
             when(mockObjectNameFactory.createName(any(String.class), any(String.class), any(MetricName.class))).thenReturn(n);
-            Gauge aGauge = mock(Gauge.class);
-            when(aGauge.getValue()).thenReturn(1);
-
             JmxReporter reporter = JmxReporter.forRegistry(registry)
                     .registerWith(mBeanServer)
                     .inDomain(name)
                     .createsObjectNamesWith(mockObjectNameFactory)
                     .build();
-            registry.register(widgetName, aGauge);
+            registry.registerGauge(widgetName, () -> 1);
             reporter.start();
             verify(mockObjectNameFactory).createName(eq("gauges"), any(String.class), eq(MetricName.build("something")));
             //verifyNoMoreInteractions(mockObjectNameFactory);

--- a/metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricRegistry.java
+++ b/metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricRegistry.java
@@ -35,6 +35,11 @@ public class MetricRegistry implements MetricSet {
         this.delegate = requireNonNull(delegate);
     }
 
+    public <T> Gauge<T> registerGauge(String name, Gauge<T> metric) throws IllegalArgumentException {
+        delegate.registerGauge(MetricName.build(name), metric.getDelegate());
+        return metric;
+    }
+
     public <T extends Metric> T register(String name, T metric) throws IllegalArgumentException {
         delegate.register(MetricName.build(name), metric.getDelegate());
         return metric;

--- a/metrics-legacy-adapter/src/test/java/com/codahale/metrics/MetricRegistryTest.java
+++ b/metrics-legacy-adapter/src/test/java/com/codahale/metrics/MetricRegistryTest.java
@@ -40,6 +40,12 @@ public class MetricRegistryTest {
     }
 
     @Test
+    public void testRegisterGauge() {
+        metricRegistry.registerGauge("test-gauge", () -> 42);
+        assertThat(metricRegistry.getGauges().get("test-gauge").getValue()).isEqualTo(42);
+    }
+
+    @Test
     public void testCreateCustomGauge() {
         Gauge gauge = metricRegistry.gauge("test-gauge-supplier", () -> () -> 42);
         assertThat(gauge.getValue()).isEqualTo(42);


### PR DESCRIPTION
Problem: Missing `registerGauge` method in `MetricRegistry` (5.0.x)
Solution: Add the `registerGauge` method to `MetricRegistry` (https://github.com/dropwizard/metrics/commit/c1d0fb9b5f44ec18d686c15e419466225f2aa816)
Result: The `registerGauge` method is added to `MetricRegistry`