### PR TITLE
FEAT: Jersey: check impl method for annotations before interface method

### DIFF
--- a/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
+++ b/metrics-jersey2/src/main/java/com/codahale/metrics/jersey2/InstrumentedResourceMethodApplicationListener.java
@@ -405,6 +405,25 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         return annotation;
     }
 
+    /**
+     * @param method the method to examine for the annotation
+     * @param annotation the annotation class (e.g. Timed, Metered, etc)
+     * @return the annotation (of type {@code T})from the given method, or null.
+     * @param <T> the type of annotation to return
+     */
+    private static <T extends Annotation> T findAnnotation(final ResourceMethod method, final Class<T> annotation) {
+        // In code-generation situations, developers define their API (via OpenAPI or gRPC or ___), and JAX-RS
+        // interfaces are generated for the defined services (which define @Path, @Produces, etc).
+        // The developer is then responsible for implementing those service interfaces.
+        // For fetching metrics annotations, we presume that any annotation on the implementing method should
+        // take precedence over the interface method, as the developer controls the former more directly.
+        T result = method.getInvocable().getHandlingMethod().getAnnotation(annotation);
+        if (result == null) {
+            result = method.getInvocable().getDefinitionMethod().getAnnotation(annotation);
+        }
+        return result;
+    }
+
     private void registerTimedAnnotations(final ResourceMethod method, final Timed classLevelTimed) {
         final Method definitionMethod = method.getInvocable().getDefinitionMethod();
         if (classLevelTimed != null) {
@@ -412,7 +431,7 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
             return;
         }
 
-        final Timed annotation = definitionMethod.getAnnotation(Timed.class);
+        final Timed annotation = findAnnotation(method, Timed.class);
         if (annotation != null) {
             registerTimers(method, definitionMethod, annotation);
         }
@@ -434,7 +453,7 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
             meters.putIfAbsent(definitionMethod, meterMetric(metrics, method, classLevelMetered));
             return;
         }
-        final Metered annotation = definitionMethod.getAnnotation(Metered.class);
+        final Metered annotation = findAnnotation(method, Metered.class);
 
         if (annotation != null) {
             meters.putIfAbsent(definitionMethod, meterMetric(metrics, method, annotation));
@@ -448,7 +467,7 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
             exceptionMeters.putIfAbsent(definitionMethod, new ExceptionMeterMetric(metrics, method, classLevelExceptionMetered));
             return;
         }
-        final ExceptionMetered annotation = definitionMethod.getAnnotation(ExceptionMetered.class);
+        final ExceptionMetered annotation = findAnnotation(method, ExceptionMetered.class);
 
         if (annotation != null) {
             exceptionMeters.putIfAbsent(definitionMethod, new ExceptionMeterMetric(metrics, method, annotation));
@@ -462,7 +481,7 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
             responseMeters.putIfAbsent(definitionMethod, new ResponseMeterMetric(metrics, method, classLevelResponseMetered));
             return;
         }
-        final ResponseMetered annotation = definitionMethod.getAnnotation(ResponseMetered.class);
+        final ResponseMetered annotation = findAnnotation(method, ResponseMetered.class);
 
         if (annotation != null) {
             responseMeters.putIfAbsent(definitionMethod, new ResponseMeterMetric(metrics, method, annotation));

--- a/metrics-jersey31/src/main/java/io/dropwizard/metrics/jersey31/InstrumentedResourceMethodApplicationListener.java
+++ b/metrics-jersey31/src/main/java/io/dropwizard/metrics/jersey31/InstrumentedResourceMethodApplicationListener.java
@@ -405,6 +405,25 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
         return annotation;
     }
 
+    /**
+     * @param method the method to examine for the annotation
+     * @param annotation the annotation class (e.g. Timed, Metered, etc)
+     * @return the annotation (of type {@code T})from the given method, or null.
+     * @param <T> the type of annotation to return
+     */
+    private static <T extends Annotation> T findAnnotation(final ResourceMethod method, final Class<T> annotation) {
+        // In code-generation situations, developers define their API (via OpenAPI or gRPC or ___), and JAX-RS
+        // interfaces are generated for the defined services (which define @Path, @Produces, etc).
+        // The developer is then responsible for implementing those service interfaces.
+        // For fetching metrics annotations, we presume that any annotation on the implementing method should
+        // take precedence over the interface method, as the developer controls the former more directly.
+        T result = method.getInvocable().getHandlingMethod().getAnnotation(annotation);
+        if (result == null) {
+            result = method.getInvocable().getDefinitionMethod().getAnnotation(annotation);
+        }
+        return result;
+    }
+
     private void registerTimedAnnotations(final ResourceMethod method, final Timed classLevelTimed) {
         final Method definitionMethod = method.getInvocable().getDefinitionMethod();
         if (classLevelTimed != null) {
@@ -412,7 +431,7 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
             return;
         }
 
-        final Timed annotation = definitionMethod.getAnnotation(Timed.class);
+        final Timed annotation = findAnnotation(method, Timed.class);
         if (annotation != null) {
             registerTimers(method, definitionMethod, annotation);
         }
@@ -434,7 +453,7 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
             meters.putIfAbsent(definitionMethod, meterMetric(metrics, method, classLevelMetered));
             return;
         }
-        final Metered annotation = definitionMethod.getAnnotation(Metered.class);
+        final Metered annotation = findAnnotation(method, Metered.class);
 
         if (annotation != null) {
             meters.putIfAbsent(definitionMethod, meterMetric(metrics, method, annotation));
@@ -448,7 +467,7 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
             exceptionMeters.putIfAbsent(definitionMethod, new ExceptionMeterMetric(metrics, method, classLevelExceptionMetered));
             return;
         }
-        final ExceptionMetered annotation = definitionMethod.getAnnotation(ExceptionMetered.class);
+        final ExceptionMetered annotation = findAnnotation(method, ExceptionMetered.class);
 
         if (annotation != null) {
             exceptionMeters.putIfAbsent(definitionMethod, new ExceptionMeterMetric(metrics, method, annotation));
@@ -462,7 +481,7 @@ public class InstrumentedResourceMethodApplicationListener implements Applicatio
             responseMeters.putIfAbsent(definitionMethod, new ResponseMeterMetric(metrics, method, classLevelResponseMetered));
             return;
         }
-        final ResponseMetered annotation = definitionMethod.getAnnotation(ResponseMetered.class);
+        final ResponseMetered annotation = findAnnotation(method, ResponseMetered.class);
 
         if (annotation != null) {
             responseMeters.putIfAbsent(definitionMethod, new ResponseMeterMetric(metrics, method, annotation));


### PR DESCRIPTION
Metrics annotations (`@Timed`, `@Metered`, etc) don’t allow annotating a resource on the *implementing* method, only on the *defining* (interface) method (or more accurately, the method corresponding to the `@Path` definition, more or less).

This patch enhances `dropwizard-metrics` to extract metrics annotations more intelligently, preferring the annotation on the implementation (and falling back to the interface / definitionMethod if the implementation annotation is absent). 

This is a change in existing behavior, but I believe there are very few cases in which the metrics annotations spans an interface and implementation class, and almost zero such cases where the developer would prefer that the interface annotations take precedence.