### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-http to 10.0.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <jackson.version>2.12.3</jackson.version>
-        <jetty9.version>9.4.49.v20220914</jetty9.version>
+        <jetty9.version>10.0.10</jetty9.version>
         <jetty10.version>10.0.12</jetty10.version>
         <jetty11.version>11.0.11</jetty11.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-http 9.4.49.v20220914
- [CVE-2022-2047](https://www.oscs1024.com/hd/CVE-2022-2047)


### What did I do？
Upgrade org.eclipse.jetty:jetty-http from 9.4.49.v20220914 to 10.0.10 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS