### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches:
     - release/*
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This commit adds explicit permissions section to workflows.

This is a security best practice because by default workflows run with extended set of permissions (except from on: pull_request from external forks).

By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an injection or compromised third party tool or action) is restricted.

It is recommended to have most strict permissions on the top level and grant write permissions on job level case by case.

Refs #2810