### PR TITLE
build: compile in-process rather than by forking `javac`

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -145,22 +145,11 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
-                            <fork>true</fork>
                             <compilerArgs>
                                 <arg>-Xlint:all</arg>
                                 <arg>-XDcompilePolicy=simple</arg>
                                 <arg>--should-stop=ifError=FLOW</arg>
                                 <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.*</arg>
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
                             </compilerArgs>
                             <annotationProcessorPaths>
                                 <path>
@@ -289,7 +278,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <release>17</release>
-                    <fork>true</fork>
                     <parameters>true</parameters>
                     <showWarnings>true</showWarnings>
                     <compilerArgs>


### PR DESCRIPTION
(I coded this change against the `5.0.x` release branch before noticing in the README that this branch is "on pause"; happy to (also) file a PR for `4.2.x` if desired.)

Suggested commit message:
```
build: compile in-process rather than by forking `javac`

The `--add-exports`/`--add-opens` flags required by Error Prone are 
currently passed as `-J` compiler arguments, which requires
`<fork>true</fork>`. Declaring them in `.mvn/jvm.config` instead lets
the compiler run inside the Maven JVM, significantly speeding up the 
build.
```

On my laptop this change speeds up the build by ~32%:
- `mvn clean install`: 3m43s -> 2m31s
- `mvn -T1C clean install` -> 1m49s -> 1m15s

Reason for opening this PR: our project runs an [integration test](https://github.com/PicnicSupermarket/error-prone-support/tree/ab47a921f63e49b741c84ad793478bafa7f453c1/integration-tests) against Dropwizard Metrics' code base, and the associated GitHub Actions builds increasingly often time out. Next to optimizing our test setup, just speeding up the build under test helps too :)