### PR TITLE
Allow override of scheduler

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -166,7 +166,19 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
             throw new IllegalArgumentException("Reporter already started");
         }
 
-        this.scheduledFuture = executor.scheduleWithFixedDelay(runnable, initialDelay, period, unit);
+        this.scheduledFuture = getScheduledFuture(initialDelay, period, unit, runnable);
+    }
+
+
+    /**
+     * Schedule the task, and return a future.
+     * The current implementation uses scheduleWithFixedDelay, replacing scheduleWithFixedRate. This avoids queueing issues, but may
+     * cause some reporters to skip metrics, as scheduleWithFixedDelay introduces a growing delta from the original start point.
+     *
+     * Overriding this in a subclass to revert to the old behavior is permitted.
+     */
+    protected ScheduledFuture<?> getScheduledFuture(long initialDelay, long period, TimeUnit unit, Runnable runnable) {
+        return executor.scheduleWithFixedDelay(runnable, initialDelay, period, unit);
     }
 
     /**


### PR DESCRIPTION
https://github.com/dropwizard/metrics/issues/1524 introduced a fix to queuing issues and ends up doing atFixedDelay rather than atFixedRate. The logic is sound enough, but leads to frustrating unanticipated issues.

Issues with binning exist in Graphite (and probably others). These accumulate "drift", and so metric gaps occur. See #2664 for two examples.

Hence allowing this to be configurable is desirable.

This is the lamest but easiest form of this - moving the method to an overridable method.

Usage would be (example graphite reporter)
* Create your own subclass of GraphiteReporter, override getScheduledFuture.
* Said class will also need to explicitly set the constructor instead of using the builder.

Pseudo code:
```
public class MyReporter extends GraphiteReporter {
     public MyReporter(....) {
         super(...)
    }

    @Override 
    public ScheduledFuture<?> getScheduledFuture(long initialDelay, long period, TimeUnit unit, Runnable runnable) {
        return executor.scheduleWithFixedRate(runnable, initialDelay, period, unit);
   }
}
```


I looked at other options but they all involved breaking or overloading constructors too much:
* making it an abstract method, and implementing at concrete classes. 
    * There are about 5 , and their constructors are hidden by builders. One could add to builders (with a lot of tedious copy/paste) but the constructors are heavily overloaded and would break other subclassers or add lots of jargon
    * Move the logic to base class. That would involve changing another heavily overloadd constructor (ScheduledReporter)

There's a lot of unfortunate outdated api design in DropWizard
* Not enough interfaces.
* Too many overloaded constructors instead of config objects.
* Lack of centralized configuration options.
* Often using concrete classes instead of interfaces, which imposes many constraints.

Those are not fixable without a major breaking version change. But we can at least offer something here.



