### PR TITLE
fix(sec): upgrade org.eclipse.jetty:jetty-http to 12.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jetty9.version>9.4.54.v20240208</jetty9.version>
+        <jetty9.version>12.0.1</jetty9.version>
         <jetty10.version>10.0.20</jetty10.version>
         <jetty11.version>11.0.20</jetty11.version>
         <jetty12.version>12.0.8</jetty12.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.eclipse.jetty:jetty-http 9.4.54.v20240208
- [CVE-2022-2047](https://www.oscs1024.com/hd/CVE-2022-2047)


### What did I do？
Upgrade org.eclipse.jetty:jetty-http from 9.4.54.v20240208 to 12.0.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS