### PR TITLE
Feature request: Make executor rescheduling possible with fixed rate - implementation with lambda

### DIFF
--- a/metrics-collectd/src/main/java/com/codahale/metrics/collectd/CollectdReporter.java
+++ b/metrics-collectd/src/main/java/com/codahale/metrics/collectd/CollectdReporter.java
@@ -9,6 +9,7 @@ import com.codahale.metrics.MetricAttribute;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.SchedulingLogic;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 import org.slf4j.Logger;
@@ -186,7 +187,7 @@ public class CollectdReporter extends ScheduledReporter {
                              String username, String password,
                              SecurityLevel securityLevel, Sanitize sanitize) {
         super(registry, REPORTER_NAME, filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop,
-                disabledMetricAttributes);
+                disabledMetricAttributes, SchedulingLogic.FIXED_DELAY);
         this.hostName = (hostname != null) ? hostname : resolveHostName();
         this.sender = sender;
         this.clock = clock;

--- a/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ConsoleReporter.java
@@ -211,7 +211,7 @@ public class ConsoleReporter extends ScheduledReporter {
                             ScheduledExecutorService executor,
                             boolean shutdownExecutorOnStop,
                             Set<MetricAttribute> disabledMetricAttributes) {
-        super(registry, "console-reporter", filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop, disabledMetricAttributes);
+        super(registry, "console-reporter", filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop, disabledMetricAttributes, SchedulingLogic.FIXED_DELAY);
         this.output = output;
         this.locale = locale;
         this.clock = clock;

--- a/metrics-core/src/main/java/com/codahale/metrics/SchedulingLogic.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/SchedulingLogic.java
@@ -1,0 +1,6 @@
+package com.codahale.metrics;
+
+public enum SchedulingLogic {
+    FIXED_DELAY,
+    FIXED_RATE
+}

--- a/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/Slf4jReporter.java
@@ -239,7 +239,7 @@ public class Slf4jReporter extends ScheduledReporter {
                           boolean shutdownExecutorOnStop,
                           Set<MetricAttribute> disabledMetricAttributes) {
         super(registry, "logger-reporter", filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop,
-                disabledMetricAttributes);
+                disabledMetricAttributes, SchedulingLogic.FIXED_DELAY);
         this.loggerProxy = loggerProxy;
         this.marker = marker;
         this.prefix = prefix;

--- a/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
+++ b/metrics-core/src/test/java/com/codahale/metrics/ScheduledReporterTest.java
@@ -5,6 +5,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.CountDownLatch;
@@ -46,6 +47,7 @@ public class ScheduledReporterTest {
     private final ScheduledReporter reporterWithCustomMockExecutor = new DummyReporter(registry, "example", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, mockExecutor);
     private final ScheduledReporter reporterWithCustomExecutor = new DummyReporter(registry, "example", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, customExecutor);
     private final DummyReporter reporterWithExternallyManagedExecutor = new DummyReporter(registry, "example", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, externalExecutor, false);
+    private final ScheduledReporter reporterWithFixedRate = new DummyReporter(registry, "example", MetricFilter.ALL, TimeUnit.SECONDS, TimeUnit.MILLISECONDS, mockExecutor, false, null, SchedulingLogic.FIXED_RATE);
     private final ScheduledReporter[] reporters = new ScheduledReporter[] {reporter, reporterWithCustomExecutor, reporterWithExternallyManagedExecutor};
 
     @Before
@@ -117,6 +119,15 @@ public class ScheduledReporterTest {
 
         verify(mockExecutor).scheduleWithFixedDelay(
             any(Runnable.class), eq(350L), eq(100L), eq(TimeUnit.MILLISECONDS)
+        );
+    }
+
+    @Test
+    public void shouldUseFixedRateWhenSpecified() throws Exception {
+        reporterWithFixedRate.start(200, TimeUnit.MILLISECONDS);
+
+        verify(mockExecutor).scheduleAtFixedRate(
+                any(Runnable.class), eq(200L), eq(200L), eq(TimeUnit.MILLISECONDS)
         );
     }
 
@@ -272,6 +283,10 @@ public class ScheduledReporterTest {
 
         DummyReporter(MetricRegistry registry, String name, MetricFilter filter, TimeUnit rateUnit, TimeUnit durationUnit, ScheduledExecutorService executor, boolean shutdownExecutorOnStop) {
             super(registry, name, filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop);
+        }
+
+        DummyReporter(MetricRegistry registry, String name, MetricFilter filter, TimeUnit rateUnit, TimeUnit durationUnit, ScheduledExecutorService executor, boolean shutdownExecutorOnStop, Set<MetricAttribute> disabledMetricAttributes, SchedulingLogic schedulingLogic) {
+            super(registry, name, filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop, disabledMetricAttributes, schedulingLogic);
         }
 
         @Override

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -10,6 +10,7 @@ import com.codahale.metrics.MetricAttribute;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
+import com.codahale.metrics.SchedulingLogic;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
 import org.slf4j.Logger;
@@ -75,6 +76,8 @@ public class GraphiteReporter extends ScheduledReporter {
         private boolean addMetricAttributesAsTags;
         private DoubleFunction<String> floatingPointFormatter;
 
+        private SchedulingLogic schedulingLogic;
+
         private Builder(MetricRegistry registry) {
             this.registry = registry;
             this.clock = Clock.defaultClock();
@@ -87,6 +90,7 @@ public class GraphiteReporter extends ScheduledReporter {
             this.disabledMetricAttributes = Collections.emptySet();
             this.addMetricAttributesAsTags = false;
             this.floatingPointFormatter = DEFAULT_FP_FORMATTER;
+            this.schedulingLogic = SchedulingLogic.FIXED_DELAY;
         }
 
         /**
@@ -212,6 +216,18 @@ public class GraphiteReporter extends ScheduledReporter {
         }
 
         /**
+         * Use custom scheduling logic.
+         * By default, logic is Fixed Delay
+         *
+         * @param schedulingLogic a scheduling logic
+         * @return {@code this}
+         */
+        public Builder withSchedulingLogic(SchedulingLogic schedulingLogic) {
+            this.schedulingLogic = schedulingLogic;
+            return this;
+        }
+
+        /**
          * Builds a {@link GraphiteReporter} with the given properties, sending metrics using the
          * given {@link GraphiteSender}.
          * <p>
@@ -243,7 +259,8 @@ public class GraphiteReporter extends ScheduledReporter {
                     shutdownExecutorOnStop,
                     disabledMetricAttributes,
                     addMetricAttributesAsTags,
-                    floatingPointFormatter);
+                    floatingPointFormatter,
+                    schedulingLogic);
         }
     }
 
@@ -318,7 +335,7 @@ public class GraphiteReporter extends ScheduledReporter {
                                Set<MetricAttribute> disabledMetricAttributes,
                                boolean addMetricAttributesAsTags) {
         this(registry, graphite, clock, prefix, rateUnit, durationUnit, filter, executor, shutdownExecutorOnStop,
-                disabledMetricAttributes, addMetricAttributesAsTags, DEFAULT_FP_FORMATTER);
+                disabledMetricAttributes, addMetricAttributesAsTags, DEFAULT_FP_FORMATTER, SchedulingLogic.FIXED_DELAY);
     }
 
     /**
@@ -338,6 +355,7 @@ public class GraphiteReporter extends ScheduledReporter {
      * @param disabledMetricAttributes  do not report specific metric attributes
      * @param addMetricAttributesAsTags if true, then add metric attributes as tags instead of suffixes
      * @param floatingPointFormatter    custom floating point formatter
+     * @param schedulingLogic           the scheduling logic for the report of metrics, default at fixed delay
      */
     protected GraphiteReporter(MetricRegistry registry,
                                GraphiteSender graphite,
@@ -350,9 +368,10 @@ public class GraphiteReporter extends ScheduledReporter {
                                boolean shutdownExecutorOnStop,
                                Set<MetricAttribute> disabledMetricAttributes,
                                boolean addMetricAttributesAsTags,
-                               DoubleFunction<String> floatingPointFormatter) {
+                               DoubleFunction<String> floatingPointFormatter,
+                               SchedulingLogic schedulingLogic) {
         super(registry, "graphite-reporter", filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop,
-                disabledMetricAttributes, SchedulingLogic.FIXED_DELAY);
+                disabledMetricAttributes, schedulingLogic);
         this.graphite = graphite;
         this.clock = clock;
         this.prefix = prefix;

--- a/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/com/codahale/metrics/graphite/GraphiteReporter.java
@@ -352,7 +352,7 @@ public class GraphiteReporter extends ScheduledReporter {
                                boolean addMetricAttributesAsTags,
                                DoubleFunction<String> floatingPointFormatter) {
         super(registry, "graphite-reporter", filter, rateUnit, durationUnit, executor, shutdownExecutorOnStop,
-                disabledMetricAttributes);
+                disabledMetricAttributes, SchedulingLogic.FIXED_DELAY);
         this.graphite = graphite;
         this.clock = clock;
         this.prefix = prefix;


### PR DESCRIPTION
Hello 👋
First of all, thanks for maintaining the project, we appreciate it.

We had an issue when using Grafana, actually, the exact same as described here: https://github.com/dropwizard/metrics/issues/2664

While having the possibility to override it is nice, we lose a lot of things by doing so, including the nice API builder on the graphite report.
The PR aims to make it configurable with the constructor.

Would that make sense to move forward with this PR?
Feel free to make any comments, long time I have not done any Java. I might not be aware of the good practices

NB: the description here is completely a copy paste from https://github.com/dropwizard/metrics/pull/4188. These are just two different proposals, I am completely fine with any of these two merged :D