### PR TITLE
feature request: make executor rescheduling configurable - no lambda implementation proposal

### DIFF
--- a/metrics-collectd/src/main/java/com/codahale/metrics/collectd/CollectdReporter.java
+++ b/metrics-collectd/src/main/java/com/codahale/metrics/collectd/CollectdReporter.java
@@ -186,7 +186,7 @@ public class CollectdReporter extends ScheduledReporter {
                              String username, String password,
                              SecurityLevel securityLevel, Sanitize sanitize) {
         super(registry, REPORTER_NAME, filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop,
-                disabledMetricAttributes);
+                disabledMetricAttributes, null);
         this.hostName = (hostname != null) ? hostname : resolveHostName();
         this.sender = sender;
         this.clock = clock;

--- a/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
@@ -211,7 +211,7 @@ public class ConsoleReporter extends ScheduledReporter {
                             ScheduledExecutorService executor,
                             boolean shutdownExecutorOnStop,
                             Set<MetricAttribute> disabledMetricAttributes) {
-        super(registry, "console-reporter", filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop, disabledMetricAttributes);
+        super(registry, "console-reporter", filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop, disabledMetricAttributes, null);
         this.output = output;
         this.locale = locale;
         this.clock = clock;

--- a/metrics-core/src/main/java/com/codahale/metrics/GetScheduledFuture.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/GetScheduledFuture.java
@@ -1,0 +1,11 @@
+package com.codahale.metrics;
+
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+@FunctionalInterface
+public interface GetScheduledFuture<T> {
+    ScheduledFuture<T> schedule(Long delay, Long period, TimeUnit unit, Runnable runnable, ScheduledExecutorService executor);
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
@@ -239,7 +239,7 @@ public class Slf4jReporter extends ScheduledReporter {
                           boolean shutdownExecutorOnStop,
                           Set<MetricAttribute> disabledMetricAttributes) {
         super(registry, "logger-reporter", filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop,
-                disabledMetricAttributes);
+                disabledMetricAttributes, null);
         this.loggerProxy = loggerProxy;
         this.marker = marker;
         this.prefix = prefix;

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -352,7 +352,7 @@ public class GraphiteReporter extends ScheduledReporter {
                                boolean addMetricAttributesAsTags,
                                DoubleFunction<String> floatingPointFormatter) {
         super(registry, "graphite-reporter", filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop,
-                disabledMetricAttributes);
+                disabledMetricAttributes, null);
         this.graphite = graphite;
         this.clock = clock;
         this.prefix = prefix;


### PR DESCRIPTION
Hello :wave:
First of all, thanks for maintaining the project, we appreciate it.

We had an issue when using Grafana, actually, the exact same as described here: https://github.com/dropwizard/metrics/issues/2664

While having the possibility to override it is nice, we lose a lot of things by doing so, including the nice API builder on the graphite report.
The PR aims to make it configurable with the constructor.

Would that make sense to move forward with this PR?
Feel free to make any comments, long time I have not done any Java. I might not be aware of the good practices

PS: I made another PR proposition here, https://github.com/dropwizard/metrics/pull/4192. Which does not use lambdas and is maybe cleaner to read / maintain. What do you think?