### PR TITLE
[JVM] Fix maximum/total memory calculation

### DIFF
--- a/metrics-jvm/src/main/java/com/codahale/metrics/jvm/MemoryUsageGaugeSet.java
+++ b/metrics-jvm/src/main/java/com/codahale/metrics/jvm/MemoryUsageGaugeSet.java
@@ -47,8 +47,8 @@ public class MemoryUsageGaugeSet implements MetricSet {
                 mxBean.getNonHeapMemoryUsage().getInit());
         gauges.put("total.used", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getUsed() +
                 mxBean.getNonHeapMemoryUsage().getUsed());
-        gauges.put("total.max", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getMax() +
-                mxBean.getNonHeapMemoryUsage().getMax());
+        gauges.put("total.max", (Gauge<Long>) () -> mxBean.getNonHeapMemoryUsage().getMax() == -1 ?
+                -1 : mxBean.getHeapMemoryUsage().getMax() + mxBean.getNonHeapMemoryUsage().getMax());
         gauges.put("total.committed", (Gauge<Long>) () -> mxBean.getHeapMemoryUsage().getCommitted() +
                 mxBean.getNonHeapMemoryUsage().getCommitted());
 
@@ -72,7 +72,7 @@ public class MemoryUsageGaugeSet implements MetricSet {
             @Override
             protected Ratio getRatio() {
                 final MemoryUsage usage = mxBean.getNonHeapMemoryUsage();
-                return Ratio.of(usage.getUsed(), usage.getMax());
+                return Ratio.of(usage.getUsed(), usage.getMax() == -1 ? usage.getCommitted() : usage.getMax());
             }
         });
 

--- a/metrics-jvm/src/test/java/com/codahale/metrics/jvm/MemoryUsageGaugeSetTest.java
+++ b/metrics-jvm/src/test/java/com/codahale/metrics/jvm/MemoryUsageGaugeSetTest.java
@@ -131,6 +131,16 @@ public class MemoryUsageGaugeSetTest {
     }
 
     @Test
+    public void hasAGaugeForTotalMaxWhenNonHeapMaxUndefined() {
+        when(nonHeap.getMax()).thenReturn(-1L);
+
+        final Gauge gauge = (Gauge) gauges.getMetrics().get("total.max");
+
+        assertThat(gauge.getValue())
+                .isEqualTo(-1L);
+    }
+
+    @Test
     public void hasAGaugeForHeapCommitted() {
         final Gauge gauge = (Gauge) gauges.getMetrics().get("heap.committed");
 
@@ -208,6 +218,15 @@ public class MemoryUsageGaugeSetTest {
 
         assertThat(gauge.getValue())
                 .isEqualTo(0.75);
+    }
+
+    @Test
+    public void hasAGaugeForNonHeapUsageWhenNonHeapMaxUndefined() {
+        when(nonHeap.getMax()).thenReturn(-1L);
+        final Gauge gauge = (Gauge) gauges.getMetrics().get("non-heap.usage");
+
+        assertThat(gauge.getValue())
+                .isEqualTo(3.0);
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/dropwizard/metrics/issues/2609

**Changes**
- when max non-heap memory is undefined then total.max is equal to -1
- when max non-heap memory is undefined then "non-heap.usage" ratio is non-heap.used / non-heap.commited (instead of non-heap.used / non-heap.max - similar to memory pools usage calculation)