### PR TITLE
Add parameter ResponseMeteredLevel to the ResponseMetered annotation jersey3

### DIFF
--- a/metrics-jersey3/src/test/java/com/codahale/metrics/jersey3/SingletonMetricsJerseyTest.java
+++ b/metrics-jersey3/src/test/java/com/codahale/metrics/jersey3/SingletonMetricsJerseyTest.java
@@ -95,38 +95,53 @@ public class SingletonMetricsJerseyTest extends JerseyTest {
     }
 
     @Test
-    public void responseMeteredMethodsAreMetered() {
+    public void responseMeteredMethodsAreMeteredWithDetailedLevel() {
         final Meter meter2xx = registry.meter(name(InstrumentedResource.class,
-                "response2xxMetered",
+                "responseMeteredDetailed",
                 "2xx-responses"));
-        final Meter meter4xx = registry.meter(name(InstrumentedResource.class,
-                "response4xxMetered",
-                "4xx-responses"));
-        final Meter meter5xx = registry.meter(name(InstrumentedResource.class,
-                "response5xxMetered",
-                "5xx-responses"));
+        final Meter meter200 = registry.meter(name(InstrumentedResource.class,
+                "responseMeteredDetailed",
+                "200-responses"));
+        final Meter meter201 = registry.meter(name(InstrumentedResource.class,
+                "responseMeteredDetailed",
+                "201-responses"));
 
         assertThat(meter2xx.getCount()).isZero();
-        assertThat(target("response-2xx-metered")
+        assertThat(meter200.getCount()).isZero();
+        assertThat(meter201.getCount()).isZero();
+        assertThat(target("response-metered-detailed")
+                .request()
+                .get().getStatus())
+                .isEqualTo(200);
+        assertThat(target("response-metered-detailed")
+                .queryParam("status_code", 201)
+                .request()
+                .get().getStatus())
+                .isEqualTo(201);
+
+        assertThat(meter2xx.getCount()).isZero();
+        assertThat(meter200.getCount()).isOne();
+        assertThat(meter201.getCount()).isOne();
+    }
+
+    @Test
+    public void responseMeteredMethodsAreMeteredWithAllLevel() {
+        final Meter meter2xx = registry.meter(name(InstrumentedResource.class,
+                "responseMeteredAll",
+                "2xx-responses"));
+        final Meter meter200 = registry.meter(name(InstrumentedResource.class,
+                "responseMeteredAll",
+                "200-responses"));
+
+        assertThat(meter2xx.getCount()).isZero();
+        assertThat(meter200.getCount()).isZero();
+        assertThat(target("response-metered-all")
                 .request()
                 .get().getStatus())
                 .isEqualTo(200);
 
-        assertThat(meter4xx.getCount()).isZero();
-        assertThat(target("response-4xx-metered")
-                .request()
-                .get().getStatus())
-                .isEqualTo(400);
-
-        assertThat(meter5xx.getCount()).isZero();
-        assertThat(target("response-5xx-metered")
-                .request()
-                .get().getStatus())
-                .isEqualTo(500);
-
-        assertThat(meter2xx.getCount()).isEqualTo(1);
-        assertThat(meter4xx.getCount()).isEqualTo(1);
-        assertThat(meter5xx.getCount()).isEqualTo(1);
+        assertThat(meter2xx.getCount()).isOne();
+        assertThat(meter200.getCount()).isOne();
     }
 
     @Test

--- a/metrics-jersey3/src/test/java/com/codahale/metrics/jersey3/SingletonMetricsResponseMeteredPerClassJerseyTest.java
+++ b/metrics-jersey3/src/test/java/com/codahale/metrics/jersey3/SingletonMetricsResponseMeteredPerClassJerseyTest.java
@@ -126,14 +126,21 @@ public class SingletonMetricsResponseMeteredPerClassJerseyTest extends JerseyTes
 
     @Test
     public void subresourcesFromLocatorsRegisterMetrics() {
+        final Meter meter2xx = registry.meter(name(InstrumentedSubResourceResponseMeteredPerClass.class,
+                "responseMeteredPerClass",
+                "2xx-responses"));
+        final Meter meter200 = registry.meter(name(InstrumentedSubResourceResponseMeteredPerClass.class,
+                "responseMeteredPerClass",
+                "200-responses"));
+
+        assertThat(meter2xx.getCount()).isZero();
+        assertThat(meter200.getCount()).isZero();
         assertThat(target("subresource/responseMeteredPerClass")
                 .request()
                 .get().getStatus())
                 .isEqualTo(200);
 
-        final Meter meter = registry.meter(name(InstrumentedSubResourceResponseMeteredPerClass.class,
-                "responseMeteredPerClass",
-                "2xx-responses"));
-        assertThat(meter.getCount()).isEqualTo(1);
+        assertThat(meter2xx.getCount()).isOne();
+        assertThat(meter200.getCount()).isOne();
     }
 }

--- a/metrics-jersey3/src/test/java/com/codahale/metrics/jersey3/resources/InstrumentedResource.java
+++ b/metrics-jersey3/src/test/java/com/codahale/metrics/jersey3/resources/InstrumentedResource.java
@@ -11,8 +11,11 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-
 import java.io.IOException;
+
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.COARSE;
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.DETAILED;
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.ALL;
 
 @Path("/")
 @Produces(MediaType.TEXT_PLAIN)
@@ -42,24 +45,24 @@ public class InstrumentedResource {
     }
 
     @GET
-    @ResponseMetered
-    @Path("/response-2xx-metered")
-    public Response response2xxMetered() {
-        return Response.ok().build();
+    @ResponseMetered(level = DETAILED)
+    @Path("/response-metered-detailed")
+    public Response responseMeteredDetailed(@QueryParam("status_code") @DefaultValue("200") int statusCode) {
+        return Response.status(Response.Status.fromStatusCode(statusCode)).build();
     }
 
     @GET
-    @ResponseMetered
-    @Path("/response-4xx-metered")
-    public Response response4xxMetered() {
-        return Response.status(Response.Status.BAD_REQUEST).build();
+    @ResponseMetered(level = COARSE)
+    @Path("/response-metered-coarse")
+    public Response responseMeteredCoarse(@QueryParam("status_code") @DefaultValue("200") int statusCode) {
+        return Response.status(Response.Status.fromStatusCode(statusCode)).build();
     }
 
     @GET
-    @ResponseMetered
-    @Path("/response-5xx-metered")
-    public Response response5xxMetered() {
-        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    @ResponseMetered(level = ALL)
+    @Path("/response-metered-all")
+    public Response responseMeteredAll(@QueryParam("status_code") @DefaultValue("200") int statusCode) {
+        return Response.status(Response.Status.fromStatusCode(statusCode)).build();
     }
 
     @Path("/subresource")

--- a/metrics-jersey3/src/test/java/com/codahale/metrics/jersey3/resources/InstrumentedSubResourceResponseMeteredPerClass.java
+++ b/metrics-jersey3/src/test/java/com/codahale/metrics/jersey3/resources/InstrumentedSubResourceResponseMeteredPerClass.java
@@ -7,7 +7,9 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-@ResponseMetered
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.ALL;
+
+@ResponseMetered(level = ALL)
 @Produces(MediaType.TEXT_PLAIN)
 public class InstrumentedSubResourceResponseMeteredPerClass {
     @GET


### PR DESCRIPTION
Adds a parameter ResponseMeteredLevel to the ResponseMetered annotation which decides whether 1xx/2xx/3xx/4xx/5xx meters, individual response code meters or both are created.

Port of #3043 