### PR TITLE
Add missing modules to metrics-bom

### DIFF
--- a/metrics-bom/pom.xml
+++ b/metrics-bom/pom.xml
@@ -87,6 +87,16 @@
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics5</groupId>
+                <artifactId>metrics-jersey3</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics5</groupId>
+                <artifactId>metrics-jersey31</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics5</groupId>
                 <artifactId>metrics-jetty10</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
`metrics-jersey3´ and `metrics-jersey31` were missing from the Dropwizard Metrics BOM.