### PR TITLE
Add a metrics-jackson3 module - metrics-json but dependent on jackson 3

### DIFF
--- a/metrics-bom/pom.xml
+++ b/metrics-bom/pom.xml
@@ -72,6 +72,11 @@
             </dependency>
             <dependency>
                 <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-jackson3</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
                 <artifactId>metrics-jakarta-servlet</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/metrics-jackson3/pom.xml
+++ b/metrics-jackson3/pom.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-parent</artifactId>
+        <version>4.2.38-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>metrics-jackson3</artifactId>
+    <name>Jackson 3 Integration for Metrics</name>
+    <packaging>bundle</packaging>
+    <description>
+        A set of Jackson modules which provide serializers for most Metrics classes.
+    </description>
+
+    <properties>
+        <javaModuleName>com.codahale.metrics.jackson3</javaModuleName>
+        <maven.compiler.release>17</maven.compiler.release>
+        <jackson.version>3.0.3</jackson.version>
+        <jackson-databind.version>3.0.3</jackson-databind.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.dropwizard.metrics</groupId>
+                <artifactId>metrics-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${byte-buddy.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-healthchecks</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson-databind.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/metrics-jackson3/src/main/java/com/codahale/metrics/jackson3/HealthCheckModule.java
+++ b/metrics-jackson3/src/main/java/com/codahale/metrics/jackson3/HealthCheckModule.java
@@ -1,0 +1,88 @@
+package com.codahale.metrics.jackson3;
+
+import com.codahale.metrics.health.HealthCheck;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.Version;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.module.SimpleSerializers;
+import tools.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+public class HealthCheckModule extends JacksonModule {
+    private static class HealthCheckResultSerializer extends StdSerializer<HealthCheck.Result> {
+
+        private static final long serialVersionUID = 1L;
+
+        private HealthCheckResultSerializer() {
+            super(HealthCheck.Result.class);
+        }
+
+        @Override
+        public void serialize(HealthCheck.Result result,
+                              JsonGenerator json,
+                              SerializationContext provider) {
+            json.writeStartObject();
+            json.writeBooleanProperty("healthy", result.isHealthy());
+
+            final String message = result.getMessage();
+            if (message != null) {
+                json.writeStringProperty("message", message);
+            }
+
+            try {
+                serializeThrowable(json, result.getError(), "error");
+            } catch (IOException ioe) {
+                throw new RuntimeException(ioe);
+            }
+            json.writeNumberProperty("duration", result.getDuration());
+
+            Map<String, Object> details = result.getDetails();
+            if (details != null && !details.isEmpty()) {
+                for (Map.Entry<String, Object> e : details.entrySet()) {
+                    json.writePOJOProperty(e.getKey(), e.getValue());
+                }
+            }
+
+            json.writeStringProperty("timestamp", result.getTimestamp());
+            json.writeEndObject();
+        }
+
+        private void serializeThrowable(JsonGenerator json, Throwable error, String name) throws IOException {
+            if (error != null) {
+                json.writeObjectPropertyStart(name);
+                json.writeStringProperty("type", error.getClass().getTypeName());
+                json.writeStringProperty("message", error.getMessage());
+                json.writeArrayPropertyStart("stack");
+                for (StackTraceElement element : error.getStackTrace()) {
+                    json.writeString(element.toString());
+                }
+                json.writeEndArray();
+
+                if (error.getCause() != null) {
+                    serializeThrowable(json, error.getCause(), "cause");
+                }
+
+                json.writeEndObject();
+            }
+        }
+    }
+
+    @Override
+    public String getModuleName() {
+        return "healthchecks";
+    }
+
+    @Override
+    public Version version() {
+        return MetricsModule.VERSION;
+    }
+
+    @Override
+    public void setupModule(SetupContext context) {
+        context.addSerializers(new SimpleSerializers(Collections.singletonList(new HealthCheckResultSerializer())));
+    }
+}

--- a/metrics-jackson3/src/main/java/com/codahale/metrics/jackson3/MetricsModule.java
+++ b/metrics-jackson3/src/main/java/com/codahale/metrics/jackson3/MetricsModule.java
@@ -1,0 +1,260 @@
+package com.codahale.metrics.jackson3;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.Version;
+import tools.jackson.databind.JacksonModule;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.module.SimpleSerializers;
+import tools.jackson.databind.ser.std.StdSerializer;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+public class MetricsModule extends JacksonModule {
+    static final Version VERSION = new Version(4, 0, 0, "", "io.dropwizard.metrics", "metrics-json");
+
+    @SuppressWarnings("rawtypes")
+    private static class GaugeSerializer extends StdSerializer<Gauge> {
+
+        private static final long serialVersionUID = 1L;
+
+        private GaugeSerializer() {
+            super(Gauge.class);
+        }
+
+        @Override
+        public void serialize(Gauge gauge,
+                              JsonGenerator json,
+                              SerializationContext provider) {
+            json.writeStartObject();
+            final Object value;
+            try {
+                value = gauge.getValue();
+                json.writePOJOProperty("value", value);
+            } catch (RuntimeException e) {
+                json.writePOJOProperty("error", e.toString());
+            }
+            json.writeEndObject();
+        }
+    }
+
+    private static class CounterSerializer extends StdSerializer<Counter> {
+
+        private static final long serialVersionUID = 1L;
+
+        private CounterSerializer() {
+            super(Counter.class);
+        }
+
+        @Override
+        public void serialize(Counter counter,
+                              JsonGenerator json,
+                              SerializationContext provider) {
+            json.writeStartObject();
+            json.writeNumberProperty("count", counter.getCount());
+            json.writeEndObject();
+        }
+    }
+
+    private static class HistogramSerializer extends StdSerializer<Histogram> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final boolean showSamples;
+
+        private HistogramSerializer(boolean showSamples) {
+            super(Histogram.class);
+            this.showSamples = showSamples;
+        }
+
+        @Override
+        public void serialize(Histogram histogram,
+                              JsonGenerator json,
+                              SerializationContext provider) {
+            json.writeStartObject();
+            final Snapshot snapshot = histogram.getSnapshot();
+            json.writeNumberProperty("count", histogram.getCount());
+            json.writeNumberProperty("max", snapshot.getMax());
+            json.writeNumberProperty("mean", snapshot.getMean());
+            json.writeNumberProperty("min", snapshot.getMin());
+            json.writeNumberProperty("p50", snapshot.getMedian());
+            json.writeNumberProperty("p75", snapshot.get75thPercentile());
+            json.writeNumberProperty("p95", snapshot.get95thPercentile());
+            json.writeNumberProperty("p98", snapshot.get98thPercentile());
+            json.writeNumberProperty("p99", snapshot.get99thPercentile());
+            json.writeNumberProperty("p999", snapshot.get999thPercentile());
+
+            if (showSamples) {
+                json.writePOJOProperty("values", snapshot.getValues());
+            }
+
+            json.writeNumberProperty("stddev", snapshot.getStdDev());
+            json.writeEndObject();
+        }
+    }
+
+    private static class MeterSerializer extends StdSerializer<Meter> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String rateUnit;
+        private final double rateFactor;
+
+        public MeterSerializer(TimeUnit rateUnit) {
+            super(Meter.class);
+            this.rateFactor = rateUnit.toSeconds(1);
+            this.rateUnit = calculateRateUnit(rateUnit, "events");
+        }
+
+        @Override
+        public void serialize(Meter meter,
+                              JsonGenerator json,
+                              SerializationContext provider) {
+            json.writeStartObject();
+            json.writeNumberProperty("count", meter.getCount());
+            json.writeNumberProperty("m15_rate", meter.getFifteenMinuteRate() * rateFactor);
+            json.writeNumberProperty("m1_rate", meter.getOneMinuteRate() * rateFactor);
+            json.writeNumberProperty("m5_rate", meter.getFiveMinuteRate() * rateFactor);
+            json.writeNumberProperty("mean_rate", meter.getMeanRate() * rateFactor);
+            json.writeStringProperty("units", rateUnit);
+            json.writeEndObject();
+        }
+    }
+
+    private static class TimerSerializer extends StdSerializer<Timer> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String rateUnit;
+        private final double rateFactor;
+        private final String durationUnit;
+        private final double durationFactor;
+        private final boolean showSamples;
+
+        private TimerSerializer(TimeUnit rateUnit,
+                                TimeUnit durationUnit,
+                                boolean showSamples) {
+            super(Timer.class);
+            this.rateUnit = calculateRateUnit(rateUnit, "calls");
+            this.rateFactor = rateUnit.toSeconds(1);
+            this.durationUnit = durationUnit.toString().toLowerCase(Locale.US);
+            this.durationFactor = 1.0 / durationUnit.toNanos(1);
+            this.showSamples = showSamples;
+        }
+
+        @Override
+        public void serialize(Timer timer,
+                              JsonGenerator json,
+                              SerializationContext provider) {
+            json.writeStartObject();
+            final Snapshot snapshot = timer.getSnapshot();
+            json.writeNumberProperty("count", timer.getCount());
+            json.writeNumberProperty("max", snapshot.getMax() * durationFactor);
+            json.writeNumberProperty("mean", snapshot.getMean() * durationFactor);
+            json.writeNumberProperty("min", snapshot.getMin() * durationFactor);
+
+            json.writeNumberProperty("p50", snapshot.getMedian() * durationFactor);
+            json.writeNumberProperty("p75", snapshot.get75thPercentile() * durationFactor);
+            json.writeNumberProperty("p95", snapshot.get95thPercentile() * durationFactor);
+            json.writeNumberProperty("p98", snapshot.get98thPercentile() * durationFactor);
+            json.writeNumberProperty("p99", snapshot.get99thPercentile() * durationFactor);
+            json.writeNumberProperty("p999", snapshot.get999thPercentile() * durationFactor);
+
+            if (showSamples) {
+                final long[] values = snapshot.getValues();
+                final double[] scaledValues = new double[values.length];
+                for (int i = 0; i < values.length; i++) {
+                    scaledValues[i] = values[i] * durationFactor;
+                }
+                json.writePOJOProperty("values", scaledValues);
+            }
+
+            json.writeNumberProperty("stddev", snapshot.getStdDev() * durationFactor);
+            json.writeNumberProperty("m15_rate", timer.getFifteenMinuteRate() * rateFactor);
+            json.writeNumberProperty("m1_rate", timer.getOneMinuteRate() * rateFactor);
+            json.writeNumberProperty("m5_rate", timer.getFiveMinuteRate() * rateFactor);
+            json.writeNumberProperty("mean_rate", timer.getMeanRate() * rateFactor);
+            json.writeStringProperty("duration_units", durationUnit);
+            json.writeStringProperty("rate_units", rateUnit);
+            json.writeEndObject();
+        }
+    }
+
+    private static class MetricRegistrySerializer extends StdSerializer<MetricRegistry> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final MetricFilter filter;
+
+        private MetricRegistrySerializer(MetricFilter filter) {
+            super(MetricRegistry.class);
+            this.filter = filter;
+        }
+
+        @Override
+        public void serialize(MetricRegistry registry,
+                              JsonGenerator json,
+                              SerializationContext provider) {
+            json.writeStartObject();
+            json.writeStringProperty("version", VERSION.toString());
+            json.writePOJOProperty("gauges", registry.getGauges(filter));
+            json.writePOJOProperty("counters", registry.getCounters(filter));
+            json.writePOJOProperty("histograms", registry.getHistograms(filter));
+            json.writePOJOProperty("meters", registry.getMeters(filter));
+            json.writePOJOProperty("timers", registry.getTimers(filter));
+            json.writeEndObject();
+        }
+    }
+
+    protected final TimeUnit rateUnit;
+    protected final TimeUnit durationUnit;
+    protected final boolean showSamples;
+    protected final MetricFilter filter;
+
+    public MetricsModule(TimeUnit rateUnit, TimeUnit durationUnit, boolean showSamples) {
+        this(rateUnit, durationUnit, showSamples, MetricFilter.ALL);
+    }
+
+    public MetricsModule(TimeUnit rateUnit, TimeUnit durationUnit, boolean showSamples, MetricFilter filter) {
+        this.rateUnit = rateUnit;
+        this.durationUnit = durationUnit;
+        this.showSamples = showSamples;
+        this.filter = filter;
+    }
+
+    @Override
+    public String getModuleName() {
+        return "metrics";
+    }
+
+    @Override
+    public Version version() {
+        return VERSION;
+    }
+
+    @Override
+    public void setupModule(SetupContext context) {
+        context.addSerializers(new SimpleSerializers(Arrays.asList(
+                new GaugeSerializer(),
+                new CounterSerializer(),
+                new HistogramSerializer(showSamples),
+                new MeterSerializer(rateUnit),
+                new TimerSerializer(rateUnit, durationUnit, showSamples),
+                new MetricRegistrySerializer(filter)
+        )));
+    }
+
+    private static String calculateRateUnit(TimeUnit unit, String name) {
+        final String s = unit.toString().toLowerCase(Locale.US);
+        return name + '/' + s.substring(0, s.length() - 1);
+    }
+}

--- a/metrics-jackson3/src/test/java/com/codahale/metrics/jackson3/HealthCheckModuleTest.java
+++ b/metrics-jackson3/src/test/java/com/codahale/metrics/jackson3/HealthCheckModuleTest.java
@@ -1,0 +1,140 @@
+package com.codahale.metrics.jackson3;
+
+import com.codahale.metrics.health.HealthCheck;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HealthCheckModuleTest {
+    private final ObjectMapper mapper = JsonMapper.builder().addModule(new HealthCheckModule()).build();
+
+    @Test
+    public void serializesAHealthyResult() throws Exception {
+        HealthCheck.Result result = HealthCheck.Result.healthy();
+        assertThat(mapper.writeValueAsString(result))
+            .isEqualTo("{\"healthy\":true,\"duration\":0,\"timestamp\":\"" + result.getTimestamp() + "\"}");
+    }
+
+    @Test
+    public void serializesAHealthyResultWithAMessage() throws Exception {
+        HealthCheck.Result result = HealthCheck.Result.healthy("yay for %s", "me");
+        assertThat(mapper.writeValueAsString(result))
+            .isEqualTo("{" +
+                "\"healthy\":true," +
+                "\"message\":\"yay for me\"," +
+                "\"duration\":0," +
+                "\"timestamp\":\"" + result.getTimestamp() + "\"" +
+                "}");
+    }
+
+    @Test
+    public void serializesAnUnhealthyResult() throws Exception {
+        HealthCheck.Result result = HealthCheck.Result.unhealthy("boo");
+        assertThat(mapper.writeValueAsString(result))
+            .isEqualTo("{" +
+                "\"healthy\":false," +
+                "\"message\":\"boo\"," +
+                "\"duration\":0," +
+                "\"timestamp\":\"" + result.getTimestamp() + "\"" +
+                "}");
+    }
+
+    @Test
+    public void serializesAnUnhealthyResultWithAnException() throws Exception {
+        final RuntimeException e = new RuntimeException("oh no");
+        e.setStackTrace(new StackTraceElement[]{
+            new StackTraceElement("Blah", "bloo", "Blah.java", 100)
+        });
+
+        HealthCheck.Result result = HealthCheck.Result.unhealthy(e);
+        assertThat(mapper.writeValueAsString(result))
+            .isEqualTo("{" +
+                "\"healthy\":false," +
+                "\"message\":\"oh no\"," +
+                "\"error\":{" +
+                "\"type\":\"java.lang.RuntimeException\"," +
+                "\"message\":\"oh no\"," +
+                "\"stack\":[\"Blah.bloo(Blah.java:100)\"]" +
+                "}," +
+                "\"duration\":0," +
+                "\"timestamp\":\"" + result.getTimestamp() + "\"" +
+                "}");
+    }
+
+    @Test
+    public void serializesAnUnhealthyResultWithNestedExceptions() throws Exception {
+        final RuntimeException a = new RuntimeException("oh no");
+        a.setStackTrace(new StackTraceElement[]{
+                new StackTraceElement("Blah", "bloo", "Blah.java", 100)
+        });
+
+        final RuntimeException b = new RuntimeException("oh well", a);
+        b.setStackTrace(new StackTraceElement[]{
+                new StackTraceElement("Blah", "blee", "Blah.java", 150)
+        });
+
+        HealthCheck.Result result = HealthCheck.Result.unhealthy(b);
+        assertThat(mapper.writeValueAsString(result))
+            .isEqualTo("{" +
+                "\"healthy\":false," +
+                "\"message\":\"oh well\"," +
+                "\"error\":{" +
+                "\"type\":\"java.lang.RuntimeException\"," +
+                "\"message\":\"oh well\"," +
+                "\"stack\":[\"Blah.blee(Blah.java:150)\"]," +
+                "\"cause\":{" +
+                "\"type\":\"java.lang.RuntimeException\"," +
+                "\"message\":\"oh no\"," +
+                "\"stack\":[\"Blah.bloo(Blah.java:100)\"]" +
+                "}" +
+                "}," +
+                "\"duration\":0," +
+                "\"timestamp\":\"" + result.getTimestamp() + "\"" +
+                "}");
+    }
+
+    @Test
+    public void serializeResultWithDetail() throws Exception {
+        Map<String, Object> complex = new LinkedHashMap<>();
+        complex.put("field", "value");
+
+        HealthCheck.Result result = HealthCheck.Result.builder()
+            .healthy()
+            .withDetail("boolean", true)
+            .withDetail("integer", 1)
+            .withDetail("long", 2L)
+            .withDetail("float", 3.546F)
+            .withDetail("double", 4.567D)
+            .withDetail("BigInteger", new BigInteger("12345"))
+            .withDetail("BigDecimal", new BigDecimal("12345.56789"))
+            .withDetail("String", "string")
+            .withDetail("complex", complex)
+            .build();
+
+        assertThat(mapper.writeValueAsString(result))
+            .isEqualTo("{" +
+                "\"healthy\":true," +
+                "\"duration\":0," +
+                "\"boolean\":true," +
+                "\"integer\":1," +
+                "\"long\":2," +
+                "\"float\":3.546," +
+                "\"double\":4.567," +
+                "\"BigInteger\":12345," +
+                "\"BigDecimal\":12345.56789," +
+                "\"String\":\"string\"," +
+                "\"complex\":{" +
+                "\"field\":\"value\"" +
+                "}," +
+                "\"timestamp\":\"" + result.getTimestamp() + "\"" +
+                "}");
+    }
+}

--- a/metrics-jackson3/src/test/java/com/codahale/metrics/jackson3/MetricsModuleTest.java
+++ b/metrics-jackson3/src/test/java/com/codahale/metrics/jackson3/MetricsModuleTest.java
@@ -1,0 +1,212 @@
+package com.codahale.metrics.jackson3;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MetricsModuleTest {
+    private final ObjectMapper mapper = JsonMapper.builder().addModule(
+            new MetricsModule(TimeUnit.SECONDS, TimeUnit.MILLISECONDS, false, MetricFilter.ALL)).build();
+
+    @Test
+    public void serializesGauges() throws Exception {
+        final Gauge<Integer> gauge = () -> 100;
+
+        assertThat(mapper.writeValueAsString(gauge))
+                .isEqualTo("{\"value\":100}");
+    }
+
+    @Test
+    public void serializesGaugesThatThrowExceptions() throws Exception {
+        final Gauge<Integer> gauge = () -> {
+            throw new IllegalArgumentException("poops");
+        };
+
+        assertThat(mapper.writeValueAsString(gauge))
+                .isEqualTo("{\"error\":\"java.lang.IllegalArgumentException: poops\"}");
+    }
+
+    @Test
+    public void serializesCounters() throws Exception {
+        final Counter counter = mock(Counter.class);
+        when(counter.getCount()).thenReturn(100L);
+
+        assertThat(mapper.writeValueAsString(counter))
+                .isEqualTo("{\"count\":100}");
+    }
+
+    @Test
+    public void serializesHistograms() throws Exception {
+        final Histogram histogram = mock(Histogram.class);
+        when(histogram.getCount()).thenReturn(1L);
+
+        final Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.getMax()).thenReturn(2L);
+        when(snapshot.getMean()).thenReturn(3.0);
+        when(snapshot.getMin()).thenReturn(4L);
+        when(snapshot.getStdDev()).thenReturn(5.0);
+        when(snapshot.getMedian()).thenReturn(6.0);
+        when(snapshot.get75thPercentile()).thenReturn(7.0);
+        when(snapshot.get95thPercentile()).thenReturn(8.0);
+        when(snapshot.get98thPercentile()).thenReturn(9.0);
+        when(snapshot.get99thPercentile()).thenReturn(10.0);
+        when(snapshot.get999thPercentile()).thenReturn(11.0);
+        when(snapshot.getValues()).thenReturn(new long[]{1, 2, 3});
+
+        when(histogram.getSnapshot()).thenReturn(snapshot);
+
+        assertThat(mapper.writeValueAsString(histogram))
+                .isEqualTo("{" +
+                        "\"count\":1," +
+                        "\"max\":2," +
+                        "\"mean\":3.0," +
+                        "\"min\":4," +
+                        "\"p50\":6.0," +
+                        "\"p75\":7.0," +
+                        "\"p95\":8.0," +
+                        "\"p98\":9.0," +
+                        "\"p99\":10.0," +
+                        "\"p999\":11.0," +
+                        "\"stddev\":5.0}");
+
+        final ObjectMapper fullMapper = JsonMapper.builder().addModule(
+                new MetricsModule(TimeUnit.SECONDS, TimeUnit.MILLISECONDS, true, MetricFilter.ALL)).build();
+
+        assertThat(fullMapper.writeValueAsString(histogram))
+                .isEqualTo("{" +
+                        "\"count\":1," +
+                        "\"max\":2," +
+                        "\"mean\":3.0," +
+                        "\"min\":4," +
+                        "\"p50\":6.0," +
+                        "\"p75\":7.0," +
+                        "\"p95\":8.0," +
+                        "\"p98\":9.0," +
+                        "\"p99\":10.0," +
+                        "\"p999\":11.0," +
+                        "\"values\":[1,2,3]," +
+                        "\"stddev\":5.0}");
+    }
+
+    @Test
+    public void serializesMeters() throws Exception {
+        final Meter meter = mock(Meter.class);
+        when(meter.getCount()).thenReturn(1L);
+        when(meter.getMeanRate()).thenReturn(2.0);
+        when(meter.getOneMinuteRate()).thenReturn(5.0);
+        when(meter.getFiveMinuteRate()).thenReturn(4.0);
+        when(meter.getFifteenMinuteRate()).thenReturn(3.0);
+
+        assertThat(mapper.writeValueAsString(meter))
+                .isEqualTo("{" +
+                        "\"count\":1," +
+                        "\"m15_rate\":3.0," +
+                        "\"m1_rate\":5.0," +
+                        "\"m5_rate\":4.0," +
+                        "\"mean_rate\":2.0," +
+                        "\"units\":\"events/second\"}");
+    }
+
+    @Test
+    public void serializesTimers() throws Exception {
+        final Timer timer = mock(Timer.class);
+        when(timer.getCount()).thenReturn(1L);
+        when(timer.getMeanRate()).thenReturn(2.0);
+        when(timer.getOneMinuteRate()).thenReturn(3.0);
+        when(timer.getFiveMinuteRate()).thenReturn(4.0);
+        when(timer.getFifteenMinuteRate()).thenReturn(5.0);
+
+        final Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.getMax()).thenReturn(TimeUnit.MILLISECONDS.toNanos(100));
+        when(snapshot.getMean()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(200));
+        when(snapshot.getMin()).thenReturn(TimeUnit.MILLISECONDS.toNanos(300));
+        when(snapshot.getStdDev()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(400));
+        when(snapshot.getMedian()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(500));
+        when(snapshot.get75thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(600));
+        when(snapshot.get95thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(700));
+        when(snapshot.get98thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(800));
+        when(snapshot.get99thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(900));
+        when(snapshot.get999thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(1000));
+
+        when(snapshot.getValues()).thenReturn(new long[]{
+                TimeUnit.MILLISECONDS.toNanos(1),
+                TimeUnit.MILLISECONDS.toNanos(2),
+                TimeUnit.MILLISECONDS.toNanos(3)
+        });
+
+        when(timer.getSnapshot()).thenReturn(snapshot);
+
+        assertThat(mapper.writeValueAsString(timer))
+                .isEqualTo("{" +
+                        "\"count\":1," +
+                        "\"max\":100.0," +
+                        "\"mean\":200.0," +
+                        "\"min\":300.0," +
+                        "\"p50\":500.0," +
+                        "\"p75\":600.0," +
+                        "\"p95\":700.0," +
+                        "\"p98\":800.0," +
+                        "\"p99\":900.0," +
+                        "\"p999\":1000.0," +
+                        "\"stddev\":400.0," +
+                        "\"m15_rate\":5.0," +
+                        "\"m1_rate\":3.0," +
+                        "\"m5_rate\":4.0," +
+                        "\"mean_rate\":2.0," +
+                        "\"duration_units\":\"milliseconds\"," +
+                        "\"rate_units\":\"calls/second\"}");
+
+        final ObjectMapper fullMapper = JsonMapper.builder().addModule(
+                new MetricsModule(TimeUnit.SECONDS, TimeUnit.MILLISECONDS, true, MetricFilter.ALL)).build();
+
+        assertThat(fullMapper.writeValueAsString(timer))
+                .isEqualTo("{" +
+                        "\"count\":1," +
+                        "\"max\":100.0," +
+                        "\"mean\":200.0," +
+                        "\"min\":300.0," +
+                        "\"p50\":500.0," +
+                        "\"p75\":600.0," +
+                        "\"p95\":700.0," +
+                        "\"p98\":800.0," +
+                        "\"p99\":900.0," +
+                        "\"p999\":1000.0," +
+                        "\"values\":[1.0,2.0,3.0]," +
+                        "\"stddev\":400.0," +
+                        "\"m15_rate\":5.0," +
+                        "\"m1_rate\":3.0," +
+                        "\"m5_rate\":4.0," +
+                        "\"mean_rate\":2.0," +
+                        "\"duration_units\":\"milliseconds\"," +
+                        "\"rate_units\":\"calls/second\"}");
+    }
+
+    @Test
+    public void serializesMetricRegistries() throws Exception {
+        final MetricRegistry registry = new MetricRegistry();
+
+        assertThat(mapper.writeValueAsString(registry))
+                .isEqualTo("{" +
+                        "\"version\":\"4.0.0\"," +
+                        "\"gauges\":{}," +
+                        "\"counters\":{}," +
+                        "\"histograms\":{}," +
+                        "\"meters\":{}," +
+                        "\"timers\":{}}");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,7 @@
                 <module>metrics-jetty12</module>
                 <module>metrics-jetty12-ee10</module>
                 <module>metrics-jetty12-ee11</module>
+                <module>metrics-jackson3</module>
             </modules>
             <build>
                 <plugins>


### PR DESCRIPTION
https://github.com/dropwizard/metrics/issues/5100

https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md

Add a metrics-jackson3 module (metrics-json but dependent on jackson 3 and with the API changes required by jackson 3 migration).       PR builds cleanly on my machine, the two tests in metrics-jackson3 pass.      

I see two untracked files after building (metrics-benchmarks/dependency-reduced-pom.xml, metrics-jcstress/dependency-reduced-pom.xml) but I don't see them checked into 4.2.x branch.    Should I add them?     Should dependency-reduced-pom.xml be added to .gitignore?