### PR TITLE
Disable CI release workflow for forks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   release:
+    if: github.repository == 'dropwizard/metrics'
     runs-on: 'ubuntu-latest'
     env:
       JAVA_OPTS: "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"


### PR DESCRIPTION
This will skip CI "Release" workflow run on forks.

Workflows can be disabled manually on forks, but if not done this will trigger and fail every time on update, manual run etc.