### PR TITLE
Add tag escaping to `JMXReporter`

### DIFF
--- a/metrics-jmx/src/main/java/io/dropwizard/metrics5/jmx/DefaultObjectNameFactory.java
+++ b/metrics-jmx/src/main/java/io/dropwizard/metrics5/jmx/DefaultObjectNameFactory.java
@@ -1,7 +1,9 @@
 package io.dropwizard.metrics5.jmx;
 
 import io.dropwizard.metrics5.MetricName;
+
 import java.util.Hashtable;
+import java.util.regex.Pattern;
 
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
@@ -9,52 +11,49 @@ import javax.management.ObjectName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Default ObjectName factory.
+ * Values are quoted when necessary. Illegal characters in domain and tag names are always replaced with '_'.
+ */
 public class DefaultObjectNameFactory implements ObjectNameFactory {
 
-    private static final char[] QUOTABLE_CHARS = new char[] {',', '=', ':', '"'};
+    // '"' is unsafe only when used at the beginning of a value, but is kept for consistency with old escaping
+    private static final char[] QUOTABLE_CHARS = new char[]{',', '=', ':', '"', '*', '?', '\n'};
+    // keys don't support quoting
+    private static final Pattern INVALID_KEY_CHARS_PATTERN = Pattern.compile("[,=:*?\n]");
+    // domain doesn't support quoting; ':' and '\n' can't be used, while '*' or '?' would turn it into a pattern
+    private static final Pattern INVALID_DOMAIN_CHARS_PATTERN = Pattern.compile("[:*?\n]");
+
     private static final Logger LOGGER = LoggerFactory.getLogger(JmxReporter.class);
 
     @Override
     public ObjectName createName(String type, String domain, MetricName name) {
         try {
-            ObjectName objectName;
             Hashtable<String, String> properties = new Hashtable<>();
 
-            properties.put("name", name.getKey());
-            properties.put("type", type);
-            properties.putAll(name.getTags());
-            objectName = new ObjectName(domain, properties);
+            name.getTags().forEach((key, value) -> {
+                String sanitizedKey = key.isEmpty()
+                        ? "_"
+                        : sanitizeValue(key, INVALID_KEY_CHARS_PATTERN);
+                properties.put(sanitizedKey, quoteIfNeeded(value));
+            });
 
-            /*
-             * The only way we can find out if we need to quote the properties is by
-             * checking an ObjectName that we've constructed.
-             */
-            if (objectName.isDomainPattern()) {
-                domain = ObjectName.quote(domain);
-            }
-            if (objectName.isPropertyValuePattern("name") || shouldQuote(objectName.getKeyProperty("name"))) {
-                properties.put("name", ObjectName.quote(name.getKey()));
-            }
-            if (objectName.isPropertyValuePattern("type") || shouldQuote(objectName.getKeyProperty("type"))) {
-                properties.put("type", ObjectName.quote(type));
-            }
-            objectName = new ObjectName(domain, properties);
+            properties.put("name", quoteIfNeeded(name.getKey()));
+            properties.put("type", quoteIfNeeded(type));
 
-            return objectName;
+            String sanitizedDomain = sanitizeValue(domain, INVALID_DOMAIN_CHARS_PATTERN);
+            return new ObjectName(sanitizedDomain, properties);
         } catch (MalformedObjectNameException e) {
-            try {
-                return new ObjectName(domain, "name", ObjectName.quote(name.getKey()));
-            } catch (MalformedObjectNameException e1) {
-                LOGGER.warn("Unable to register {} {}", type, name, e1);
-                throw new RuntimeException(e1);
-            }
+            LOGGER.warn("Unable to register {} {}", type, name, e);
+            throw new RuntimeException(e);
         }
     }
 
     /**
      * Determines whether the value requires quoting.
      * According to the {@link ObjectName} documentation, values can be quoted or unquoted. Unquoted
-     * values may not contain any of the characters comma, equals, colon, or quote.
+     * values may not contain any of the characters: comma, equals, colon, quote or newline, and
+     * turn the object name into a pattern if they contain an asterisk or a question mark.
      *
      * @param value a value to test
      * @return true when it requires quoting, false otherwise
@@ -66,6 +65,14 @@ public class DefaultObjectNameFactory implements ObjectNameFactory {
             }
         }
         return false;
+    }
+
+    private String quoteIfNeeded(final String value) {
+        return shouldQuote(value) ? ObjectName.quote(value) : value;
+    }
+
+    private String sanitizeValue(final String value, final Pattern pattern) {
+        return pattern.matcher(value).replaceAll("_");
     }
 
 }

--- a/metrics-jmx/src/test/java/io/dropwizard/metrics5/jmx/DefaultObjectNameFactoryTest.java
+++ b/metrics-jmx/src/test/java/io/dropwizard/metrics5/jmx/DefaultObjectNameFactoryTest.java
@@ -2,8 +2,12 @@ package io.dropwizard.metrics5.jmx;
 
 import io.dropwizard.metrics5.MetricName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import javax.management.ObjectName;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,31 +15,149 @@ import static org.assertj.core.api.Assertions.assertThat;
 class DefaultObjectNameFactoryTest {
 
     @Test
-    void createsObjectNameWithDomainInInput() {
+    void createsObjectName() {
         DefaultObjectNameFactory f = new DefaultObjectNameFactory();
         ObjectName on = f.createName("type", "com.domain", MetricName.build("something.with.dots").tagged("foo", "bar", "baz", "biz"));
+
+        assertIsRegistrable(on);
         assertThat(on.getDomain()).isEqualTo("com.domain");
-        assertThat(on.getKeyProperty("foo")).isEqualTo("bar");
-        assertThat(on.getKeyProperty("baz")).isEqualTo("biz");
-    }
-
-    @Test
-    void createsObjectNameWithNameAsKeyPropertyName() {
-        DefaultObjectNameFactory f = new DefaultObjectNameFactory();
-        ObjectName on = f.createName("type", "com.domain", MetricName.build("something.with.dots").tagged("foo", "bar", "baz", "biz"));
         assertThat(on.getKeyProperty("name")).isEqualTo("something.with.dots");
+        assertThat(on.getKeyProperty("type")).isEqualTo("type");
         assertThat(on.getKeyProperty("foo")).isEqualTo("bar");
         assertThat(on.getKeyProperty("baz")).isEqualTo("biz");
+    }
 
+    @ParameterizedTest
+    @MethodSource("unsafeNames")
+    void handlesUnsafeCharactersInDomain(UnsafeName name) {
+        DefaultObjectNameFactory f = new DefaultObjectNameFactory();
+        ObjectName on = f.createName("count", name.raw, MetricName.build("name").tagged("foo", "bar", "baz", "biz"));
+
+        assertIsRegistrable(on);
+        assertThat(on.getDomain()).isEqualTo(name.asDomain);
+        assertThat(on.getKeyProperty("type")).isEqualTo("count");
+        assertThat(on.getKeyProperty("name")).isEqualTo("name");
+        assertThat(on.getKeyProperty("foo")).isEqualTo("bar");
+        assertThat(on.getKeyProperty("baz")).isEqualTo("biz");
+    }
+
+    @ParameterizedTest
+    @MethodSource("unsafeNames")
+    void handlesUnsafeCharactersInName(UnsafeName name) {
+        DefaultObjectNameFactory f = new DefaultObjectNameFactory();
+        ObjectName on = f.createName("count", "com.domain", MetricName.build(name.raw).tagged("foo", "bar", "baz", "biz"));
+
+        assertIsRegistrable(on);
+        assertThat(on.getDomain()).isEqualTo("com.domain");
+        assertThat(on.getKeyProperty("type")).isEqualTo("count");
+        assertThat(on.getKeyProperty("name")).isEqualTo(name.quoted);
+        assertThat(on.getKeyProperty("foo")).isEqualTo("bar");
+        assertThat(on.getKeyProperty("baz")).isEqualTo("biz");
+    }
+
+    @ParameterizedTest
+    @MethodSource("unsafeNames")
+    void handlesUnsafeCharactersInType(UnsafeName name) {
+        DefaultObjectNameFactory f = new DefaultObjectNameFactory();
+        ObjectName on = f.createName(name.raw, "com.domain", MetricName.build("name").tagged("foo", "bar", "baz", "biz"));
+
+        assertIsRegistrable(on);
+        assertThat(on.getDomain()).isEqualTo("com.domain");
+        assertThat(on.getKeyProperty("type")).isEqualTo(name.quoted);
+        assertThat(on.getKeyProperty("name")).isEqualTo("name");
+        assertThat(on.getKeyProperty("foo")).isEqualTo("bar");
+        assertThat(on.getKeyProperty("baz")).isEqualTo("biz");
+    }
+
+    @ParameterizedTest
+    @MethodSource("unsafeNames")
+    void handlesUnsafeCharactersInTagValue(UnsafeName name) {
+        DefaultObjectNameFactory f = new DefaultObjectNameFactory();
+        ObjectName on = f.createName("count", "com.domain", MetricName.build("name").tagged("foo", name.raw));
+
+        assertIsRegistrable(on);
+        assertThat(on.getDomain()).isEqualTo("com.domain");
+        assertThat(on.getKeyProperty("type")).isEqualTo("count");
+        assertThat(on.getKeyProperty("name")).isEqualTo("name");
+        assertThat(on.getKeyProperty("foo")).isEqualTo(name.quoted);
+    }
+
+    @ParameterizedTest
+    @MethodSource("unsafeNames")
+    void handlesUnsafeCharactersInTagName(UnsafeName name) {
+        DefaultObjectNameFactory f = new DefaultObjectNameFactory();
+        ObjectName on = f.createName("count", "com.domain", MetricName.build("name").tagged(name.raw, "bar"));
+
+        assertIsRegistrable(on);
+        assertThat(on.getDomain()).isEqualTo("com.domain");
+        assertThat(on.getKeyProperty("type")).isEqualTo("count");
+        assertThat(on.getKeyProperty("name")).isEqualTo("name");
+        assertThat(on.getKeyProperty(name.asKey)).isEqualTo("bar");
     }
 
     @Test
-    void createsObjectNameWithNameWithDisallowedUnquotedCharacters() {
+    public void doesNotQuoteNamesThatAreValidUnquotedValues() {
         DefaultObjectNameFactory f = new DefaultObjectNameFactory();
-        ObjectName on = f.createName("type", "com.domain", MetricName.build("something.with.quotes(\"ABcd\")").tagged("foo", "bar", "baz", "biz"));
-        assertThatCode(() -> new ObjectName(on.toString())).doesNotThrowAnyException();
-        assertThat(on.getKeyProperty("name")).isEqualTo("\"something.with.quotes(\\\"ABcd\\\")\"");
-        assertThat(on.getKeyProperty("foo")).isEqualTo("bar");
-        assertThat(on.getKeyProperty("baz")).isEqualTo("biz");
+        ObjectName on = f.createName("type-.", "domain-.", MetricName.build("name-.").tagged("foo-.", "bar-."));
+
+        assertIsRegistrable(on);
+        assertThat(on.getDomain()).isEqualTo("domain-.");
+        assertThat(on.getKeyProperty("type")).isEqualTo("type-.");
+        assertThat(on.getKeyProperty("name")).isEqualTo("name-.");
+        assertThat(on.getKeyProperty("foo-.")).isEqualTo("bar-.");
+    }
+
+    @Test
+    public void allowsEmptyNameAndTagValue() {
+        DefaultObjectNameFactory f = new DefaultObjectNameFactory();
+        ObjectName on = f.createName("", "", MetricName.build("").tagged("", ""));
+
+        assertIsRegistrable(on);
+        assertThat(on.getDomain()).isEqualTo("");
+        assertThat(on.getKeyProperty("type")).isEqualTo("");
+        assertThat(on.getKeyProperty("name")).isEqualTo("");
+        assertThat(on.getKeyProperty("_")).isEqualTo("");
+    }
+
+    @Test
+    public void tagsDontOverrideNameAndType() {
+        DefaultObjectNameFactory f = new DefaultObjectNameFactory();
+        MetricName metric = MetricName.build("name").tagged("type", "t", "domain", "d", "name", "n", "k", "v");
+        ObjectName on = f.createName("type", "domain", metric);
+
+        assertIsRegistrable(on);
+        assertThat(on.getDomain()).isEqualTo("domain");
+        assertThat(on.getKeyProperty("type")).isEqualTo("type");
+        assertThat(on.getKeyProperty("name")).isEqualTo("name");
+        assertThat(on.getKeyProperty("k")).isEqualTo("v");
+    }
+
+    private static void assertIsRegistrable(ObjectName on) {
+        assertThatCode(() -> new ObjectName(on.toString()))
+                .as("%s should be parseable", on)
+                .doesNotThrowAnyException();
+        assertThat(on.isPattern())
+                .as("%s should not be a pattern", on)
+                .isFalse();
+    }
+
+    private static Stream<UnsafeName> unsafeNames() {
+        // raw, quoted, asKey, asDomain
+        return Stream.of(
+                new UnsafeName("a,b", "\"a,b\"", "a_b", "a,b"),
+                new UnsafeName("a=b", "\"a=b\"", "a_b", "a=b"),
+                new UnsafeName("a:b", "\"a:b\"", "a_b", "a_b"),
+                new UnsafeName("a\nb", "\"a\\nb\"", "a_b", "a_b"),
+                new UnsafeName("a*b", "\"a\\*b\"", "a_b", "a_b"),
+                new UnsafeName("a?b", "\"a\\?b\"", "a_b", "a_b"),
+                new UnsafeName("quotes(\"ABcd\")", "\"quotes(\\\"ABcd\\\")\"", "quotes(\"ABcd\")","quotes(\"ABcd\")")
+        );
+    }
+
+    private record UnsafeName(String raw, String quoted, String asKey, String asDomain) {
+        @Override
+        public String toString() {
+            return raw;
+        }
     }
 }


### PR DESCRIPTION
A set of changes to `DefaultObjectNameFactory`:

* added tag escaping
* prevented tags from overwriting `type` and `name`
* added `domain` sanitization to make this safe

Illegal characters in domain and tag names are replaced with `_`. Now the only way for `createName` to fail would be to pass it null values.

Fixes #5387