### PR TITLE
Fix slowTickIfNecessary with infrequently used EWMA

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/EWMA.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/EWMA.java
@@ -82,6 +82,14 @@ public class EWMA {
     }
 
     /**
+     * Set the rate to the smallest possible positive value. Used to avoid calling tick a large number of times.
+     */
+    public void reset() {
+        uncounted.reset();
+        rate = Double.MIN_NORMAL;
+    }
+
+    /**
      * Mark the passage of time and decay the current rate accordingly.
      */
     public void tick() {

--- a/metrics-core/src/main/java/com/codahale/metrics/ExponentialMovingAverages.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ExponentialMovingAverages.java
@@ -11,7 +11,27 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class ExponentialMovingAverages implements MovingAverages {
 
+    /**
+     * If ticking would reduce even Long.MAX_VALUE in the 15 minute EWMA below this target then don't bother
+     * ticking in a loop and instead reset all the EWMAs.
+     */
+    private static final double maxTickZeroTarget = 0.0001;
+    private static final int maxTicks;
     private static final long TICK_INTERVAL = TimeUnit.SECONDS.toNanos(5);
+
+    static
+    {
+        int m3Ticks = 1;
+        final EWMA m3 = EWMA.fifteenMinuteEWMA();
+        m3.update(Long.MAX_VALUE);
+        do
+        {
+            m3.tick();
+            m3Ticks++;
+        }
+        while (m3.getRate(TimeUnit.SECONDS) > maxTickZeroTarget);
+        maxTicks = m3Ticks;
+    }
 
     private final EWMA m1Rate = EWMA.oneMinuteEWMA();
     private final EWMA m5Rate = EWMA.fiveMinuteEWMA();
@@ -51,10 +71,19 @@ public class ExponentialMovingAverages implements MovingAverages {
             final long newIntervalStartTick = newTick - age % TICK_INTERVAL;
             if (lastTick.compareAndSet(oldTick, newIntervalStartTick)) {
                 final long requiredTicks = age / TICK_INTERVAL;
-                for (long i = 0; i < requiredTicks; i++) {
-                    m1Rate.tick();
-                    m5Rate.tick();
-                    m15Rate.tick();
+                if (requiredTicks >= maxTicks) {
+                    m1Rate.reset();
+                    m5Rate.reset();
+                    m15Rate.reset();
+                }
+                else
+                {
+                    for (long i = 0; i < requiredTicks; i++)
+                    {
+                        m1Rate.tick();
+                        m5Rate.tick();
+                        m15Rate.tick();
+                    }
                 }
             }
         }

--- a/metrics-core/src/test/java/com/codahale/metrics/ExponentialMovingAveragesTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ExponentialMovingAveragesTest.java
@@ -1,0 +1,26 @@
+package com.codahale.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ExponentialMovingAveragesTest
+{
+    @Test
+    public void testMaxTicks()
+    {
+        final Clock clock = mock(Clock.class);
+        when(clock.getTick()).thenReturn(0L, Long.MAX_VALUE);
+        final ExponentialMovingAverages ema = new ExponentialMovingAverages(clock);
+        ema.update(Long.MAX_VALUE);
+        ema.tickIfNecessary();
+        final long secondNanos = TimeUnit.SECONDS.toNanos(1);
+        assertEquals(ema.getM1Rate(), Double.MIN_NORMAL * secondNanos, 0.0);
+        assertEquals(ema.getM5Rate(), Double.MIN_NORMAL * secondNanos, 0.0);
+        assertEquals(ema.getM15Rate(), Double.MIN_NORMAL * secondNanos, 0.0);
+    }
+}


### PR DESCRIPTION
EWMA.tickIfNecessary does an amount of work that is linear to the amount of time that has passed since the last time the EWMA was ticked. For infrequently used EWMA this can lead to pauses observed in the 700-800 millisecond range after a few hundred days.

It's not really necessary to perform every tick as all that is doing is slowly approaching the smallest representable positive number in a double. Instead pick a number close to zero and then bound the number of ticks to allow that to be reachable from the largest value representable by the EWMA. Actually approaching the smallest representable number is still measurably slow and not particularly useful.