### PR TITLE
Correction for the Jetty-12 QTP metrics

### DIFF
--- a/metrics-jetty12/src/main/java/io/dropwizard/metrics/jetty12/InstrumentedQueuedThreadPool.java
+++ b/metrics-jetty12/src/main/java/io/dropwizard/metrics/jetty12/InstrumentedQueuedThreadPool.java
@@ -127,15 +127,10 @@ public class InstrumentedQueuedThreadPool extends QueuedThreadPool {
         metricRegistry.register(name(prefix, NAME_UTILIZATION), new RatioGauge() {
             @Override
             protected Ratio getRatio() {
-                return Ratio.of(getThreads() - getIdleThreads(), getThreads());
+                return  Ratio.of(getUtilizedThreads(), getThreads() - getLeasedThreads());
             }
         });
-        metricRegistry.register(name(prefix, NAME_UTILIZATION_MAX), new RatioGauge() {
-            @Override
-            protected Ratio getRatio() {
-                return Ratio.of(getThreads() - getIdleThreads(), getMaxThreads());
-            }
-        });
+        metricRegistry.registerGauge(name(prefix, NAME_UTILIZATION_MAX), this::getUtilizationRate);
         metricRegistry.registerGauge(name(prefix, NAME_SIZE), this::getThreads);
         // This assumes the QueuedThreadPool is using a BlockingArrayQueue or
         // ArrayBlockingQueue for its queue, and is therefore a constant-time operation.


### PR DESCRIPTION
This uses Jetty-12 recommended way to calculate thread pool utilization. Taking into account number of threads that are leased to internal components, and therefore cannot be used to execute transient jobs.