### PR TITLE
Add response code meters for jetty9

### DIFF
--- a/metrics-jetty9/pom.xml
+++ b/metrics-jetty9/pom.xml
@@ -43,7 +43,10 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-annotation</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
+++ b/metrics-jetty9/src/main/java/com/codahale/metrics/jetty9/InstrumentedHandler.java
@@ -5,6 +5,7 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.RatioGauge;
 import com.codahale.metrics.Timer;
+import com.codahale.metrics.annotation.ResponseMeteredLevel;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.server.AsyncContextState;
 import org.eclipse.jetty.server.Handler;
@@ -18,9 +19,19 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import static com.codahale.metrics.MetricRegistry.name;
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.ALL;
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.COARSE;
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.DETAILED;
 
 /**
  * A Jetty {@link Handler} which records various metrics about an underlying {@link Handler}
@@ -55,6 +66,8 @@ public class InstrumentedHandler extends HandlerWrapper {
     private static final String NAME_PERCENT_5XX_1M = "percent-5xx-1m";
     private static final String NAME_PERCENT_5XX_5M = "percent-5xx-5m";
     private static final String NAME_PERCENT_5XX_15M = "percent-5xx-15m";
+    private static final Set<ResponseMeteredLevel> COARSE_METER_LEVELS = EnumSet.of(COARSE, ALL);
+    private static final Set<ResponseMeteredLevel> DETAILED_METER_LEVELS = EnumSet.of(DETAILED, ALL);
 
     private final MetricRegistry metricRegistry;
 
@@ -82,7 +95,9 @@ public class InstrumentedHandler extends HandlerWrapper {
     // the number of requests that expired while suspended
     private Meter asyncTimeouts;
 
-    private Meter[] responses;
+    private final ResponseMeteredLevel responseMeteredLevel;
+    private List<Meter> responses;
+    private Map<Integer, Meter> responseCodeMeters;
 
     private Timer getRequests;
     private Timer postRequests;
@@ -115,8 +130,20 @@ public class InstrumentedHandler extends HandlerWrapper {
      * @param prefix   the prefix to use for the metrics names
      */
     public InstrumentedHandler(MetricRegistry registry, String prefix) {
+        this(registry, prefix, COARSE);
+    }
+
+    /**
+     * Create a new instrumented handler using a given metrics registry.
+     *
+     * @param registry the registry for the metrics
+     * @param prefix   the prefix to use for the metrics names
+     * @param responseMeteredLevel the level to determine individual/aggregate response codes that are instrumented
+     */
+    public InstrumentedHandler(MetricRegistry registry, String prefix, ResponseMeteredLevel responseMeteredLevel) {
         this.metricRegistry = registry;
         this.prefix = prefix;
+        this.responseMeteredLevel = responseMeteredLevel;
 
         try {
             DISPATCHED_HACK = HttpChannelState.State.valueOf("HANDLING");
@@ -149,13 +176,15 @@ public class InstrumentedHandler extends HandlerWrapper {
         this.asyncDispatches = metricRegistry.meter(name(prefix, NAME_ASYNC_DISPATCHES));
         this.asyncTimeouts = metricRegistry.meter(name(prefix, NAME_ASYNC_TIMEOUTS));
 
-        this.responses = new Meter[]{
-                metricRegistry.meter(name(prefix, NAME_1XX_RESPONSES)), // 1xx
-                metricRegistry.meter(name(prefix, NAME_2XX_RESPONSES)), // 2xx
-                metricRegistry.meter(name(prefix, NAME_3XX_RESPONSES)), // 3xx
-                metricRegistry.meter(name(prefix, NAME_4XX_RESPONSES)), // 4xx
-                metricRegistry.meter(name(prefix, NAME_5XX_RESPONSES))  // 5xx
-        };
+        this.responseCodeMeters = DETAILED_METER_LEVELS.contains(responseMeteredLevel) ? new ConcurrentHashMap<>() : Collections.emptyMap();
+        this.responses = COARSE_METER_LEVELS.contains(responseMeteredLevel) ?
+                Collections.unmodifiableList(Arrays.asList(
+                        metricRegistry.meter(name(prefix, NAME_1XX_RESPONSES)), // 1xx
+                        metricRegistry.meter(name(prefix, NAME_2XX_RESPONSES)), // 2xx
+                        metricRegistry.meter(name(prefix, NAME_3XX_RESPONSES)), // 3xx
+                        metricRegistry.meter(name(prefix, NAME_4XX_RESPONSES)), // 4xx
+                        metricRegistry.meter(name(prefix, NAME_5XX_RESPONSES))  // 5xx
+                )) : Collections.emptyList();
 
         this.getRequests = metricRegistry.timer(name(prefix, NAME_GET_REQUESTS));
         this.postRequests = metricRegistry.timer(name(prefix, NAME_POST_REQUESTS));
@@ -171,7 +200,7 @@ public class InstrumentedHandler extends HandlerWrapper {
         metricRegistry.register(name(prefix, NAME_PERCENT_4XX_1M), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
-                return Ratio.of(responses[3].getOneMinuteRate(),
+                return Ratio.of(responses.get(3).getOneMinuteRate(),
                         requests.getOneMinuteRate());
             }
         });
@@ -179,7 +208,7 @@ public class InstrumentedHandler extends HandlerWrapper {
         metricRegistry.register(name(prefix, NAME_PERCENT_4XX_5M), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
-                return Ratio.of(responses[3].getFiveMinuteRate(),
+                return Ratio.of(responses.get(3).getFiveMinuteRate(),
                         requests.getFiveMinuteRate());
             }
         });
@@ -187,7 +216,7 @@ public class InstrumentedHandler extends HandlerWrapper {
         metricRegistry.register(name(prefix, NAME_PERCENT_4XX_15M), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
-                return Ratio.of(responses[3].getFifteenMinuteRate(),
+                return Ratio.of(responses.get(3).getFifteenMinuteRate(),
                         requests.getFifteenMinuteRate());
             }
         });
@@ -195,7 +224,7 @@ public class InstrumentedHandler extends HandlerWrapper {
         metricRegistry.register(name(prefix, NAME_PERCENT_5XX_1M), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
-                return Ratio.of(responses[4].getOneMinuteRate(),
+                return Ratio.of(responses.get(4).getOneMinuteRate(),
                         requests.getOneMinuteRate());
             }
         });
@@ -203,7 +232,7 @@ public class InstrumentedHandler extends HandlerWrapper {
         metricRegistry.register(name(prefix, NAME_PERCENT_5XX_5M), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
-                return Ratio.of(responses[4].getFiveMinuteRate(),
+                return Ratio.of(responses.get(4).getFiveMinuteRate(),
                         requests.getFiveMinuteRate());
             }
         });
@@ -211,7 +240,7 @@ public class InstrumentedHandler extends HandlerWrapper {
         metricRegistry.register(name(prefix, NAME_PERCENT_5XX_15M), new RatioGauge() {
             @Override
             public Ratio getRatio() {
-                return Ratio.of(responses[4].getFifteenMinuteRate(),
+                return Ratio.of(responses.get(4).getFifteenMinuteRate(),
                         requests.getFifteenMinuteRate());
             }
         });
@@ -252,7 +281,9 @@ public class InstrumentedHandler extends HandlerWrapper {
         metricRegistry.remove(name(prefix, NAME_PERCENT_5XX_1M));
         metricRegistry.remove(name(prefix, NAME_PERCENT_5XX_5M));
         metricRegistry.remove(name(prefix, NAME_PERCENT_5XX_15M));
-
+        responseCodeMeters.keySet().stream()
+                .map(sc -> name(getMetricPrefix(), String.format("%d-responses", sc)))
+                .forEach(m -> metricRegistry.remove(m));
         super.doStop();
     }
 
@@ -329,19 +360,34 @@ public class InstrumentedHandler extends HandlerWrapper {
     }
 
     private void updateResponses(HttpServletRequest request, HttpServletResponse response, long start, boolean isHandled) {
-        final int responseStatus;
         if (isHandled) {
-            responseStatus = response.getStatus() / 100;
+            mark(response.getStatus());
         } else {
-            responseStatus = 4; // will end up with a 404 response sent by HttpChannel.handle
-        }
-        if (responseStatus >= 1 && responseStatus <= 5) {
-            responses[responseStatus - 1].mark();
+            mark(404);; // will end up with a 404 response sent by HttpChannel.handle
         }
         activeRequests.dec();
         final long elapsedTime = System.currentTimeMillis() - start;
         requests.update(elapsedTime, TimeUnit.MILLISECONDS);
         requestTimer(request.getMethod()).update(elapsedTime, TimeUnit.MILLISECONDS);
+    }
+
+    private void mark(int statusCode) {
+        if (DETAILED_METER_LEVELS.contains(responseMeteredLevel)) {
+            getResponseCodeMeter(statusCode).mark();
+        }
+
+        if (COARSE_METER_LEVELS.contains(responseMeteredLevel)) {
+            final int responseStatus = statusCode / 100;
+            if (responseStatus >= 1 && responseStatus <= 5) {
+                responses.get(responseStatus - 1).mark();
+            }
+        }
+    }
+
+    private Meter getResponseCodeMeter(int statusCode) {
+        return responseCodeMeters
+                .computeIfAbsent(statusCode, sc -> metricRegistry
+                        .meter(name(getMetricPrefix(), String.format("%d-responses", sc))));
     }
 
     private String getMetricPrefix() {

--- a/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHandlerTest.java
+++ b/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHandlerTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.ALL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class InstrumentedHandlerTest {
@@ -29,7 +30,7 @@ public class InstrumentedHandlerTest {
     private final MetricRegistry registry = new MetricRegistry();
     private final Server server = new Server();
     private final ServerConnector connector = new ServerConnector(server);
-    private final InstrumentedHandler handler = new InstrumentedHandler(registry);
+    private final InstrumentedHandler handler = new InstrumentedHandler(registry, null, ALL);
 
     @Before
     public void setUp() throws Exception {
@@ -66,6 +67,7 @@ public class InstrumentedHandlerTest {
                 MetricRegistry.name(TestHandler.class, "handler.2xx-responses"),
                 MetricRegistry.name(TestHandler.class, "handler.3xx-responses"),
                 MetricRegistry.name(TestHandler.class, "handler.4xx-responses"),
+                MetricRegistry.name(TestHandler.class, "handler.404-responses"),
                 MetricRegistry.name(TestHandler.class, "handler.5xx-responses"),
                 MetricRegistry.name(TestHandler.class, "handler.percent-4xx-1m"),
                 MetricRegistry.name(TestHandler.class, "handler.percent-4xx-5m"),
@@ -124,6 +126,8 @@ public class InstrumentedHandlerTest {
     private void assertResponseTimesValid() {
         assertThat(registry.getMeters().get(metricName() + ".2xx-responses")
             .getCount()).isGreaterThan(0L);
+        assertThat(registry.getMeters().get(metricName() + ".200-responses")
+                .getCount()).isGreaterThan(0L);
 
 
         assertThat(registry.getTimers().get(metricName() + ".get-requests")

--- a/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHttpChannelListenerTest.java
+++ b/metrics-jetty9/src/test/java/com/codahale/metrics/jetty9/InstrumentedHttpChannelListenerTest.java
@@ -18,8 +18,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
 
+import static com.codahale.metrics.annotation.ResponseMeteredLevel.ALL;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class InstrumentedHttpChannelListenerTest {
@@ -32,7 +32,7 @@ public class InstrumentedHttpChannelListenerTest {
     @Before
     public void setUp() throws Exception {
         registry = new MetricRegistry();
-        connector.addBean(new InstrumentedHttpChannelListener(registry, MetricRegistry.name(TestHandler.class, "handler")));
+        connector.addBean(new InstrumentedHttpChannelListener(registry, MetricRegistry.name(TestHandler.class, "handler"), ALL));
         server.addConnector(connector);
         server.setHandler(handler);
         server.start();
@@ -57,6 +57,7 @@ public class InstrumentedHttpChannelListenerTest {
                 metricName("1xx-responses"),
                 metricName("2xx-responses"),
                 metricName("3xx-responses"),
+                metricName("404-responses"),
                 metricName("4xx-responses"),
                 metricName("5xx-responses"),
                 metricName("percent-4xx-1m"),
@@ -119,6 +120,8 @@ public class InstrumentedHttpChannelListenerTest {
 
         assertThat(registry.getMeters().get(metricName("2xx-responses"))
             .getCount()).isPositive();
+        assertThat(registry.getMeters().get(metricName("200-responses"))
+                .getCount()).isPositive();
 
         assertThat(registry.getTimers().get(metricName("get-requests"))
             .getSnapshot().getMedian()).isPositive();


### PR DESCRIPTION
Similar to https://github.com/dropwizard/metrics/pull/3043, we have use cases where we want to instrument specific server response codes instead of the aggregated  1xx/2xx/3xx/4xx/5xx meters.

This PR adds configurable individual response code meters in jetty. If this approach is acceptable, I'll create an accompanying PR in dropwizard to allow this to be specified in config via [AbstractServerFactory](https://github.com/dropwizard/dropwizard/blob/release/2.1.x/dropwizard-core/src/main/java/io/dropwizard/server/AbstractServerFactory.java)

This change is backwards compatible and the default behavior will only include the existing 1xx/2xx/3xx/4xx/5xx meters. Can port this over to metrics-jetty10 and metrics-jetty11 modules as well. 