### PR TITLE
Add response code meters for ResponseMetered annotation

### DIFF
--- a/docs/source/manual/jersey.rst
+++ b/docs/source/manual/jersey.rst
@@ -56,7 +56,7 @@ application's ``ResourceConfig`` as a singleton provider for this to work.
         }
 
         @GET
-        @ResponseMetered
+        @ResponseMetered(level = ResponseMeteredLevel.ALL)
         @Path("/response-metered")
         public Response responseMetered(@QueryParam("invalid") @DefaultValue("false") boolean invalid) {
             if (invalid) {
@@ -74,6 +74,6 @@ If the annotation is placed on the class, it will apply to all its resource meth
 
 * ``@Timed`` adds a timer and measures time spent in that method.
 * ``@Metered`` adds a meter and measures the rate at which the resource method is accessed.
-* ``@ResponseMetered`` adds a meter and measures rate for each class of response codes (1xx/2xx/3xx/4xx/5xx).
+* ``@ResponseMetered`` adds meters and measures rate for response codes based on the selected level.
 * ``@ExceptionMetered`` adds a meter and measures how often the specified exception occurs when processing the resource.
   If the ``cause`` is not specified, the default is ``Exception.class``.

--- a/metrics-annotation/src/main/java/com/codahale/metrics/annotation/ResponseMetered.java
+++ b/metrics-annotation/src/main/java/com/codahale/metrics/annotation/ResponseMetered.java
@@ -12,14 +12,14 @@ import java.lang.annotation.Target;
  * <p>
  * Given a method like this:
  * <pre><code>
- *     {@literal @}ResponseMetered(name = "fancyName")
+ *     {@literal @}ResponseMetered(name = "fancyName", level = ResponseMeteredLevel.ALL)
  *     public String fancyName(String name) {
  *         return "Sir Captain " + name;
  *     }
  * </code></pre>
  * <p>
- * A meter for the defining class with the name {@code fancyName} will be created for every response code
- * in addition to 1xx/2xx/3xx/4xx/5xx responses. Each time the {@code #fancyName(String)} method is invoked,
+ * Meters for the defining class with the name {@code fancyName} will be created for response codes
+ * based on the ResponseMeteredLevel selected. Each time the {@code #fancyName(String)} method is invoked,
  * the appropriate response meter will be marked.
  */
 @Inherited
@@ -37,4 +37,9 @@ public @interface ResponseMetered {
      * relative to the annotated class. When annotating a class, this must be {@code false}.
      */
     boolean absolute() default false;
+
+    /**
+     * @return the ResponseMeteredLevel which decides which response code meters are marked.
+     */
+    ResponseMeteredLevel level() default ResponseMeteredLevel.COARSE;
 }

--- a/metrics-annotation/src/main/java/com/codahale/metrics/annotation/ResponseMetered.java
+++ b/metrics-annotation/src/main/java/com/codahale/metrics/annotation/ResponseMetered.java
@@ -18,8 +18,9 @@ import java.lang.annotation.Target;
  *     }
  * </code></pre>
  * <p>
- * A meter for the defining class with the name {@code fancyName} will be created for 1xx/2xx/3xx/4xx/5xx responses
- * and each time the {@code #fancyName(String)} method is invoked, the appropriate response meter will be marked.
+ * A meter for the defining class with the name {@code fancyName} will be created for every response code
+ * in addition to 1xx/2xx/3xx/4xx/5xx responses. Each time the {@code #fancyName(String)} method is invoked,
+ * the appropriate response meter will be marked.
  */
 @Inherited
 @Documented

--- a/metrics-annotation/src/main/java/com/codahale/metrics/annotation/ResponseMeteredLevel.java
+++ b/metrics-annotation/src/main/java/com/codahale/metrics/annotation/ResponseMeteredLevel.java
@@ -1,23 +1,23 @@
 package com.codahale.metrics.annotation;
 
 /**
- * ResponseMeteredLevel is a parameter for the ResponseMetered annotation. The constants of this enumerated type
- * decide what meters are included when a class or method is annotated with the ResponseMetered annotation.
- *
+ * {@link ResponseMeteredLevel} is a parameter for the {@link ResponseMetered} annotation.
+ * The constants of this enumerated type decide what meters are included when a class
+ * or method is annotated with the {@link ResponseMetered} annotation.
  */
 public enum ResponseMeteredLevel {
     /**
-     * Will include meters for 1xx/2xx/3xx/4xx/5xx responses
+     * Include meters for 1xx/2xx/3xx/4xx/5xx responses
      */
     COARSE,
 
     /**
-     * Will include meters for every response code
+     * Include meters for every response code (200, 201, 303, 304, 401, 404, 501, etc.)
      */
     DETAILED,
 
     /**
-     * Will include meters for every response code in addition to top level 1xx/2xx/3xx/4xx/5xx responses
+     * Include meters for every response code in addition to top level 1xx/2xx/3xx/4xx/5xx responses
      */
     ALL;
 }

--- a/metrics-annotation/src/main/java/com/codahale/metrics/annotation/ResponseMeteredLevel.java
+++ b/metrics-annotation/src/main/java/com/codahale/metrics/annotation/ResponseMeteredLevel.java
@@ -1,0 +1,23 @@
+package com.codahale.metrics.annotation;
+
+/**
+ * ResponseMeteredLevel is a parameter for the ResponseMetered annotation. The constants of this enumerated type
+ * decide what meters are included when a class or method is annotated with the ResponseMetered annotation.
+ *
+ */
+public enum ResponseMeteredLevel {
+    /**
+     * Will include meters for 1xx/2xx/3xx/4xx/5xx responses
+     */
+    COARSE,
+
+    /**
+     * Will include meters for every response code
+     */
+    DETAILED,
+
+    /**
+     * Will include meters for every response code in addition to top level 1xx/2xx/3xx/4xx/5xx responses
+     */
+    ALL;
+}

--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
@@ -135,7 +135,7 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
     private static class ResponseMeterMetric {
         private static final Set<ResponseMeteredLevel> COARSE_METER_LEVELS = EnumSet.of(COARSE, ALL);
         private static final Set<ResponseMeteredLevel> DETAILED_METER_LEVELS = EnumSet.of(DETAILED, ALL);
-        public final List<Meter> meters;
+        private final List<Meter> meters;
         private final Map<Integer, Meter> responseCodeMeters;
         private final MetricRegistry metricRegistry;
         private final String metricName;
@@ -171,7 +171,7 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
             }
         }
 
-        public Meter getResponseCodeMeter(int statusCode) {
+        private Meter getResponseCodeMeter(int statusCode) {
             return responseCodeMeters
                     .computeIfAbsent(statusCode, sc -> metricRegistry
                             .meter(name(metricName, String.format("%d-responses", sc))));

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
@@ -99,12 +99,27 @@ public class SingletonMetricsJerseyTest extends JerseyTest {
         final Meter meter2xx = registry.meter(name(InstrumentedResource.class,
                 "response2xxMetered",
                 "2xx-responses"));
+        final Meter meter200 = registry.meter(name(InstrumentedResource.class,
+                "response2xxMetered",
+                "200-responses"));
         final Meter meter4xx = registry.meter(name(InstrumentedResource.class,
                 "response4xxMetered",
                 "4xx-responses"));
+        final Meter meter400 = registry.meter(name(InstrumentedResource.class,
+                "response4xxMetered",
+                "400-responses"));
+        final Meter meter401 = registry.meter(name(InstrumentedResource.class,
+                "response4xxMetered",
+                "401-responses"));
         final Meter meter5xx = registry.meter(name(InstrumentedResource.class,
                 "response5xxMetered",
                 "5xx-responses"));
+        final Meter meter500 = registry.meter(name(InstrumentedResource.class,
+                "response5xxMetered",
+                "500-responses"));
+        final Meter meter503 = registry.meter(name(InstrumentedResource.class,
+                "response5xxMetered",
+                "503-responses"));
 
         assertThat(meter2xx.getCount()).isZero();
         assertThat(target("response-2xx-metered")
@@ -118,15 +133,31 @@ public class SingletonMetricsJerseyTest extends JerseyTest {
                 .get().getStatus())
                 .isEqualTo(400);
 
+        assertThat(target("response-4xx-metered")
+                .queryParam("status_code", 401)
+                .request()
+                .get().getStatus())
+                .isEqualTo(401);
+
         assertThat(meter5xx.getCount()).isZero();
         assertThat(target("response-5xx-metered")
                 .request()
                 .get().getStatus())
                 .isEqualTo(500);
+        assertThat(target("response-5xx-metered")
+                .queryParam("status_code", 503)
+                .request()
+                .get().getStatus())
+                .isEqualTo(503);
 
         assertThat(meter2xx.getCount()).isEqualTo(1);
-        assertThat(meter4xx.getCount()).isEqualTo(1);
-        assertThat(meter5xx.getCount()).isEqualTo(1);
+        assertThat(meter4xx.getCount()).isEqualTo(2);
+        assertThat(meter5xx.getCount()).isEqualTo(2);
+        assertThat(meter200.getCount()).isEqualTo(1);
+        assertThat(meter400.getCount()).isEqualTo(1);
+        assertThat(meter401.getCount()).isEqualTo(1);
+        assertThat(meter500.getCount()).isEqualTo(1);
+        assertThat(meter503.getCount()).isEqualTo(1);
     }
 
     @Test

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsJerseyTest.java
@@ -95,69 +95,73 @@ public class SingletonMetricsJerseyTest extends JerseyTest {
     }
 
     @Test
-    public void responseMeteredMethodsAreMetered() {
+    public void responseMeteredMethodsAreMeteredWithCoarseLevel() {
         final Meter meter2xx = registry.meter(name(InstrumentedResource.class,
-                "response2xxMetered",
+                "responseMeteredCoarse",
                 "2xx-responses"));
         final Meter meter200 = registry.meter(name(InstrumentedResource.class,
-                "response2xxMetered",
+                "responseMeteredCoarse",
                 "200-responses"));
-        final Meter meter4xx = registry.meter(name(InstrumentedResource.class,
-                "response4xxMetered",
-                "4xx-responses"));
-        final Meter meter400 = registry.meter(name(InstrumentedResource.class,
-                "response4xxMetered",
-                "400-responses"));
-        final Meter meter401 = registry.meter(name(InstrumentedResource.class,
-                "response4xxMetered",
-                "401-responses"));
-        final Meter meter5xx = registry.meter(name(InstrumentedResource.class,
-                "response5xxMetered",
-                "5xx-responses"));
-        final Meter meter500 = registry.meter(name(InstrumentedResource.class,
-                "response5xxMetered",
-                "500-responses"));
-        final Meter meter503 = registry.meter(name(InstrumentedResource.class,
-                "response5xxMetered",
-                "503-responses"));
 
         assertThat(meter2xx.getCount()).isZero();
-        assertThat(target("response-2xx-metered")
+        assertThat(meter200.getCount()).isZero();
+        assertThat(target("response-metered-coarse")
                 .request()
                 .get().getStatus())
                 .isEqualTo(200);
 
-        assertThat(meter4xx.getCount()).isZero();
-        assertThat(target("response-4xx-metered")
-                .request()
-                .get().getStatus())
-                .isEqualTo(400);
+        assertThat(meter2xx.getCount()).isOne();
+        assertThat(meter200.getCount()).isZero();
+    }
 
-        assertThat(target("response-4xx-metered")
-                .queryParam("status_code", 401)
-                .request()
-                .get().getStatus())
-                .isEqualTo(401);
+    @Test
+    public void responseMeteredMethodsAreMeteredWithDetailedLevel() {
+        final Meter meter2xx = registry.meter(name(InstrumentedResource.class,
+                "responseMeteredDetailed",
+                "2xx-responses"));
+        final Meter meter200 = registry.meter(name(InstrumentedResource.class,
+                "responseMeteredDetailed",
+                "200-responses"));
+        final Meter meter201 = registry.meter(name(InstrumentedResource.class,
+                "responseMeteredDetailed",
+                "201-responses"));
 
-        assertThat(meter5xx.getCount()).isZero();
-        assertThat(target("response-5xx-metered")
+        assertThat(meter2xx.getCount()).isZero();
+        assertThat(meter200.getCount()).isZero();
+        assertThat(meter201.getCount()).isZero();
+        assertThat(target("response-metered-detailed")
                 .request()
                 .get().getStatus())
-                .isEqualTo(500);
-        assertThat(target("response-5xx-metered")
-                .queryParam("status_code", 503)
+                .isEqualTo(200);
+        assertThat(target("response-metered-detailed")
+                .queryParam("status_code", 201)
                 .request()
                 .get().getStatus())
-                .isEqualTo(503);
+                .isEqualTo(201);
 
-        assertThat(meter2xx.getCount()).isEqualTo(1);
-        assertThat(meter4xx.getCount()).isEqualTo(2);
-        assertThat(meter5xx.getCount()).isEqualTo(2);
-        assertThat(meter200.getCount()).isEqualTo(1);
-        assertThat(meter400.getCount()).isEqualTo(1);
-        assertThat(meter401.getCount()).isEqualTo(1);
-        assertThat(meter500.getCount()).isEqualTo(1);
-        assertThat(meter503.getCount()).isEqualTo(1);
+        assertThat(meter2xx.getCount()).isZero();
+        assertThat(meter200.getCount()).isOne();
+        assertThat(meter201.getCount()).isOne();
+    }
+
+    @Test
+    public void responseMeteredMethodsAreMeteredWithAllLevel() {
+        final Meter meter2xx = registry.meter(name(InstrumentedResource.class,
+                "responseMeteredAll",
+                "2xx-responses"));
+        final Meter meter200 = registry.meter(name(InstrumentedResource.class,
+                "responseMeteredAll",
+                "200-responses"));
+
+        assertThat(meter2xx.getCount()).isZero();
+        assertThat(meter200.getCount()).isZero();
+        assertThat(target("response-metered-all")
+                .request()
+                .get().getStatus())
+                .isEqualTo(200);
+
+        assertThat(meter2xx.getCount()).isOne();
+        assertThat(meter200.getCount()).isOne();
     }
 
     @Test

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsResponseMeteredPerClassJerseyTest.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsResponseMeteredPerClassJerseyTest.java
@@ -129,18 +129,18 @@ public class SingletonMetricsResponseMeteredPerClassJerseyTest extends JerseyTes
         final Meter meter2xx = registry.meter(name(InstrumentedSubResourceResponseMeteredPerClass.class,
                 "responseMeteredPerClass",
                 "2xx-responses"));
-        final Meter meter201 = registry.meter(name(InstrumentedSubResourceResponseMeteredPerClass.class,
+        final Meter meter200 = registry.meter(name(InstrumentedSubResourceResponseMeteredPerClass.class,
                 "responseMeteredPerClass",
                 "200-responses"));
 
         assertThat(meter2xx.getCount()).isZero();
-        assertThat(meter2xx.getCount()).isZero();
+        assertThat(meter200.getCount()).isZero();
         assertThat(target("subresource/responseMeteredPerClass")
                 .request()
                 .get().getStatus())
                 .isEqualTo(200);
 
         assertThat(meter2xx.getCount()).isOne();
-        assertThat(meter2xx.getCount()).isOne();
+        assertThat(meter200.getCount()).isOne();
     }
 }

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsResponseMeteredPerClassJerseyTest.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsResponseMeteredPerClassJerseyTest.java
@@ -62,11 +62,6 @@ public class SingletonMetricsResponseMeteredPerClassJerseyTest extends JerseyTes
                 .request()
                 .get().getStatus())
                 .isEqualTo(400);
-        assertThat(target("responseMetered4xxPerClass")
-                .queryParam("status_code", 401)
-                .request()
-                .get().getStatus())
-                .isEqualTo(401);
         assertThat(target("responseMeteredBadRequestPerClass")
                 .request()
                 .get().getStatus())
@@ -75,15 +70,11 @@ public class SingletonMetricsResponseMeteredPerClassJerseyTest extends JerseyTes
         final Meter meter4xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
                 "responseMetered4xxPerClass",
                 "4xx-responses"));
-        final Meter meter401 = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
-                "responseMetered4xxPerClass",
-                "401-responses"));
         final Meter meterException4xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
                 "responseMeteredBadRequestPerClass",
                 "4xx-responses"));
 
-        assertThat(meter4xx.getCount()).isEqualTo(2);
-        assertThat(meter401.getCount()).isEqualTo(1);
+        assertThat(meter4xx.getCount()).isEqualTo(1);
         assertThat(meterException4xx.getCount()).isEqualTo(1);
     }
 
@@ -93,22 +84,12 @@ public class SingletonMetricsResponseMeteredPerClassJerseyTest extends JerseyTes
                 .request()
                 .get().getStatus())
                 .isEqualTo(500);
-        assertThat(target("responseMetered5xxPerClass")
-                .queryParam("status_code", 503)
-                .request()
-                .get().getStatus())
-                .isEqualTo(503);
 
         final Meter meter5xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
                 "responseMetered5xxPerClass",
                 "5xx-responses"));
 
-        final Meter meter503 = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
-                "responseMetered5xxPerClass",
-                "503-responses"));
-
-        assertThat(meter5xx.getCount()).isEqualTo(2);
-        assertThat(meter503.getCount()).isEqualTo(1);
+        assertThat(meter5xx.getCount()).isEqualTo(1);
     }
 
     @Test
@@ -145,14 +126,21 @@ public class SingletonMetricsResponseMeteredPerClassJerseyTest extends JerseyTes
 
     @Test
     public void subresourcesFromLocatorsRegisterMetrics() {
+        final Meter meter2xx = registry.meter(name(InstrumentedSubResourceResponseMeteredPerClass.class,
+                "responseMeteredPerClass",
+                "2xx-responses"));
+        final Meter meter201 = registry.meter(name(InstrumentedSubResourceResponseMeteredPerClass.class,
+                "responseMeteredPerClass",
+                "200-responses"));
+
+        assertThat(meter2xx.getCount()).isZero();
+        assertThat(meter2xx.getCount()).isZero();
         assertThat(target("subresource/responseMeteredPerClass")
                 .request()
                 .get().getStatus())
                 .isEqualTo(200);
 
-        final Meter meter = registry.meter(name(InstrumentedSubResourceResponseMeteredPerClass.class,
-                "responseMeteredPerClass",
-                "2xx-responses"));
-        assertThat(meter.getCount()).isEqualTo(1);
+        assertThat(meter2xx.getCount()).isOne();
+        assertThat(meter2xx.getCount()).isOne();
     }
 }

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsResponseMeteredPerClassJerseyTest.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/SingletonMetricsResponseMeteredPerClassJerseyTest.java
@@ -62,6 +62,11 @@ public class SingletonMetricsResponseMeteredPerClassJerseyTest extends JerseyTes
                 .request()
                 .get().getStatus())
                 .isEqualTo(400);
+        assertThat(target("responseMetered4xxPerClass")
+                .queryParam("status_code", 401)
+                .request()
+                .get().getStatus())
+                .isEqualTo(401);
         assertThat(target("responseMeteredBadRequestPerClass")
                 .request()
                 .get().getStatus())
@@ -70,11 +75,15 @@ public class SingletonMetricsResponseMeteredPerClassJerseyTest extends JerseyTes
         final Meter meter4xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
                 "responseMetered4xxPerClass",
                 "4xx-responses"));
+        final Meter meter401 = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
+                "responseMetered4xxPerClass",
+                "401-responses"));
         final Meter meterException4xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
                 "responseMeteredBadRequestPerClass",
                 "4xx-responses"));
 
-        assertThat(meter4xx.getCount()).isEqualTo(1);
+        assertThat(meter4xx.getCount()).isEqualTo(2);
+        assertThat(meter401.getCount()).isEqualTo(1);
         assertThat(meterException4xx.getCount()).isEqualTo(1);
     }
 
@@ -84,12 +93,22 @@ public class SingletonMetricsResponseMeteredPerClassJerseyTest extends JerseyTes
                 .request()
                 .get().getStatus())
                 .isEqualTo(500);
+        assertThat(target("responseMetered5xxPerClass")
+                .queryParam("status_code", 503)
+                .request()
+                .get().getStatus())
+                .isEqualTo(503);
 
         final Meter meter5xx = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
                 "responseMetered5xxPerClass",
                 "5xx-responses"));
 
-        assertThat(meter5xx.getCount()).isEqualTo(1);
+        final Meter meter503 = registry.meter(name(InstrumentedResourceResponseMeteredPerClass.class,
+                "responseMetered5xxPerClass",
+                "503-responses"));
+
+        assertThat(meter5xx.getCount()).isEqualTo(2);
+        assertThat(meter503.getCount()).isEqualTo(1);
     }
 
     @Test

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
@@ -14,6 +14,10 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.io.IOException;
 
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.COARSE;
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.DETAILED;
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.ALL;
+
 @Path("/")
 @Produces(MediaType.TEXT_PLAIN)
 public class InstrumentedResource {
@@ -42,23 +46,23 @@ public class InstrumentedResource {
     }
 
     @GET
-    @ResponseMetered
-    @Path("/response-2xx-metered")
-    public Response response2xxMetered() {
-        return Response.ok().build();
-    }
-
-    @GET
-    @ResponseMetered
-    @Path("/response-4xx-metered")
-    public Response response4xxMetered(@QueryParam("status_code") @DefaultValue("400") int statusCode) {
+    @ResponseMetered(level = DETAILED)
+    @Path("/response-metered-detailed")
+    public Response responseMeteredDetailed(@QueryParam("status_code") @DefaultValue("200") int statusCode) {
         return Response.status(Response.Status.fromStatusCode(statusCode)).build();
     }
 
     @GET
-    @ResponseMetered
-    @Path("/response-5xx-metered")
-    public Response response5xxMetered(@QueryParam("status_code") @DefaultValue("500") int statusCode) {
+    @ResponseMetered(level = COARSE)
+    @Path("/response-metered-coarse")
+    public Response responseMeteredCoarse(@QueryParam("status_code") @DefaultValue("200") int statusCode) {
+        return Response.status(Response.Status.fromStatusCode(statusCode)).build();
+    }
+
+    @GET
+    @ResponseMetered(level = ALL)
+    @Path("/response-metered-all")
+    public Response responseMeteredAll(@QueryParam("status_code") @DefaultValue("200") int statusCode) {
         return Response.status(Response.Status.fromStatusCode(statusCode)).build();
     }
 

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResource.java
@@ -51,15 +51,15 @@ public class InstrumentedResource {
     @GET
     @ResponseMetered
     @Path("/response-4xx-metered")
-    public Response response4xxMetered() {
-        return Response.status(Response.Status.BAD_REQUEST).build();
+    public Response response4xxMetered(@QueryParam("status_code") @DefaultValue("400") int statusCode) {
+        return Response.status(Response.Status.fromStatusCode(statusCode)).build();
     }
 
     @GET
     @ResponseMetered
     @Path("/response-5xx-metered")
-    public Response response5xxMetered() {
-        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    public Response response5xxMetered(@QueryParam("status_code") @DefaultValue("500") int statusCode) {
+        return Response.status(Response.Status.fromStatusCode(statusCode)).build();
     }
 
     @Path("/subresource")

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResourceResponseMeteredPerClass.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResourceResponseMeteredPerClass.java
@@ -6,8 +6,6 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -24,14 +22,14 @@ public class InstrumentedResourceResponseMeteredPerClass {
 
     @GET
     @Path("/responseMetered4xxPerClass")
-    public Response responseMetered4xxPerClass(@QueryParam("status_code") @DefaultValue("400") int statusCode) {
-        return Response.status(Response.Status.fromStatusCode(statusCode)).build();
+    public Response responseMetered4xxPerClass() {
+        return Response.status(Response.Status.BAD_REQUEST).build();
     }
 
     @GET
     @Path("/responseMetered5xxPerClass")
-    public Response responseMetered5xxPerClass(@QueryParam("status_code") @DefaultValue("500") int statusCode) {
-        return Response.status(Response.Status.fromStatusCode(statusCode)).build();
+    public Response responseMetered5xxPerClass() {
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
     }
 
     @GET

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResourceResponseMeteredPerClass.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResourceResponseMeteredPerClass.java
@@ -6,6 +6,8 @@ import javax.ws.rs.BadRequestException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResourceResponseMeteredPerClass.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedResourceResponseMeteredPerClass.java
@@ -22,14 +22,14 @@ public class InstrumentedResourceResponseMeteredPerClass {
 
     @GET
     @Path("/responseMetered4xxPerClass")
-    public Response responseMetered4xxPerClass() {
-        return Response.status(Response.Status.BAD_REQUEST).build();
+    public Response responseMetered4xxPerClass(@QueryParam("status_code") @DefaultValue("400") int statusCode) {
+        return Response.status(Response.Status.fromStatusCode(statusCode)).build();
     }
 
     @GET
     @Path("/responseMetered5xxPerClass")
-    public Response responseMetered5xxPerClass() {
-        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    public Response responseMetered5xxPerClass(@QueryParam("status_code") @DefaultValue("500") int statusCode) {
+        return Response.status(Response.Status.fromStatusCode(statusCode)).build();
     }
 
     @GET

--- a/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedSubResourceResponseMeteredPerClass.java
+++ b/metrics-jersey2/src/test/java/com/codahale/metrics/jersey2/resources/InstrumentedSubResourceResponseMeteredPerClass.java
@@ -1,13 +1,17 @@
 package com.codahale.metrics.jersey2.resources;
 
 import com.codahale.metrics.annotation.ResponseMetered;
+import com.codahale.metrics.annotation.ResponseMeteredLevel;
+
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-@ResponseMetered
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.ALL;
+
+@ResponseMetered(level = ALL)
 @Produces(MediaType.TEXT_PLAIN)
 public class InstrumentedSubResourceResponseMeteredPerClass {
     @GET


### PR DESCRIPTION
Currently the ResponseMetered annotation gives us top level 1xx/2xx/3xx/4xx/5xx meters. We have many use cases where we care about specific response codes like 401/503 and end up manually instrumenting code to create these meters. This PR adds meters for individual response codes in addition to the 1xx/2xx/3xx/4xx/5xx meters in the ResponseMetered annotation.

Hoping others find this useful and I'm open to suggestions/feedback. 

Happy to add this functionality to metrics-jersey3 and metrics-jersey31 as well if this approach is acceptable. Can also create a PR to add individual response code meters to the jetty InstrumentedHandler