### PR TITLE
Add check in ScheduledReporter's stop method

### DIFF
--- a/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
+++ b/metrics-core/src/main/java/com/codahale/metrics/ScheduledReporter.java
@@ -220,10 +220,13 @@ public abstract class ScheduledReporter implements Closeable, Reporter {
             executor.shutdown(); // Disable new tasks from being submitted
         }
 
-        try {
-            report(); // Report metrics one last time
-        } catch (Exception e) {
-            LOG.warn("Final reporting of metrics failed.", e);
+        if (this.scheduledFuture != null) {
+            // Reporter started, try to report metrics one last time
+            try {
+                report();
+            } catch (Exception e) {
+                LOG.warn("Final reporting of metrics failed.", e);
+            }
         }
 
         if (shutdownExecutorOnStop) {

--- a/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
+++ b/metrics-graphite/src/test/java/com/codahale/metrics/graphite/GraphiteReporterTest.java
@@ -445,6 +445,7 @@ public class GraphiteReporterTest {
 
     @Test
     public void closesConnectionOnReporterStop() throws Exception {
+        reporter.start(1, TimeUnit.SECONDS);
         reporter.stop();
 
         final InOrder inOrder = inOrder(graphite);


### PR DESCRIPTION
Check whether reporter is started before reporting metrics one last time.

Closes https://github.com/dropwizard/metrics/issues/4135