### PR TITLE
feat: bump baseline to Java 17

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java_version: [11, 17, 21]
+        java_version: [17, 21]
         os:
         - ubuntu-latest
     env:

--- a/metrics-caffeine3/pom.xml
+++ b/metrics-caffeine3/pom.xml
@@ -17,9 +17,6 @@
 
     <properties>
         <javaModuleName>io.dropwizard.metrics5.caffeine3</javaModuleName>
-
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencyManagement>

--- a/metrics-jetty10/pom.xml
+++ b/metrics-jetty10/pom.xml
@@ -19,9 +19,6 @@
     <properties>
         <javaModuleName>io.dropwizard.metrics5.jetty10</javaModuleName>
 
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
         <slf4j.version>2.0.16</slf4j.version>
     </properties>
 

--- a/metrics-jetty11/pom.xml
+++ b/metrics-jetty11/pom.xml
@@ -19,9 +19,6 @@
     <properties>
         <javaModuleName>io.dropwizard.metrics5.jetty11</javaModuleName>
 
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-
         <slf4j.version>2.0.16</slf4j.version>
     </properties>
 

--- a/metrics-jetty12-ee10/pom.xml
+++ b/metrics-jetty12-ee10/pom.xml
@@ -19,8 +19,6 @@
     <properties>
         <javaModuleName>io.dropwizard.metrics.jetty12.ee10</javaModuleName>
 
-        <maven.compiler.release>17</maven.compiler.release>
-
         <slf4j.version>2.0.16</slf4j.version>
     </properties>
 

--- a/metrics-jetty12/pom.xml
+++ b/metrics-jetty12/pom.xml
@@ -19,8 +19,6 @@
     <properties>
         <javaModuleName>io.dropwizard.metrics.jetty12</javaModuleName>
 
-        <maven.compiler.release>17</maven.compiler.release>
-
         <slf4j.version>2.0.16</slf4j.version>
     </properties>
 

--- a/metrics-logback14/pom.xml
+++ b/metrics-logback14/pom.xml
@@ -18,9 +18,6 @@
     <properties>
         <javaModuleName>io.dropwizard.metrics5.logback14</javaModuleName>
         <logback14.version>1.4.14</logback14.version>
-
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencyManagement>

--- a/metrics-logback15/pom.xml
+++ b/metrics-logback15/pom.xml
@@ -18,9 +18,6 @@
     <properties>
         <javaModuleName>io.dropwizard.metrics5.logback15</javaModuleName>
         <logback15.version>1.5.11</logback15.version>
-
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -138,68 +138,6 @@
 
     <profiles>
         <profile>
-            <id>jdk8</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <compilerId>javac-with-errorprone</compilerId>
-                            <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                            <showWarnings>true</showWarnings>
-                            <compilerArgument>-Xlint:all</compilerArgument>
-                            <source>1.8</source>
-                            <target>1.8</target>
-                            <fork>true</fork>
-                            <compilerArgs combine.children="append">
-                                <arg>-XepExcludedPaths:.*/target/generated-sources/.*</arg>
-                                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${errorprone.javac.version}/javac-${errorprone.javac.version}.jar</arg>
-                            </compilerArgs>
-                        </configuration>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.codehaus.plexus</groupId>
-                                <artifactId>plexus-compiler-javac-errorprone</artifactId>
-                                <version>2.15.0</version>
-                            </dependency>
-                            <!-- override plexus-compiler-javac-errorprone's dependency on
-                                 Error Prone with the latest version -->
-                            <dependency>
-                                <groupId>com.google.errorprone</groupId>
-                                <artifactId>error_prone_core</artifactId>
-                                <version>${errorprone.version}</version>
-                            </dependency>
-                        </dependencies>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>jdk11</id>
-            <activation>
-                <jdk>11</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>${maven-compiler-plugin.version}</version>
-                        <configuration>
-                            <source>1.8</source>
-                            <target>1.8</target>
-                            <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                            <showWarnings>true</showWarnings>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>jdk17</id>
             <activation>
                 <jdk>[17,)</jdk>
@@ -364,7 +302,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <release>8</release>
+                    <release>17</release>
                     <fork>true</fork>
                     <parameters>true</parameters>
                     <showWarnings>true</showWarnings>


### PR DESCRIPTION
BREAKING CHANGE: Dropwizard Metrics now requires consumers to use at least Java 17.