### PR TITLE
fix(sec): upgrade com.fasterxml.jackson.core:jackson-databind to 2.14.0-rc1

### DIFF
--- a/metrics-jakarta-servlets/pom.xml
+++ b/metrics-jakarta-servlets/pom.xml
@@ -20,7 +20,7 @@
         <javaModuleName>io.dropwizard.metrics.servlets</javaModuleName>
         <papertrail.profiler.version>1.1.1</papertrail.profiler.version>
         <servlet.version>5.0.0</servlet.version>
-        <jackson.version>2.12.7.1</jackson.version>
+        <jackson.version>2.14.0-rc1</jackson.version>
         <slf4j.version>2.0.0</slf4j.version>
     </properties>
 


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.fasterxml.jackson.core:jackson-databind 2.12.7.1
- [CVE-2022-42004](https://www.oscs1024.com/hd/CVE-2022-42004)


### What did I do？
Upgrade com.fasterxml.jackson.core:jackson-databind from 2.12.7.1 to 2.14.0-rc1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS