### PR TITLE
fix(sec): upgrade ch.qos.logback:logback-classic to 1.4.12

### DIFF
--- a/metrics-logback/pom.xml
+++ b/metrics-logback/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <javaModuleName>com.codahale.metrics.logback</javaModuleName>
-        <logback.version>1.2.13</logback.version>
+        <logback.version>1.4.12</logback.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in ch.qos.logback:logback-classic 1.2.13
- [CVE-2023-6378](https://www.oscs1024.com/hd/CVE-2023-6378)


### What did I do？
Upgrade ch.qos.logback:logback-classic from 1.2.13 to 1.4.12 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS